### PR TITLE
Repair stale LikeC4 mapping sync

### DIFF
--- a/docs/ADAPTER-MAPPINGS.md
+++ b/docs/ADAPTER-MAPPINGS.md
@@ -65,8 +65,23 @@ then appends only unmapped concepts and relationships. Architecture-state
 planning subjects are excluded. External identities use deterministic
 lower-camel local IDs; collisions receive a document prefix and, only when
 still necessary, a numeric suffix. Existing mappings and their authored
-overrides are preserved. The candidate mapping is validated before an atomic
-replacement, and a second sync is a no-op.
+overrides are preserved. Mappings whose native subject no longer exists are
+reported as stale but do not prevent missing live subjects from being added.
+The candidate mapping is validated before an atomic replacement, and a second
+sync is a no-op.
+
+Remove stale entries only when that destructive intent is explicit:
+
+```sh
+yarramate-likec4 map --sync --prune \
+  .yarramate/integrations/likec4/subject-mapping.yaml \
+  .yarramate/workspace.yaml
+```
+
+Pruning and adding missing entries happen in one atomic update. This is useful
+after a native subject is renamed: the retired external identity is released,
+so the replacement can receive its deterministic identity without an
+unnecessary collision suffix.
 
 The governed-change test fixture has a native document and explicit mapping:
 

--- a/docs/BACKLOG-DISPOSITION.md
+++ b/docs/BACKLOG-DISPOSITION.md
@@ -21,8 +21,8 @@ The current repository implements the agreed foundation for:
 - projection-driven LikeC4 element, comparison, dynamic, and deployment
   views in one generated project, with relationship rationale retained in
   logical and dynamic output;
-- non-destructive LikeC4 mapping synchronization and source-located project
-  reference diagnostics;
+- non-destructive LikeC4 mapping synchronization, opt-in stale-entry pruning,
+  and source-located project reference diagnostics;
 - explicit Graphify node observation producing standard evidence overlays.
 
 There is no remaining concrete, locally actionable item in the agreed Core 0.1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -126,8 +126,9 @@ notation.
   ordered dynamic views over projected relationship subjects, and
   native relationship descriptions on dynamic steps, and regression-fixture
   and self-dogfooding mappings are implemented. Non-destructive deterministic
-  subject-mapping synchronization and source-located project-reference
-  diagnostics are also implemented. Import, round-tripping and general
+  subject-mapping synchronization, explicit stale-entry pruning, and
+  source-located project-reference diagnostics are also implemented. Import,
+  round-tripping and general
   styling parity remain future adapter work.
   Adapter-owned deployment nodes and named instances of projected concepts
   are implemented with regression validation.**

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -195,5 +195,15 @@ yarramate-likec4 map --sync \
   .yarramate/workspace.yaml
 ```
 
+Sync preserves and reports mappings for native subjects that no longer exist.
+After confirming that those subjects were intentionally removed or renamed,
+delete the stale entries while adding missing mappings with:
+
+```sh
+yarramate-likec4 map --sync --prune \
+  .yarramate/integrations/likec4/subject-mapping.yaml \
+  .yarramate/workspace.yaml
+```
+
 Treat exit `0` as successful execution, `1` as correctness diagnostics, and
 `2` as invocation or file failure.

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -15,7 +15,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createHash, randomUUID } from 'node:crypto'
 import Ajv2020Module from 'ajv/dist/2020.js'
-import { isSeq, parseDocument } from 'yaml'
+import { isMap, isSeq, parseDocument } from 'yaml'
 import {
   isMainModule,
   resolveCliWorkspaceSources,
@@ -105,7 +105,7 @@ const publishFiles = (
 
 const usage =
   'Usage:\n' +
-  '  yarramate-likec4 map --sync <mapping.yaml> <workspace-or-source...>\n' +
+  '  yarramate-likec4 map --sync [--prune] <mapping.yaml> <workspace-or-source...>\n' +
   '  yarramate-likec4 check <projection.yaml> <mapping.yaml> [--json] [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
   '  yarramate-likec4 check <likec4-project.yaml> [--json] <workspace-or-source...>\n' +
   '  yarramate-likec4 export <projection.yaml> <mapping.yaml> [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
@@ -150,7 +150,10 @@ const runLikeC4MapSync = (
   args: readonly string[],
   cwd: string,
 ): CliResult => {
-  const [sync, mappingPath, ...sourcePaths] = args
+  const sync = args[0]
+  const prune = args[1] === '--prune'
+  const mappingPath = args[prune ? 2 : 1]
+  const sourcePaths = args.slice(prune ? 3 : 2)
   if (
     sync !== '--sync' ||
     mappingPath === undefined ||
@@ -208,14 +211,23 @@ const runLikeC4MapSync = (
         stderr: '',
       }
     }
+    const graphSubjects = new Set(
+      compilation.graph.subjects.map(({ id }) => id),
+    )
+    const staleCount = loaded.mapping.mappings.filter(
+      ({ native }) => !graphSubjects.has(native),
+    ).length
     const validation = validateAdapterMapping(
       compilation.graph,
       loaded.mapping,
     )
-    if (!validation.ok) {
+    const blockingDiagnostics = validation.ok
+      ? []
+      : validation.diagnostics.filter(({ code }) => code !== 'YM601')
+    if (blockingDiagnostics.length > 0) {
       return {
         exitCode: 1,
-        stdout: diagnosticJson(validation.diagnostics),
+        stdout: diagnosticJson(blockingDiagnostics),
         stderr: '',
       }
     }
@@ -223,7 +235,9 @@ const runLikeC4MapSync = (
       loaded.mapping.mappings.map(({ native }) => native),
     )
     const claimedExternal = new Set(
-      loaded.mapping.mappings.map(({ external }) => external),
+      loaded.mapping.mappings
+        .filter(({ native }) => !prune || graphSubjects.has(native))
+        .map(({ external }) => external),
     )
     const architectureStates = new Set(
       compilation.graph.claims
@@ -257,18 +271,33 @@ const runLikeC4MapSync = (
           type: subject.type,
         }
       })
-    if (additions.length === 0) {
+    if (additions.length === 0 && (!prune || staleCount === 0)) {
       return {
         exitCode: 0,
-        stdout: `LikeC4 mapping ${mappingPath} is already synchronized\n`,
+        stdout:
+          staleCount === 0
+            ? `LikeC4 mapping ${mappingPath} is already synchronized\n`
+            : `LikeC4 mapping ${mappingPath} has ${staleCount} stale ${staleCount === 1 ? 'mapping' : 'mappings'} (use --prune)\n`,
         stderr: '',
       }
     }
     const document = parseDocument(original)
+    const mappings = document.getIn(['mappings'], true)
+    if (prune && isSeq(mappings)) {
+      const firstMappingWasPruned =
+        mappings.items.length > 0 &&
+        isMap(mappings.items[0]) &&
+        !graphSubjects.has(String(mappings.items[0].get('native')))
+      mappings.items = mappings.items.filter(
+        (item) =>
+          !isMap(item) ||
+          graphSubjects.has(String(item.get('native'))),
+      )
+      if (firstMappingWasPruned) mappings.commentBefore = undefined
+    }
     for (const addition of additions) {
       document.addIn(['mappings'], addition)
     }
-    const mappings = document.getIn(['mappings'], true)
     if (isSeq(mappings)) mappings.flow = false
     const candidate = document.toString({ lineWidth: 0 })
     const candidateMapping = loadAdapterMapping({
@@ -286,10 +315,15 @@ const runLikeC4MapSync = (
       compilation.graph,
       candidateMapping.mapping,
     )
-    if (!candidateValidation.ok) {
+    const candidateBlockingDiagnostics = candidateValidation.ok
+      ? []
+      : candidateValidation.diagnostics.filter(
+          ({ code }) => prune || code !== 'YM601',
+        )
+    if (candidateBlockingDiagnostics.length > 0) {
       return {
         exitCode: 1,
-        stdout: diagnosticJson(candidateValidation.diagnostics),
+        stdout: diagnosticJson(candidateBlockingDiagnostics),
         stderr: '',
       }
     }
@@ -301,7 +335,14 @@ const runLikeC4MapSync = (
     }
     return {
       exitCode: 0,
-      stdout: `Added ${additions.length} LikeC4 mappings to ${mappingPath}\n`,
+      stdout: prune
+        ? additions.length > 0
+          ? `Added ${additions.length} and pruned ${staleCount} stale LikeC4 ${staleCount === 1 ? 'mapping' : 'mappings'} in ${mappingPath}\n`
+          : `Pruned ${staleCount} stale LikeC4 ${staleCount === 1 ? 'mapping' : 'mappings'} from ${mappingPath}\n`
+        : `Added ${additions.length} LikeC4 ${additions.length === 1 ? 'mapping' : 'mappings'} to ${mappingPath}` +
+          (staleCount === 0
+            ? '\n'
+            : `; left ${staleCount} stale ${staleCount === 1 ? 'mapping' : 'mappings'} (use --prune)\n`),
       stderr: '',
     }
   } catch (error) {

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -113,6 +113,133 @@ mappings:
     }
   })
 
+  it('adds missing mappings while retaining and reporting stale entries', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-stale-'))
+    const mapping = join(parent, 'mapping.yaml')
+    try {
+      writeFileSync(
+        join(parent, 'architecture.yaml'),
+        `format: yarramate/v1
+id: delivery
+profile: yarramate/core@0.1
+concepts:
+  - id: current-api
+    kind: applicationComponent
+    name: Current API
+relationships: []
+`,
+      )
+      writeFileSync(
+        join(parent, 'workspace.yaml'),
+        `format: yarramate/workspace/v1
+id: delivery
+documents: [architecture.yaml]
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`,
+      )
+      writeFileSync(
+        mapping,
+        `format: yarramate/adapter-mapping/v1
+id: delivery-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  # Retained until pruning is explicit.
+  - native: delivery#renamed-api
+    external: renamedApi
+    type: concept
+`,
+      )
+
+      expect(
+        runLikeC4Cli(
+          ['map', '--sync', 'mapping.yaml', 'workspace.yaml'],
+          parent,
+        ),
+      ).toEqual({
+        exitCode: 0,
+        stdout:
+          'Added 1 LikeC4 mapping to mapping.yaml; left 1 stale mapping (use --prune)\n',
+        stderr: '',
+      })
+      const synchronized = readFileSync(mapping, 'utf8')
+      expect(synchronized).toContain(
+        '# Retained until pruning is explicit.',
+      )
+      expect(synchronized).toContain('native: delivery#renamed-api')
+      expect(synchronized).toContain('native: delivery#current-api')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('prunes stale mappings only when explicitly requested', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-prune-'))
+    const mapping = join(parent, 'mapping.yaml')
+    try {
+      writeFileSync(
+        join(parent, 'architecture.yaml'),
+        `format: yarramate/v1
+id: delivery
+profile: yarramate/core@0.1
+concepts:
+  - id: current-api
+    kind: applicationComponent
+    name: Current API
+relationships: []
+`,
+      )
+      writeFileSync(
+        join(parent, 'workspace.yaml'),
+        `format: yarramate/workspace/v1
+id: delivery
+documents: [architecture.yaml]
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`,
+      )
+      writeFileSync(
+        mapping,
+        `format: yarramate/adapter-mapping/v1
+id: delivery-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  # Removed together with the stale mapping.
+  - native: delivery#renamed-api
+    external: renamedApi
+    type: concept
+`,
+      )
+
+      expect(
+        runLikeC4Cli(
+          ['map', '--sync', '--prune', 'mapping.yaml', 'workspace.yaml'],
+          parent,
+        ),
+      ).toEqual({
+        exitCode: 0,
+        stdout:
+          'Added 1 and pruned 1 stale LikeC4 mapping in mapping.yaml\n',
+        stderr: '',
+      })
+      const synchronized = readFileSync(mapping, 'utf8')
+      expect(synchronized).not.toContain('delivery#renamed-api')
+      expect(synchronized).not.toContain(
+        '# Removed together with the stale mapping.',
+      )
+      expect(synchronized).toContain('native: delivery#current-api')
+      expect(synchronized).toContain('external: currentApi')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('checks a complete adapter export without writing derived output', () => {
     const result = runLikeC4Cli(
       [


### PR DESCRIPTION
## What changed

- allow additive mapping sync to continue when retired native subjects leave stale mappings
- report and retain stale entries by default
- add explicit atomic `--prune` support that removes stale entries and releases their external identities
- document the safe default and destructive opt-in

## Root cause

The generic adapter validator rejected missing native subjects before mapping synchronization could discover and append replacement subjects.

## Validation

- `CI=true pnpm verify`
- bundled skill validation
- `npm pack --dry-run`
- 199 tests pass

Closes #22