### PR TITLE
Resolve adoption feedback

### DIFF
--- a/.yarramate/architecture/product.yaml
+++ b/.yarramate/architecture/product.yaml
@@ -110,11 +110,23 @@ relationships:
     kind: association
     from: evidence-intent-separation
     to: reconcile-intent-and-evidence
+    description: Reconciliation reports where evidence challenges declared architecture without rewriting the accepted intent.
+    references:
+      - id: governing-decisions
+        ref: yarramate-repository#architecture-decisions
   - id: cli-supports-discovery
     kind: association
     from: stable-cli
     to: discover-project-architecture
+    description: Agent harnesses use the stable CLI to produce reviewable discovery proposals without a privileged agent API.
+    references:
+      - id: implementation-interface
+        ref: yarramate-engine#cli
   - id: cli-supports-design
     kind: association
     from: stable-cli
     to: design-solution-before-build
+    description: Agent harnesses use the same stable CLI to capture design intent before implementation begins.
+    references:
+      - id: implementation-interface
+        ref: yarramate-engine#cli

--- a/docs/ADAPTER-MAPPINGS.md
+++ b/docs/ADAPTER-MAPPINGS.md
@@ -51,6 +51,23 @@ agent harnesses.
 Successful loads normalize mapping entry order by native identity, external
 identity, and type.
 
+The LikeC4 adapter can add missing entries without replacing existing external
+identities:
+
+```sh
+yarramate-likec4 map --sync \
+  .yarramate/integrations/likec4/subject-mapping.yaml \
+  .yarramate/workspace.yaml
+```
+
+The command compiles the explicit workspace, validates the existing mapping,
+then appends only unmapped concepts and relationships. Architecture-state
+planning subjects are excluded. External identities use deterministic
+lower-camel local IDs; collisions receive a document prefix and, only when
+still necessary, a numeric suffix. Existing mappings and their authored
+overrides are preserved. The candidate mapping is validated before an atomic
+replacement, and a second sync is a no-op.
+
 The governed-change test fixture has a native document and explicit mapping:
 
 ```sh
@@ -93,6 +110,9 @@ the authored value that can correct the failure:
 | `YMLC105` | A compared architecture state is absent from the graph. | Projection state selector. |
 | `YMLC106` | A compared state is omitted from the projection query. | Projection `states` array. |
 | `YMLC107` | Two project entries resolve to the same LikeC4 view identity. | Duplicate project view `id`, or `projection` when no override is present. |
+| `YMLC108` | A dynamic step does not select a relationship. | Project dynamic-step relationship. |
+| `YMLC109` | A deployment identity, parent, or projected subject is invalid. | The corresponding project deployment field. |
+| `YMLC110` | A project mapping, kind mapping, or projection is missing or unreadable. | The referencing project field. |
 
 Schema and source parsing failures retain their existing Core diagnostic
 codes in the same envelope. Mixed Core and adapter failures use the shared
@@ -177,6 +197,12 @@ yarramate-likec4 export-project \
   .yarramate-out/likec4 \
   .yarramate/workspace.yaml
 ```
+
+Every `mapping`, `kindMapping`, and `views[].projection` path in a LikeC4
+project definition is repository-relative: it resolves from the CLI working
+directory, normally the repository root, not from the project-definition
+file. Absolute paths, backslashes, and `..` traversal are rejected so the
+project cannot escape that explicit root.
 
 The adapter unions mapped subjects and claims into one `model` block, then
 emits one ordinary LikeC4 view per projection. This avoids duplicate

--- a/docs/BACKLOG-DISPOSITION.md
+++ b/docs/BACKLOG-DISPOSITION.md
@@ -17,9 +17,12 @@ The current repository implements the agreed foundation for:
   portable agent skill;
 - evidence evaluation and provider-neutral reconciliation;
 - packed consumer installation and the stable CLI;
+- successful check-result scale counts without a Core completeness policy;
 - projection-driven LikeC4 element, comparison, dynamic, and deployment
   views in one generated project, with relationship rationale retained in
   logical and dynamic output;
+- non-destructive LikeC4 mapping synchronization and source-located project
+  reference diagnostics;
 - explicit Graphify node observation producing standard evidence overlays.
 
 There is no remaining concrete, locally actionable item in the agreed Core 0.1

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -99,6 +99,17 @@ A named semantic connection between concepts, such as `realization`,
 `assignment`, or `triggering`.
 _Avoid_: Arrow type, edge style
 
+**Required constraint**:
+An identified claim that a concept is bound by or must satisfy a referenced
+rule. It declares applicability, not implementation or proof of satisfaction.
+_Avoid_: Realization, enforcement result
+
+**Realization relationship**:
+A relationship claiming that its source implements or fulfils a more abstract
+target. It does not by itself make the target a required constraint on the
+source.
+_Avoid_: Constraint applicability, automatic compliance
+
 **Profile**:
 A versioned vocabulary and set of semantic constraints that extends YarraMate
 Core.
@@ -175,7 +186,8 @@ _Avoid_: Certification, architecture score, implementation workflow
 
 **Check result**:
 A versioned machine-readable outcome containing deterministic correctness
-diagnostics.
+diagnostics and, on success, counts of the compiled documents, concepts,
+relationships, and architecture states.
 _Avoid_: Approval record, completeness score, human console text
 
 **Diagnostic result**:

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -79,6 +79,13 @@ evaluate the stable generated claim ID and report through an evidence overlay;
 the observation does not mutate declared intent or become a Core validation
 result.
 
+`constraints` and `realization` express different claims. A constraint entry
+means the concept is bound by the referenced rule; a realization relationship
+means its source implements or fulfils its target. A component that must obey a
+rule uses `constraints`. A component that implements the mechanism described
+by a rule may use `realization`. Declare both only when both facts are
+architecturally meaningful; neither implies the other.
+
 Concepts and relationships may cite any other workspace subject through
 explicitly identified references:
 
@@ -183,6 +190,28 @@ Kind names are supplied by the selected explicit profile. The schema accepts a
 kind string because profiles are extensible; compilation rejects a kind absent
 from the selected catalogue.
 
+## Decomposing a model
+
+A native document is a stable semantic identity and review boundary, not a
+required layer, diagram, subsystem, or file-size unit. Split documents when a
+cohesive body of architecture is easier to own and review independently—for
+example by subsystem, bounded responsibility, or kind of knowledge such as
+structure, governance rules, interaction flows, and evolution planning. Keep a
+small model together when splitting would add navigation without clarifying
+ownership or review.
+
+Cross-document endpoints, owners, constraints, identified references,
+architecture-state ordering, and `presentIn` references use globally qualified
+`document#subject` identities and have the same correctness checks as local
+references. Architecture states are workspace planning contexts and may be
+declared in one document and referenced from any other compiled document.
+
+There is no correctness threshold for concepts or relationships per document.
+The practical costs of decomposition are explicit qualification and reviewing
+more files. Moving an existing subject between documents changes its globally
+qualified identity, so choose durable boundaries and treat later moves as
+semantic renames rather than harmless file organization.
+
 ## Compiled graph
 
 `compileWorkspace(sources)` is the library interface. On success it returns a
@@ -253,8 +282,9 @@ yarramate check architecture/*.yaml --json
 Explicit files are checked as one workspace, so qualified references may cross
 between them. Exit status is `0` when valid,
 `1` for correctness diagnostics, and `2` for invocation or file errors.
-`--json` emits a deterministic `yarramate/check-result/v1` object with `ok`
-and `diagnostics`. Its normative structure is
+`--json` emits a deterministic `yarramate/check-result/v1` object with `ok`,
+`diagnostics`, and successful-workspace `counted` totals for documents,
+concepts, relationships, and architecture states. Its normative structure is
 `schema/yarramate-check-result.schema.json`, exported as
 `yarramate/schema/check-result`. The command does not write compiled artifacts.
 

--- a/docs/PRODUCT-CONTRACT.md
+++ b/docs/PRODUCT-CONTRACT.md
@@ -140,7 +140,9 @@ yarramate reconcile
 
 Machine-readable checking uses the versioned
 `yarramate/check-result/v1` contract. It reports deterministic correctness
-diagnostics only; it is not an approval, completeness, or quality score.
+diagnostics and successful-workspace subject counts; it is not an approval,
+completeness, shrink policy, or quality score. Consumers decide whether a
+count change is acceptable.
 Other JSON-producing semantic commands report correctness failures through
 the versioned `yarramate/diagnostic-result/v1` contract.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,9 @@ notation.
   workspace-wide with architecture-state applicability; additional
   contradiction coverage remains deliberately incremental.**
 - Emit stable, source-located, machine-readable diagnostics. **Implemented as
-  the normative `yarramate/check-result/v1` contract for `check --json`.**
+  the normative `yarramate/check-result/v1` contract for `check --json`,
+  including additive successful-workspace document, concept, relationship,
+  and architecture-state counts.**
 - Keep completeness and organizational governance opt-in.
 
 ## 0.4 — Profiles and projections
@@ -123,8 +125,10 @@ notation.
   comparison visualization, explicit per-view membership after model union,
   ordered dynamic views over projected relationship subjects, and
   native relationship descriptions on dynamic steps, and regression-fixture
-  and self-dogfooding mappings are implemented. Import, round-tripping and
-  general styling parity remain future adapter work.
+  and self-dogfooding mappings are implemented. Non-destructive deterministic
+  subject-mapping synchronization and source-located project-reference
+  diagnostics are also implemented. Import, round-tripping and general
+  styling parity remain future adapter work.
   Adapter-owned deployment nodes and named instances of projected concepts
   are implemented with regression validation.**
 - Generic evidence-provider interface.

--- a/docs/adr/0015-constraints-are-identified-reference-claims.md
+++ b/docs/adr/0015-constraints-are-identified-reference-claims.md
@@ -25,6 +25,12 @@ Core checks reference existence and local constraint-ID uniqueness. It does
 not require a particular target kind, evaluate satisfaction, infer
 enforcement, or define exceptions and waivers.
 
+The constraint claim and a `realization` relationship are not alternate
+spellings. `constraints` says that its subject is bound by or must satisfy the
+referenced rule. `realization` says that its source implements or fulfils a
+more abstract target. Use `constraints` for applicability, `realization` for
+implementation, and both only when both independent statements are intended.
+
 ## Consequences
 
 Multiple constraints remain concise, reorder-safe, and queryable in graph v2.

--- a/schema/yarramate-check-result.schema.json
+++ b/schema/yarramate-check-result.schema.json
@@ -17,6 +17,9 @@
       "items": {
         "$ref": "#/$defs/diagnostic"
       }
+    },
+    "counted": {
+      "$ref": "#/$defs/counted"
     }
   },
   "allOf": [
@@ -30,6 +33,7 @@
         "required": ["ok"]
       },
       "then": {
+        "required": ["counted"],
         "properties": {
           "diagnostics": {
             "maxItems": 0
@@ -46,6 +50,17 @@
     }
   ],
   "$defs": {
+    "counted": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documents", "concepts", "relationships", "states"],
+      "properties": {
+        "documents": { "type": "integer", "minimum": 0 },
+        "concepts": { "type": "integer", "minimum": 0 },
+        "relationships": { "type": "integer", "minimum": 0 },
+        "states": { "type": "integer", "minimum": 0 }
+      }
+    },
     "diagnostic": {
       "type": "object",
       "additionalProperties": false,

--- a/schema/yarramate-likec4-diagnostic-result.schema.json
+++ b/schema/yarramate-likec4-diagnostic-result.schema.json
@@ -34,7 +34,7 @@
                 "const": "error"
               },
               "code": {
-                "enum": ["YMLC101", "YMLC102", "YMLC103", "YMLC104", "YMLC105", "YMLC106"]
+                "enum": ["YMLC101", "YMLC102", "YMLC103", "YMLC104", "YMLC105", "YMLC106", "YMLC107", "YMLC108", "YMLC109", "YMLC110"]
               },
               "message": {
                 "type": "string",

--- a/schema/yarramate-likec4-project.schema.json
+++ b/schema/yarramate-likec4-project.schema.json
@@ -41,6 +41,7 @@
     },
     "path": {
       "type": "string",
+      "description": "Repository-relative path resolved from the CLI working directory. Parent traversal, absolute paths, and backslashes are rejected.",
       "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
     },
     "subjectIdentity": {

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -190,6 +190,9 @@ yarramate view <projection.yaml> .yarramate/workspace.yaml
 yarramate compare <from-state> <to-state> .yarramate/workspace.yaml
 yarramate evidence <evidence.yaml> .yarramate/workspace.yaml
 yarramate reconcile .yarramate/workspace.yaml
+yarramate-likec4 map --sync \
+  .yarramate/integrations/likec4/subject-mapping.yaml \
+  .yarramate/workspace.yaml
 ```
 
 Treat exit `0` as successful execution, `1` as correctness diagnostics, and

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -15,12 +15,18 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createHash, randomUUID } from 'node:crypto'
 import Ajv2020Module from 'ajv/dist/2020.js'
-import { parseDocument } from 'yaml'
+import { isSeq, parseDocument } from 'yaml'
 import {
   isMainModule,
   resolveCliWorkspaceSources,
   type CliResult,
 } from '../cli-support.js'
+import { compileWorkspace } from '../compiler.js'
+import {
+  adapterMappingLocation,
+  loadAdapterMapping,
+  validateAdapterMapping,
+} from '../adapter-mapping.js'
 import { locateSourcePath } from '../source-document.js'
 import {
   prepareLikeC4Export,
@@ -99,6 +105,7 @@ const publishFiles = (
 
 const usage =
   'Usage:\n' +
+  '  yarramate-likec4 map --sync <mapping.yaml> <workspace-or-source...>\n' +
   '  yarramate-likec4 check <projection.yaml> <mapping.yaml> [--json] [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
   '  yarramate-likec4 check <likec4-project.yaml> [--json] <workspace-or-source...>\n' +
   '  yarramate-likec4 export <projection.yaml> <mapping.yaml> [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
@@ -133,6 +140,175 @@ const checkJson = (
 
 const sameJson = (left: unknown, right: unknown) =>
   JSON.stringify(left) === JSON.stringify(right)
+
+const lowerCamel = (value: string) =>
+  value.replaceAll(/-([a-z0-9])/g, (_, character: string) =>
+    character.toUpperCase(),
+  )
+
+const runLikeC4MapSync = (
+  args: readonly string[],
+  cwd: string,
+): CliResult => {
+  const [sync, mappingPath, ...sourcePaths] = args
+  if (
+    sync !== '--sync' ||
+    mappingPath === undefined ||
+    mappingPath.startsWith('-') ||
+    sourcePaths.length === 0 ||
+    sourcePaths.some((path) => path.startsWith('-'))
+  ) {
+    return { exitCode: 2, stdout: '', stderr: usage }
+  }
+  try {
+    const resolved = resolveCliWorkspaceSources(sourcePaths, cwd)
+    if (!resolved.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(resolved.diagnostics),
+        stderr: '',
+      }
+    }
+    const compilation = compileWorkspace(
+      resolved.paths.map((path) => ({
+        path,
+        source: readFileSync(resolve(cwd, path), 'utf8'),
+      })),
+    )
+    if (!compilation.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(compilation.diagnostics),
+        stderr: '',
+      }
+    }
+    const absoluteMappingPath = resolve(cwd, mappingPath)
+    const original = readFileSync(absoluteMappingPath, 'utf8')
+    const loaded = loadAdapterMapping({
+      path: mappingPath,
+      source: original,
+    })
+    if (!loaded.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(loaded.diagnostics),
+        stderr: '',
+      }
+    }
+    if (loaded.mapping.adapter !== 'likec4') {
+      const location = adapterMappingLocation(loaded.mapping, 'adapter')
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson([{
+          severity: 'error',
+          code: 'YMLC101',
+          message: `Adapter mapping targets "${loaded.mapping.adapter}", not "likec4"`,
+          ...location,
+        }]),
+        stderr: '',
+      }
+    }
+    const validation = validateAdapterMapping(
+      compilation.graph,
+      loaded.mapping,
+    )
+    if (!validation.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(validation.diagnostics),
+        stderr: '',
+      }
+    }
+    const mapped = new Set(
+      loaded.mapping.mappings.map(({ native }) => native),
+    )
+    const claimedExternal = new Set(
+      loaded.mapping.mappings.map(({ external }) => external),
+    )
+    const architectureStates = new Set(
+      compilation.graph.claims
+        .filter(({ predicate }) => predicate === 'yarramate/state/type')
+        .map(({ subject }) => subject),
+    )
+    const additions = compilation.graph.subjects
+      .filter(
+        ({ id }) => !mapped.has(id) && !architectureStates.has(id),
+      )
+      .map((subject) => {
+        const [documentId, localId] = subject.id.split('#') as [
+          string,
+          string,
+        ]
+        const local = lowerCamel(localId)
+        let external = local
+        if (claimedExternal.has(external)) {
+          external = `${lowerCamel(documentId)}_${local}`
+        }
+        let suffix = 2
+        const base = external
+        while (claimedExternal.has(external)) {
+          external = `${base}_${suffix}`
+          suffix += 1
+        }
+        claimedExternal.add(external)
+        return {
+          native: subject.id,
+          external,
+          type: subject.type,
+        }
+      })
+    if (additions.length === 0) {
+      return {
+        exitCode: 0,
+        stdout: `LikeC4 mapping ${mappingPath} is already synchronized\n`,
+        stderr: '',
+      }
+    }
+    const document = parseDocument(original)
+    for (const addition of additions) {
+      document.addIn(['mappings'], addition)
+    }
+    const mappings = document.getIn(['mappings'], true)
+    if (isSeq(mappings)) mappings.flow = false
+    const candidate = document.toString({ lineWidth: 0 })
+    const candidateMapping = loadAdapterMapping({
+      path: mappingPath,
+      source: candidate,
+    })
+    if (!candidateMapping.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(candidateMapping.diagnostics),
+        stderr: '',
+      }
+    }
+    const candidateValidation = validateAdapterMapping(
+      compilation.graph,
+      candidateMapping.mapping,
+    )
+    if (!candidateValidation.ok) {
+      return {
+        exitCode: 1,
+        stdout: diagnosticJson(candidateValidation.diagnostics),
+        stderr: '',
+      }
+    }
+    const staged = stageFile(absoluteMappingPath, candidate)
+    try {
+      staged.publish()
+    } finally {
+      staged.cleanup()
+    }
+    return {
+      exitCode: 0,
+      stdout: `Added ${additions.length} LikeC4 mappings to ${mappingPath}\n`,
+      stderr: '',
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { exitCode: 2, stdout: '', stderr: `${message}\n` }
+  }
+}
 
 const publishGeneratedProject = (
   cwd: string,
@@ -278,6 +454,9 @@ export function runLikeC4Cli(
   args: readonly string[],
   cwd: string = process.cwd(),
 ): CliResult {
+  if (args[0] === 'map') {
+    return runLikeC4MapSync(args.slice(1), cwd)
+  }
   const [command, projectionPath, mappingPath, ...options] = args
   let projectDefinitionMode = false
   if (
@@ -404,38 +583,102 @@ export function runLikeC4Cli(
           stderr: '',
         }
       }
+      const referencedSources = new Map<string, {
+        readonly path: string
+        readonly source: string
+      }>()
+      const referenceDiagnostics: LikeC4PreparationDiagnostic[] = []
+      const readProjectReference = (
+        path: string,
+        label: 'mapping' | 'kind mapping' | 'projection',
+        yamlPath: readonly (string | number)[],
+        pointer: string,
+      ) => {
+        const existing = referencedSources.get(path)
+        if (existing !== undefined) return existing
+        try {
+          const source = {
+            path,
+            source: readFileSync(resolve(cwd, path), 'utf8'),
+          }
+          referencedSources.set(path, source)
+          return source
+        } catch (error) {
+          const location = locateSourcePath(
+            projectSource.path,
+            loadedProject.document.yaml,
+            loadedProject.document.lineCounter,
+            yamlPath,
+            pointer,
+          )
+          const absent =
+            error instanceof Error &&
+            'code' in error &&
+            error.code === 'ENOENT'
+          referenceDiagnostics.push({
+            severity: 'error',
+            code: 'YMLC110',
+            message: absent
+              ? `LikeC4 project ${label} "${path}" does not exist`
+              : `LikeC4 project ${label} "${path}" cannot be read`,
+            ...location,
+          })
+          return undefined
+        }
+      }
+      const subjectMapping = readProjectReference(
+        loadedProject.document.value.mapping,
+        'mapping',
+        ['mapping'],
+        '/mapping',
+      )
+      const kindMapping =
+        loadedProject.document.value.kindMapping === undefined
+          ? undefined
+          : readProjectReference(
+              loadedProject.document.value.kindMapping,
+              'kind mapping',
+              ['kindMapping'],
+              '/kindMapping',
+            )
+      const projections = loadedProject.document.value.views.map(
+        (view, index) =>
+          readProjectReference(
+            view.projection,
+            'projection',
+            ['views', index, 'projection'],
+            `/views/${index}/projection`,
+          ),
+      )
+      if (
+        referenceDiagnostics.length > 0 ||
+        subjectMapping === undefined
+      ) {
+        return {
+          exitCode: 1,
+          stdout: diagnosticOutput(
+            referenceDiagnostics.sort((left, right) =>
+              left.path.localeCompare(right.path) ||
+              left.line - right.line ||
+              left.column - right.column ||
+              left.code.localeCompare(right.code) ||
+              left.message.localeCompare(right.message),
+            ),
+          ),
+          stderr: '',
+        }
+      }
       const preparedViews = loadedProject.document.value.views.map(
-        (view) => ({
+        (view, index) => ({
           view,
           prepared: prepareLikeC4Export({
             sources,
-            projection: {
-              path: view.projection,
-              source: readFileSync(
-                resolve(cwd, view.projection),
-                'utf8',
-              ),
-            },
-            subjectMapping: {
-              path: loadedProject.document.value.mapping,
-              source: readFileSync(
-                resolve(cwd, loadedProject.document.value.mapping),
-                'utf8',
-              ),
-            },
+            projection: projections[index]!,
+            subjectMapping,
             ...(loadedProject.document.value.kindMapping === undefined
               ? {}
               : {
-                  kindMapping: {
-                    path: loadedProject.document.value.kindMapping,
-                    source: readFileSync(
-                      resolve(
-                        cwd,
-                        loadedProject.document.value.kindMapping,
-                      ),
-                      'utf8',
-                    ),
-                  },
+                  kindMapping: kindMapping!,
                 }),
             ...(view.compare === undefined
               ? {}

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -250,15 +250,43 @@ export function runCheckCommand(
       ? optionalDiagnostics
       : result.diagnostics
 
+    const counted = result.ok
+      ? (() => {
+          const states = new Set(
+            result.graph.claims
+              .filter(
+                ({ predicate }) =>
+                  predicate === 'yarramate/state/type',
+              )
+              .map(({ subject }) => subject),
+          )
+          return {
+            documents: result.graph.documents.length,
+            concepts: result.graph.subjects.filter(
+              ({ id, type }) => type === 'concept' && !states.has(id),
+            ).length,
+            relationships: result.graph.subjects.filter(
+              ({ type }) => type === 'relationship',
+            ).length,
+            states: states.size,
+          }
+        })()
+      : undefined
+
     if (json) {
       return {
         exitCode: ok ? 0 : 1,
-        stdout: checkResultJson(ok, ok ? [] : diagnostics),
+        stdout: checkResultJson(
+          ok,
+          ok ? [] : diagnostics,
+          ok ? counted : undefined,
+        ),
         stderr: '',
       }
     }
 
     if (ok && result.ok) {
+      const successfulCounts = counted!
       const documentCount = result.graph.documents.length
       const profileCount = coreSources.length - documentCount
       const mappingCount = mappingSources.length
@@ -295,7 +323,12 @@ export function runCheckCommand(
       ].join(' and ')
       return {
         exitCode: 0,
-        stdout: `Checked ${checked}: no errors\n`,
+        stdout:
+          `Checked ${checked} (` +
+          `${successfulCounts.concepts} ${successfulCounts.concepts === 1 ? 'concept' : 'concepts'}, ` +
+          `${successfulCounts.relationships} ${successfulCounts.relationships === 1 ? 'relationship' : 'relationships'}, ` +
+          `${successfulCounts.states} ${successfulCounts.states === 1 ? 'state' : 'states'}` +
+          '): no errors\n',
         stderr: '',
       }
     }

--- a/src/cli-support.ts
+++ b/src/cli-support.ts
@@ -39,12 +39,22 @@ export const diagnosticJson = (diagnostics: unknown) =>
     2,
   )}\n`
 
-export const checkResultJson = (ok: boolean, diagnostics: unknown) =>
+export const checkResultJson = (
+  ok: boolean,
+  diagnostics: unknown,
+  counted?: {
+    readonly documents: number
+    readonly concepts: number
+    readonly relationships: number
+    readonly states: number
+  },
+) =>
   `${JSON.stringify(
     {
       format: 'yarramate/check-result/v1',
       ok,
       diagnostics,
+      ...(counted === undefined ? {} : { counted }),
     },
     null,
     2,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -57,6 +57,14 @@ describe('YarraMate CLI', () => {
       validate(JSON.parse(success.stdout)),
       JSON.stringify(validate.errors ?? []),
     ).toBe(true)
+    expect(JSON.parse(success.stdout)).toMatchObject({
+      counted: {
+        documents: 1,
+        concepts: 2,
+        relationships: 1,
+        states: 0,
+      },
+    })
     expect(
       validate(JSON.parse(failure.stdout)),
       JSON.stringify(validate.errors ?? []),
@@ -103,7 +111,8 @@ describe('YarraMate CLI', () => {
 
     expect(result).toEqual({
       exitCode: 0,
-      stdout: 'Checked 1 document: no errors\n',
+      stdout:
+        'Checked 1 document (2 concepts, 1 relationship, 0 states): no errors\n',
       stderr: '',
     })
   })
@@ -153,7 +162,8 @@ describe('YarraMate CLI', () => {
 
     expect(result).toEqual({
       exitCode: 0,
-      stdout: 'Checked 1 document and 1 profile: no errors\n',
+      stdout:
+        'Checked 1 document and 1 profile (2 concepts, 1 relationship, 0 states): no errors\n',
       stderr: '',
     })
   })
@@ -170,7 +180,8 @@ describe('YarraMate CLI', () => {
 
     expect(result).toEqual({
       exitCode: 0,
-      stdout: 'Checked 1 document and 1 adapter mapping: no errors\n',
+      stdout:
+        'Checked 1 document and 1 adapter mapping (2 concepts, 1 relationship, 0 states): no errors\n',
       stderr: '',
     })
   })
@@ -522,7 +533,8 @@ describe('YarraMate CLI', () => {
         runCli(['check', '.yarramate/workspace.yaml'], directory),
       ).toEqual({
         exitCode: 0,
-        stdout: 'Checked 1 document: no errors\n',
+        stdout:
+          'Checked 1 document (0 concepts, 0 relationships, 0 states): no errors\n',
         stderr: '',
       })
     } finally {

--- a/test/journeys.test.ts
+++ b/test/journeys.test.ts
@@ -37,6 +37,12 @@ describe('agent journeys through the stable CLI', () => {
       format: 'yarramate/check-result/v1',
       ok: true,
       diagnostics: [],
+      counted: {
+        documents: 1,
+        concepts: 4,
+        relationships: 3,
+        states: 0,
+      },
     })
     expect(JSON.parse(evidence.stdout).summary).toEqual({
       confirmed: 3,

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -20,6 +20,99 @@ const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const Ajv2020 = Ajv2020Module.default
 
 describe('YarraMate LikeC4 adapter CLI', () => {
+  it('syncs missing subject mappings without changing authored overrides', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-map-'))
+    const architecture = join(parent, 'architecture.yaml')
+    const workspace = join(parent, 'workspace.yaml')
+    const mapping = join(parent, 'mapping.yaml')
+    try {
+      writeFileSync(
+        architecture,
+        `format: yarramate/v1
+id: delivery
+profile: yarramate/core@0.1
+states:
+  - id: target
+    kind: target
+    name: Target
+concepts:
+  - id: delivery-api
+    kind: applicationComponent
+    name: Delivery API
+  - id: delivery-store
+    kind: dataObject
+    name: Delivery store
+relationships:
+  - id: api-reads-store
+    kind: access
+    from: delivery-api
+    to: delivery-store
+    mode: read
+`,
+      )
+      writeFileSync(
+        workspace,
+        `format: yarramate/workspace/v1
+id: delivery
+documents: [architecture.yaml]
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`,
+      )
+      writeFileSync(
+        mapping,
+        `format: yarramate/adapter-mapping/v1
+id: delivery-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: delivery#delivery-api
+    external: customApi
+    type: concept
+`,
+      )
+
+      const first = runLikeC4Cli(
+        ['map', '--sync', 'mapping.yaml', 'workspace.yaml'],
+        parent,
+      )
+      expect(first).toEqual({
+        exitCode: 0,
+        stdout: 'Added 2 LikeC4 mappings to mapping.yaml\n',
+        stderr: '',
+      })
+      expect(readFileSync(mapping, 'utf8')).toContain(
+        'external: customApi',
+      )
+      expect(readFileSync(mapping, 'utf8')).toContain(
+        'native: delivery#delivery-store\n    external: deliveryStore\n    type: concept',
+      )
+      expect(readFileSync(mapping, 'utf8')).toContain(
+        'native: delivery#api-reads-store\n    external: apiReadsStore\n    type: relationship',
+      )
+      expect(readFileSync(mapping, 'utf8')).not.toContain(
+        'native: delivery#target',
+      )
+
+      const before = readFileSync(mapping, 'utf8')
+      expect(
+        runLikeC4Cli(
+          ['map', '--sync', 'mapping.yaml', 'workspace.yaml'],
+          parent,
+        ),
+      ).toEqual({
+        exitCode: 0,
+        stdout: 'LikeC4 mapping mapping.yaml is already synchronized\n',
+        stderr: '',
+      })
+      expect(readFileSync(mapping, 'utf8')).toBe(before)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('checks a complete adapter export without writing derived output', () => {
     const result = runLikeC4Cli(
       [
@@ -960,6 +1053,59 @@ views:
             column: 9,
           },
         ],
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a missing project projection at its authored reference', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-missing-projection-'),
+    )
+    const definition = join(parent, 'project.yaml')
+    try {
+      writeFileSync(
+        definition,
+        `format: yarramate/likec4-project/v1
+id: missing-projection
+version: "1.0"
+title: Missing projection
+mapping: test/fixtures/valid/governed-change.likec4-mapping.yaml
+views:
+  - projection: missing-projection.yaml
+`,
+      )
+
+      const result = runLikeC4Cli(
+        [
+          'check',
+          definition,
+          '--json',
+          'test/fixtures/valid/governed-change.workspace.yaml',
+        ],
+        repositoryRoot,
+      )
+
+      expect(result).toEqual({
+        exitCode: 1,
+        stdout:
+          '{\n' +
+          '  "format": "yarramate/likec4-check-result/v1",\n' +
+          '  "ok": false,\n' +
+          '  "diagnostics": [\n' +
+          '    {\n' +
+          '      "severity": "error",\n' +
+          '      "code": "YMLC110",\n' +
+          '      "message": "LikeC4 project projection \\"missing-projection.yaml\\" does not exist",\n' +
+          `      "path": ${JSON.stringify(definition)},\n` +
+          '      "pointer": "/views/0/projection",\n' +
+          '      "line": 7,\n' +
+          '      "column": 17\n' +
+          '    }\n' +
+          '  ]\n' +
+          '}\n',
+        stderr: '',
       })
     } finally {
       rmSync(parent, { recursive: true, force: true })

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -248,6 +248,12 @@ evidence:
         format: 'yarramate/check-result/v1',
         ok: true,
         diagnostics: [],
+        counted: {
+          documents: 1,
+          concepts: 3,
+          relationships: 1,
+          states: 2,
+        },
       })
       expect(
         JSON.parse(


### PR DESCRIPTION
## What changed

- add `yarramate-likec4 map --sync` to append deterministic mappings while preserving authored overrides
- add successful-workspace document, concept, relationship, and architecture-state counts to human and JSON check results
- define native-document decomposition guidance and workspace-wide state references
- clarify that required constraints express applicability while realization expresses implementation
- document LikeC4 project paths as repository-relative to the CLI working directory
- report missing or unreadable project mappings and projections as source-located `YMLC110` diagnostics
- adopt relationship rationale and identified references in the repository self-model

## Why

Real-world adoption at 251 subjects exposed repetitive mapping maintenance, invisible model shrinkage, uncertain document boundaries, ambiguous constraint modelling, and raw filesystem errors from project references. These changes make those workflows deterministic and reviewable without adding completeness policy or changing native authority.

## Impact

- Mapping synchronization is explicit, non-destructive, validated, and idempotent.
- `yarramate/check-result/v1` success values add a closed `counted` object; consumers still own any shrink policy.
- Existing project paths retain their current repository-root behavior, now documented in the schema and guide.
- Missing project references are correctness diagnostics with the exact authored pointer and location.
- Constraint applicability and realization remain independent claims.

## Validation

- `CI=true pnpm verify` — 197 tests, typecheck, self-check, and generated LikeC4 validation passed
- packaged YarraMate architecture skill validation passed
- `npm pack --dry-run` — 77-file consumer surface inspected
- `git diff --check`

Closes #15.
Closes #16.
Closes #17.
Closes #18.
Closes #19.
