### PR TITLE
init declares the model to agent harnesses via AGENTS.md

### DIFF
--- a/docs/adr/0040-init-declares-the-model-to-agent-harnesses.md
+++ b/docs/adr/0040-init-declares-the-model-to-agent-harnesses.md
@@ -1,0 +1,20 @@
+# Init declares the model to agent harnesses
+
+Status: accepted
+
+A canonical model that harnesses never discover is never consulted, and the
+difference between a model used every session and one used never is usually
+a single missing pointer.
+
+`yarramate init` therefore writes an `AGENTS.md` section at the workspace
+root declaring that `.yarramate/` holds the canonical architecture, that
+the model is authoritative over prose when they disagree, and which
+commands orient, validate, and provide bounded context. `AGENTS.md` is the
+emerging cross-harness convention and is read by the major coding agents;
+YarraMate does not write harness-specific files.
+
+The write follows the same safety rules as the rest of init: a missing
+`AGENTS.md` is created containing only the section, an existing file is
+appended to exactly once (keyed on the section heading), and a file that
+already declares the section is left untouched. Init still refuses to touch
+an existing `.yarramate/`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -366,9 +366,42 @@ const runInit = (options: readonly string[], cwd: string): CliResult => {
       'evidence: []\n',
     'utf8',
   )
+  const agentsPath = resolve(workspaceRoot, 'AGENTS.md')
+  const displayAgentsPath = relative(cwd, agentsPath)
+  const agentsMarker = '## YarraMate architecture'
+  const agentsBlock =
+    `${agentsMarker}\n` +
+    '\n' +
+    'This repository declares its architecture as canonical, versioned\n' +
+    'YarraMate documents in `.yarramate/`. When prose documentation and the\n' +
+    'model disagree, the model is authoritative.\n' +
+    '\n' +
+    '- Orient first: `yarramate status .yarramate/workspace.yaml --json`\n' +
+    '- Validate changes: `yarramate check .yarramate/workspace.yaml --json`\n' +
+    '- Bounded task context: `yarramate context <projection.yaml> .yarramate/workspace.yaml`\n' +
+    '\n' +
+    'Author native documents only; never edit generated output.\n'
+  let agentsNote: string
+  if (!existsSync(agentsPath)) {
+    writeFileSync(agentsPath, agentsBlock, 'utf8')
+    agentsNote = `Created ${displayAgentsPath} with the YarraMate pointer\n`
+  } else {
+    const existingAgents = readFileSync(agentsPath, 'utf8')
+    if (existingAgents.includes(agentsMarker)) {
+      agentsNote = `${displayAgentsPath} already declares the YarraMate pointer\n`
+    } else {
+      writeFileSync(
+        agentsPath,
+        `${existingAgents.replace(/\n*$/, '\n\n')}${agentsBlock}`,
+        'utf8',
+      )
+      agentsNote = `Extended ${displayAgentsPath} with the YarraMate pointer\n`
+    }
+  }
   return {
     exitCode: 0,
-    stdout: `Created ${displayPath} and ${displayManifestPath}\n`,
+    stdout:
+      `Created ${displayPath} and ${displayManifestPath}\n` + agentsNote,
     stderr: '',
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -476,9 +476,13 @@ describe('YarraMate CLI', () => {
       expect(created).toEqual({
         exitCode: 0,
         stdout:
-          'Created .yarramate/architecture/main.yaml and .yarramate/workspace.yaml\n',
+          'Created .yarramate/architecture/main.yaml and .yarramate/workspace.yaml\n' +
+          'Created AGENTS.md with the YarraMate pointer\n',
         stderr: '',
       })
+      expect(readFileSync(join(directory, 'AGENTS.md'), 'utf8')).toContain(
+        '## YarraMate architecture',
+      )
       expect(
         readFileSync(join(directory, '.yarramate/architecture/main.yaml'), 'utf8'),
       ).toBe(
@@ -508,6 +512,40 @@ describe('YarraMate CLI', () => {
         stderr:
           '.yarramate/architecture/main.yaml and .yarramate/workspace.yaml already exist; nothing was changed\n',
       })
+    } finally {
+      rmSync(directory, { recursive: true })
+    }
+  })
+
+  it('extends an existing AGENTS.md once and never duplicates the pointer', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'yarramate-agents-'))
+    try {
+      writeFileSync(
+        join(directory, 'AGENTS.md'),
+        '# Project agents guide\n\nExisting instructions.\n',
+      )
+
+      const created = runCli(['init', '.'], directory)
+      expect(created.exitCode).toBe(0)
+      expect(created.stdout).toContain(
+        'Extended AGENTS.md with the YarraMate pointer',
+      )
+      const extended = readFileSync(join(directory, 'AGENTS.md'), 'utf8')
+      expect(extended.startsWith('# Project agents guide\n')).toBe(true)
+      expect(extended).toContain('Existing instructions.')
+      expect(extended).toContain('## YarraMate architecture')
+
+      rmSync(join(directory, '.yarramate'), { recursive: true })
+      const again = runCli(['init', '.'], directory)
+      expect(again.exitCode).toBe(0)
+      expect(again.stdout).toContain(
+        'AGENTS.md already declares the YarraMate pointer',
+      )
+      expect(
+        readFileSync(join(directory, 'AGENTS.md'), 'utf8').match(
+          /## YarraMate architecture/g,
+        ),
+      ).toHaveLength(1)
     } finally {
       rmSync(directory, { recursive: true })
     }

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -153,7 +153,8 @@ describe('consumer package contract', () => {
         })
 
       expect(run(['init', '.'])).toBe(
-        'Created .yarramate/architecture/main.yaml and .yarramate/workspace.yaml\n',
+        'Created .yarramate/architecture/main.yaml and .yarramate/workspace.yaml\n' +
+          'Created AGENTS.md with the YarraMate pointer\n',
       )
       writeFileSync(
         join(consumer, '.yarramate/architecture/main.yaml'),


### PR DESCRIPTION
## Summary

- `yarramate init` now plants the discoverability pointer that decides whether a model gets used: an `AGENTS.md` section stating that `.yarramate/` is the canonical architecture, authoritative over prose, plus the orient/validate/context commands.
- Safety mirrors the rest of init: create when missing, append exactly once when present (keyed on the `## YarraMate architecture` heading), never touch a file that already declares the section, and still refuse to touch an existing `.yarramate/`.
- `AGENTS.md` is the cross-harness convention read by the major coding agents; no harness-specific files are written. ADR 0040.

## Note

The pointer references `yarramate status`, which lands in #35 — merge that first (or together).

## Validation

- `pnpm run verify` ✅ — 205 tests across 20 files
- New test: extends an existing AGENTS.md preserving content, and never duplicates the pointer on re-init

🤖 Generated with [Claude Code](https://claude.com/claude-code)