### PR TITLE
Add safe model maintenance journey

### DIFF
--- a/docs/PRODUCT-JOURNEYS.md
+++ b/docs/PRODUCT-JOURNEYS.md
@@ -64,6 +64,25 @@ unfashionable design into an error.
   explicit rendering-coverage statement;
 - valid native documents ready to evolve alongside implementation.
 
+## Maintain an existing model
+
+An agent harness starts from a model that already validates:
+
+1. discover the repository's authored workspace, evidence, projection, and
+   adapter paths;
+2. establish a passing read-only baseline;
+3. find every reference to the subjects or claims being changed;
+4. update the smallest coherent set of canonical inputs;
+5. verify Core and optional adapters before applying any repair command;
+6. review mapping repairs as ordinary tracked authoring changes;
+7. require the maintained model and configured adapters to pass before
+   handoff.
+
+This journey covers normal evolution such as renames, retired concepts,
+changed relationships, and gaps resolved into decisions. It does not introduce
+an approval workflow. A mutating synchronization command cannot serve as a CI
+verification gate.
+
 ## Shared lifecycle
 
 ```text

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: yarramate-architecture
-description: Discover architecture in an existing repository or design a new solution before implementation using native YarraMate documents and the stable CLI. Use when an agent needs to map a codebase, propose an evidence-backed architecture model, brainstorm solution alternatives, define current/transition/target architecture, reconcile intent with evidence, or provide bounded architecture context to implementation work.
+description: Discover, design, or maintain repository architecture using native YarraMate documents and the stable CLI. Use when an agent needs to map a codebase, propose an evidence-backed architecture model, brainstorm solution alternatives, evolve a model that already validates, rename or replace semantic subjects safely, define current/transition/target architecture, reconcile intent with evidence, or provide bounded architecture context to implementation work.
 ---
 
 # YarraMate architecture
 
-Use one repository-native lifecycle for discovery and design:
+Use one repository-native lifecycle for discovery, design, and maintenance:
 
 ```text
 evidence or design conversation
@@ -26,7 +26,10 @@ automatically.
   existing project**.
 - Intent and a not-yet-built solution are the starting point: follow **Design
   a new solution**.
-- Declared architecture and implementation both exist: begin with discovery,
+- A validating native model must change: follow **Maintain an existing
+  model**.
+- Declared architecture and implementation both exist but no model change is
+  requested: begin with discovery,
   preserve the declared model, then report supported, contradicted, unknown,
   and unobserved claims without silently rewriting it.
 
@@ -67,6 +70,7 @@ yarramate evidence .yarramate/evidence/<evidence>.yaml .yarramate/workspace.yaml
 yarramate reconcile .yarramate/workspace.yaml
 yarramate context .yarramate/projections/<projection>.yaml .yarramate/workspace.yaml
 yarramate view .yarramate/projections/<projection>.yaml .yarramate/workspace.yaml
+yarramate-likec4 check .yarramate/integrations/likec4/project.yaml --json .yarramate/workspace.yaml
 yarramate-likec4 map --sync .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
 yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
 ```
@@ -112,6 +116,7 @@ yarramate context .yarramate/projections/<target>.yaml .yarramate/workspace.yaml
 yarramate view .yarramate/projections/<target>.yaml .yarramate/workspace.yaml
 yarramate view .yarramate/projections/<flow>.yaml .yarramate/workspace.yaml
 yarramate compare <document-id>#<baseline-state> <document-id>#<target-state> .yarramate/workspace.yaml
+yarramate-likec4 check .yarramate/integrations/likec4/project.yaml --json .yarramate/workspace.yaml
 yarramate-likec4 map --sync .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
 yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
 ```
@@ -125,10 +130,64 @@ yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yar
    implementation context. Do not generate code until the requested design
    decision is reviewable.
 
+## Maintain an existing model
+
+Use this journey for a deliberate change to a model that already passes its
+checks, including a renamed subject, resolved gap, changed relationship, or
+retired concept.
+
+1. Discover the authored layout before assuming paths:
+   - read the workspace `documents`, `projections`, `adapterMappings`, and
+     `evidence` entries;
+   - locate any `yarramate/likec4-project/v1` document and follow its `mapping`
+     field;
+   - treat paths shown below as examples, not required repository layout.
+   Discover the repository’s authored paths instead of assuming these examples.
+2. Establish a passing baseline with Core and every configured read-only
+   adapter check. If the baseline already fails, separate those pre-existing
+   diagnostics from the requested maintenance change.
+3. Before changing an identity, search its local and globally qualified forms
+   across every workspace input. Account for:
+   - `references[].ref` citations;
+   - relationship `from` and `to` endpoints;
+   - evidence `subject` entries and stable claim targets;
+   - adapter mapping `native` entries;
+   - projection selectors, architecture states, ownership, and constraints.
+4. Make the smallest coherent edit and update all referring authored inputs.
+   Do not rewrite unrelated architectural intent.
+5. Run the read-only checks before any repair command so drift remains
+   observable:
+
+```sh
+yarramate check .yarramate/workspace.yaml --json
+yarramate-likec4 check .yarramate/integrations/likec4/project.yaml --json .yarramate/workspace.yaml
+```
+
+6. If the adapter check reports intended mapping drift, repair it locally,
+   inspect the tracked diff, then verify again. Use `--prune` only after
+   confirming that stale native subjects were intentionally renamed or
+   removed:
+
+```sh
+yarramate-likec4 map --sync --prune .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
+git diff -- .yarramate
+yarramate check .yarramate/workspace.yaml --json
+yarramate-likec4 check .yarramate/integrations/likec4/project.yaml --json .yarramate/workspace.yaml
+yarramate-likec4 export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
+```
+
+7. Require both configured read-only checks to exit successfully after the
+   edit. The maintained model must pass before handoff. Report changed
+   identities, updated dependants, mapping repairs, generated output, and any
+   intentionally deferred architecture work.
+
 ## Correctness and authority
 
 - Treat `check` as deterministic correctness, never as architecture approval,
   completeness, or quality scoring.
+- A repair command cannot serve as verification. Run read-only adapter checks
+  before `map --sync`, use sync only while authoring, and never put sync in a
+  CI verification gate.
 - Keep LikeC4 optional. Default to visual output for these guided journeys,
   but respect an explicit request for tool-neutral semantic output only.
 - Keep adapter fields outside native documents.

--- a/skills/yarramate-architecture/agents/openai.yaml
+++ b/skills/yarramate-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "YarraMate Architecture"
-  short_description: "Discover and design repository architecture"
-  default_prompt: "Use $yarramate-architecture to discover or design this project architecture with native YarraMate documents."
+  short_description: "Discover, design, and maintain architecture"
+  default_prompt: "Use $yarramate-architecture to discover, design, or safely maintain this project architecture."

--- a/skills/yarramate-architecture/references/journey-checklists.md
+++ b/skills/yarramate-architecture/references/journey-checklists.md
@@ -60,3 +60,11 @@ Design is minimally useful when:
 - intended projections are rendered through a current LikeC4 project;
 - rendering coverage gaps are stated, including intentional omissions;
 - missing detail is visible without becoming a Core correctness error.
+
+Maintenance is complete only when:
+
+- all references to a changed identity were found before editing;
+- native documents and configured adapters pass their read-only checks;
+- any mapping sync or prune was reviewed as an authored Git change;
+- generated views are current;
+- changed identities and updated dependants are reported at handoff.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -15,8 +15,10 @@ adapterMappings: []
 evidence: [evidence/*.yaml]
 ```
 
-Paths are relative to the manifest. Keep canonical inputs under `.yarramate/`
-and generated artifacts under `.yarramate-out/`.
+Paths are relative to the manifest. `.yarramate/` for canonical inputs and
+`.yarramate-out/` for generated artifacts are recommended examples, not fixed
+CLI paths. In an existing repository, read its workspace and project documents
+and preserve the authored layout.
 
 ## Native document
 
@@ -196,6 +198,9 @@ Give every ordered flow its own focused projection and dynamic view. A dynamic
 view takes its title and description from its projection; reusing one broad
 projection for several flows makes their rendered identities ambiguous.
 Ensure every intended projection is listed in the project.
+In an existing repository, locate the project by its
+`yarramate/likec4-project/v1` format and follow its `mapping` field instead of
+assuming the example paths below.
 
 Start the referenced mapping as a valid empty mapping, then let sync populate
 it:
@@ -231,6 +236,10 @@ yarramate view <projection.yaml> .yarramate/workspace.yaml
 yarramate compare <from-state> <to-state> .yarramate/workspace.yaml
 yarramate evidence <evidence.yaml> .yarramate/workspace.yaml
 yarramate reconcile .yarramate/workspace.yaml
+yarramate-likec4 check \
+  .yarramate/integrations/likec4/project.yaml \
+  --json \
+  .yarramate/workspace.yaml
 yarramate-likec4 map --sync \
   .yarramate/integrations/likec4/subject-mapping.yaml \
   .yarramate/workspace.yaml
@@ -239,6 +248,12 @@ yarramate-likec4 export-project \
   .yarramate-out/likec4 \
   .yarramate/workspace.yaml
 ```
+
+`yarramate-likec4 check` is read-only verification and belongs in CI.
+Run it before sync when checking an existing mapping so missing or stale
+entries remain observable. `map --sync [--prune]` is an authoring repair: it
+mutates a tracked mapping, so review and commit its diff. Never use a repair
+command as a CI gate.
 
 Sync preserves and reports mappings for native subjects that no longer exist.
 After confirming that those subjects were intentionally removed or renamed,

--- a/test/journeys.test.ts
+++ b/test/journeys.test.ts
@@ -128,11 +128,12 @@ describe('agent journeys through the stable CLI', () => {
 
     expect(skill).toContain('## Discover an existing project')
     expect(skill).toContain('## Design a new solution')
+    expect(skill).toContain('## Maintain an existing model')
     expect(skill).toContain('yarramate check')
     expect(skill).toContain('yarramate context')
     expect(skill.match(/yarramate compile/g)).toHaveLength(2)
-    expect(skill.match(/yarramate-likec4 map --sync/g)).toHaveLength(2)
-    expect(skill.match(/yarramate-likec4 export-project/g)).toHaveLength(2)
+    expect(skill.match(/yarramate-likec4 map --sync/g)).toHaveLength(3)
+    expect(skill.match(/yarramate-likec4 export-project/g)).toHaveLength(3)
     expect(skill).toContain('Which concepts appear in no projection?')
     expect(skill).toContain(
       'Which ordered relationship chains have no dynamic view?',
@@ -141,6 +142,33 @@ describe('agent journeys through the stable CLI', () => {
       'Which projections are absent from the LikeC4 project?',
     )
     expect(skill).toContain('views produced')
+    for (const section of [
+      skill.slice(
+        skill.indexOf('## Discover an existing project'),
+        skill.indexOf('## Design a new solution'),
+      ),
+      skill.slice(
+        skill.indexOf('## Design a new solution'),
+        skill.indexOf('## Maintain an existing model'),
+      ),
+      skill.slice(
+        skill.indexOf('## Maintain an existing model'),
+        skill.indexOf('## Correctness and authority'),
+      ),
+    ]) {
+      expect(section).toMatch(
+        /yarramate-likec4 check[\s\S]*yarramate-likec4 map --sync/,
+      )
+    }
+    expect(skill).toContain(
+      'A repair command cannot serve as verification.',
+    )
+    expect(skill).toContain(
+      'The maintained model must pass before handoff.',
+    )
+    expect(skill).toContain(
+      'Discover the repository’s authored paths instead of assuming these examples.',
+    )
     expect(skill).toMatch(
       /Never promote evidence into declared intent\s+automatically\./,
     )


### PR DESCRIPTION
## What changed

- add a third guided journey for maintaining an existing valid model
- discover authored workspace, evidence, projection, mapping, and project paths instead of assuming a fixed layout
- enumerate identity dependants before renames or retirements
- run read-only LikeC4 verification before mapping repair
- reserve `map --sync [--prune]` for reviewed local authoring and prohibit it as a CI gate
- require Core and configured adapter checks to pass before maintenance handoff
- update product journey docs, skill metadata, references, and regression coverage

## Root cause

The portable skill covered initial discovery and design but not normal model evolution. Its visualization sequence synchronized mappings before verification, allowing a mutating repair to hide the drift a gate was meant to detect.

## Validation

- `CI=true pnpm verify`
- 199 tests pass
- bundled skill validation
- package dry-run
- independent clean-context rename forward test

Closes #29
Closes #30