### PR TITLE
Fix CLI help exit status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -684,6 +684,9 @@ export function runCli(
   cwd: string = process.cwd(),
 ): CliResult {
   const [command, ...options] = args
+  if (command === '--help' || command === '-h' || command === 'help') {
+    return { exitCode: 0, stdout: usage, stderr: '' }
+  }
   if (command === 'init') {
     return runInit(options, cwd)
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -17,6 +17,17 @@ const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const Ajv2020 = Ajv2020Module.default
 
 describe('YarraMate CLI', () => {
+  it.each(['--help', '-h', 'help'])(
+    'prints usage successfully for %s',
+    (argument) => {
+      const result = runCli([argument], repositoryRoot)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Usage:')
+      expect(result.stderr).toBe('')
+    },
+  )
+
   it('emits check results conforming to the normative result schema', () => {
     const schema = JSON.parse(
       readFileSync(


### PR DESCRIPTION
## Summary

- recognize `--help`, `-h`, and `help` as successful CLI requests
- add regression coverage for all three forms
- prepare patch version 0.1.1

## Validation

- 19 test files, 192 tests
- typecheck
- build
- built CLI smoke test