### PR TITLE
Question catalogue draft and first catalogue-driven self-model enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .likec4/
 coverage/
 .yarramate-out/
+graphify-out/
 .DS_Store
 *.tgz
 .env

--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -202,56 +202,67 @@ concepts:
     kind: applicationService
     name: Check command
     description: Reports deterministic source-located diagnostics without writing compiled output.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: init-command
     kind: applicationService
     name: Init command
     description: Creates a minimal native workspace without overwriting an existing document.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: add-command
     kind: applicationService
     name: Add command
     description: Adds a concept only when the candidate workspace compiles successfully.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: connect-command
     kind: applicationService
     name: Connect command
     description: Adds a relationship only when the candidate workspace compiles successfully.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: compile-command
     kind: applicationService
     name: Compile command
     description: Emits the normative graph-v2 interchange document without writing a derived artifact.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: evidence-command
     kind: applicationService
     name: Evidence command
     description: Evaluates one evidence document over compiled native sources.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: reconcile-command
     kind: applicationService
     name: Reconcile command
     description: Emits provider-neutral workspace reconciliation for review by humans and agents.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: graphify-observe-command
     kind: applicationService
     name: Graphify observe command
     description: Emits a standard evidence overlay from a Graphify graph and explicit adapter mapping.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: likec4-export-command
     kind: applicationService
     name: LikeC4 export command
     description: Emits source or atomically replaces guarded derived LikeC4 project files without changing native documents.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: likec4-check-command
     kind: applicationService
     name: LikeC4 check command
     description: Validates the complete bundled adapter path without writing derived output.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: compare-command
     kind: applicationService
     name: Compare command
     description: Emits a deterministic architecture-state comparison for humans, CI, and agents.
+    owner: yarramate-product#yarramate-maintainers
     status: current
     presentIn:
       - yarramate-evolution#state-foundation
@@ -857,3 +868,45 @@ relationships:
     from: profile-catalogue
     to: relationship-policy-catalogue
     mode: write
+  - id: init-command-serves-agent-harness
+    kind: serving
+    from: init-command
+    to: yarramate-product#agent-harness
+  - id: add-command-serves-agent-harness
+    kind: serving
+    from: add-command
+    to: yarramate-product#agent-harness
+  - id: connect-command-serves-agent-harness
+    kind: serving
+    from: connect-command
+    to: yarramate-product#agent-harness
+  - id: compile-command-serves-agent-harness
+    kind: serving
+    from: compile-command
+    to: yarramate-product#agent-harness
+  - id: evidence-command-serves-agent-harness
+    kind: serving
+    from: evidence-command
+    to: yarramate-product#agent-harness
+  - id: reconcile-command-serves-agent-harness
+    kind: serving
+    from: reconcile-command
+    to: yarramate-product#agent-harness
+  - id: graphify-observe-command-serves-agent-harness
+    kind: serving
+    from: graphify-observe-command
+    to: yarramate-product#agent-harness
+  - id: projection-evaluation-reads-definition-schema
+    kind: access
+    from: evaluate-projection
+    to: projection-schema
+    mode: read
+  - id: likec4-export-reads-kind-mapping-schema
+    kind: access
+    from: export-likec4
+    to: likec4-kind-mapping-schema
+    mode: read
+  - id: projection-result-schema-describes-result
+    kind: realization
+    from: projection-result-schema
+    to: projection-result

--- a/.yarramate/architecture/product.yaml
+++ b/.yarramate/architecture/product.yaml
@@ -6,6 +6,26 @@ concepts:
     kind: businessActor
     name: YarraMate maintainers
     description: People accountable for stewardship of the YarraMate Core repository.
+  - id: agent-harness
+    kind: businessActor
+    name: Agent harness
+    description: Automated coding or architecture agent that orchestrates the stable CLI and consumes its machine-readable contracts.
+  - id: adopting-team
+    kind: businessActor
+    name: Adopting team
+    description: People applying YarraMate to their own repository and reviewing its proposals through Git.
+  - id: architecture-drift
+    kind: driver
+    name: Architecture drift
+    description: Architecture documentation decays away from implementation when it is not deterministic and checkable.
+  - id: trustworthy-agent-context
+    kind: driver
+    name: Trustworthy agent context
+    description: Agents abandon architecture context they cannot verify as current and correct.
+  - id: repository-stewardship
+    kind: businessFunction
+    name: Repository stewardship
+    description: Review, merge, and ADR governance for the YarraMate repository as described in GOVERNANCE.md.
   - id: shared-architecture-context
     kind: goal
     name: Shared architecture context
@@ -40,34 +60,41 @@ concepts:
   - id: compile-native-architecture
     kind: capability
     name: Compile native architecture
+    owner: yarramate-maintainers
     status: current
   - id: validate-native-architecture
     kind: capability
     name: Validate native architecture
+    owner: yarramate-maintainers
     status: current
   - id: provide-machine-context
     kind: capability
     name: Provide machine-readable context
+    owner: yarramate-maintainers
     status: current
   - id: evaluate-architecture-evidence
     kind: capability
     name: Evaluate architecture evidence
     description: Compare provider observations with existing semantic subjects and claims without changing canonical intent.
+    owner: yarramate-maintainers
     status: current
   - id: discover-project-architecture
     kind: capability
     name: Discover project architecture
     description: Guide an agent harness from existing project evidence to a reviewable native architecture proposal.
+    owner: yarramate-maintainers
     status: current
   - id: design-solution-before-build
     kind: capability
     name: Design solution before build
     description: Guide people and an agent harness from intent and alternatives to a reviewable target solution.
+    owner: yarramate-maintainers
     status: current
   - id: reconcile-intent-and-evidence
     kind: capability
     name: Reconcile intent and evidence
     description: Compare declared architecture with provider observations without allowing evidence to mutate intent.
+    owner: yarramate-maintainers
     status: current
 relationships:
   - id: repository-operation-supports-context
@@ -130,3 +157,31 @@ relationships:
     references:
       - id: implementation-interface
         ref: yarramate-engine#cli
+  - id: maintainers-perform-stewardship
+    kind: assignment
+    from: yarramate-maintainers
+    to: repository-stewardship
+  - id: harness-performs-discovery
+    kind: assignment
+    from: agent-harness
+    to: discover-project-architecture
+  - id: harness-performs-design
+    kind: assignment
+    from: agent-harness
+    to: design-solution-before-build
+  - id: adopting-team-performs-design
+    kind: assignment
+    from: adopting-team
+    to: design-solution-before-build
+  - id: drift-drives-shared-context
+    kind: influence
+    from: architecture-drift
+    to: shared-architecture-context
+  - id: agent-trust-drives-shared-context
+    kind: influence
+    from: trustworthy-agent-context
+    to: shared-architecture-context
+  - id: machine-context-realizes-shared-context
+    kind: realization
+    from: provide-machine-context
+    to: shared-architecture-context

--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -32,6 +32,7 @@ concepts:
     kind: applicationComponent
     name: LikeC4 adapter prototype
     description: Optional validated vocabulary and visualization prototype.
+    owner: yarramate-product#yarramate-maintainers
     status: current
   - id: compiler-source
     kind: repository-file

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -387,3 +387,765 @@ mappings:
   - native: yarramate-repository#likec4-cli-source
     external: repositoryLikec4CliSource
     type: concept
+  - native: yarramate-engine#adapter-validation-reads-graph
+    external: adapterValidationReadsGraph
+    type: relationship
+  - native: yarramate-engine#adapter-validation-reads-mapping
+    external: adapterValidationReadsMapping
+    type: relationship
+  - native: yarramate-engine#adapter-validation-reads-schema
+    external: adapterValidationReadsSchema
+    type: relationship
+  - native: yarramate-engine#add-command-serves-agent-harness
+    external: addCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#check-command-reads-result-schema
+    external: checkCommandReadsResultSchema
+    type: relationship
+  - native: yarramate-engine#check-command-serves-core-contract-check
+    external: checkCommandServesCoreContractCheck
+    type: relationship
+  - native: yarramate-engine#check-command-writes-result
+    external: checkCommandWritesResult
+    type: relationship
+  - native: yarramate-engine#cli-provides-add
+    external: cliProvidesAdd
+    type: relationship
+  - native: yarramate-engine#cli-provides-check
+    external: cliProvidesCheck
+    type: relationship
+  - native: yarramate-engine#cli-provides-compile
+    external: cliProvidesCompile
+    type: relationship
+  - native: yarramate-engine#cli-provides-connect
+    external: cliProvidesConnect
+    type: relationship
+  - native: yarramate-engine#cli-provides-evidence
+    external: cliProvidesEvidence
+    type: relationship
+  - native: yarramate-engine#cli-provides-init
+    external: cliProvidesInit
+    type: relationship
+  - native: yarramate-engine#cli-provides-reconciliation
+    external: cliProvidesReconciliation
+    type: relationship
+  - native: yarramate-engine#cli-reads-diagnostic-result-schema
+    external: cliReadsDiagnosticResultSchema
+    type: relationship
+  - native: yarramate-engine#cli-uses-workspace-loader
+    external: cliUsesWorkspaceLoader
+    type: relationship
+  - native: yarramate-engine#cli-validates-adapter-mapping
+    external: cliValidatesAdapterMapping
+    type: relationship
+  - native: yarramate-engine#cli-writes-diagnostic-result
+    external: cliWritesDiagnosticResult
+    type: relationship
+  - native: yarramate-engine#compare-command-serves-comparison
+    external: compareCommandServesComparison
+    type: relationship
+  - native: yarramate-engine#comparison-produces-result
+    external: comparisonProducesResult
+    type: relationship
+  - native: yarramate-engine#comparison-schema-describes-result
+    external: comparisonSchemaDescribesResult
+    type: relationship
+  - native: yarramate-engine#compilation-writes-graph
+    external: compilationWritesGraph
+    type: relationship
+  - native: yarramate-engine#compile-command-serves-agent-harness
+    external: compileCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#compiler-builds-graph
+    external: compilerBuildsGraph
+    type: relationship
+  - native: yarramate-engine#compiler-delivers-compilation
+    external: compilerDeliversCompilation
+    type: relationship
+  - native: yarramate-engine#compiler-delivers-validation
+    external: compilerDeliversValidation
+    type: relationship
+  - native: yarramate-engine#compiler-evaluates-projections
+    external: compilerEvaluatesProjections
+    type: relationship
+  - native: yarramate-engine#compiler-parses
+    external: compilerParses
+    type: relationship
+  - native: yarramate-engine#compiler-serializes-graph
+    external: compilerSerializesGraph
+    type: relationship
+  - native: yarramate-engine#compiler-validates-semantics
+    external: compilerValidatesSemantics
+    type: relationship
+  - native: yarramate-engine#compiler-validates-structure
+    external: compilerValidatesStructure
+    type: relationship
+  - native: yarramate-engine#connect-command-serves-agent-harness
+    external: connectCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#core-contract-check-reads-manifest
+    external: coreContractCheckReadsManifest
+    type: relationship
+  - native: yarramate-engine#core-contract-checker-checks-surface
+    external: coreContractCheckerChecksSurface
+    type: relationship
+  - native: yarramate-engine#core-contract-checker-loads-contract
+    external: coreContractCheckerLoadsContract
+    type: relationship
+  - native: yarramate-engine#core-contract-load-reads-manifest
+    external: coreContractLoadReadsManifest
+    type: relationship
+  - native: yarramate-engine#core-contract-load-reads-schema
+    external: coreContractLoadReadsSchema
+    type: relationship
+  - native: yarramate-engine#core-contract-schema-describes-manifest
+    external: coreContractSchemaDescribesManifest
+    type: relationship
+  - native: yarramate-engine#evidence-command-serves-agent-harness
+    external: evidenceCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#evidence-evaluation-reads-document
+    external: evidenceEvaluationReadsDocument
+    type: relationship
+  - native: yarramate-engine#evidence-evaluation-reads-graph
+    external: evidenceEvaluationReadsGraph
+    type: relationship
+  - native: yarramate-engine#evidence-evaluation-reads-report-schema
+    external: evidenceEvaluationReadsReportSchema
+    type: relationship
+  - native: yarramate-engine#evidence-evaluation-reads-schema
+    external: evidenceEvaluationReadsSchema
+    type: relationship
+  - native: yarramate-engine#evidence-evaluation-writes-report
+    external: evidenceEvaluationWritesReport
+    type: relationship
+  - native: yarramate-engine#evidence-evaluator-delivers-capability
+    external: evidenceEvaluatorDeliversCapability
+    type: relationship
+  - native: yarramate-engine#evidence-evaluator-evaluates-overlay
+    external: evidenceEvaluatorEvaluatesOverlay
+    type: relationship
+  - native: yarramate-engine#evidence-evaluator-reconciles-reports
+    external: evidenceEvaluatorReconcilesReports
+    type: relationship
+  - native: yarramate-engine#graph-delivers-machine-context
+    external: graphDeliversMachineContext
+    type: relationship
+  - native: yarramate-engine#graphify-adapter-delivers-evidence
+    external: graphifyAdapterDeliversEvidence
+    type: relationship
+  - native: yarramate-engine#graphify-adapter-observes-nodes
+    external: graphifyAdapterObservesNodes
+    type: relationship
+  - native: yarramate-engine#graphify-adapter-provides-observation
+    external: graphifyAdapterProvidesObservation
+    type: relationship
+  - native: yarramate-engine#graphify-observation-reads-mapping
+    external: graphifyObservationReadsMapping
+    type: relationship
+  - native: yarramate-engine#graphify-observation-writes-evidence
+    external: graphifyObservationWritesEvidence
+    type: relationship
+  - native: yarramate-engine#graphify-observe-command-serves-agent-harness
+    external: graphifyObserveCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#init-command-serves-agent-harness
+    external: initCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-assembles-project
+    external: likec4AdapterAssemblesProject
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-performs-export
+    external: likec4AdapterPerformsExport
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-renders-deployment-view
+    external: likec4AdapterRendersDeploymentView
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-renders-dynamic-view
+    external: likec4AdapterRendersDynamicView
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-renders-state-comparison
+    external: likec4AdapterRendersStateComparison
+    type: relationship
+  - native: yarramate-engine#likec4-check-serves-export
+    external: likec4CheckServesExport
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-deployment-view
+    external: likec4CommandServesDeploymentView
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-dynamic-view
+    external: likec4CommandServesDynamicView
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-export
+    external: likec4CommandServesExport
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-project-assembly
+    external: likec4CommandServesProjectAssembly
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-state-comparison
+    external: likec4CommandServesStateComparison
+    type: relationship
+  - native: yarramate-engine#likec4-comparison-reads-state-comparison
+    external: likec4ComparisonReadsStateComparison
+    type: relationship
+  - native: yarramate-engine#likec4-export-reads-kind-mapping
+    external: likec4ExportReadsKindMapping
+    type: relationship
+  - native: yarramate-engine#likec4-export-reads-kind-mapping-schema
+    external: likec4ExportReadsKindMappingSchema
+    type: relationship
+  - native: yarramate-engine#likec4-export-reads-mapping
+    external: likec4ExportReadsMapping
+    type: relationship
+  - native: yarramate-engine#likec4-export-reads-projection
+    external: likec4ExportReadsProjection
+    type: relationship
+  - native: yarramate-engine#likec4-project-assembly-reads-definition
+    external: likec4ProjectAssemblyReadsDefinition
+    type: relationship
+  - native: yarramate-engine#likec4-project-assembly-reads-definition-schema
+    external: likec4ProjectAssemblyReadsDefinitionSchema
+    type: relationship
+  - native: yarramate-engine#likec4-project-assembly-reads-marker-schema
+    external: likec4ProjectAssemblyReadsMarkerSchema
+    type: relationship
+  - native: yarramate-engine#likec4-project-assembly-reads-projections
+    external: likec4ProjectAssemblyReadsProjections
+    type: relationship
+  - native: yarramate-engine#likec4-project-assembly-reads-starter-pack
+    external: likec4ProjectAssemblyReadsStarterPack
+    type: relationship
+  - native: yarramate-engine#parse-reads-native-document
+    external: parseReadsNativeDocument
+    type: relationship
+  - native: yarramate-engine#parse-triggers-structure-validation
+    external: parseTriggersStructureValidation
+    type: relationship
+  - native: yarramate-engine#parser-flows-document
+    external: parserFlowsDocument
+    type: relationship
+  - native: yarramate-engine#profile-supplies-kinds
+    external: profileSuppliesKinds
+    type: relationship
+  - native: yarramate-engine#profile-supplies-policies
+    external: profileSuppliesPolicies
+    type: relationship
+  - native: yarramate-engine#projection-evaluation-delivers-context
+    external: projectionEvaluationDeliversContext
+    type: relationship
+  - native: yarramate-engine#projection-evaluation-reads-definition
+    external: projectionEvaluationReadsDefinition
+    type: relationship
+  - native: yarramate-engine#projection-evaluation-reads-definition-schema
+    external: projectionEvaluationReadsDefinitionSchema
+    type: relationship
+  - native: yarramate-engine#projection-evaluation-reads-graph
+    external: projectionEvaluationReadsGraph
+    type: relationship
+  - native: yarramate-engine#projection-evaluation-writes-result
+    external: projectionEvaluationWritesResult
+    type: relationship
+  - native: yarramate-engine#projection-result-schema-describes-result
+    external: projectionResultSchemaDescribesResult
+    type: relationship
+  - native: yarramate-engine#reconcile-command-serves-agent-harness
+    external: reconcileCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#reconciliation-delivers-capability
+    external: reconciliationDeliversCapability
+    type: relationship
+  - native: yarramate-engine#reconciliation-reads-evidence-report
+    external: reconciliationReadsEvidenceReport
+    type: relationship
+  - native: yarramate-engine#reconciliation-reads-report-schema
+    external: reconciliationReadsReportSchema
+    type: relationship
+  - native: yarramate-engine#reconciliation-writes-report
+    external: reconciliationWritesReport
+    type: relationship
+  - native: yarramate-engine#semantic-validation-flows-diagnostics
+    external: semanticValidationFlowsDiagnostics
+    type: relationship
+  - native: yarramate-engine#semantic-validation-reads-kinds
+    external: semanticValidationReadsKinds
+    type: relationship
+  - native: yarramate-engine#semantic-validation-reads-policies
+    external: semanticValidationReadsPolicies
+    type: relationship
+  - native: yarramate-engine#semantic-validation-triggers-compilation
+    external: semanticValidationTriggersCompilation
+    type: relationship
+  - native: yarramate-engine#serialization-reads-graph
+    external: serializationReadsGraph
+    type: relationship
+  - native: yarramate-engine#serialization-reads-graph-schema
+    external: serializationReadsGraphSchema
+    type: relationship
+  - native: yarramate-engine#source-loader-loads-document
+    external: sourceLoaderLoadsDocument
+    type: relationship
+  - native: yarramate-engine#state-engine-performs-comparison
+    external: stateEnginePerformsComparison
+    type: relationship
+  - native: yarramate-engine#structure-triggers-semantic-validation
+    external: structureTriggersSemanticValidation
+    type: relationship
+  - native: yarramate-engine#validation-reads-schema
+    external: validationReadsSchema
+    type: relationship
+  - native: yarramate-engine#validation-writes-diagnostics
+    external: validationWritesDiagnostics
+    type: relationship
+  - native: yarramate-engine#workspace-loader-resolves-manifest
+    external: workspaceLoaderResolvesManifest
+    type: relationship
+  - native: yarramate-engine#workspace-resolution-reads-manifest
+    external: workspaceResolutionReadsManifest
+    type: relationship
+  - native: yarramate-engine#workspace-resolution-reads-schema
+    external: workspaceResolutionReadsSchema
+    type: relationship
+  - native: yarramate-product#adopting-team
+    external: adoptingTeam
+    type: concept
+  - native: yarramate-product#adopting-team-performs-design
+    external: adoptingTeamPerformsDesign
+    type: relationship
+  - native: yarramate-product#agent-harness
+    external: agentHarness
+    type: concept
+  - native: yarramate-product#agent-trust-drives-shared-context
+    external: agentTrustDrivesSharedContext
+    type: relationship
+  - native: yarramate-product#architecture-drift
+    external: architectureDrift
+    type: concept
+  - native: yarramate-product#canonical-documents-support-context
+    external: canonicalDocumentsSupportContext
+    type: relationship
+  - native: yarramate-product#cli-supports-context
+    external: cliSupportsContext
+    type: relationship
+  - native: yarramate-product#cli-supports-design
+    external: cliSupportsDesign
+    type: relationship
+  - native: yarramate-product#cli-supports-discovery
+    external: cliSupportsDiscovery
+    type: relationship
+  - native: yarramate-product#correctness-supports-context
+    external: correctnessSupportsContext
+    type: relationship
+  - native: yarramate-product#design-supports-context
+    external: designSupportsContext
+    type: relationship
+  - native: yarramate-product#discovery-supports-context
+    external: discoverySupportsContext
+    type: relationship
+  - native: yarramate-product#drift-drives-shared-context
+    external: driftDrivesSharedContext
+    type: relationship
+  - native: yarramate-product#evidence-separation-supports-discovery
+    external: evidenceSeparationSupportsDiscovery
+    type: relationship
+  - native: yarramate-product#evidence-separation-supports-reconciliation
+    external: evidenceSeparationSupportsReconciliation
+    type: relationship
+  - native: yarramate-product#harness-performs-design
+    external: harnessPerformsDesign
+    type: relationship
+  - native: yarramate-product#harness-performs-discovery
+    external: harnessPerformsDiscovery
+    type: relationship
+  - native: yarramate-product#machine-context-realizes-shared-context
+    external: machineContextRealizesSharedContext
+    type: relationship
+  - native: yarramate-product#maintainers-perform-stewardship
+    external: maintainersPerformStewardship
+    type: relationship
+  - native: yarramate-product#reconciliation-supports-context
+    external: reconciliationSupportsContext
+    type: relationship
+  - native: yarramate-product#repository-operation-supports-context
+    external: repositoryOperationSupportsContext
+    type: relationship
+  - native: yarramate-product#repository-stewardship
+    external: repositoryStewardship
+    type: concept
+  - native: yarramate-product#trustworthy-agent-context
+    external: trustworthyAgentContext
+    type: concept
+  - native: yarramate-repository#adapter-mapping-schema-source
+    external: adapterMappingSchemaSource
+    type: concept
+  - native: yarramate-repository#adapter-mapping-source
+    external: adapterMappingSource
+    type: concept
+  - native: yarramate-repository#adapter-mapping-tests
+    external: adapterMappingTests
+    type: concept
+  - native: yarramate-repository#adapter-schema-realizes-mapping-schema
+    external: adapterSchemaRealizesMappingSchema
+    type: relationship
+  - native: yarramate-repository#adapter-source-realizes-validation
+    external: adapterSourceRealizesValidation
+    type: relationship
+  - native: yarramate-repository#adapter-specializes-authoring
+    external: adapterSpecializesAuthoring
+    type: relationship
+  - native: yarramate-repository#adapter-tests-validate-mapping
+    external: adapterTestsValidateMapping
+    type: relationship
+  - native: yarramate-repository#agent-skill-realizes-design
+    external: agentSkillRealizesDesign
+    type: relationship
+  - native: yarramate-repository#agent-skill-realizes-discovery
+    external: agentSkillRealizesDiscovery
+    type: relationship
+  - native: yarramate-repository#agent-skill-realizes-reconciliation
+    external: agentSkillRealizesReconciliation
+    type: relationship
+  - native: yarramate-repository#backlog-disposition-qualifies-roadmap
+    external: backlogDispositionQualifiesRoadmap
+    type: relationship
+  - native: yarramate-repository#check-command-source-realizes-command
+    external: checkCommandSourceRealizesCommand
+    type: relationship
+  - native: yarramate-repository#check-result-schema-realizes-schema
+    external: checkResultSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#check-result-schema-source
+    external: checkResultSchemaSource
+    type: concept
+  - native: yarramate-repository#cli-source
+    external: cliSource
+    type: concept
+  - native: yarramate-repository#cli-source-realizes-cli
+    external: cliSourceRealizesCli
+    type: relationship
+  - native: yarramate-repository#cli-support-source
+    external: cliSupportSource
+    type: concept
+  - native: yarramate-repository#cli-support-source-realizes-cli
+    external: cliSupportSourceRealizesCli
+    type: relationship
+  - native: yarramate-repository#cli-tests
+    external: cliTests
+    type: concept
+  - native: yarramate-repository#cli-tests-validate-cli
+    external: cliTestsValidateCli
+    type: relationship
+  - native: yarramate-repository#compiler-source
+    external: compilerSource
+    type: concept
+  - native: yarramate-repository#compiler-source-realizes-compiler
+    external: compilerSourceRealizesCompiler
+    type: relationship
+  - native: yarramate-repository#compiler-tests
+    external: compilerTests
+    type: concept
+  - native: yarramate-repository#consumer-guide-realizes-design
+    external: consumerGuideRealizesDesign
+    type: relationship
+  - native: yarramate-repository#consumer-guide-realizes-discovery
+    external: consumerGuideRealizesDiscovery
+    type: relationship
+  - native: yarramate-repository#consumer-package-realizes-cli
+    external: consumerPackageRealizesCli
+    type: relationship
+  - native: yarramate-repository#consumer-package-realizes-design
+    external: consumerPackageRealizesDesign
+    type: relationship
+  - native: yarramate-repository#consumer-package-realizes-discovery
+    external: consumerPackageRealizesDiscovery
+    type: relationship
+  - native: yarramate-repository#contract-realizes-canonical-documents
+    external: contractRealizesCanonicalDocuments
+    type: relationship
+  - native: yarramate-repository#contract-realizes-stable-cli
+    external: contractRealizesStableCli
+    type: relationship
+  - native: yarramate-repository#contract-realizes-tool-neutral-core
+    external: contractRealizesToolNeutralCore
+    type: relationship
+  - native: yarramate-repository#core-contract-release-manifest
+    external: coreContractReleaseManifest
+    type: concept
+  - native: yarramate-repository#core-contract-release-realizes-manifest
+    external: coreContractReleaseRealizesManifest
+    type: relationship
+  - native: yarramate-repository#core-contract-schema-source
+    external: coreContractSchemaSource
+    type: concept
+  - native: yarramate-repository#core-contract-schema-source-realizes-schema
+    external: coreContractSchemaSourceRealizesSchema
+    type: relationship
+  - native: yarramate-repository#core-contract-source
+    external: coreContractSource
+    type: concept
+  - native: yarramate-repository#core-contract-source-realizes-checker
+    external: coreContractSourceRealizesChecker
+    type: relationship
+  - native: yarramate-repository#core-contract-tests
+    external: coreContractTests
+    type: concept
+  - native: yarramate-repository#core-contract-tests-validate-checker
+    external: coreContractTestsValidateChecker
+    type: relationship
+  - native: yarramate-repository#decisions-realize-contract
+    external: decisionsRealizeContract
+    type: relationship
+  - native: yarramate-repository#diagnostic-result-schema-realizes-schema
+    external: diagnosticResultSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#diagnostic-result-schema-source
+    external: diagnosticResultSchemaSource
+    type: concept
+  - native: yarramate-repository#document-schema-realizes-schema
+    external: documentSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#document-schema-source
+    external: documentSchemaSource
+    type: concept
+  - native: yarramate-repository#evidence-report-schema-realizes-report-schema
+    external: evidenceReportSchemaRealizesReportSchema
+    type: relationship
+  - native: yarramate-repository#evidence-report-schema-source
+    external: evidenceReportSchemaSource
+    type: concept
+  - native: yarramate-repository#evidence-schema-realizes-evidence-schema
+    external: evidenceSchemaRealizesEvidenceSchema
+    type: relationship
+  - native: yarramate-repository#evidence-schema-source
+    external: evidenceSchemaSource
+    type: concept
+  - native: yarramate-repository#evidence-source
+    external: evidenceSource
+    type: concept
+  - native: yarramate-repository#evidence-source-realizes-evaluator
+    external: evidenceSourceRealizesEvaluator
+    type: relationship
+  - native: yarramate-repository#evidence-tests
+    external: evidenceTests
+    type: concept
+  - native: yarramate-repository#evidence-tests-validate-evaluation
+    external: evidenceTestsValidateEvaluation
+    type: relationship
+  - native: yarramate-repository#evolution-model-realizes-states
+    external: evolutionModelRealizesStates
+    type: relationship
+  - native: yarramate-repository#graph-schema-realizes-graph-schema
+    external: graphSchemaRealizesGraphSchema
+    type: relationship
+  - native: yarramate-repository#graph-schema-source
+    external: graphSchemaSource
+    type: concept
+  - native: yarramate-repository#graph-schema-tests
+    external: graphSchemaTests
+    type: concept
+  - native: yarramate-repository#graph-source
+    external: graphSource
+    type: concept
+  - native: yarramate-repository#graph-source-realizes-serialization
+    external: graphSourceRealizesSerialization
+    type: relationship
+  - native: yarramate-repository#graph-tests-validate-interchange
+    external: graphTestsValidateInterchange
+    type: relationship
+  - native: yarramate-repository#graphify-cli-realizes-command
+    external: graphifyCliRealizesCommand
+    type: relationship
+  - native: yarramate-repository#graphify-source-realizes-adapter
+    external: graphifySourceRealizesAdapter
+    type: relationship
+  - native: yarramate-repository#graphify-tests-validate-observation
+    external: graphifyTestsValidateObservation
+    type: relationship
+  - native: yarramate-repository#journey-guide-realizes-design
+    external: journeyGuideRealizesDesign
+    type: relationship
+  - native: yarramate-repository#journey-guide-realizes-discovery
+    external: journeyGuideRealizesDiscovery
+    type: relationship
+  - native: yarramate-repository#journey-tests-verify-design
+    external: journeyTestsVerifyDesign
+    type: relationship
+  - native: yarramate-repository#journey-tests-verify-discovery
+    external: journeyTestsVerifyDiscovery
+    type: relationship
+  - native: yarramate-repository#likec4-check-result-schema-source
+    external: likec4CheckResultSchemaSource
+    type: concept
+  - native: yarramate-repository#likec4-check-schema-realizes-schema
+    external: likec4CheckSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-cli-source-realizes-check
+    external: likec4CliSourceRealizesCheck
+    type: relationship
+  - native: yarramate-repository#likec4-cli-source-realizes-command
+    external: likec4CliSourceRealizesCommand
+    type: relationship
+  - native: yarramate-repository#likec4-cli-tests
+    external: likec4CliTests
+    type: concept
+  - native: yarramate-repository#likec4-cli-tests-validate-check
+    external: likec4CliTestsValidateCheck
+    type: relationship
+  - native: yarramate-repository#likec4-cli-tests-validate-command
+    external: likec4CliTestsValidateCommand
+    type: relationship
+  - native: yarramate-repository#likec4-diagnostic-result-schema-source
+    external: likec4DiagnosticResultSchemaSource
+    type: concept
+  - native: yarramate-repository#likec4-diagnostic-schema-realizes-schema
+    external: likec4DiagnosticSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-export-mapping-source
+    external: likec4ExportMappingSource
+    type: concept
+  - native: yarramate-repository#likec4-export-projection-source
+    external: likec4ExportProjectionSource
+    type: concept
+  - native: yarramate-repository#likec4-export-source-realizes-adapter
+    external: likec4ExportSourceRealizesAdapter
+    type: relationship
+  - native: yarramate-repository#likec4-export-tests
+    external: likec4ExportTests
+    type: concept
+  - native: yarramate-repository#likec4-export-tests-validate-adapter
+    external: likec4ExportTestsValidateAdapter
+    type: relationship
+  - native: yarramate-repository#likec4-generated-project-schema-source
+    external: likec4GeneratedProjectSchemaSource
+    type: concept
+  - native: yarramate-repository#likec4-generated-schema-realizes-schema
+    external: likec4GeneratedSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-generated-v2-schema-realizes-schema
+    external: likec4GeneratedV2SchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-kind-mapping-schema-source
+    external: likec4KindMappingSchemaSource
+    type: concept
+  - native: yarramate-repository#likec4-kind-mapping-source
+    external: likec4KindMappingSource
+    type: concept
+  - native: yarramate-repository#likec4-kind-profile-realizes-mapping
+    external: likec4KindProfileRealizesMapping
+    type: relationship
+  - native: yarramate-repository#likec4-kind-profile-source
+    external: likec4KindProfileSource
+    type: concept
+  - native: yarramate-repository#likec4-kind-schema-realizes-schema
+    external: likec4KindSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-kind-source-realizes-mapping
+    external: likec4KindSourceRealizesMapping
+    type: relationship
+  - native: yarramate-repository#likec4-kind-tests-validate-mapping
+    external: likec4KindTestsValidateMapping
+    type: relationship
+  - native: yarramate-repository#likec4-mapping-source-realizes-mapping
+    external: likec4MappingSourceRealizesMapping
+    type: relationship
+  - native: yarramate-repository#likec4-prepare-source-realizes-export
+    external: likec4PrepareSourceRealizesExport
+    type: relationship
+  - native: yarramate-repository#likec4-prepare-tests
+    external: likec4PrepareTests
+    type: concept
+  - native: yarramate-repository#likec4-prepare-tests-validate-export
+    external: likec4PrepareTestsValidateExport
+    type: relationship
+  - native: yarramate-repository#likec4-project-definition-realizes-definition
+    external: likec4ProjectDefinitionRealizesDefinition
+    type: relationship
+  - native: yarramate-repository#likec4-project-schema-realizes-schema
+    external: likec4ProjectSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#likec4-project-source-realizes-assembly
+    external: likec4ProjectSourceRealizesAssembly
+    type: relationship
+  - native: yarramate-repository#likec4-projection-source-realizes-definition
+    external: likec4ProjectionSourceRealizesDefinition
+    type: relationship
+  - native: yarramate-repository#package-tests-verify-consumer-package
+    external: packageTestsVerifyConsumerPackage
+    type: relationship
+  - native: yarramate-repository#profile-schema-realizes-catalogue
+    external: profileSchemaRealizesCatalogue
+    type: relationship
+  - native: yarramate-repository#profile-schema-source
+    external: profileSchemaSource
+    type: concept
+  - native: yarramate-repository#projection-result-schema-realizes-schema
+    external: projectionResultSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#projection-result-schema-source
+    external: projectionResultSchemaSource
+    type: concept
+  - native: yarramate-repository#projection-schema-realizes-context
+    external: projectionSchemaRealizesContext
+    type: relationship
+  - native: yarramate-repository#projection-schema-source
+    external: projectionSchemaSource
+    type: concept
+  - native: yarramate-repository#projection-source-realizes-context
+    external: projectionSourceRealizesContext
+    type: relationship
+  - native: yarramate-repository#reconciliation-report-schema-realizes-schema
+    external: reconciliationReportSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#reconciliation-source-realizes-function
+    external: reconciliationSourceRealizesFunction
+    type: relationship
+  - native: yarramate-repository#repository-evidence
+    external: repositoryEvidence
+    type: concept
+  - native: yarramate-repository#repository-evidence-realizes-document
+    external: repositoryEvidenceRealizesDocument
+    type: relationship
+  - native: yarramate-repository#roadmap-serves-contract
+    external: roadmapServesContract
+    type: relationship
+  - native: yarramate-repository#root-manifest-realizes-workspace
+    external: rootManifestRealizesWorkspace
+    type: relationship
+  - native: yarramate-repository#root-workspace-manifest
+    external: rootWorkspaceManifest
+    type: concept
+  - native: yarramate-repository#source-document-source
+    external: sourceDocumentSource
+    type: concept
+  - native: yarramate-repository#source-document-source-realizes-loader
+    external: sourceDocumentSourceRealizesLoader
+    type: relationship
+  - native: yarramate-repository#state-comparison-schema-realizes-schema
+    external: stateComparisonSchemaRealizesSchema
+    type: relationship
+  - native: yarramate-repository#state-source-realizes-engine
+    external: stateSourceRealizesEngine
+    type: relationship
+  - native: yarramate-repository#state-tests-validate-comparison
+    external: stateTestsValidateComparison
+    type: relationship
+  - native: yarramate-repository#tests-validate-compiler
+    external: testsValidateCompiler
+    type: relationship
+  - native: yarramate-repository#workspace-schema-realizes-workspace-schema
+    external: workspaceSchemaRealizesWorkspaceSchema
+    type: relationship
+  - native: yarramate-repository#workspace-schema-source
+    external: workspaceSchemaSource
+    type: concept
+  - native: yarramate-repository#workspace-source
+    external: workspaceSource
+    type: concept
+  - native: yarramate-repository#workspace-source-realizes-loader
+    external: workspaceSourceRealizesLoader
+    type: relationship
+  - native: yarramate-repository#workspace-tests
+    external: workspaceTests
+    type: concept
+  - native: yarramate-repository#workspace-tests-validate-resolution
+    external: workspaceTestsValidateResolution
+    type: relationship

--- a/docs/research/question-catalogue/README.md
+++ b/docs/research/question-catalogue/README.md
@@ -1,0 +1,92 @@
+# Question catalogue (research draft)
+
+Status: draft for review — not a normative contract. Nothing here is wired
+into the compiler, CLI, or package exports.
+
+A question catalogue is the versioned, opinionated artifact behind the
+proposed enrichment journey: after `init` and initial discovery, an agent
+interviews the workspace — answering what evidence can answer and escalating
+genuine design decisions to a human. This directory contains:
+
+- `yarramate-question-catalogue.schema.json` — draft JSON Schema for
+  `yarramate/question-catalogue/v1`;
+- `core-enrichment.yaml` — seed catalogue: 13 questions across motivation,
+  business, and hygiene waves against `yarramate/core@0.1`;
+- `evaluate-catalogue.mjs` — reference evaluator demonstrating that every
+  trigger is deterministic against a compiled graph-v2 workspace.
+
+## Evaluation model
+
+- A question binds a **trigger**: one or more deterministic conditions over
+  the compiled graph (AND). The question is **open** wherever the trigger
+  matches and **closed** when it no longer matches.
+- Interview state is **recomputed, never stored**. Re-running the evaluation
+  after any edit yields exactly the still-open questions. No session files,
+  no second canonical store.
+- `scope: subject` questions evaluate once per subject matched by a selector
+  whose vocabulary mirrors the projection query (`kinds`, `kindMatching`,
+  `statuses`, `documents`). `scope: workspace` questions evaluate once.
+- Every question must state its **materiality** — the decision its answer
+  changes. A question that cannot is deleted, not softened.
+- **authority** encodes escalation: `evidence` (agent may propose from
+  repository evidence), `human` (genuine design decision), `either`
+  (evidence proposes, human confirms). In every case an answer lands as a
+  reviewable native-document diff; evidence never silently authors intent.
+
+### Trigger conditions (v1 draft)
+
+| Condition | Scope | Open when |
+| --- | --- | --- |
+| `missing-claim` | subject | subject has no claim with `predicate` |
+| `missing-relationship` | subject | no relationship claim of `kinds` touches the subject in `direction` |
+| `isolated` | subject | subject participates in no relationship **and** is not the target of any reference-bearing claim |
+| `no-subject-of-kind` | workspace | no concept of `kinds` exists |
+| `no-state-defined` | workspace | no architecture state is declared |
+
+## Pressure test against the self-model
+
+Run against this repository's compiled workspace:
+
+```sh
+yarramate compile .yarramate/workspace.yaml > /tmp/graph.json
+node docs/research/question-catalogue/evaluate-catalogue.mjs \
+  docs/research/question-catalogue/yarramate-question-catalogue.schema.json \
+  docs/research/question-catalogue/core-enrichment.yaml \
+  /tmp/graph.json
+```
+
+First run (2026-07-29, v0.3.3 self-model): **70 open questions**, including
+19 concepts without owners, 7 services without a declared consumer, 34
+undescribed concepts, one unrealized goal (Shared architecture context), and
+no stakeholder/driver concepts at all. The findings are plausible on sight,
+which is the point: the triggers find real gaps without an LLM in the loop.
+
+## Open decisions
+
+1. **`kindMatching: descendants`** needs profile lineage; graph v2 carries
+   profile identities only. The gap engine should resolve descendants through
+   the library's profile resolution. The reference evaluator matches exactly
+   and says so.
+2. **`isolated` semantics.** First draft counted only relationship claims and
+   false-positived an actor referenced by nine ownership claims. Current
+   draft: reference-bearing claims (ownership, identified references,
+   constraints) also express participation. Revisit whether that list should
+   be explicit in the schema.
+3. **Serving direction.** `service-consumer-unknown` assumes services serve
+   outward (service → consumer). Models that attach serving to components
+   instead will under-fire. May need an `any` direction or an endpoint-role
+   refinement.
+3a. **`information-unaccessed` is too narrow** (found while dogfooding the
+   first enrichment session, 2026-07-29). Schema dataObjects legitimately
+   participate through outgoing `realization` "describes" edges, not incoming
+   access; 3 of 5 residual matches were false positives of this shape. The
+   condition needs an any-relationship variant, or schema-like information
+   deserves its own question.
+4. **Where catalogues live.** Options: workspace manifest entries (like
+   evidence), standalone files passed to a future `yarramate interrogate`,
+   or shipped with the skill. Draft assumes standalone explicit files,
+   matching the CLI's explicit-source convention.
+5. **`extends` composition semantics** (union, no shadowing — mirroring
+   profiles) are declared in the schema but deferred to the gap engine.
+6. **Ranking.** Open-question ordering (e.g. by graph centrality of the
+   subject) is an engine concern, deliberately not encoded in the catalogue.

--- a/docs/research/question-catalogue/core-enrichment.yaml
+++ b/docs/research/question-catalogue/core-enrichment.yaml
@@ -1,0 +1,297 @@
+format: yarramate/question-catalogue/v1
+id: core-enrichment
+version: "0.1"
+profile: yarramate/core@0.1
+presentation:
+  title: Core enrichment interview
+  description: >-
+    Seed questions for the enrichment journey. Motivation and business waves,
+    plus cross-cutting hygiene. Each question states the decision its answer
+    changes; a question that cannot is deleted, not softened.
+
+waves:
+  - id: motivation
+    name: Motivation
+    description: Why the system exists and what constrains it.
+  - id: business
+    name: Business
+    description: Who acts, what is served, and what information matters.
+  - id: hygiene
+    name: Model hygiene
+    description: Cross-cutting completeness that keeps every wave honest.
+
+questions:
+  # ---- motivation ----------------------------------------------------------
+  - id: outcome-missing
+    wave: motivation
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+          - yarramate/core@0.1#outcome
+    question: >-
+      What outcome justifies this system's existence?
+    materiality: >-
+      Without a declared goal or outcome, no alternative can be selected or
+      rejected on grounds anyone can review; every later trade-off becomes
+      taste.
+    authority: human
+    resolution: >-
+      Add at least one goal or outcome concept and relate principal services
+      to it with realization.
+
+  - id: stakeholders-missing
+    wave: motivation
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#stakeholder
+          - yarramate/core@0.1#driver
+    question: >-
+      Which stakeholders and drivers shape this architecture?
+    materiality: >-
+      Drivers decide which qualities dominate when requirements conflict;
+      unstated drivers get re-litigated in every review.
+    authority: human
+    resolution: >-
+      Add stakeholder and driver concepts; use influence relationships toward
+      the goals they shape.
+
+  - id: constraints-missing
+    wave: motivation
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#constraint
+          - yarramate/core@0.1#requirement
+    question: >-
+      Which constraints and requirements are non-negotiable?
+    materiality: >-
+      Non-negotiable constraints eliminate alternatives outright; discovering
+      them after design selection invalidates the selection.
+    authority: human
+    resolution: >-
+      Add constraint or requirement concepts and attach constraint references
+      from the subjects they bind.
+
+  - id: goal-unrealized
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#goal
+        - yarramate/core@0.1#outcome
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+    question: >-
+      Nothing realizes {subject.name}. What fulfils it — or is it
+      aspirational?
+    materiality: >-
+      An unrealized goal either reprioritizes the roadmap or should be
+      declared aspirational so it stops steering design.
+    authority: either
+    resolution: >-
+      Add realization relationships from the fulfilling capability or
+      service, or record the aspirational status in the goal's description.
+
+  # ---- business ------------------------------------------------------------
+  - id: service-consumer-unknown
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#technologyService
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: outgoing
+    question: >-
+      Who or what consumes {subject.name}?
+    materiality: >-
+      A service with no consumer is either the system boundary stated
+      implicitly, missing model detail, or scope to delete.
+    authority: either
+    resolution: >-
+      Add serving relationships to the consuming actor, process, or
+      component; if the consumer is external, model it as an actor.
+
+  - id: owner-missing
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#capability
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/ownership/owner
+    question: >-
+      Who is accountable for {subject.name}?
+    materiality: >-
+      Ownership decides who accepts changes, budgets maintenance, and
+      adjudicates constraint conflicts for the subject.
+    authority: either
+    resolution: >-
+      Add an owner reference to an accountable actor (evidence such as
+      CODEOWNERS may propose it; a human confirms accountability).
+
+  - id: actor-unassigned
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessActor
+        - yarramate/core@0.1#businessRole
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#assignment
+        direction: outgoing
+    question: >-
+      What behavior is {subject.name} actually responsible for?
+    materiality: >-
+      An actor with no assignment is either decorative or hiding an
+      undeclared responsibility boundary.
+    authority: either
+    resolution: >-
+      Add assignment relationships to the processes, functions, or services
+      the actor performs, or remove the actor.
+
+  - id: information-unaccessed
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessObject
+        - yarramate/core@0.1#dataObject
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#access
+        direction: incoming
+    question: >-
+      Which behavior creates and maintains {subject.name}?
+    materiality: >-
+      Information nothing accesses cannot be owned, persisted, or exchanged
+      correctly; write responsibility determines consistency boundaries.
+    authority: either
+    resolution: >-
+      Add access relationships (with modes) from the behavior that reads and
+      writes it.
+
+  - id: no-service-declared
+    wave: business
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#businessService
+          - yarramate/core@0.1#applicationService
+          - yarramate/core@0.1#technologyService
+    question: >-
+      What does this system offer its environment, and to whom?
+    materiality: >-
+      Declared services define the solution boundary; without them the model
+      cannot say what is inside versus outside.
+    authority: human
+    resolution: >-
+      Add the externally meaningful services and serve them to their
+      consumers.
+
+  # ---- hygiene -------------------------------------------------------------
+  - id: concept-isolated
+    wave: hygiene
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#capability
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#businessActor
+        - yarramate/core@0.1#dataObject
+        - yarramate/core@0.1#businessObject
+    trigger:
+      - condition: isolated
+    question: >-
+      {subject.name} relates to nothing. How does it participate in the
+      architecture — or should it be removed?
+    materiality: >-
+      An isolated concept either misses relationships the design depends on
+      or inflates the model with noise that dilutes trust.
+    authority: either
+    resolution: >-
+      Connect it with its real relationships or delete it; do not keep
+      unexplained inventory.
+
+  - id: concept-undescribed
+    wave: hygiene
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#capability
+        - yarramate/core@0.1#dataObject
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/concept/description
+    question: >-
+      What does {subject.name} mean — and what does it deliberately not
+      include?
+    materiality: >-
+      Undescribed subjects accumulate contradictory interpretations; the
+      description is where scope disputes are settled once.
+    authority: either
+    resolution: >-
+      Add a description claim stating meaning and explicit exclusions.
+
+  - id: status-missing
+    wave: hygiene
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#capability
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/lifecycle/status
+    question: >-
+      Is {subject.name} current, planned, or retired?
+    materiality: >-
+      Lifecycle status separates the architecture that exists from the one
+      that is intended; conflating them corrupts both discovery and design.
+    authority: either
+    resolution: >-
+      Add a lifecycle status claim; planned subjects should also appear in a
+      target architecture state where states are used.
+
+  - id: states-undefined
+    wave: hygiene
+    scope: workspace
+    trigger:
+      - condition: no-state-defined
+    question: >-
+      Does change shape matter here — should baseline, transition, or target
+      states be declared?
+    materiality: >-
+      Without architecture states, current and target intent share one
+      undifferentiated model and comparisons are impossible.
+    authority: human
+    resolution: >-
+      Declare architecture states and mark presence with present-in where the
+      distinction carries decisions; explicitly decline states otherwise.

--- a/docs/research/question-catalogue/evaluate-catalogue.mjs
+++ b/docs/research/question-catalogue/evaluate-catalogue.mjs
@@ -1,0 +1,131 @@
+// Draft reference evaluator for yarramate/question-catalogue/v1.
+// Validates the catalogue against the draft schema, then evaluates every
+// trigger deterministically against a compiled graph-v2 workspace.
+// Simplification vs the intended gap engine: kindMatching is evaluated as
+// "exact" because graph v2 carries profile identities, not kind lineage.
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire('/Users/nabsha/work/yarrasys/projects/yarramate/package.json');
+const Ajv2020 = require('ajv/dist/2020').default;
+const YAML = require('yaml');
+
+const [schemaPath, cataloguePath, graphPath] = process.argv.slice(2);
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+const catalogue = YAML.parse(readFileSync(cataloguePath, 'utf8'));
+const graph = JSON.parse(readFileSync(graphPath, 'utf8'));
+
+// --- validate ---------------------------------------------------------------
+const ajv = new Ajv2020({ allErrors: true });
+const validate = ajv.compile(schema);
+if (!validate(catalogue)) {
+  console.error('CATALOGUE INVALID:');
+  for (const e of validate.errors) console.error(` ${e.instancePath} ${e.message}`);
+  process.exit(1);
+}
+const waveIds = new Set(catalogue.waves.map((w) => w.id));
+for (const q of catalogue.questions) {
+  if (!waveIds.has(q.wave)) {
+    console.error(`CATALOGUE INVALID: question ${q.id} references unknown wave ${q.wave}`);
+    process.exit(1);
+  }
+}
+console.log(`catalogue valid: ${catalogue.id}@${catalogue.version}, ${catalogue.questions.length} questions, ${catalogue.waves.length} waves`);
+
+// --- index the graph --------------------------------------------------------
+const concepts = new Set(graph.subjects.filter((s) => s.type === 'concept').map((s) => s.id));
+const byPredicate = new Map();
+const claimsBySubject = new Map();
+for (const c of graph.claims) {
+  if (!byPredicate.has(c.predicate)) byPredicate.set(c.predicate, []);
+  byPredicate.get(c.predicate).push(c);
+  if (!claimsBySubject.has(c.subject)) claimsBySubject.set(c.subject, []);
+  claimsBySubject.get(c.subject).push(c);
+}
+const isRelPredicate = (p) => p.includes('#');
+const relClaims = graph.claims.filter((c) => isRelPredicate(c.predicate));
+
+const kindOf = new Map();
+for (const c of byPredicate.get('yarramate/concept/kind') ?? []) kindOf.set(c.subject, c.object.value);
+const nameOf = new Map();
+for (const c of byPredicate.get('yarramate/concept/name') ?? []) nameOf.set(c.subject, c.object.value);
+const statusOf = new Map();
+for (const c of byPredicate.get('yarramate/lifecycle/status') ?? []) statusOf.set(c.subject, c.object.value);
+const stateSubjects = new Set((byPredicate.get('yarramate/state/type') ?? []).map((c) => c.subject));
+
+// state subjects are not enrichment targets for concept questions
+for (const s of stateSubjects) concepts.delete(s);
+
+// --- selector ---------------------------------------------------------------
+function selectSubjects(selector) {
+  const kinds = new Set(selector.kinds);
+  let ids = [...concepts].filter((id) => kinds.has(kindOf.get(id)));
+  if (selector.statuses) {
+    const st = new Set(selector.statuses);
+    ids = ids.filter((id) => st.has(statusOf.get(id)));
+  }
+  if (selector.documents) {
+    const docs = new Set(selector.documents);
+    ids = ids.filter((id) => docs.has(id.split('#')[0]));
+  }
+  return ids;
+}
+
+// --- conditions -------------------------------------------------------------
+function holds(cond, subjectId) {
+  switch (cond.condition) {
+    case 'missing-claim':
+      return !(claimsBySubject.get(subjectId) ?? []).some((c) => c.predicate === cond.predicate);
+    case 'missing-relationship': {
+      const kinds = new Set(cond.kinds);
+      const touches = relClaims.filter((c) => kinds.has(c.predicate));
+      const out = touches.some((c) => c.subject === subjectId);
+      const inc = touches.some((c) => c.object?.ref === subjectId);
+      if (cond.direction === 'outgoing') return !out;
+      if (cond.direction === 'incoming') return !inc;
+      return !out && !inc;
+    }
+    case 'isolated':
+      // A subject is isolated only if it participates in no relationship AND
+      // is not the target of any reference-bearing claim (ownership,
+      // identified reference, constraint), which also expresses participation.
+      return (
+        !relClaims.some((c) => c.subject === subjectId || c.object?.ref === subjectId) &&
+        !graph.claims.some((c) => !isRelPredicate(c.predicate) && c.object?.ref === subjectId)
+      );
+    case 'no-subject-of-kind': {
+      const kinds = new Set(cond.kinds);
+      return ![...concepts].some((id) => kinds.has(kindOf.get(id)));
+    }
+    case 'no-state-defined':
+      return stateSubjects.size === 0;
+    default:
+      throw new Error(`unknown condition ${cond.condition}`);
+  }
+}
+
+// --- evaluate ---------------------------------------------------------------
+const label = (id) => nameOf.get(id) ?? id;
+let totalOpen = 0;
+for (const wave of catalogue.waves) {
+  const qs = catalogue.questions.filter((q) => q.wave === wave.id);
+  console.log(`\n== ${wave.name} ==`);
+  for (const q of qs) {
+    if (q.scope === 'workspace') {
+      const open = q.trigger.every((c) => holds(c, null));
+      console.log(`  ${open ? 'OPEN  ' : 'closed'} ${q.id}${open ? ` — ${q.question.trim()}` : ''}`);
+      if (open) totalOpen += 1;
+    } else {
+      const matches = selectSubjects(q.subjects).filter((id) => q.trigger.every((c) => holds(c, id)));
+      totalOpen += matches.length;
+      const examples = matches.slice(0, 3).map(label).join('; ');
+      console.log(`  ${matches.length ? 'OPEN  ' : 'closed'} ${q.id} (${matches.length} subjects)${matches.length ? ` — e.g. ${examples}` : ''}`);
+      if (matches.length) {
+        const rendered = q.question.trim().replaceAll('{subject.name}', label(matches[0])).replaceAll('{subject.id}', matches[0]);
+        console.log(`         ask: "${rendered}" [authority: ${q.authority}]`);
+      }
+    }
+  }
+}
+console.log(`\ntotal open questions on this workspace: ${totalOpen}`);

--- a/docs/research/question-catalogue/yarramate-question-catalogue.schema.json
+++ b/docs/research/question-catalogue/yarramate-question-catalogue.schema.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/question-catalogue/v1",
+  "title": "YarraMate question catalogue (research draft)",
+  "description": "A versioned, opinionated catalogue of enrichment questions. Each question binds a deterministic trigger evaluated against a compiled graph-v2 workspace: the question is open wherever its trigger matches and closed when it no longer matches. Interview state is recomputed, never stored.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "id", "version", "profile", "waves", "questions"],
+  "properties": {
+    "format": {
+      "const": "yarramate/question-catalogue/v1"
+    },
+    "id": {
+      "$ref": "#/$defs/id"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "profile": {
+      "description": "Profile identity whose vocabulary the triggers are expressed against.",
+      "$ref": "#/$defs/profileIdentity"
+    },
+    "extends": {
+      "description": "Catalogue identities whose waves and questions this catalogue includes. Local ids may not shadow inherited ids. Resolution semantics deferred to the gap engine.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/catalogueIdentity"
+      }
+    },
+    "presentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyText"
+        }
+      }
+    },
+    "waves": {
+      "description": "Ordered interview phases. Array order is interview order. The wave taxonomy is catalogue opinion, not engine semantics.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "$ref": "#/$defs/id"
+          },
+          "name": {
+            "$ref": "#/$defs/nonEmptyText"
+          },
+          "description": {
+            "$ref": "#/$defs/nonEmptyText"
+          }
+        }
+      }
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/question"
+      }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "nonEmptyText": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profileIdentity": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/-]*@[0-9][0-9A-Za-z.-]*$"
+    },
+    "catalogueIdentity": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/-]*@[0-9][0-9A-Za-z.-]*$"
+    },
+    "qualifiedKind": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/-]*@[0-9][0-9A-Za-z.-]*#[A-Za-z][A-Za-z0-9-]*$"
+    },
+    "claimPredicate": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/@.#-]*$"
+    },
+    "subjectSelector": {
+      "description": "Which subjects a subject-scope question applies to. Field vocabulary mirrors the projection query selector (ADR 0017).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kinds"],
+      "properties": {
+        "kinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/qualifiedKind"
+          }
+        },
+        "kindMatching": {
+          "enum": ["exact", "descendants"],
+          "default": "descendants"
+        },
+        "statuses": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["planned", "current", "retired"]
+          }
+        },
+        "documents": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        }
+      }
+    },
+    "condition": {
+      "description": "One deterministic trigger condition. All conditions in a trigger must hold (AND) for the question to be open.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["condition", "predicate"],
+          "properties": {
+            "condition": {
+              "const": "missing-claim"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["condition", "kinds", "direction"],
+          "properties": {
+            "condition": {
+              "const": "missing-relationship"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": ["incoming", "outgoing", "any"]
+            },
+            "kindMatching": {
+              "enum": ["exact", "descendants"],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["condition"],
+          "properties": {
+            "condition": {
+              "const": "isolated"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["condition", "kinds"],
+          "properties": {
+            "condition": {
+              "const": "no-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": ["exact", "descendants"],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["condition"],
+          "properties": {
+            "condition": {
+              "const": "no-state-defined"
+            }
+          }
+        }
+      ]
+    },
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "wave",
+        "scope",
+        "trigger",
+        "question",
+        "materiality",
+        "authority"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "wave": {
+          "description": "Wave id declared in this catalogue (or an extended one).",
+          "$ref": "#/$defs/id"
+        },
+        "scope": {
+          "description": "subject: evaluated once per matching subject. workspace: evaluated once per workspace.",
+          "enum": ["subject", "workspace"]
+        },
+        "subjects": {
+          "$ref": "#/$defs/subjectSelector"
+        },
+        "trigger": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/condition"
+          }
+        },
+        "question": {
+          "description": "Human-facing phrasing. Subject-scope questions may interpolate {subject.id} and {subject.name}.",
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "materiality": {
+          "description": "Which architectural decision the answer changes. A question that cannot state this does not belong in the catalogue.",
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "authority": {
+          "description": "Who may answer. evidence: an agent may propose the answer from repository evidence (still lands as a reviewable diff). human: a genuine design decision that must be escalated. either: evidence may propose, human confirms.",
+          "enum": ["evidence", "human", "either"]
+        },
+        "resolution": {
+          "description": "Guidance for how an accepted answer should land as native authoring (which claim, relationship, or state to add).",
+          "$ref": "#/$defs/nonEmptyText"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "subject"
+              }
+            }
+          },
+          "then": {
+            "required": ["subjects"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "workspace"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["subjects"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1601,7 +1601,7 @@ mappings:
             subject: 'yarramate-repository#likec4-export-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/16/kind',
-            line: 74,
+            line: 75,
             column: 11,
           },
           {
@@ -1612,7 +1612,7 @@ mappings:
             subject: 'yarramate-repository#likec4-prepare-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/19/kind',
-            line: 86,
+            line: 87,
             column: 11,
           },
           {
@@ -1623,7 +1623,7 @@ mappings:
             subject: 'yarramate-repository#likec4-project-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/20/kind',
-            line: 90,
+            line: 91,
             column: 11,
           },
           {
@@ -1635,7 +1635,7 @@ mappings:
               'yarramate-repository#likec4-project-definition-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/21/kind',
-            line: 94,
+            line: 95,
             column: 11,
           },
           {
@@ -1647,7 +1647,7 @@ mappings:
               'yarramate-repository#likec4-project-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/48/kind',
-            line: 207,
+            line: 208,
             column: 11,
           },
           {
@@ -1659,7 +1659,7 @@ mappings:
               'yarramate-repository#likec4-generated-project-v2-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/49/kind',
-            line: 211,
+            line: 212,
             column: 11,
           },
         ],


### PR DESCRIPTION
## Summary

- Adds a research draft of `yarramate/question-catalogue/v1` under `docs/research/question-catalogue/`: a versioned, opinionated catalogue of enrichment questions where every question binds a deterministic trigger over compiled graph v2, a materiality rationale, and an escalation authority (`evidence` / `human` / `either`). Includes the `core-enrichment@0.1` seed catalogue (13 questions in motivation, business, and hygiene waves) and a reference evaluator. Nothing is wired into the compiler, CLI, or package exports.
- Runs the first catalogue-driven enrichment session on the repository self-model, closing the motivation and business waves (70 → 39 open questions): declares agent-harness and adopting-team actors, architecture-drift and trustworthy-agent-context drivers, a repository-stewardship function assigned to maintainers, ownership for all commands/capabilities/the LikeC4 prototype, serving edges from the CLI commands to the agent-harness consumer, and a realization of the shared-architecture-context goal.
- Subject-mapping sync back-fills 254 previously unmapped LikeC4 entries (most of the diff by volume).
- Ignores `graphify-out/` generated output.

## Notes for review

- Human decisions in the session (stakeholders, ownership batch, consumer-modeling direction, stewardship function) were made interactively and land here as reviewable intent; accepting this PR is the Git acceptance step of ADR 0030's lifecycle.
- Dogfooding surfaced two catalogue trigger refinements (`isolated` participation semantics, `information-unaccessed` too narrow for schema dataObjects) — recorded as open decisions in the draft README rather than patched silently.
- Remaining open questions (34 undescribed concepts, 5 schema residuals) are deliberately deferred to a follow-up session.

## Validation

- `yarramate check` ✅ (171 concepts, 207 relationships, 4 documents)
- `yarramate-likec4 check` ✅, project re-exported
- `yarramate reconcile` ✅ 47/47 observations confirmed, 0 contradicted
- Catalogue validates against the draft schema; evaluator re-run confirms 70 → 39

🤖 Generated with [Claude Code](https://claude.com/claude-code)