### PR TITLE
Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.7.0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript


### PR DESCRIPTION
## Summary

Replaces the useful updates from closed Dependabot PRs #3, #4, and #5 in one recoverable change:

- `actions/setup-node` v5 → v7
- `actions/checkout` v5 → v7
- `pnpm/action-setup` v4 → v6

PR #6 is intentionally excluded because Node 26 types do not match the project's Node 22+ runtime contract, TypeScript 7 is an unnecessary major jump, and the proposed lockfile failed the minimum-release-age policy.

## Validation

- workflow YAML parsing
- `git diff --check`
- `pnpm run verify`: 19 test files, 192 tests, native self-check, LikeC4 generation and validation
- the three original Dependabot action updates each passed hosted CI and CodeQL independently

## Contract impact

None.