### PR TITLE
Add GitHub community health foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Tell us about incorrect or unexpected YarraMate behaviour.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report this. A minimal reproduction is helpful but never required.
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: Include commands, diagnostics, or relevant document fragments when useful. Remove private information.
+      placeholder: I expected … but YarraMate …
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Steps, a small example, or a repository link are all welcome.
+  - type: input
+    id: version
+    attributes:
+      label: YarraMate version
+      placeholder: "0.1.1, a commit SHA, or unknown"
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Native documents or compiler
+        - CLI
+        - JSON Schemas or graph interchange
+        - Agent skill
+        - LikeC4 adapter
+        - Graphify adapter
+        - Documentation
+        - Unsure
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, Node.js version, package manager, and agent harness when relevant.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public-report check
+      options:
+        - label: I have removed credentials and private repository content.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,5 @@
 blank_issues_enabled: true
-contact_links: []
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/yarrasys/yarramate/security/advisories/new
+    about: Report security vulnerabilities privately, not in a public issue.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,22 @@
+name: Documentation
+description: Report unclear, missing, or incorrect documentation.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where is the problem?
+      placeholder: A URL, file path, command, diagnostic, or topic
+  - type: textarea
+    id: problem
+    attributes:
+      label: What was unclear or missing?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Optional—plain-language intent is enough; polished wording is not required.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Improvement or feature
+description: Suggest a capability, adoption improvement, or semantic change.
+title: "idea: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: Ideas at any level of detail are welcome. You do not need to arrive with a solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to accomplish?
+      description: Describe the user or agent journey and where it currently becomes difficult.
+    validations:
+      required: true
+  - type: textarea
+    id: direction
+    attributes:
+      label: Possible direction
+      description: Optional—share an API, document shape, workflow, or trade-off you have in mind.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Likely surface
+      options:
+        - Native semantics or profile
+        - Compiler or validation
+        - CLI
+        - Agent journey or skill
+        - Projection or visualization
+        - Evidence or reconciliation
+        - Adapter
+        - Documentation or onboarding
+        - Unsure
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Optional—tell us what you do today.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,18 @@
+name: Question
+description: Ask about using, extending, or contributing to YarraMate.
+title: "question: "
+labels:
+  - question
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: What would you like to know?
+      description: Include enough context to understand what you are building or exploring.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried or read?
+      description: Optional—this helps us find documentation gaps.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Australia/Melbourne
+    open-pull-requests-limit: 5
+    groups:
+      development:
+        dependency-type: development
+      production:
+        dependency-type: production
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,17 @@ Describe the problem and the change.
 
 List the checks you ran. Use `pnpm run verify` when practical.
 
+## Related issue
+
+Link an issue when one exists. Small, self-contained fixes do not require one.
+
 ## Contract impact
 
 Note any change to native semantics, schemas, graph interchange, diagnostics,
 stable CLI behaviour, or adapter boundaries. Write `None` when not applicable.
+
+## Checklist
+
+- [ ] Tests or documentation cover the change where appropriate.
+- [ ] Generated output and build artifacts are not committed.
+- [ ] Semantic or stable-interface changes have prior discussion and an ADR where required.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
           version: 11.7.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "17 16 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyse:
+    name: analyse
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use YarraMate in published work, please cite this software."
+title: YarraMate
+abstract: "A tool-neutral semantic architecture engine and guided methodology."
+type: software
+authors:
+  - name: YarraMate contributors
+version: 0.1.1
+date-released: 2026-07-28
+url: "https://github.com/yarrasys/yarramate"
+repository-code: "https://github.com/yarrasys/yarramate"
+license: MIT

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of conduct
+
+YarraMate is an open-source project where people should be able to participate
+without harassment, intimidation, or needless hostility.
+
+## Expected behaviour
+
+- Be respectful, patient, and constructive.
+- Critique ideas and changes, not people.
+- Assume good intent while remaining clear about technical evidence.
+- Welcome questions and contributions from people with different backgrounds
+  and levels of experience.
+- Respect privacy and avoid publishing another person's private information.
+
+## Unacceptable behaviour
+
+Harassment, discriminatory language, personal attacks, threats, sexualised
+attention, sustained disruption, and deliberate exposure of private
+information are not accepted in project spaces.
+
+## Reporting
+
+For ordinary project disagreements, open an issue or contact a maintainer in
+the relevant discussion. For sensitive conduct concerns, use
+[GitHub's private vulnerability reporting form](https://github.com/yarrasys/yarramate/security/advisories/new)
+and begin the report title with `Conduct report:`. Reports will be handled as
+privately and promptly as practical.
+
+Maintainers may edit or remove contributions and may temporarily or
+permanently restrict participation when needed to protect the project and its
+participants. Decisions should be proportionate, documented privately where
+appropriate, and focused on restoring a safe, productive environment.
+
+This code applies to the repository and other spaces where someone is
+representing YarraMate.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,22 @@
+# Governance
+
+YarraMate uses lightweight, repository-native governance.
+
+- Anyone may open an issue or pull request.
+- GitHub records authorship, review, discussion, history, and acceptance.
+- Maintainers merge changes based on product fit, evidence, compatibility,
+  maintainability, and the documented product contract.
+- Small fixes may go directly to a pull request.
+- Semantic, schema, stable CLI, and substantial feature changes should begin
+  with an issue and normally require an ADR.
+- Maintainers may close inactive or out-of-scope work with an explanation;
+  proposals may be reopened when new evidence or implementation capacity
+  appears.
+
+There are no contributor ranks, voting procedures, mandatory issue
+assignments, CLA, DCO, or separate approval workflow. As the contributor
+community grows, this document can evolve through the same issue and pull
+request process.
+
+The authoritative product boundaries remain
+[docs/PRODUCT-CONTRACT.md](docs/PRODUCT-CONTRACT.md) and ADR 0002.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # YarraMate
 
+[![npm](https://img.shields.io/npm/v/yarramate)](https://www.npmjs.com/package/yarramate)
+[![CI](https://github.com/yarrasys/yarramate/actions/workflows/ci.yml/badge.svg)](https://github.com/yarrasys/yarramate/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml/badge.svg)](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml)
+[![license: MIT](https://img.shields.io/github/license/yarrasys/yarramate)](LICENSE)
+
 YarraMate is a tool-neutral semantic architecture engine and guided
 methodology. It turns architectural intent into deterministic, testable
 context shared by people and agents.
@@ -94,8 +99,16 @@ pnpm docs:dev
 
 ## CLI
 
-Build the repository, then invoke the same executable surface intended for
-published use:
+Install the published executable or invoke it directly with `npx`:
+
+```sh
+npm install --global yarramate
+yarramate --help
+
+npx yarramate check .yarramate/workspace.yaml
+```
+
+When developing the repository, build and invoke the same executable surface:
 
 ```sh
 pnpm build
@@ -117,7 +130,7 @@ For a local consumer test, create a package artifact:
 
 ```sh
 pnpm pack --pack-destination /tmp/yarramate-package
-npm install --global /tmp/yarramate-package/yarramate-0.1.0.tgz
+npm install --global /tmp/yarramate-package/yarramate-*.tgz
 yarramate --help
 ```
 
@@ -169,6 +182,8 @@ You do not need to provide a solution, formal proposal, or implementation.
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes to native
 semantics or stable interfaces. Report suspected vulnerabilities according to
-[SECURITY.md](SECURITY.md).
+[SECURITY.md](SECURITY.md). Participation is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md), and help channels are described in
+[SUPPORT.md](SUPPORT.md).
 
 YarraMate is available under the [MIT License](LICENSE).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,15 @@
+# Getting help
+
+Use [GitHub Issues](https://github.com/yarrasys/yarramate/issues/new/choose)
+for usage questions, unexpected behaviour, documentation gaps, and feature
+ideas. Questions are welcome even when you do not yet have a minimal example
+or know whether the problem is a bug.
+
+Before sharing logs or architecture documents, remove credentials, private
+source code, internal hostnames, and other sensitive material.
+
+YarraMate is currently pre-release and maintained on a best-effort basis.
+There is no guaranteed response time or private support channel.
+
+Do not report security vulnerabilities publicly. Follow
+[SECURITY.md](SECURITY.md) instead.


### PR DESCRIPTION
## Summary

- add welcoming issue forms, support, conduct, governance, and citation metadata
- add Dependabot and CodeQL automation
- add README status badges and current published-install guidance
- strengthen the PR template without requiring an issue for small fixes
- update GitHub Actions to current checkout and Node setup majors

## Validation

- parsed all new YAML files
- `git diff --check`
- `pnpm run verify`: 19 test files, 192 tests, native self-check, LikeC4 generation and validation

## Contract impact

None. These changes affect repository community health and automation only.