### PR TITLE
Composite GitHub Action: architecture drift signal on PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,123 @@
+name: 'YarraMate architecture drift'
+description: >-
+  Check a YarraMate workspace and report intent-vs-evidence drift.
+  Fails on correctness errors and, by default, on contradicted claims.
+branding:
+  icon: 'layers'
+  color: 'blue'
+inputs:
+  workspace:
+    description: 'Path to the explicit workspace manifest'
+    required: false
+    default: '.yarramate/workspace.yaml'
+  version:
+    description: 'yarramate npm version to run'
+    required: false
+    default: 'latest'
+  fail-on-contradiction:
+    description: 'Fail when reconciliation reports contradicted claims'
+    required: false
+    default: 'true'
+outputs:
+  check-ok:
+    description: 'true when yarramate check passed'
+    value: ${{ steps.drift.outputs.check-ok }}
+  contradicted:
+    description: 'Count of contradicted claims from reconciliation'
+    value: ${{ steps.drift.outputs.contradicted }}
+  unknown:
+    description: 'Count of unknown observations from reconciliation'
+    value: ${{ steps.drift.outputs.unknown }}
+  not-observed:
+    description: 'Count of not-observed claims from reconciliation'
+    value: ${{ steps.drift.outputs.not-observed }}
+  findings:
+    description: 'Total reconciliation findings'
+    value: ${{ steps.drift.outputs.findings }}
+runs:
+  using: 'composite'
+  steps:
+    - id: drift
+      shell: bash
+      env:
+        WORKSPACE: ${{ inputs.workspace }}
+        VERSION: ${{ inputs.version }}
+        FAIL_ON_CONTRADICTION: ${{ inputs.fail-on-contradiction }}
+      run: |
+        set -uo pipefail
+
+        summary() { printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"; }
+        output() { printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"; }
+
+        summary '## YarraMate architecture drift'
+        summary ''
+
+        CHECK_JSON=$(npx --yes "yarramate@${VERSION}" check "$WORKSPACE" --json)
+        if [ -z "$CHECK_JSON" ]; then
+          summary "❌ \`yarramate check\` produced no output for \`${WORKSPACE}\` (missing workspace or invocation error)."
+          output 'check-ok' 'false'
+          output 'contradicted' '0'
+          output 'unknown' '0'
+          output 'not-observed' '0'
+          output 'findings' '0'
+          exit 1
+        fi
+        CHECK_OK=$(printf '%s' "$CHECK_JSON" | jq -r '.ok // false')
+        output 'check-ok' "$CHECK_OK"
+
+        if [ "$CHECK_OK" != 'true' ]; then
+          summary '❌ `yarramate check` failed:'
+          summary ''
+          summary '```'
+          printf '%s' "$CHECK_JSON" \
+            | jq -r '.diagnostics[]? | "\(.path):\(.line):\(.column) \(.code) \(.message)"' \
+            >> "$GITHUB_STEP_SUMMARY"
+          summary '```'
+          output 'contradicted' '0'
+          output 'unknown' '0'
+          output 'not-observed' '0'
+          output 'findings' '0'
+          exit 1
+        fi
+
+        COUNTED=$(printf '%s' "$CHECK_JSON" | jq -r \
+          '"\(.counted.concepts) concepts, \(.counted.relationships) relationships, \(.counted.states) states, \(.counted.documents) documents"')
+        summary "✅ Check passed: ${COUNTED}"
+
+        RECONCILE_JSON=$(npx --yes "yarramate@${VERSION}" reconcile "$WORKSPACE")
+        RECONCILE_EXIT=$?
+        if [ "$RECONCILE_EXIT" -ne 0 ]; then
+          summary ''
+          summary '❌ `yarramate reconcile` failed after a passing check.'
+          exit 1
+        fi
+
+        CONTRADICTED=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.contradicted // 0')
+        UNKNOWN=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.unknown // 0')
+        NOT_OBSERVED=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.notObserved // 0')
+        FINDINGS=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.findings // 0')
+        OBSERVATIONS=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.observations // 0')
+        CONFIRMED=$(printf '%s' "$RECONCILE_JSON" | jq -r '.summary.confirmed // 0')
+        output 'contradicted' "$CONTRADICTED"
+        output 'unknown' "$UNKNOWN"
+        output 'not-observed' "$NOT_OBSERVED"
+        output 'findings' "$FINDINGS"
+
+        summary ''
+        if [ "$FINDINGS" -eq 0 ]; then
+          summary "✅ Reconciliation: ${OBSERVATIONS} observations, ${CONFIRMED} confirmed, no findings"
+        else
+          summary "⚠️ Reconciliation: ${OBSERVATIONS} observations, ${CONFIRMED} confirmed, ${FINDINGS} findings (${CONTRADICTED} contradicted, ${UNKNOWN} unknown, ${NOT_OBSERVED} not observed)"
+          summary ''
+          summary '| Result | Target | Provider | Evidence document |'
+          summary '| --- | --- | --- | --- |'
+          printf '%s' "$RECONCILE_JSON" \
+            | jq -r '.findings[] | "| \(.result) | `\(.target.id)` | \(.provider) | \(.evidenceDocument) |"' \
+            >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        if [ "$FAIL_ON_CONTRADICTION" = 'true' ] && [ "$CONTRADICTED" -gt 0 ]; then
+          summary ''
+          summary '❌ Failing: declared architecture is contradicted by evidence.'
+          exit 1
+        fi

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -143,3 +143,31 @@ yarramate-graphify observe \
 Graphify extraction remains a separate installation and operation. The
 adapter observes only explicitly mapped nodes and never promotes them into
 canonical architecture.
+
+## Continuous drift signal in CI
+
+The repository root ships a composite GitHub Action that checks the
+workspace and reports intent-vs-evidence drift on every pull request:
+
+```yaml
+name: architecture
+on: pull_request
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: yarrasys/yarramate@main
+        with:
+          workspace: .yarramate/workspace.yaml
+```
+
+The job fails on deterministic correctness errors and, by default, when
+reconciliation reports contradicted claims; unknown and not-observed
+findings are reported in the job summary without failing. Set
+`fail-on-contradiction: 'false'` to make the whole signal advisory. The
+action never mutates sources — it runs only the read-only `check` and
+`reconcile` commands, so it is safe as a required check.


### PR DESCRIPTION
## Summary

- Adds a root `action.yml` so consumers can write `uses: yarrasys/yarramate@<ref>`: it runs the read-only `check` and `reconcile` commands against a workspace, writes a job summary (counts + findings table), exposes `check-ok` / `contradicted` / `unknown` / `not-observed` / `findings` as outputs, and fails on correctness errors and — by default — contradicted claims (`fail-on-contradiction: 'false'` makes it advisory).
- Never mutates sources, so it is safe as a required check; unknown/not-observed findings report without failing, matching the reconciliation philosophy (findings without remediation, ADR 0032).
- Usage documented in `docs/CONSUMING-YARRAMATE.md`.

This is the retention play from the adoption backlog: a model CI keeps honest is a model agents can trust.

## Validation

- `pnpm run verify` ✅ (action is not part of the npm pack surface — `files` whitelist unchanged)
- action.yml parses; embedded bash lints clean (`bash -n`); every jq extraction path exercised against real `check --json` and `reconcile` output from the self-model
- Not exercised on a live runner in this PR — recommend a follow-up smoke run once merged (e.g. a manual workflow_dispatch using `uses: ./`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)