### PR TITLE
Release v0.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.2.0
+version: 0.3.0
 date-released: 2026-07-28
 url: "https://github.com/yarrasys/yarramate"
 repository-code: "https://github.com/yarrasys/yarramate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What changed

- bump npm and citation metadata from 0.2.0 to 0.3.0

## Why

This minor release publishes the new non-destructive LikeC4 mapping sync command, additive successful check counts, source-located project-reference diagnostics, and adoption guidance delivered for issues #15–#19.

## Validation

- `CI=true pnpm verify` — 197 tests, typecheck, self-check, and LikeC4 validation passed
- packaged architecture skill validation passed
- `npm pack --dry-run` — 77-file consumer surface inspected
- `git diff --check`
