### PR TITLE
Enrichment session 2: hygiene wave closed, catalogue 0.2

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -267,53 +267,75 @@ concepts:
     presentIn:
       - yarramate-evolution#state-foundation
       - yarramate-evolution#core-contract-foundation
+  - id: likec4-check-result
+    kind: dataObject
+    name: LikeC4 adapter check result
+    description: Versioned machine-readable verdict of the bundled adapter path check.
+    status: current
+  - id: likec4-diagnostic-result
+    kind: dataObject
+    name: LikeC4 adapter diagnostic result
+    description: Machine-readable failure payload shared by LikeC4 adapter commands.
+    status: current
   - id: native-document
     kind: dataObject
     name: Native YAML document
+    description: Canonical authored YAML declaring concepts, relationships, and states under one selected profile.
     status: current
   - id: document-schema
     kind: dataObject
     name: Native document JSON Schema
+    description: Normative structure for native yarramate/v1 documents; vocabulary validity belongs to the selected profile.
     status: current
   - id: kind-catalogue
     kind: dataObject
     name: Concept kind catalogue
+    description: Resolved concept kinds with aspects and lineage available to a compilation.
     status: current
   - id: relationship-policy-catalogue
     kind: dataObject
     name: Relationship policy catalogue
+    description: Resolved relationship kinds with endpoint aspect constraints available to a compilation.
     status: current
   - id: semantic-graph
     kind: dataObject
     name: Tool-neutral semantic graph
+    description: Claim-centred tool-neutral compilation output; every fact is a sourced claim.
     status: current
   - id: diagnostics
     kind: dataObject
     name: Source-located diagnostics
+    description: Deterministic source-located errors pointing at authored input; never advice or taste.
     status: current
   - id: check-result
     kind: dataObject
     name: Machine-readable check result
+    description: Versioned machine-readable verdict of a check run, consumed by CI and agent harnesses.
     status: current
   - id: check-result-schema
     kind: dataObject
     name: Check result JSON Schema
+    description: Normative structure for the yarramate/check-result/v1 contract.
     status: current
   - id: diagnostic-result
     kind: dataObject
     name: Semantic command diagnostic result
+    description: Shared machine-readable failure payload emitted by semantic commands that cannot produce their primary output.
     status: current
   - id: diagnostic-result-schema
     kind: dataObject
     name: Diagnostic result JSON Schema
+    description: Normative structure for the yarramate/diagnostic-result/v1 contract.
     status: current
   - id: likec4-diagnostic-result-schema
     kind: dataObject
     name: LikeC4 diagnostic result JSON Schema
+    description: Normative structure for LikeC4 adapter failure payloads.
     status: current
   - id: likec4-generated-project-schema
     kind: dataObject
     name: Generated LikeC4 project marker JSON Schema
+    description: Normative marker structure guarding single-view generated LikeC4 projects.
     status: current
   - id: likec4-project-definition
     kind: dataObject
@@ -323,10 +345,12 @@ concepts:
   - id: likec4-project-schema
     kind: dataObject
     name: LikeC4 project definition JSON Schema
+    description: Normative structure for LikeC4 project definitions composing projections as views.
     status: current
   - id: likec4-generated-project-v2-schema
     kind: dataObject
     name: Multi-view generated LikeC4 project marker JSON Schema
+    description: Normative marker structure guarding multi-view generated LikeC4 projects.
     status: current
   - id: likec4-kind-mapping
     kind: dataObject
@@ -336,10 +360,12 @@ concepts:
   - id: likec4-kind-mapping-schema
     kind: dataObject
     name: LikeC4 kind mapping JSON Schema
+    description: Normative structure for explicit LikeC4 kind compatibility declarations.
     status: current
   - id: likec4-check-result-schema
     kind: dataObject
     name: LikeC4 check result JSON Schema
+    description: Normative structure for the LikeC4 adapter check verdict.
     status: current
   - id: adapter-mapping
     kind: dataObject
@@ -349,26 +375,32 @@ concepts:
   - id: adapter-mapping-schema
     kind: dataObject
     name: Adapter mapping JSON Schema
+    description: Normative structure for optional adapter subject mappings; it does not admit adapter fields into native documents.
     status: current
   - id: semantic-graph-schema
     kind: dataObject
     name: Semantic graph v2 JSON Schema
+    description: Normative structure for the yarramate/graph/v2 interchange contract.
     status: current
   - id: projection-definition
     kind: dataObject
     name: Semantic projection definition
+    description: Portable selector describing one bounded semantic slice; presentation only, never new semantics.
     status: current
   - id: projection-schema
     kind: dataObject
     name: Projection definition JSON Schema
+    description: Normative structure for projection definitions.
     status: current
   - id: projection-result
     kind: dataObject
     name: Deterministic projection result
+    description: Deterministic bounded context produced by evaluating a projection against the compiled graph.
     status: current
   - id: projection-result-schema
     kind: dataObject
     name: Projection result JSON Schema
+    description: Normative structure for the yarramate/projection-result/v1 contract.
     status: current
   - id: starter-view-pack
     kind: dataObject
@@ -386,6 +418,7 @@ concepts:
   - id: state-comparison-schema
     kind: dataObject
     name: Architecture-state comparison JSON Schema
+    description: Normative structure for architecture-state comparison results.
     status: current
     presentIn:
       - yarramate-evolution#state-foundation
@@ -400,32 +433,39 @@ concepts:
   - id: core-contract-schema
     kind: dataObject
     name: Core contract JSON Schema
+    description: Normative structure for Core release contract manifests.
     status: current
     presentIn:
       - yarramate-evolution#core-contract-foundation
   - id: workspace-manifest
     kind: dataObject
     name: Workspace manifest
+    description: Explicit versioned declaration of every workspace input; nothing is discovered implicitly.
     status: current
   - id: workspace-schema
     kind: dataObject
     name: Workspace manifest JSON Schema
+    description: Normative structure for workspace manifests.
     status: current
   - id: evidence-document
     kind: dataObject
     name: Evidence overlay document
+    description: Provider observations about existing subjects and claims; evidence supports or challenges intent and never authors it.
     status: current
   - id: evidence-report
     kind: dataObject
     name: Deterministic evidence report
+    description: Deterministic evaluation of one evidence document against the compiled graph.
     status: current
   - id: evidence-schema
     kind: dataObject
     name: Evidence overlay JSON Schema
+    description: Normative structure for evidence overlay documents.
     status: current
   - id: evidence-report-schema
     kind: dataObject
     name: Evidence report JSON Schema
+    description: Normative structure for the yarramate/evidence-report/v1 contract.
     status: current
   - id: reconciliation-report
     kind: dataObject
@@ -435,6 +475,7 @@ concepts:
   - id: reconciliation-report-schema
     kind: dataObject
     name: Reconciliation report JSON Schema
+    description: Normative structure for workspace reconciliation reports.
     status: current
 relationships:
   - id: core-contract-checker-loads-contract
@@ -910,3 +951,26 @@ relationships:
     kind: realization
     from: projection-result-schema
     to: projection-result
+  - id: likec4-check-result-schema-describes-result
+    kind: realization
+    from: likec4-check-result-schema
+    to: likec4-check-result
+  - id: likec4-diagnostic-result-schema-describes-result
+    kind: realization
+    from: likec4-diagnostic-result-schema
+    to: likec4-diagnostic-result
+  - id: likec4-check-writes-result
+    kind: access
+    from: likec4-check-command
+    to: likec4-check-result
+    mode: write
+  - id: likec4-check-writes-diagnostics
+    kind: access
+    from: likec4-check-command
+    to: likec4-diagnostic-result
+    mode: write
+  - id: likec4-export-writes-diagnostics
+    kind: access
+    from: likec4-export-command
+    to: likec4-diagnostic-result
+    mode: write

--- a/.yarramate/architecture/product.yaml
+++ b/.yarramate/architecture/product.yaml
@@ -60,16 +60,19 @@ concepts:
   - id: compile-native-architecture
     kind: capability
     name: Compile native architecture
+    description: Turn declared native documents into the deterministic tool-neutral semantic graph.
     owner: yarramate-maintainers
     status: current
   - id: validate-native-architecture
     kind: capability
     name: Validate native architecture
+    description: Check deterministic correctness of declared architecture; never completeness or taste.
     owner: yarramate-maintainers
     status: current
   - id: provide-machine-context
     kind: capability
     name: Provide machine-readable context
+    description: Serve bounded, verifiable slices of declared architecture to people, CI, and agent harnesses.
     owner: yarramate-maintainers
     status: current
   - id: evaluate-architecture-evidence

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1149,3 +1149,24 @@ mappings:
   - native: yarramate-repository#workspace-tests-validate-resolution
     external: workspaceTestsValidateResolution
     type: relationship
+  - native: yarramate-engine#likec4-check-result
+    external: likec4CheckResult
+    type: concept
+  - native: yarramate-engine#likec4-check-result-schema-describes-result
+    external: likec4CheckResultSchemaDescribesResult
+    type: relationship
+  - native: yarramate-engine#likec4-check-writes-diagnostics
+    external: likec4CheckWritesDiagnostics
+    type: relationship
+  - native: yarramate-engine#likec4-check-writes-result
+    external: likec4CheckWritesResult
+    type: relationship
+  - native: yarramate-engine#likec4-diagnostic-result
+    external: likec4DiagnosticResult
+    type: concept
+  - native: yarramate-engine#likec4-diagnostic-result-schema-describes-result
+    external: likec4DiagnosticResultSchemaDescribesResult
+    type: relationship
+  - native: yarramate-engine#likec4-export-writes-diagnostics
+    external: likec4ExportWritesDiagnostics
+    type: relationship

--- a/docs/research/question-catalogue/README.md
+++ b/docs/research/question-catalogue/README.md
@@ -61,6 +61,13 @@ undescribed concepts, one unrealized goal (Shared architecture context), and
 no stakeholder/driver concepts at all. The findings are plausible on sight,
 which is the point: the triggers find real gaps without an LLM in the loop.
 
+Two interview sessions later (same day): **0 open questions**. Session one
+closed the motivation and business waves (70 → 39) through four interactive
+decisions and evidence-backed proposals; session two closed the hygiene wave
+(descriptions for every significant concept, two previously unmodeled LikeC4
+result objects) and shipped catalogue 0.2. Interview state was recomputed
+from the graph each session — nothing was stored between them.
+
 ## Open decisions
 
 1. **`kindMatching: descendants`** needs profile lineage; graph v2 carries
@@ -79,9 +86,10 @@ which is the point: the triggers find real gaps without an LLM in the loop.
 3a. **`information-unaccessed` is too narrow** (found while dogfooding the
    first enrichment session, 2026-07-29). Schema dataObjects legitimately
    participate through outgoing `realization` "describes" edges, not incoming
-   access; 3 of 5 residual matches were false positives of this shape. The
-   condition needs an any-relationship variant, or schema-like information
-   deserves its own question.
+   access; 3 of 5 residual matches were false positives of this shape.
+   **Resolved in catalogue 0.2**: the trigger now accepts any access or
+   realization relationship in any direction — no schema change was needed,
+   which is the versioned-catalogue mechanism working as intended.
 4. **Where catalogues live.** Options: workspace manifest entries (like
    evidence), standalone files passed to a future `yarramate interrogate`,
    or shipped with the skill. Draft assumes standalone explicit files,

--- a/docs/research/question-catalogue/core-enrichment.yaml
+++ b/docs/research/question-catalogue/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.1"
+version: "0.2"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -179,7 +179,8 @@ questions:
       - condition: missing-relationship
         kinds:
           - yarramate/core@0.1#access
-        direction: incoming
+          - yarramate/core@0.1#realization
+        direction: any
     question: >-
       Which behavior creates and maintains {subject.name}?
     materiality: >-


### PR DESCRIPTION
## Summary

- Adds evidence-grounded descriptions to all 34 previously undescribed significant concepts (31 engine data objects, 3 product capabilities) — each states meaning, several state deliberate exclusions.
- Models the two genuinely missing information subjects found in session one: LikeC4 adapter check result and diagnostic result data objects, with `describes` realizations from their schemas and write access from the commands that emit them.
- Releases catalogue **0.2**: `information-unaccessed` now triggers on the absence of any access **or** realization relationship in any direction, resolving the schema-dataObject false positives — a catalogue-data fix with no schema change, which is the versioned-catalogue mechanism working as intended.
- Research README records the outcome: **70 → 39 → 0 open questions** across two same-day sessions, with interview state recomputed from the graph each time (nothing stored).

## Validation

- `pnpm run verify` ✅ — 199 tests across 19 files (exit code checked)
- `yarramate check` ✅ 173 concepts, 212 relationships · LikeC4 check ✅ · views re-exported · mapping sync added 7 entries
- Catalogue 0.2 validates against the draft schema; evaluator reports 0 open questions on the self-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)