### PR TITLE
yarramate-mcp: read-only MCP adapter over the stable CLI

### DIFF
--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -144,6 +144,26 @@ Graphify extraction remains a separate installation and operation. The
 adapter observes only explicitly mapped nodes and never promotes them into
 canonical architecture.
 
+## MCP server for agent harnesses
+
+Harnesses that load MCP servers can connect the bundled read-only adapter:
+
+```json
+{
+  "mcpServers": {
+    "yarramate": {
+      "command": "yarramate-mcp"
+    }
+  }
+}
+```
+
+It exposes `yarramate_status`, `yarramate_check`, `yarramate_reconcile`,
+and `yarramate_context` (projection path or ad-hoc subjects, with an
+optional token budget). Every tool call executes the same stable CLI in
+the server's working directory; nothing mutates native documents, and
+authoring stays with the CLI and Git review.
+
 ## Continuous drift signal in CI
 
 The repository root ships a composite GitHub Action that checks the

--- a/docs/adr/0044-mcp-affordance-is-an-adapter-over-the-stable-cli.md
+++ b/docs/adr/0044-mcp-affordance-is-an-adapter-over-the-stable-cli.md
@@ -1,0 +1,20 @@
+# MCP affordance is an adapter over the stable CLI
+
+Status: accepted
+
+Agent harnesses discover typed tool schemas more reliably than `--help`
+text, and several load MCP servers by default. YarraMate meets them with
+`yarramate-mcp`: a dependency-free stdio server exposing read-only
+architecture context — status, check, reconcile, and bounded context
+(projection, ad-hoc subjects, token budget).
+
+The server is an adapter in exactly the sense the product contract
+requires: every tool call executes the same stable CLI surface, no
+privileged API or second semantics exists, and nothing mutates native
+documents. Like the LikeC4 and Graphify adapters it ships as a separate
+binary outside the Core release contract, and Core does not depend on it.
+
+Write operations (`add`, `connect`, `new`) stay CLI-only for now: a write
+tool changes the server's safety class from "always safe to connect" to
+"reviewed per deployment", and that step deserves its own decision once
+read-only usage proves itself.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "bin": {
     "yarramate": "dist/cli.js",
     "yarramate-likec4": "dist/adapters/likec4-cli.js",
-    "yarramate-graphify": "dist/adapters/graphify-cli.js"
+    "yarramate-graphify": "dist/adapters/graphify-cli.js",
+    "yarramate-mcp": "dist/adapters/mcp-cli.js"
   },
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/adapters/mcp-cli.ts
+++ b/src/adapters/mcp-cli.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { createInterface } from 'node:readline'
+import { isMainModule } from '../cli-support.js'
+import { runCli } from '../cli.js'
+
+interface JsonRpcRequest {
+  readonly jsonrpc: '2.0'
+  readonly id?: number | string | null
+  readonly method: string
+  readonly params?: Record<string, unknown>
+}
+
+interface ToolDefinition {
+  readonly name: string
+  readonly description: string
+  readonly inputSchema: Record<string, unknown>
+  readonly arguments: (input: Record<string, unknown>) => readonly string[]
+}
+
+const workspaceProperty = {
+  workspace: {
+    type: 'string',
+    description:
+      'Path to the explicit workspace manifest, for example .yarramate/workspace.yaml',
+  },
+} as const
+
+const tools: readonly ToolDefinition[] = [
+  {
+    name: 'yarramate_status',
+    description:
+      'One-call workspace orientation: check verdict, reconciliation summary, and a titled inventory of documents, states, projections, evidence, and contracts.',
+    inputSchema: {
+      type: 'object',
+      required: ['workspace'],
+      properties: workspaceProperty,
+    },
+    arguments: (input) => ['status', String(input.workspace), '--json'],
+  },
+  {
+    name: 'yarramate_check',
+    description:
+      'Deterministic correctness check of a workspace; returns the machine-readable check result. Never a quality or completeness judgement.',
+    inputSchema: {
+      type: 'object',
+      required: ['workspace'],
+      properties: workspaceProperty,
+    },
+    arguments: (input) => ['check', String(input.workspace), '--json'],
+  },
+  {
+    name: 'yarramate_reconcile',
+    description:
+      'Compare declared architecture with evaluated evidence; returns the reconciliation report with contradicted, unknown, and not-observed findings.',
+    inputSchema: {
+      type: 'object',
+      required: ['workspace'],
+      properties: workspaceProperty,
+    },
+    arguments: (input) => ['reconcile', String(input.workspace)],
+  },
+  {
+    name: 'yarramate_context',
+    description:
+      'Bounded architecture context. Provide either a projection path or one or more globally qualified subjects (document-id#local-id) for an ad-hoc connected neighbourhood. Optional token budget switches to a compact ranked rendering.',
+    inputSchema: {
+      type: 'object',
+      required: ['workspace'],
+      properties: {
+        ...workspaceProperty,
+        projection: {
+          type: 'string',
+          description: 'Path to an authored projection definition',
+        },
+        subjects: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Globally qualified subject identities for ad-hoc context',
+        },
+        budget: {
+          type: 'integer',
+          minimum: 1,
+          description:
+            'Approximate token budget for the compact rendering',
+        },
+      },
+    },
+    arguments: (input) => {
+      const budget =
+        typeof input.budget === 'number'
+          ? ['--budget', String(input.budget)]
+          : []
+      if (typeof input.projection === 'string') {
+        return [
+          'context',
+          input.projection,
+          String(input.workspace),
+          ...budget,
+        ]
+      }
+      const subjects = Array.isArray(input.subjects)
+        ? input.subjects.flatMap((subject) => [
+            '--subject',
+            String(subject),
+          ])
+        : []
+      return ['context', ...subjects, String(input.workspace), ...budget]
+    },
+  },
+]
+
+const respond = (id: number | string | null, result: unknown): void => {
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`,
+  )
+}
+
+const respondError = (
+  id: number | string | null,
+  code: number,
+  message: string,
+): void => {
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } })}\n`,
+  )
+}
+
+export const handleRequest = (request: JsonRpcRequest): void => {
+  const id = request.id ?? null
+  if (request.method === 'initialize') {
+    respond(id, {
+      protocolVersion: '2025-06-18',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'yarramate', version: '0.1' },
+      instructions:
+        'Read-only architecture context for YarraMate workspaces. The native documents in the repository remain canonical; this server never mutates them.',
+    })
+    return
+  }
+  if (request.method === 'tools/list') {
+    respond(id, {
+      tools: tools.map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
+      })),
+    })
+    return
+  }
+  if (request.method === 'tools/call') {
+    const params = request.params ?? {}
+    const name = typeof params.name === 'string' ? params.name : ''
+    const tool = tools.find((candidate) => candidate.name === name)
+    if (tool === undefined) {
+      respondError(id, -32602, `Unknown tool "${name}"`)
+      return
+    }
+    const input =
+      typeof params.arguments === 'object' && params.arguments !== null
+        ? (params.arguments as Record<string, unknown>)
+        : {}
+    const result = runCli([...tool.arguments(input)], process.cwd())
+    respond(id, {
+      content: [
+        {
+          type: 'text',
+          text:
+            result.exitCode === 0
+              ? result.stdout
+              : result.stdout || result.stderr,
+        },
+      ],
+      isError: result.exitCode !== 0,
+    })
+    return
+  }
+  if (request.id !== undefined) {
+    respondError(id, -32601, `Method "${request.method}" not found`)
+  }
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  const lines = createInterface({ input: process.stdin })
+  lines.on('line', (line) => {
+    const text = line.trim()
+    if (text.length === 0) return
+    let request: JsonRpcRequest
+    try {
+      request = JSON.parse(text) as JsonRpcRequest
+    } catch {
+      respondError(null, -32700, 'Parse error')
+      return
+    }
+    try {
+      handleRequest(request)
+    } catch (error) {
+      respondError(
+        request.id ?? null,
+        -32603,
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  })
+}

--- a/test/mcp-cli.test.ts
+++ b/test/mcp-cli.test.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const exchange = (
+  requests: readonly Record<string, unknown>[],
+): readonly Record<string, unknown>[] => {
+  const stdout = execFileSync(
+    process.execPath,
+    ['dist/adapters/mcp-cli.js'],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      input: requests
+        .map((request) => `${JSON.stringify(request)}\n`)
+        .join(''),
+    },
+  )
+  return stdout
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
+describe('yarramate-mcp stdio adapter', () => {
+  it('initializes, lists read-only tools, and serves status', () => {
+    const [init, list, status] = exchange([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'yarramate_status',
+          arguments: { workspace: '.yarramate/workspace.yaml' },
+        },
+      },
+    ])
+
+    expect(init).toMatchObject({
+      result: { serverInfo: { name: 'yarramate' } },
+    })
+    const tools = (
+      list as { result: { tools: readonly { name: string }[] } }
+    ).result.tools.map(({ name }) => name)
+    expect(tools).toEqual([
+      'yarramate_status',
+      'yarramate_check',
+      'yarramate_reconcile',
+      'yarramate_context',
+    ])
+    const call = status as {
+      result: {
+        isError: boolean
+        content: readonly { text: string }[]
+      }
+    }
+    expect(call.result.isError).toBe(false)
+    expect(JSON.parse(call.result.content[0]!.text)).toMatchObject({
+      format: 'yarramate/status-result/v1',
+      workspace: 'yarramate',
+    })
+  })
+
+  it('serves budgeted ad-hoc context through the context tool', () => {
+    const [call] = exchange([
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'yarramate_context',
+          arguments: {
+            workspace: 'test/fixtures/valid/minimal.yaml',
+            subjects: ['checkout#approval-api'],
+            budget: 300,
+          },
+        },
+      },
+    ])
+
+    const result = (
+      call as {
+        result: {
+          isError: boolean
+          content: readonly { text: string }[]
+        }
+      }
+    ).result
+    expect(result.isError).toBe(false)
+    expect(result.content[0]!.text).toContain(
+      'context ad-hoc-context@0.0',
+    )
+  })
+
+  it('reports unknown tools and failed commands distinctly', () => {
+    const [unknown, failing] = exchange([
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'yarramate_delete_everything', arguments: {} },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'yarramate_check',
+          arguments: { workspace: 'does-not-exist.yaml' },
+        },
+      },
+    ])
+
+    expect(unknown).toMatchObject({
+      error: { code: -32602 },
+    })
+    expect(
+      (failing as { result: { isError: boolean } }).result.isError,
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- New adapter binary `yarramate-mcp`: a dependency-free stdio MCP server exposing four read-only typed tools — `yarramate_status`, `yarramate_check`, `yarramate_reconcile`, `yarramate_context` (authored projection or ad-hoc subjects, optional `--budget`).
- Every tool call executes the same stable CLI surface in the server's working directory — an adapter in exactly the product-contract sense: no privileged API, no second semantics, nothing mutates native documents. Ships like the LikeC4/Graphify adapter binaries, outside the Core release contract.
- Write tools (`add`/`connect`/`new`) deliberately stay CLI-only: a write tool changes the server's safety class from "always safe to connect" to "reviewed per deployment" — that step gets its own decision once read-only usage proves itself. ADR 0044; consumer guide documents harness configuration.

## Stacked

⚠️ Based on #43 (`feat/context-budget`) because the context tool's `budget` parameter needs it — merge #43 first and GitHub retargets this to main.

## Validation

- `pnpm run verify` ✅ (exit code checked) — includes new `test/mcp-cli.test.ts`: initialize/tools-list/status round-trip over real stdio, budgeted ad-hoc context, unknown-tool vs failed-command error distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)