### PR TITLE
Render and audit architecture journeys

### DIFF
--- a/docs/PRODUCT-JOURNEYS.md
+++ b/docs/PRODUCT-JOURNEYS.md
@@ -29,6 +29,9 @@ automatically promotes observations into canonical claims.
 - one or more concise native architecture documents;
 - explicit provenance in the Git change and optional evidence overlays;
 - at least one useful projection;
+- when visual output is selected, a current generated LikeC4 project for the
+  intended views;
+- explicit reporting of modelled subjects or flows that the views omit;
 - deterministic `check` and context output;
 - a deterministic reconciliation report when evidence overlays exist;
 - no unreviewed mutation of architectural intent.
@@ -57,6 +60,8 @@ unfashionable design into an error.
 - a coherent target solution boundary and its principal relationships;
 - alternatives or state transitions recorded only where they aid a decision;
 - focused projections suitable for review and agent context;
+- when visual output is selected, a current generated LikeC4 project and an
+  explicit rendering-coverage statement;
 - valid native documents ready to evolve alongside implementation.
 
 ## Shared lifecycle

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -52,19 +52,34 @@ document, projection, evidence, or architecture-state syntax is needed.
    YAML directly when states or several related declarations make that clearer.
 6. Add an evidence overlay only for existing subjects or stable claim IDs.
    Evidence supports or challenges the proposal; it is not a second model.
-7. Add one focused projection that answers the repository-orientation
-   question.
-8. Run:
+7. Add the focused projections needed to answer the
+   repository-orientation question. Add a separate projection for every
+   ordered flow that needs a dynamic view, then include each intended view in
+   `.yarramate/integrations/likec4/project.yaml`.
+8. Unless the user requested semantic-only output, create the optional LikeC4
+   mapping and project described in the authoring reference. Synchronize the
+   project mapping before every export, then run:
 
 ```sh
 yarramate check .yarramate/workspace.yaml --json
+yarramate compile .yarramate/workspace.yaml
 yarramate evidence .yarramate/evidence/<evidence>.yaml .yarramate/workspace.yaml
 yarramate reconcile .yarramate/workspace.yaml
 yarramate context .yarramate/projections/<projection>.yaml .yarramate/workspace.yaml
 yarramate view .yarramate/projections/<projection>.yaml .yarramate/workspace.yaml
+yarramate-likec4 map --sync .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
+yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
 ```
 
-9. Present observations, reconciliation findings, interpretive proposals,
+9. Audit rendering coverage before handoff. Answer these as reporting
+   questions, not Core correctness rules:
+   - Which concepts appear in no projection?
+   - Which ordered relationship chains have no dynamic view?
+   - Which projections are absent from the LikeC4 project?
+   Inspect compiled subjects, projection results, and the project definition;
+   state intentional omissions explicitly. A green check does not answer
+   these questions.
+10. Present observations, reconciliation findings, interpretive proposals,
    evidence gaps, and Git diff separately. Do not claim completeness from a
    green check and do not automatically turn findings into edits.
 
@@ -84,17 +99,29 @@ yarramate view .yarramate/projections/<projection>.yaml .yarramate/workspace.yam
 5. Create:
    - an alternatives projection for the decision;
    - a bounded target projection for implementation agents.
-6. Run:
+   - one focused projection per ordered flow that needs a dynamic view.
+   Include every intended view in
+   `.yarramate/integrations/likec4/project.yaml`.
+6. Synchronize the project mapping before every export, then run:
 
 ```sh
 yarramate check .yarramate/workspace.yaml --json
+yarramate compile .yarramate/workspace.yaml
 yarramate context .yarramate/projections/<alternatives>.yaml .yarramate/workspace.yaml
 yarramate context .yarramate/projections/<target>.yaml .yarramate/workspace.yaml
 yarramate view .yarramate/projections/<target>.yaml .yarramate/workspace.yaml
-yarramate compare <baseline-state> <target-state> .yarramate/workspace.yaml
+yarramate view .yarramate/projections/<flow>.yaml .yarramate/workspace.yaml
+yarramate compare <document-id>#<baseline-state> <document-id>#<target-state> .yarramate/workspace.yaml
+yarramate-likec4 map --sync .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
+yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
 ```
 
-7. Present alternatives, selected intent, unresolved decisions, and bounded
+   Skip the two adapter commands only when the user requested semantic-only
+   output, and report that no visual project was produced.
+7. Audit rendering coverage using the same three reporting questions from
+   discovery. State which omissions are intentional; do not convert partial
+   coverage into a validation failure.
+8. Present alternatives, selected intent, unresolved decisions, and bounded
    implementation context. Do not generate code until the requested design
    decision is reviewable.
 
@@ -102,6 +129,8 @@ yarramate compare <baseline-state> <target-state> .yarramate/workspace.yaml
 
 - Treat `check` as deterministic correctness, never as architecture approval,
   completeness, or quality scoring.
+- Keep LikeC4 optional. Default to visual output for these guided journeys,
+  but respect an explicit request for tool-neutral semantic output only.
 - Keep adapter fields outside native documents.
 - Use globally qualified identities at CLI and projection boundaries.
 - Preserve source-located diagnostics verbatim when asking the author to fix
@@ -119,7 +148,9 @@ Report:
 - journey used and question answered;
 - canonical files proposed or changed;
 - observations and evidence results;
-- projections produced;
+- projections and views produced, including the LikeC4 project and generated
+  output path;
+- rendering coverage gaps and whether the generated output is current;
 - validation commands and outcomes;
 - unresolved architectural decisions;
 - whether changes are merely proposed or already accepted in Git.

--- a/skills/yarramate-architecture/references/journey-checklists.md
+++ b/skills/yarramate-architecture/references/journey-checklists.md
@@ -46,6 +46,9 @@ Discovery is minimally useful when:
 - significant proposed subjects have traceable observations or are explicitly
   identified as interpretation;
 - a focused projection gives an agent useful repository context;
+- intended projections are rendered through a current LikeC4 project;
+- concepts outside all projections, ordered flows without dynamic views, and
+  projections absent from the project are reported as coverage gaps;
 - evidence has not been promoted automatically.
 
 Design is minimally useful when:
@@ -54,4 +57,6 @@ Design is minimally useful when:
 - material alternatives remain reviewable;
 - the selected target has explicit boundaries and relationships;
 - a bounded target projection can guide implementation;
+- intended projections are rendered through a current LikeC4 project;
+- rendering coverage gaps are stated, including intentional omissions;
 - missing detail is visible without becoming a Core correctness error.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -172,6 +172,47 @@ Evidence evaluates an existing subject or stable claim ID. Results are
 observed subject directly through evidence or mutate declared intent from an
 evidence result.
 
+## LikeC4 project
+
+Keep visualization configuration outside native documents:
+
+```yaml
+format: yarramate/likec4-project/v1
+id: delivery
+version: "1.0"
+title: Delivery architecture
+mapping: .yarramate/integrations/likec4/subject-mapping.yaml
+views:
+  - projection: .yarramate/projections/delivery-target.yaml
+  - id: submit-order
+    projection: .yarramate/projections/submit-order.yaml
+    dynamic:
+      steps:
+        - relationship: delivery#customer-triggers-submit
+        - relationship: delivery#submit-triggers-confirmation
+```
+
+Give every ordered flow its own focused projection and dynamic view. A dynamic
+view takes its title and description from its projection; reusing one broad
+projection for several flows makes their rendered identities ambiguous.
+Ensure every intended projection is listed in the project.
+
+Start the referenced mapping as a valid empty mapping, then let sync populate
+it:
+
+```yaml
+format: yarramate/adapter-mapping/v1
+id: delivery-likec4
+version: "1.0"
+adapter: likec4
+mappings: []
+```
+
+`export-project` writes `.yarramate-out/likec4/yarramate.generated.json` with
+digests for generated files. It refuses to replace a generated file that was
+hand-edited. Treat that refusal as drift to inspect; do not delete the marker
+or overwrite the output manually.
+
 ## Stable commands
 
 ```sh
@@ -192,6 +233,10 @@ yarramate evidence <evidence.yaml> .yarramate/workspace.yaml
 yarramate reconcile .yarramate/workspace.yaml
 yarramate-likec4 map --sync \
   .yarramate/integrations/likec4/subject-mapping.yaml \
+  .yarramate/workspace.yaml
+yarramate-likec4 export-project \
+  .yarramate/integrations/likec4/project.yaml \
+  .yarramate-out/likec4 \
   .yarramate/workspace.yaml
 ```
 

--- a/test/journeys.test.ts
+++ b/test/journeys.test.ts
@@ -130,6 +130,17 @@ describe('agent journeys through the stable CLI', () => {
     expect(skill).toContain('## Design a new solution')
     expect(skill).toContain('yarramate check')
     expect(skill).toContain('yarramate context')
+    expect(skill.match(/yarramate compile/g)).toHaveLength(2)
+    expect(skill.match(/yarramate-likec4 map --sync/g)).toHaveLength(2)
+    expect(skill.match(/yarramate-likec4 export-project/g)).toHaveLength(2)
+    expect(skill).toContain('Which concepts appear in no projection?')
+    expect(skill).toContain(
+      'Which ordered relationship chains have no dynamic view?',
+    )
+    expect(skill).toContain(
+      'Which projections are absent from the LikeC4 project?',
+    )
+    expect(skill).toContain('views produced')
     expect(skill).toMatch(
       /Never promote evidence into declared intent\s+automatically\./,
     )


### PR DESCRIPTION
## What changed

- make both guided journeys compile, synchronize LikeC4 subject mappings, and export the declared project
- require one focused projection per ordered dynamic flow and wire intended projections into the project
- add a pre-handoff rendering coverage audit for unprojected concepts, unrendered ordered chains, and projections absent from the project
- document generated-file digest protection and keep LikeC4 optional for explicit semantic-only work
- strengthen the portable-skill regression contract

## Why

The prior runbooks stopped at Markdown views, so agents could truthfully report success without generating LikeC4 output or noticing modelled content absent from all rendered views. Core validation was correctly green because rendering completeness is not a deterministic correctness rule.

## Validation

- `CI=true pnpm verify`
- 199 tests pass
- bundled skill validation
- package dry-run
- independent clean-context forward test

Closes #25
Closes #26