### PR TITLE
Diagnostics carry repair information

### DIFF
--- a/docs/adr/0039-diagnostics-carry-repair-information.md
+++ b/docs/adr/0039-diagnostics-carry-repair-information.md
@@ -1,0 +1,20 @@
+# Diagnostics carry repair information
+
+Status: accepted
+
+Source-located diagnostics already say where input is wrong. They now also
+say what would make it right, because the dominant consumer loop — an agent
+or person editing until `check` passes — pays one full round-trip for every
+fact a message withholds.
+
+Schema violations name the expected value: a `const` mismatch states the
+constant, and an `enum` mismatch lists the allowed values (capped at eight).
+Unknown concept and relationship kinds suggest the closest declared kind in
+the selected profile by edit distance, with a deterministic tie-break so
+diagnostic output stays reproducible. No new diagnostic codes are
+introduced, severities and locations are unchanged, and messages remain
+plain text within the existing check-result and diagnostic-result
+contracts.
+
+Suggestions are repair hints, never corrections: the compiler still rejects
+the input, and nothing is auto-fixed.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4,6 +4,10 @@ import {
   conceptKinds,
   relationshipPolicies,
 } from './profile.js'
+import {
+  closestCandidate,
+  describeSchemaViolation,
+} from './source-document.js'
 import documentSchema from '../schema/yarramate-document.schema.json' with {
   type: 'json',
 }
@@ -295,7 +299,7 @@ function compileWorkspaceResolved(
           code: 'YM201',
           message: property
             ? `Property "${property}" is not allowed`
-            : `Profile schema violation: ${error.message ?? error.keyword}`,
+            : `Profile schema violation: ${describeSchemaViolation(error)}`,
           path: input.path,
           pointer,
           line: position.line,
@@ -543,7 +547,7 @@ function compileWorkspaceResolved(
                 code: 'YM201',
                 message: property
                   ? `Property "${property}" is not allowed`
-                  : `Document schema violation: ${error.message ?? error.keyword}`,
+                  : `Document schema violation: ${describeSchemaViolation(error)}`,
                 path: input.path,
                 pointer,
                 line: source.line,
@@ -808,7 +812,15 @@ function compileWorkspaceResolved(
         diagnostics.push({
           severity: 'error',
           code: 'YM401',
-          message: `Unknown concept kind "${concept.kind}" in profile "${value.profile}"`,
+          message: `Unknown concept kind "${concept.kind}" in profile "${value.profile}"${(() => {
+            const suggestion = closestCandidate(
+              concept.kind,
+              selectedProfile.conceptKinds.keys(),
+            )
+            return suggestion === undefined
+              ? ''
+              : `; did you mean "${suggestion}"?`
+          })()}`,
           path: input.path,
           pointer,
           line: source.line,
@@ -1082,7 +1094,15 @@ function compileWorkspaceResolved(
         diagnostics.push({
           severity: 'error',
           code: 'YM402',
-          message: `Unknown relationship kind "${relationship.kind}" in profile "${value.profile}"`,
+          message: `Unknown relationship kind "${relationship.kind}" in profile "${value.profile}"${(() => {
+            const suggestion = closestCandidate(
+              relationship.kind,
+              selectedProfile.relationshipKinds.keys(),
+            )
+            return suggestion === undefined
+              ? ''
+              : `; did you mean "${suggestion}"?`
+          })()}`,
           path: input.path,
           pointer,
           line: source.line,

--- a/src/source-document.ts
+++ b/src/source-document.ts
@@ -1,4 +1,4 @@
-import type { ValidateFunction } from 'ajv'
+import type { ErrorObject, ValidateFunction } from 'ajv'
 import { LineCounter, parseDocument } from 'yaml'
 import type {
   Diagnostic,
@@ -28,6 +28,68 @@ export const diagnosticOrder = (left: Diagnostic, right: Diagnostic) =>
   left.column - right.column ||
   left.code.localeCompare(right.code) ||
   left.message.localeCompare(right.message)
+
+export const describeSchemaViolation = (
+  error: Pick<ErrorObject, 'keyword' | 'message' | 'params'>,
+): string => {
+  const base = error.message ?? error.keyword
+  if (error.keyword === 'const') {
+    return `${base}: expected ${JSON.stringify(error.params.allowedValue)}`
+  }
+  if (
+    error.keyword === 'enum' &&
+    Array.isArray(error.params.allowedValues)
+  ) {
+    const allowed = error.params.allowedValues as readonly unknown[]
+    const shown = allowed
+      .slice(0, 8)
+      .map((value) => JSON.stringify(value))
+      .join(', ')
+    return `${base}: ${shown}${allowed.length > 8 ? ', …' : ''}`
+  }
+  return base
+}
+
+const editDistance = (left: string, right: string): number => {
+  const previous = Array.from(
+    { length: right.length + 1 },
+    (_, index) => index,
+  )
+  for (let i = 1; i <= left.length; i += 1) {
+    let diagonal = previous[0]!
+    previous[0] = i
+    for (let j = 1; j <= right.length; j += 1) {
+      const above = previous[j]!
+      previous[j] = Math.min(
+        above + 1,
+        previous[j - 1]! + 1,
+        diagonal + (left[i - 1] === right[j - 1] ? 0 : 1),
+      )
+      diagonal = above
+    }
+  }
+  return previous[right.length]!
+}
+
+export const closestCandidate = (
+  value: string,
+  candidates: Iterable<string>,
+): string | undefined => {
+  const threshold = Math.max(2, Math.floor(value.length / 4))
+  let best: string | undefined
+  let bestDistance = threshold + 1
+  for (const candidate of [...candidates].sort()) {
+    const distance = editDistance(
+      value.toLowerCase(),
+      candidate.toLowerCase(),
+    )
+    if (distance < bestDistance) {
+      best = candidate
+      bestDistance = distance
+    }
+  }
+  return best
+}
 
 export function locateSourcePath(
   sourcePath: string,
@@ -109,7 +171,7 @@ export function loadSourceDocument<T>(
             code: 'YM201',
             message: property
               ? `Property "${property}" is not allowed`
-              : `${schemaLabel} schema violation: ${error.message ?? error.keyword}`,
+              : `${schemaLabel} schema violation: ${describeSchemaViolation(error)}`,
             ...location,
           }
         })

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -1466,7 +1466,8 @@ relationships:
         {
           severity: 'error',
           code: 'YM201',
-          message: 'Document schema violation: must be equal to one of the allowed values',
+          message:
+            'Document schema violation: must be equal to one of the allowed values: "planned", "current", "retired"',
           path: 'invalid-lifecycle.yaml',
           pointer: '/concepts/0/status',
           line: 8,

--- a/test/diagnostic-repair.test.ts
+++ b/test/diagnostic-repair.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { compileWorkspace } from '../src/compiler.js'
+
+const document = (body: string) => ({
+  path: 'architecture/example.yaml',
+  source: body,
+})
+
+const messagesOf = (sources: readonly { path: string; source: string }[]) => {
+  const result = compileWorkspace(sources)
+  expect(result.ok).toBe(false)
+  return result.ok ? [] : result.diagnostics.map(({ message }) => message)
+}
+
+describe('repair-oriented diagnostics', () => {
+  it('suggests the closest concept kind for a near miss', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: a\n    kind: applicationServic\n    name: A\nrelationships: []\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Unknown concept kind "applicationServic" in profile "yarramate/core@0.1"; did you mean "applicationService"?',
+    )
+  })
+
+  it('suggests the closest relationship kind for a near miss', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: a\n    kind: applicationService\n    name: A\nrelationships:\n  - id: r\n    kind: servin\n    from: a\n    to: a\n',
+      ),
+    ])
+    expect(
+      messages.some((message) =>
+        message.includes('did you mean "serving"?'),
+      ),
+    ).toBe(true)
+  })
+
+  it('offers no suggestion when nothing is close', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: a\n    kind: zzzzzzzzzz\n    name: A\nrelationships: []\n',
+      ),
+    ])
+    const unknown = messages.find((message) =>
+      message.startsWith('Unknown concept kind "zzzzzzzzzz"'),
+    )
+    expect(unknown).toBeDefined()
+    expect(unknown).not.toContain('did you mean')
+  })
+
+  it('names the expected constant on format violations', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/document/v9\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: a\n    kind: applicationService\n    name: A\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Document schema violation: must be equal to constant: expected "yarramate/v1"',
+    )
+  })
+
+  it('lists the allowed values on enum violations', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: a\n    kind: applicationService\n    name: A\n    status: activ\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Document schema violation: must be equal to one of the allowed values: "planned", "current", "retired"',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- `const` schema violations now name the expected constant (`must be equal to constant: expected "yarramate/v1"`), and `enum` violations list the allowed values (capped at eight).
- Unknown concept kinds (YM401) and relationship kinds (YM402) suggest the closest declared kind in the selected profile by edit distance — `"applicationServic"` → `did you mean "applicationService"?` — with a deterministic tie-break so diagnostic ordering stays reproducible.
- No new diagnostic codes; severities, locations, and the check-result / diagnostic-result contracts are unchanged. Suggestions are repair hints, never corrections — nothing is auto-fixed. ADR 0039.

## Motivation

Agent-experience backlog item: an empirically-measured self-repair loop on a broken document took 3 round-trips because messages withheld the expected constant and offered no near-miss suggestion. Each fact a message withholds costs every consumer a full edit-check round-trip.

## Validation

- `pnpm run verify` ✅ — 204 tests across 20 files
- New `test/diagnostic-repair.test.ts`: near-miss suggestions for concept and relationship kinds, no-suggestion behavior when nothing is close, expected-constant and allowed-values rendering
- One existing exact-message expectation updated for the richer enum message

🤖 Generated with [Claude Code](https://claude.com/claude-code)