### PR TITLE
Release v0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.1.1
+version: 0.2.0
 date-released: 2026-07-28
 url: "https://github.com/yarrasys/yarramate"
 repository-code: "https://github.com/yarrasys/yarramate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What changed

- bump the npm package and citation metadata from 0.1.1 to 0.2.0

## Why

This minor release publishes the additive native relationship-description and identified-reference contracts, plus the packed-consumer LikeC4 specification asset fix.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm verify` — 195 tests, typecheck, self-check, and LikeC4 validation passed
- `CI=true npm_config_cache=/tmp/yarramate-npm-cache npm pack --dry-run`
- inspected all 77 packed files; `assets/likec4/specification.likec4` is included
- `git diff --check`
