### PR TITLE
Implement the context benchmark: suite schema, frozen task suites, runner

### DIFF
--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -1,0 +1,73 @@
+# Context benchmark (research implementation)
+
+Status: research artifact — nothing here is wired into the compiler, CLI, or
+package exports. The protocol is frozen in [DESIGN.md](DESIGN.md); this
+directory adds the task suites and the runner that make it executable.
+
+```text
+context-benchmark/
+  DESIGN.md                              # frozen protocol: hypotheses, conditions, metrics
+  yarramate-benchmark-suite.schema.json  # draft schema for yarramate/benchmark-suite/v1
+  tasks/                                 # frozen task suites, one per repository
+  runner/
+    validate-suite.mjs                   # schema + cross-checks (ids, family minimums, prompt leakage)
+    conditions.mjs                       # condition A/B/C instructions (B and C verbatim-identical)
+    inject-stale.mjs                     # condition C: deterministic contradicted-claim injection
+    run-benchmark.mjs                    # tasks x conditions matrix, workdir isolation, transcripts
+    score.mjs                            # deterministic metrics + human adjudication queue
+```
+
+## Freeze policy
+
+Task suites are frozen at merge, before any condition is run (DESIGN.md,
+"Task suite"). Editing a merged suite invalidates comparisons; add a new suite
+file instead. Ground-truth answers cite the code locations they were verified
+against — the source repository at the pinned commit is the authority, never
+the model.
+
+## Corpus
+
+Suites reference the models published in
+[yarramate-gallery](https://github.com/yarrasys/yarramate-gallery) at pinned
+source commits. `yarramate-self.yaml` is `headline: false` and reported
+separately (self-serving ground truth). ⚠️ Headline pooling wants **N ≥ 5**
+external repositories; the gallery currently provides 4 — add a fifth showcase
+before publishing pooled numbers.
+
+## Running
+
+```sh
+cd docs/research/context-benchmark
+
+# 1. validate every suite
+node runner/validate-suite.mjs yarramate-benchmark-suite.schema.json tasks/*.yaml
+
+# 2. inspect the matrix (no side effects, no cost)
+node runner/run-benchmark.mjs --suite tasks/miniflux.yaml --out /tmp/bench --dry-run
+
+# 3. live run — one suite, one condition, one capability tier (costs agent tokens)
+node runner/run-benchmark.mjs --suite tasks/miniflux.yaml \
+  --gallery ~/work/yarrasys/projects/yarramate-gallery \
+  --toolchain <dir>/node_modules/.bin \
+  --out results/2026-07-29 --conditions B --label sonnet \
+  --harness 'claude -p --output-format json --model sonnet'
+
+# 4. deterministic scoring + adjudication queue
+node runner/score.mjs --runs results/2026-07-29/runs.jsonl \
+  --suite tasks/miniflux.yaml --toolchain <dir>/node_modules/.bin
+```
+
+The harness command receives the composed prompt (condition instruction +
+frozen task text) on stdin and runs with the isolated task workdir as cwd; the
+pinned toolchain is prepended to its PATH so `yarramate` resolves to the
+benchmark version. For the H2 tier sweep, repeat step 3 with a different
+`--model`/`--label` pair. Model-maintenance tasks are skipped under condition
+A (no workspace to maintain).
+
+## What stays human
+
+Comprehension and change verdicts: `score.mjs` emits
+`adjudication-queue.jsonl` with the transcript path, ground truth or rubric,
+and the computed wrong-file edits; a human records pass/fail. Pooled deltas
+and confidence intervals are computed only after adjudication — report
+negative results with the same prominence as positive ones.

--- a/docs/research/context-benchmark/runner/conditions.mjs
+++ b/docs/research/context-benchmark/runner/conditions.mjs
@@ -1,0 +1,30 @@
+// Condition definitions for the context benchmark (DESIGN.md, "Conditions").
+// B and C share one verbatim instruction string: the agent must not be able to
+// tell a stale model from a fresh one by prompt text ("Prompt leakage" threat).
+
+const BASE = 'Work in the repository at the current directory.';
+
+const MODEL_AVAILABLE =
+  `${BASE} It contains a committed .yarramate architecture workspace; the ` +
+  'yarramate CLI is installed and can query it (status, context, check).';
+
+export const CONDITIONS = {
+  A: {
+    description: 'baseline: repository and prose docs only',
+    instruction: `${BASE} Its README and documentation are available.`,
+    model: 'none',
+    families: ['comprehension', 'change'],
+  },
+  B: {
+    description: 'yarramate: committed model + CLI available',
+    instruction: MODEL_AVAILABLE,
+    model: 'fresh',
+    families: ['comprehension', 'change', 'model-maintenance'],
+  },
+  C: {
+    description: 'stale: model with injected contradicted claims',
+    instruction: MODEL_AVAILABLE,
+    model: 'stale',
+    families: ['comprehension', 'change', 'model-maintenance'],
+  },
+};

--- a/docs/research/context-benchmark/runner/inject-stale.mjs
+++ b/docs/research/context-benchmark/runner/inject-stale.mjs
@@ -1,0 +1,152 @@
+// Condition C staleness injector: make the model lie about the code while the
+// evidence overlay records what the code actually shows, so reconciliation
+// reports the injected claims as contradicted (DESIGN.md, H3).
+//
+// Deterministic mutation: among relationship claims that carry a confirmed
+// evidence observation, pick the largest same-kind group, take the first
+// <count> with pairwise-distinct targets (sorted by claim id), rotate their
+// `to` endpoints, and flip the matching observations to "contradicted".
+// Same-kind rotation keeps endpoints existing and kind semantics legal.
+//
+// Self-verifies with the pinned CLI: check must stay green and reconcile must
+// report at least <count> contradicted claims, otherwise exits non-zero.
+//
+// Usage: node inject-stale.mjs --workspace <dir-or-workspace.yaml> --cli <yarramate-bin> [--count 3]
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const require = createRequire(join(repoRoot, 'package.json'));
+const YAML = require('yaml');
+
+const args = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+const workspaceArg = opt('workspace');
+const cli = opt('cli');
+const count = Number(opt('count', '3'));
+if (!workspaceArg || !cli) {
+  console.error('usage: inject-stale.mjs --workspace <dir-or-workspace.yaml> --cli <yarramate-bin> [--count 3]');
+  process.exit(2);
+}
+
+const workspacePath = workspaceArg.endsWith('.yaml') ? resolve(workspaceArg) : resolve(workspaceArg, 'workspace.yaml');
+const modelDir = dirname(workspacePath);
+
+const yamlFiles = [];
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) walk(path);
+    else if (entry.endsWith('.yaml')) yamlFiles.push(path);
+  }
+};
+walk(modelDir);
+
+const documents = [];
+const evidences = [];
+for (const path of yamlFiles) {
+  const parsed = YAML.parse(readFileSync(path, 'utf8'));
+  if (!parsed || typeof parsed !== 'object') continue;
+  if (parsed.format === 'yarramate/v1') documents.push({ path, parsed });
+  else if (parsed.format === 'yarramate/evidence/v1') evidences.push({ path, parsed });
+}
+if (documents.length === 0 || evidences.length === 0) {
+  console.error(`inject-stale: found ${documents.length} documents and ${evidences.length} evidence overlays under ${modelDir}; need both`);
+  process.exit(1);
+}
+
+const confirmedClaims = new Set();
+for (const { parsed } of evidences) {
+  for (const obs of parsed.observations ?? []) {
+    if (obs.result === 'confirmed' && obs.claim) confirmedClaims.add(obs.claim);
+  }
+}
+
+const candidates = [];
+for (const { path, parsed } of documents) {
+  for (const rel of parsed.relationships ?? []) {
+    const claim = `${parsed.id}#${rel.id}`;
+    if (confirmedClaims.has(claim)) candidates.push({ claim, rel, kind: rel.kind, path });
+  }
+}
+const byKind = new Map();
+for (const c of candidates) byKind.set(c.kind, [...(byKind.get(c.kind) ?? []), c]);
+const group = [...byKind.values()].sort((a, b) => b.length - a.length)[0] ?? [];
+group.sort((a, b) => a.claim.localeCompare(b.claim));
+
+const picked = [];
+const seenTargets = new Set();
+for (const c of group) {
+  if (seenTargets.has(c.rel.to)) continue;
+  seenTargets.add(c.rel.to);
+  picked.push(c);
+  if (picked.length === count) break;
+}
+if (picked.length < count) {
+  console.error(`inject-stale: needed ${count} same-kind confirmed relationship claims with distinct targets, found ${picked.length}`);
+  process.exit(1);
+}
+
+const originalTargets = picked.map((c) => c.rel.to);
+picked.forEach((c, i) => {
+  c.rel.to = originalTargets[(i + 1) % picked.length];
+});
+
+const staleClaims = new Set(picked.map((c) => c.claim));
+for (const { path, parsed } of evidences) {
+  let touched = false;
+  for (const obs of parsed.observations ?? []) {
+    if (obs.claim && staleClaims.has(obs.claim)) {
+      obs.result = 'contradicted';
+      touched = true;
+    }
+  }
+  if (touched) writeFileSync(path, YAML.stringify(parsed));
+}
+for (const { path, parsed } of documents) {
+  if (picked.some((c) => c.path === path)) writeFileSync(path, YAML.stringify(parsed));
+}
+
+// --- self-verify ------------------------------------------------------------
+const run = (bin, cmdArgs) => {
+  try {
+    return { out: execFileSync(bin, cmdArgs, { encoding: 'utf8' }), code: 0 };
+  } catch (error) {
+    return { out: `${error.stdout ?? ''}${error.stderr ?? ''}`, code: error.status ?? 1 };
+  }
+};
+
+const check = run(cli, ['check', workspacePath, '--json']);
+let checkOk = false;
+try {
+  checkOk = JSON.parse(check.out).ok === true;
+} catch {
+  checkOk = false;
+}
+if (!checkOk) {
+  console.error(`inject-stale: check no longer passes after mutation:\n${check.out}`);
+  process.exit(1);
+}
+
+const reconcile = run(cli, ['reconcile', workspacePath]);
+let contradicted = null;
+try {
+  const report = JSON.parse(reconcile.out);
+  contradicted = report.summary?.contradicted ?? report.contradicted ?? null;
+} catch {
+  const match = reconcile.out.match(/contradicted\D{0,5}(\d+)/i) ?? reconcile.out.match(/(\d+)\s+contradicted/i);
+  if (match) contradicted = Number(match[1]);
+}
+if (contradicted === null || contradicted < count) {
+  console.error(`inject-stale: expected >= ${count} contradicted claims, reconcile reported ${contradicted}:\n${reconcile.out}`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ mutated: [...staleClaims].sort(), contradicted }));

--- a/docs/research/context-benchmark/runner/run-benchmark.mjs
+++ b/docs/research/context-benchmark/runner/run-benchmark.mjs
@@ -1,0 +1,164 @@
+// Matrix runner for one benchmark suite: tasks x conditions, sequential.
+// Materializes an isolated workdir per run (pinned clone + condition-specific
+// model placement), invokes a headless agent harness with the condition
+// instruction + frozen task prompt, and appends one record per run to
+// <out>/runs.jsonl. Scoring is a separate step (score.mjs).
+//
+// Runs cost real agent tokens; nothing executes without an explicit harness
+// command, and --dry-run prints the full matrix without materializing anything.
+//
+// Usage:
+//   node run-benchmark.mjs --suite tasks/<name>.yaml --gallery <gallery-repo-dir> \
+//     --toolchain <dir with yarramate bins> --out <results-dir> \
+//     [--conditions A,B,C] [--tasks id,id] [--label tier-name] \
+//     [--harness 'claude -p --output-format json'] [--dry-run]
+//
+// The harness command receives the composed prompt on stdin and runs with the
+// task workdir as cwd. Anything printed to stdout is captured as the transcript.
+
+import { execSync, execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, rmSync, cpSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CONDITIONS } from './conditions.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..', '..', '..', '..');
+const require = createRequire(join(repoRoot, 'package.json'));
+const YAML = require('yaml');
+
+const args = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+const flag = (name) => args.includes(`--${name}`);
+
+const suitePath = opt('suite');
+const outDir = opt('out');
+if (!suitePath || !outDir) {
+  console.error('usage: run-benchmark.mjs --suite <suite.yaml> --out <dir> [--gallery <dir>] [--toolchain <bin-dir>] [--conditions A,B,C] [--tasks id,id] [--label tier] [--harness <cmd>] [--dry-run]');
+  process.exit(2);
+}
+const suite = YAML.parse(readFileSync(suitePath, 'utf8'));
+const galleryDir = opt('gallery');
+const toolchain = opt('toolchain');
+const harness = opt('harness', 'claude -p --output-format json');
+const label = opt('label', 'default');
+const conditionIds = opt('conditions', 'A,B,C').split(',');
+const onlyTasks = opt('tasks') ? new Set(opt('tasks').split(',')) : null;
+const dryRun = flag('dry-run');
+
+const modelSourceDir = () => {
+  if (suite.repository.gallery && !galleryDir) {
+    console.error('run-benchmark: suite references a gallery model; pass --gallery <local clone of the gallery repo>');
+    process.exit(2);
+  }
+  const base = suite.repository.gallery ? galleryDir : repoRoot;
+  const model = suite.repository.model;
+  return model.endsWith('.yarramate') ? join(base, model) : join(base, model, '.yarramate');
+};
+
+const matrix = [];
+for (const conditionId of conditionIds) {
+  const condition = CONDITIONS[conditionId];
+  if (!condition) {
+    console.error(`run-benchmark: unknown condition ${conditionId}`);
+    process.exit(2);
+  }
+  for (const task of suite.tasks) {
+    if (onlyTasks && !onlyTasks.has(task.id)) continue;
+    if (!condition.families.includes(task.family)) continue;
+    matrix.push({ conditionId, condition, task });
+  }
+}
+
+if (dryRun) {
+  console.log(`suite=${suite.suite} label=${label} harness=${JSON.stringify(harness)} runs=${matrix.length}`);
+  for (const { conditionId, task } of matrix) console.log(`  ${conditionId} ${task.family.padEnd(17)} ${task.id}`);
+  process.exit(0);
+}
+
+if (!toolchain) {
+  console.error('run-benchmark: --toolchain <dir with pinned yarramate bins> is required for live runs (conditions B/C verification)');
+  process.exit(2);
+}
+
+mkdirSync(outDir, { recursive: true });
+const cacheDir = join(outDir, 'cache', suite.suite);
+if (!existsSync(cacheDir)) {
+  mkdirSync(cacheDir, { recursive: true });
+  execSync('git init -q', { cwd: cacheDir });
+  execFileSync('git', ['fetch', '-q', '--depth', '1', suite.repository.source, suite.repository.commit], { cwd: cacheDir });
+  execSync('git checkout -q FETCH_HEAD', { cwd: cacheDir });
+}
+
+const runsPath = join(outDir, 'runs.jsonl');
+for (const [index, { conditionId, condition, task }] of matrix.entries()) {
+  const runDir = join(outDir, suite.suite, label, conditionId, task.id);
+  const workdir = join(runDir, 'repo');
+  rmSync(runDir, { recursive: true, force: true });
+  mkdirSync(runDir, { recursive: true });
+  cpSync(cacheDir, workdir, { recursive: true });
+
+  const workspaceDir = join(workdir, '.yarramate');
+  rmSync(workspaceDir, { recursive: true, force: true });
+  if (condition.model !== 'none') {
+    cpSync(modelSourceDir(), workspaceDir, { recursive: true });
+    if (condition.model === 'stale') {
+      const injected = execFileSync('node', [
+        join(here, 'inject-stale.mjs'),
+        '--workspace', workspaceDir,
+        '--cli', join(toolchain, 'yarramate'),
+      ], { encoding: 'utf8' });
+      writeFileSync(join(runDir, 'inject.json'), injected);
+    }
+  }
+  execSync('git add -A && git -c user.email=bench@local -c user.name=bench commit -qm baseline --allow-empty', { cwd: workdir });
+
+  const prompt = `${condition.instruction}\n\n${task.prompt}`;
+  writeFileSync(join(runDir, 'prompt.txt'), prompt);
+
+  console.log(`[${index + 1}/${matrix.length}] ${suite.suite} ${conditionId} ${task.id}`);
+  const started = Date.now();
+  const result = spawnSync('bash', ['-lc', harness], {
+    cwd: workdir,
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, PATH: `${toolchain}:${process.env.PATH}` },
+  });
+  const durationMs = Date.now() - started;
+  writeFileSync(join(runDir, 'transcript.json'), result.stdout ?? '');
+  writeFileSync(join(runDir, 'stderr.log'), result.stderr ?? '');
+
+  let metrics = null;
+  try {
+    const parsed = JSON.parse(result.stdout);
+    metrics = {
+      numTurns: parsed.num_turns ?? null,
+      inputTokens: parsed.usage?.input_tokens ?? null,
+      outputTokens: parsed.usage?.output_tokens ?? null,
+      costUsd: parsed.total_cost_usd ?? null,
+    };
+  } catch {
+    metrics = null;
+  }
+
+  appendFileSync(runsPath, `${JSON.stringify({
+    suite: suite.suite,
+    headline: suite.headline,
+    label,
+    condition: conditionId,
+    task: task.id,
+    family: task.family,
+    exitCode: result.status,
+    durationMs,
+    metrics,
+    runDir,
+    finishedAt: new Date().toISOString(),
+  })}\n`);
+}
+
+console.log(`done: ${matrix.length} runs appended to ${runsPath}`);

--- a/docs/research/context-benchmark/runner/score.mjs
+++ b/docs/research/context-benchmark/runner/score.mjs
@@ -1,0 +1,145 @@
+// Scoring for benchmark runs (DESIGN.md, "Metrics").
+// Deterministic metrics are computed here; ground-truth and rubric items are
+// emitted to an adjudication queue for a human — this script never judges
+// free-form agent output.
+//
+// Per run record from runs.jsonl:
+// - model-maintenance: run the pinned CLI against the post-run workspace and
+//   evaluate the task's `expect` list (check-pass, no-contradicted,
+//   catalogue-not-worse, likec4-check-pass);
+// - change: compute the wrong-file edit rate (files changed vs the task's
+//   `touches` paths) from the workdir's git diff against the baseline commit;
+// - comprehension/change verdicts: append to adjudication-queue.jsonl with the
+//   ground truth or rubric attached.
+//
+// Usage: node score.mjs --runs <runs.jsonl> --suite <suite.yaml> --toolchain <bin-dir> [--catalogue <catalogue.yaml>]
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..', '..', '..', '..');
+const require = createRequire(join(repoRoot, 'package.json'));
+const YAML = require('yaml');
+
+const args = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+const runsPath = opt('runs');
+const suitePath = opt('suite');
+const toolchain = opt('toolchain');
+const cataloguePath = opt('catalogue', join(repoRoot, 'docs/research/question-catalogue/core-enrichment.yaml'));
+if (!runsPath || !suitePath || !toolchain) {
+  console.error('usage: score.mjs --runs <runs.jsonl> --suite <suite.yaml> --toolchain <bin-dir> [--catalogue <catalogue.yaml>]');
+  process.exit(2);
+}
+
+const suite = YAML.parse(readFileSync(suitePath, 'utf8'));
+const tasksById = new Map(suite.tasks.map((t) => [t.id, t]));
+const outDir = dirname(runsPath);
+const scoresPath = join(outDir, 'scores.jsonl');
+const queuePath = join(outDir, 'adjudication-queue.jsonl');
+writeFileSync(scoresPath, '');
+writeFileSync(queuePath, '');
+
+const cli = (bin, cmdArgs, cwd) => {
+  try {
+    return { out: execFileSync(join(toolchain, bin), cmdArgs, { encoding: 'utf8', cwd, maxBuffer: 64 * 1024 * 1024 }), code: 0 };
+  } catch (error) {
+    return { out: `${error.stdout ?? ''}${error.stderr ?? ''}`, code: error.status ?? 1 };
+  }
+};
+const catalogueOpen = (workspaceDir, cwd) => {
+  const compiled = cli('yarramate', ['compile', join(workspaceDir, 'workspace.yaml')], cwd);
+  if (compiled.code !== 0) return null;
+  const graphPath = join(cwd, 'compiled-graph.json');
+  writeFileSync(graphPath, compiled.out);
+  try {
+    const evaluated = execFileSync('node', [
+      join(repoRoot, 'docs/research/question-catalogue/evaluate-catalogue.mjs'),
+      join(repoRoot, 'docs/research/question-catalogue/yarramate-question-catalogue.schema.json'),
+      cataloguePath,
+      graphPath,
+    ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+    const open = evaluated.match(/total open questions[^:]*:\s*(\d+)/i);
+    return open ? Number(open[1]) : null;
+  } catch {
+    return null;
+  }
+};
+
+const records = readFileSync(runsPath, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+for (const record of records) {
+  const task = tasksById.get(record.task);
+  if (!task) continue;
+  const workdir = join(record.runDir, 'repo');
+  const workspaceDir = join(workdir, '.yarramate');
+  const score = { ...record, deterministic: null, wrongFiles: null, adjudication: false };
+
+  if (task.family === 'change' && existsSync(workdir)) {
+    const changed = execFileSync('git', ['diff', '--name-only', 'HEAD'], { cwd: workdir, encoding: 'utf8' })
+      .trim().split('\n').filter(Boolean).filter((f) => !f.startsWith('.yarramate'));
+    const expected = task.touches.filter((t) => t.includes('/') || t.includes('.'));
+    score.wrongFiles = {
+      changed,
+      expected,
+      unexpected: changed.filter((f) => !expected.some((e) => f === e || f.startsWith(e))),
+    };
+  }
+
+  if (task.family === 'model-maintenance' && existsSync(workspaceDir)) {
+    const results = {};
+    for (const expectation of task.scoring.deterministic.expect) {
+      if (expectation === 'check-pass') {
+        const check = cli('yarramate', ['check', join(workspaceDir, 'workspace.yaml'), '--json'], workdir);
+        results[expectation] = check.code === 0 && (() => { try { return JSON.parse(check.out).ok === true; } catch { return false; } })();
+      } else if (expectation === 'no-contradicted') {
+        const reconcile = cli('yarramate', ['reconcile', join(workspaceDir, 'workspace.yaml')], workdir);
+        try {
+          results[expectation] = JSON.parse(reconcile.out).summary.contradicted === 0;
+        } catch {
+          results[expectation] = null;
+        }
+      } else if (expectation === 'likec4-check-pass') {
+        const projectPath = '.yarramate/integrations/likec4/project.yaml';
+        if (existsSync(join(workdir, projectPath))) {
+          const check = cli('yarramate-likec4', ['check', projectPath, '--json', '.yarramate/workspace.yaml'], workdir);
+          results[expectation] = check.code === 0;
+        } else {
+          results[expectation] = null;
+        }
+      } else if (expectation === 'catalogue-not-worse') {
+        const baseline = record.catalogueBaseline ?? null;
+        const after = catalogueOpen(workspaceDir, workdir);
+        results[expectation] = baseline === null || after === null ? null : after <= baseline;
+        score.catalogue = { baseline, after };
+      }
+    }
+    score.deterministic = results;
+  }
+
+  if (task.family === 'comprehension' || task.family === 'change') {
+    score.adjudication = true;
+    appendFileSync(queuePath, `${JSON.stringify({
+      suite: record.suite,
+      label: record.label,
+      condition: record.condition,
+      task: task.id,
+      family: task.family,
+      prompt: task.prompt,
+      groundTruth: task.groundTruth ?? null,
+      rubric: task.scoring.rubric ?? null,
+      transcript: join(record.runDir, 'transcript.json'),
+      wrongFiles: score.wrongFiles,
+    })}\n`);
+  }
+
+  appendFileSync(scoresPath, `${JSON.stringify(score)}\n`);
+}
+
+console.log(`scored ${records.length} runs -> ${scoresPath}; adjudication queue -> ${queuePath}`);

--- a/docs/research/context-benchmark/runner/validate-suite.mjs
+++ b/docs/research/context-benchmark/runner/validate-suite.mjs
@@ -1,0 +1,61 @@
+// Draft validator for yarramate/benchmark-suite/v1 task suites.
+// Schema validation plus the cross-checks the schema cannot express:
+// unique task ids, per-family minimums, and condition-neutral prompts.
+// Usage: node validate-suite.mjs <schema.json> <suite.yaml> [suite.yaml ...]
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const require = createRequire(join(repoRoot, 'package.json'));
+const Ajv2020 = require('ajv/dist/2020').default;
+const YAML = require('yaml');
+
+const [schemaPath, ...suitePaths] = process.argv.slice(2);
+if (!schemaPath || suitePaths.length === 0) {
+  console.error('usage: validate-suite.mjs <schema.json> <suite.yaml> [suite.yaml ...]');
+  process.exit(2);
+}
+
+const ajv = new Ajv2020({ allErrors: true });
+const validate = ajv.compile(JSON.parse(readFileSync(schemaPath, 'utf8')));
+
+// Comprehension and change prompts run under condition A (no model), so they
+// must not hint at a preferred context source (DESIGN.md, "Prompt leakage").
+// Model-maintenance prompts necessarily reference the workspace and only run
+// under model-present conditions. Checked lexically; phrasing review still applies.
+const leakage = /yarramate|projection|likec4|architecture model|\.yarramate/i;
+
+const MIN_PER_FAMILY = 2;
+let failed = false;
+const fail = (file, message) => {
+  failed = true;
+  console.error(`${file}: ${message}`);
+};
+
+for (const suitePath of suitePaths) {
+  const suite = YAML.parse(readFileSync(suitePath, 'utf8'));
+  if (!validate(suite)) {
+    for (const err of validate.errors) fail(suitePath, `schema ${err.instancePath || '/'} ${err.message}`);
+    continue;
+  }
+
+  const ids = new Set();
+  const families = { comprehension: 0, change: 0, 'model-maintenance': 0 };
+  for (const task of suite.tasks) {
+    if (ids.has(task.id)) fail(suitePath, `duplicate task id ${task.id}`);
+    ids.add(task.id);
+    families[task.family] += 1;
+    if (task.family !== 'model-maintenance' && leakage.test(task.prompt)) {
+      fail(suitePath, `task ${task.id}: prompt mentions a context source (leakage)`);
+    }
+  }
+  for (const [family, count] of Object.entries(families)) {
+    if (count < MIN_PER_FAMILY) fail(suitePath, `family ${family} has ${count} tasks, needs >= ${MIN_PER_FAMILY}`);
+  }
+  if (!failed) console.log(`${suitePath}: ok (${suite.tasks.length} tasks, headline=${suite.headline})`);
+}
+
+process.exit(failed ? 1 : 0);

--- a/docs/research/context-benchmark/tasks/fastify.yaml
+++ b/docs/research/context-benchmark/tasks/fastify.yaml
@@ -1,0 +1,288 @@
+# Frozen benchmark task suite: fastify (yarramate/benchmark-suite/v1).
+# Authored before any condition run (DESIGN.md "Task suite"); ground truth was
+# verified by reading the source at the pinned commit — the code, not the
+# gallery model, is the authority. Comprehension and change prompts are
+# condition-neutral; model-maintenance prompts necessarily reference the
+# committed workspace and only run under model-present conditions.
+type: yarramate/benchmark-suite/v1
+suite: fastify
+headline: true
+repository:
+  name: fastify
+  source: https://github.com/fastify/fastify
+  commit: 812608e5c9cb0b643b3eb186c2e9e84bbb7ed8ee
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/fastify
+
+tasks:
+  # --- Comprehension -------------------------------------------------------
+  - id: ff-encapsulation-child-state
+    family: comprehension
+    prompt: >-
+      When fastify.register(plugin) runs a plugin in its own encapsulated
+      context, the framework produces a child instance for that plugin.
+      Answer precisely, citing the relevant source files: (a) which file and
+      function create the child instance, and what is the object relationship
+      between the child and its parent instance; (b) which pieces of
+      per-instance state are freshly rebuilt or copied onto the child at
+      creation time, rather than reached through the parent via the prototype
+      chain; (c) three hook arrays are deliberately reset to empty on the
+      child instead of being copied from the parent — name all three and
+      explain why they must not be copied.
+    groundTruth:
+      answer: >-
+        (a) lib/plugin-override.js exports override(), installed as avvio's
+        override hook in fastify.js (avvio.override = override,
+        fastify.js:377). The child is created with Object.create(old), so it
+        prototype-inherits from the parent, and is pushed onto the parent's
+        kChildren list. (b) Rebuilt/copied onto the child: Reply and Request
+        constructors (Reply.buildReply / Request.buildRequest), the
+        content-type parser (buildContentTypeParser), the hook store
+        (buildHooks, which slices each hook array), the route prefix
+        (buildRoutePrefix with opts.prefix), log level, a new schema
+        controller layered on the parent's (SchemaController.
+        buildSchemaController(old[kSchemaController])) with rebound
+        getSchema/getSchemas, a fresh kChildren array, a rebound ready
+        (kAvvioBoot), a derived registered-plugins tracker and plugin name
+        chain, kErrorHandlerAlreadySet = false, merged log serializers, and —
+        when opts.prefix is set — a re-arranged 404 level
+        (kFourOhFour.arrange404). (c) onReady, onListen and preClose are
+        reset to [] in buildHooks (lib/hooks.js:87-89). Application hooks are
+        executed by walking each instance's kChildren tree
+        (hookRunnerApplication and onListenHookRunner recurse into children),
+        so copying the parent's entries into every child would run those
+        boot/shutdown hooks once per descendant instead of once.
+      verifiedAgainst:
+        - lib/plugin-override.js:28-74
+        - lib/hooks.js:73-91
+        - lib/hooks.js:93-150
+        - lib/hooks.js:183-207
+        - fastify.js:360-381
+    scoring:
+      method: ground-truth
+
+  - id: ff-body-parser-selection
+    family: comprehension
+    prompt: >-
+      Consider a POST route on a fastify server built with default options
+      and no custom content-type parsers registered beyond the built-ins.
+      For each of the following three incoming requests, state which internal
+      module decides what happens to the request body, what the outcome is,
+      and — where the request is rejected — the HTTP status code and the
+      coded error used: (1) the request carries the header "Content-Type:
+      application/vnd.foo+toml" (syntactically valid, but no parser and no
+      catch-all parser is registered for it); (2) the request has no
+      Content-Type header and no body (no content-length or
+      transfer-encoding); (3) the request has no Content-Type header but
+      does carry a non-empty body. Cite the files involved.
+    groundTruth:
+      answer: >-
+        Dispatch happens in lib/handle-request.js handleRequest(). (1) The
+        header is present and valid, so the route context's content-type
+        parser runs (lib/handle-request.js:87). ContentTypeParser.prototype.
+        run (lib/content-type-parser.js:187-199) resolves the parser via
+        getParser (exact match, then media-type, then regexp list, then the
+        '' catch-all); all miss because the defaults only register
+        application/json and text/plain (lib/content-type-parser.js:33-42),
+        so run() sends FST_ERR_CTP_INVALID_MEDIA_TYPE — HTTP 415 Unsupported
+        Media Type (lib/errors.js:111-115). (2) isEmptyBody()
+        (lib/handle-request.js:112-117) is true, so body parsing is skipped
+        entirely and the request proceeds to preValidation/validation/handler
+        with request.body undefined (lib/handle-request.js:66-70). (3) The
+        catch-all parser is attempted via contentTypeParser.run('', ...)
+        (lib/handle-request.js:73); no catch-all is registered by default, so
+        getParser returns undefined and the same 415
+        FST_ERR_CTP_INVALID_MEDIA_TYPE is sent. Special case verified in
+        code: requests dispatched to a 404 context skip parsing and go
+        straight to the handler (lib/content-type-parser.js:191-194).
+      verifiedAgainst:
+        - lib/handle-request.js:25-117
+        - lib/content-type-parser.js:33-42
+        - lib/content-type-parser.js:119-156
+        - lib/content-type-parser.js:187-233
+        - lib/errors.js:111-115
+    scoring:
+      method: ground-truth
+
+  - id: ff-retire-avvio
+    family: comprehension
+    prompt: >-
+      fastify declares a runtime dependency on the third-party package avvio.
+      Suppose avvio were retired from the codebase with no replacement.
+      (a) Which public instance methods would stop working because avvio
+      itself provides or backs them? (b) Beyond those methods, name two
+      framework behaviors that would break because they are wired through
+      avvio callbacks, and cite the file(s) where each is wired in.
+    groundTruth:
+      answer: >-
+        (a) register (avvio's use, exposed under the name register via
+        expose: { use: 'register' }), after, ready (avvio's ready is cached
+        as kAvvioBoot and wrapped by fastify's own ready), onClose, close,
+        and printPlugins (bound to avvio.prettyPrint). fastify.js initializes
+        these to null with the comment "initialized by Avvio"
+        (fastify.js:248-254) and avvio fills them in (fastify.js:360-381).
+        addHook('onClose', fn) also delegates to avvio's onClose
+        (fastify.js:603-604 region: name === 'onClose' branch). (b) Two
+        avvio-callback-wired behaviors: plugin encapsulation — avvio calls
+        the override assigned at fastify.js:377 (lib/plugin-override.js) to
+        create each child instance; and boot/shutdown application-hook
+        ordering — hookRunnerApplication threads onReady and preClose hooks
+        through the avvio boot callback (fastify[kAvvioBoot]) including
+        per-child recursion and AVVIO_ERRORS_MAP/plugin-timeout translation
+        (lib/hooks.js:93-181, fastify.js:368-390). Without avvio neither
+        plugin isolation nor ordered ready/close execution exists.
+      verifiedAgainst:
+        - fastify.js:248-254
+        - fastify.js:360-390
+        - fastify.js:577-618
+        - lib/plugin-override.js:28-74
+        - lib/hooks.js:93-181
+    scoring:
+      method: ground-truth
+
+  # --- Change --------------------------------------------------------------
+  - id: ff-add-has-hook
+    family: change
+    prompt: >-
+      Add a public instance method hasHook(hookName) to fastify. Behavior:
+      it returns true when at least one handler is registered for hookName
+      in the calling instance's own hook store (its encapsulation context,
+      including hooks copied into a child context at registration time), and
+      false otherwise. It must cover the request/reply lifecycle hooks (e.g.
+      onRequest, preHandler, onSend) and the application hooks kept in the
+      instance hook store (e.g. onRoute, onReady, preClose). For a hook name
+      the store does not support (e.g. "onFoo", or onClose, which is managed
+      by the boot orchestrator rather than the store), it must throw the
+      existing coded error FST_ERR_HOOK_NOT_SUPPORTED rather than a plain
+      Error. Derive hook-name support from the canonical hook definitions in
+      lib/hooks.js instead of introducing a second hard-coded list, and
+      update the TypeScript declarations so the method is part of the typed
+      instance surface. Do not change the behavior of addHook.
+    touches:
+      - fastify.js
+      - lib/hooks.js
+      - types/instance.d.ts
+      - hook-system
+      - public-api
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          hasHook is exposed on the fastify instance and returns correct
+          booleans by consulting the instance's own hook store (kHooks) for
+          both lifecycle hooks and store-kept application hooks; it does not
+          maintain a separate registry.
+        - >-
+          Unsupported hook names (including onClose) throw the existing
+          FST_ERR_HOOK_NOT_SUPPORTED coded error; no new bare Error or new
+          error code is introduced for this case.
+        - >-
+          Hook-name support is derived from lib/hooks.js (the Hooks store
+          and/or its exported hook lists); no duplicated hard-coded hook-name
+          list is added in fastify.js or elsewhere.
+        - >-
+          types/instance.d.ts declares hasHook with hook-name typing
+          consistent with the existing addHook overloads, and addHook
+          behavior is unchanged.
+
+  - id: ff-ctp-remove-unknown-error
+    family: change
+    prompt: >-
+      Today fastify.removeContentTypeParser("application/xml") silently does
+      nothing when no parser is registered for that content type. Change
+      this: removing a content type (string or RegExp) that has no registered
+      parser must fail with a new coded error FST_ERR_CTP_PARSER_NOT_FOUND,
+      created and exported following the framework's existing coded-error
+      conventions (the createError factory in lib/errors.js, FST_ERR_CTP_
+      prefix, an appropriate status code). The array form of
+      removeContentTypeParser must fail the same way if any listed content
+      type has no registered parser. The existing guard that throws
+      FST_ERR_CTP_INSTANCE_ALREADY_STARTED when the instance has already
+      started must keep taking precedence. Document the new error code in
+      docs/Reference/Errors.md and add it to the error-code union in
+      types/errors.d.ts. Successful removals of registered parsers must keep
+      working exactly as before.
+    touches:
+      - lib/content-type-parser.js
+      - lib/errors.js
+      - docs/Reference/Errors.md
+      - types/errors.d.ts
+      - content-type-parser
+      - error-handling
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          FST_ERR_CTP_PARSER_NOT_FOUND is defined in lib/errors.js via the
+          existing createError factory with the FST_ERR_CTP_ prefix and is
+          exported alongside the other codes.
+        - >-
+          removeContentTypeParser throws the new error for unregistered
+          content types in both the single and array forms, while removal of
+          registered parsers (string and RegExp) still succeeds and actually
+          deregisters the parser.
+        - >-
+          The FST_ERR_CTP_INSTANCE_ALREADY_STARTED guard still fires first
+          when the instance has started, and no silent no-op path remains
+          reachable through the public removeContentTypeParser API for
+          unknown types.
+        - >-
+          The new code is documented in docs/Reference/Errors.md and added to
+          the error-code union in types/errors.d.ts.
+
+  # --- Model maintenance ---------------------------------------------------
+  - id: ff-model-log-controller
+    family: model-maintenance
+    prompt: >-
+      A code-level change has landed in fastify that the committed .yarramate
+      workspace predates: per-request logging is now mediated by an internal
+      LogController. The class lives in lib/log-controller.js,
+      createLogController builds it from the server options (re-exported
+      through lib/logger-factory.js and wired into the instance in
+      fastify.js), it gates per-request log lines via disableRequestLogging /
+      isLogDisabled and carries requestIdLogLabel, and the 404 path reports
+      route-not-found through it (basic404 in lib/four-oh-four.js calls
+      routeNotFound on it). The workspace's logging concept still cites only
+      lib/logger-factory.js and lib/logger-pino.js. Update the .yarramate
+      workspace so the logging subsystem accurately reflects the
+      LogController: amend the logging concept (or add a dedicated concept
+      under the framework grouping) with descriptions and evidence pointing
+      at the files above, and add or adjust relationships where the code
+      shows them (for example the 404/not-found path consuming the
+      LogController for its route-not-found log line). The workspace must
+      still pass its checks and must not contradict the code as it stands.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-not-worse
+
+  - id: ff-model-schema-split-target
+    family: model-maintenance
+    prompt: >-
+      The fastify maintainers plan to split the schema subsystem that
+      lib/schema-controller.js currently owns end-to-end: request-side
+      validation (the shared schema bucket plus validator compilation backed
+      by @fastify/ajv-compiler, applied in lib/validation.js) will remain
+      with the schema controller, while response-side serialization
+      (serializer compilation backed by
+      @fastify/fast-json-stringify-compiler and the reply's serializer
+      resolution) will move to a new dedicated serializer controller module.
+      Update the .yarramate workspace to represent this as a planned target
+      state without misrepresenting the present: introduce a serialization
+      concept, move the serving relationship from the
+      "@fastify/fast-json-stringify-compiler (external)" dependency (dep-fjs)
+      and the serving relationship toward the Request/Reply layer
+      (schema-serves-reply) to that concept in the target structure, and keep
+      the currently observed single schema-engine arrangement accurate for
+      the as-is state (the split does not exist in the code today, so no
+      claim may assert it as observed). The workspace must still pass its
+      checks and the generated LikeC4 export must remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/httpie.yaml
+++ b/docs/research/context-benchmark/tasks/httpie.yaml
@@ -1,0 +1,340 @@
+# Frozen benchmark task suite for httpie (context benchmark H1/H2/H3).
+# Ground truth verified against the source at the pinned commit; the gallery
+# model was used only to select targets, never as the authority.
+type: yarramate/benchmark-suite/v1
+suite: httpie
+headline: true
+repository:
+  name: httpie
+  source: https://github.com/httpie/cli
+  commit: 5b604c37c6c67e18e7c3e9aee6c88a8c22b98345
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/httpie
+
+tasks:
+  # ---------------------------------------------------------------- comprehension
+  - id: ht-comp-download-filename
+    family: comprehension
+    prompt: >-
+      When a response body is saved with --download and no explicit --output
+      file is given, HTTPie picks the target filename automatically. Identify:
+      (1) the module that owns this filename-resolution logic; (2) the function
+      that extracts a filename from the Content-Disposition response header;
+      (3) the function that derives a fallback filename from the URL and the
+      response Content-Type; (4) how collisions with files that already exist
+      on disk are avoided (name the function and describe the scheme); and
+      (5) the method that ties these steps together to open the output file.
+    groundTruth:
+      answer: >-
+        httpie/downloads.py owns all of it. filename_from_content_disposition
+        (downloads.py:85) parses the Content-Disposition header via
+        mailbox.Message.get_filename and sanitises the result (basename,
+        lstrip('.'), strip). filename_from_url (downloads.py:106) falls back to
+        the last URL path segment (or 'index'), appending an extension guessed
+        from the Content-Type via mimetypes.guess_extension (with special
+        cases: text/plain -> .txt, .htm -> .html). get_unique_filename
+        (downloads.py:151) avoids collisions by probing with os.path.exists
+        and appending numeric suffixes -1, -2, ... until an unused name is
+        found, trimming the name first via trim_filename_if_needed so it stays
+        within the filesystem's max filename length. The static method
+        Downloader._get_output_file_from_response (downloads.py:288) ties them
+        together: prefer Content-Disposition, else URL-derived, then uniquify
+        and open the file in mode 'a+b'. It is called from Downloader.start
+        only when no --output file was provided.
+      verifiedAgainst:
+        - httpie/downloads.py:85-103
+        - httpie/downloads.py:106-123
+        - httpie/downloads.py:126-159
+        - httpie/downloads.py:288-304
+        - httpie/downloads.py:226-230
+    scoring:
+      method: ground-truth
+
+  - id: ht-comp-plugin-registry-retire
+    family: comprehension
+    prompt: >-
+      Suppose the file httpie/plugins/registry.py were deleted from this
+      repository with no other changes. State what that file provides, list
+      every module that imports from it, explain what each importer uses it
+      for, and summarise which user-facing capabilities of the http/https
+      command and of the httpie maintenance command would break.
+    groundTruth:
+      answer: >-
+        registry.py instantiates the process-wide singleton
+        plugin_manager = PluginManager() and registers the seven built-in
+        plugins (BasicAuthPlugin, DigestAuthPlugin, BearerAuthPlugin,
+        HeadersFormatter, JSONFormatter, XMLFormatter, ColorFormatter).
+        Importers: httpie/core.py (raw_main calls
+        plugin_manager.load_installed_plugins(env.config.plugins_dir) at
+        startup and --debug prints repr(plugin_manager)); httpie/cli/argparser.py
+        (_process_auth resolves the default auth plugin via
+        get_auth_plugins()[0] and looks up --auth-type via get_auth_plugin);
+        httpie/cli/definition.py (--auth-type lazy choices via
+        getter=plugin_manager.get_auth_plugin_mapping); httpie/client.py
+        (build_requests_session mounts adapters from get_transport_plugins);
+        httpie/output/processing.py (Conversion uses get_converters, Formatting
+        uses get_formatters_grouped); httpie/sessions.py (Session.auth
+        reconstructs stored session auth via get_auth_plugin);
+        httpie/manager/tasks/plugins.py (the httpie plugins list task iterates
+        plugin_manager.iter_entry_points). Breakage: both console commands fail
+        at import time, taking down all authentication (-a/--auth,
+        --auth-type, netrc, session-stored auth), third-party plugin loading,
+        transport adapter mounting, pretty-printing (headers/JSON/XML/colors
+        formatters), mime converters, and httpie plugins list.
+      verifiedAgainst:
+        - httpie/plugins/registry.py
+        - httpie/core.py:24
+        - httpie/core.py:46
+        - httpie/core.py:281
+        - httpie/cli/argparser.py:28
+        - httpie/cli/argparser.py:285
+        - httpie/cli/argparser.py:304
+        - httpie/cli/definition.py:23
+        - httpie/cli/definition.py:689
+        - httpie/client.py:23
+        - httpie/client.py:177
+        - httpie/output/processing.py:5
+        - httpie/output/processing.py:21
+        - httpie/output/processing.py:36
+        - httpie/sessions.py:21
+        - httpie/sessions.py:278
+        - httpie/manager/tasks/plugins.py:197-201
+    scoring:
+      method: ground-truth
+
+  - id: ht-comp-session-lifecycle
+    family: comprehension
+    prompt: >-
+      For an invocation like `http --session=api example.org/endpoint`,
+      explain: (a) which module loads the named session and where on disk the
+      session file lives, including how the path differs when the session name
+      contains a path separator; (b) at which points in the request pipeline
+      the session's stored headers, cookies, and auth are applied to the
+      outgoing request, including the precedence between session headers and
+      command-line headers, and between session auth and -a/--auth given on
+      the command line; and (c) under exactly which conditions the session
+      file is written back to disk at the end of the run.
+    groundTruth:
+      answer: >-
+        (a) httpie/client.py collect_messages calls get_httpie_session
+        (httpie/sessions.py:92) when --session/--session-read-only is set. For
+        a plain name the path is <config_dir>/sessions/<host>/<name>.json
+        (session_hostname_to_dirname, sessions.py:46; ':' in host:port becomes
+        '_'); if the name contains os.path.sep it is an "anonymous" session and
+        is treated as an explicit file path (is_anonymous_session,
+        sessions.py:42, os.path.expanduser at sessions.py:107).
+        (b) All inside collect_messages (httpie/client.py:43-101): session
+        headers are passed as base_headers into make_request_kwargs, where
+        precedence is defaults < session headers < CLI headers
+        (client.py:343-346: make_default_headers, then update(base_headers),
+        then update(args.headers)); cookies are applied by assigning
+        requests_session.cookies = httpie_session.cookies (client.py:76); for
+        auth, CLI auth wins - if args.auth_plugin is set the CLI auth is
+        written INTO the session (client.py:77-82), otherwise stored session
+        auth is applied as request_kwargs['auth'] (client.py:83-85, rebuilt via
+        Session.auth, sessions.py:272-299). In the other direction,
+        update_headers (client.py:75, sessions.py:230) merges request headers
+        back into the session, skipping Content-*/If-* prefixes and the
+        default HTTPie/ User-Agent, and folding a Cookie header into the
+        cookie jar.
+        (c) After the request/response loop (client.py:136-140): saved when
+        the session file is new OR --session (read-write) was used; an
+        existing session opened with --session-read-only is not written.
+        Before saving, cookies are refreshed from the requests session and
+        expired cookies are removed.
+      verifiedAgainst:
+        - httpie/client.py:43-101
+        - httpie/client.py:136-140
+        - httpie/client.py:325-374
+        - httpie/sessions.py:29-57
+        - httpie/sessions.py:92-121
+        - httpie/sessions.py:200-262
+        - httpie/sessions.py:272-304
+    scoring:
+      method: ground-truth
+
+  # ---------------------------------------------------------------------- change
+  - id: ht-change-download-dir
+    family: change
+    prompt: >-
+      Add a --download-dir DIR option to the http/https command. Semantics:
+      it is only meaningful together with --download, and only when the
+      filename is chosen automatically - using it without --download, or
+      combining it with an explicit --output FILE, must be rejected with a
+      clear parser error (like the existing --continue validations). When
+      active, automatically named downloads (name derived from
+      Content-Disposition or from the URL) are created inside DIR instead of
+      the current working directory, and the existing unique-suffix collision
+      avoidance must test for existing files inside DIR. If DIR does not
+      exist, fail with a clear error rather than creating it implicitly.
+      Behaviour when the new flag is absent must be completely unchanged.
+      Include help text consistent with the neighbouring download options.
+    touches:
+      - httpie/cli/definition.py
+      - httpie/cli/argparser.py
+      - httpie/core.py
+      - httpie/downloads.py
+      - httpie#arg-parser
+      - httpie#download-manager
+    scoring:
+      method: rubric
+      rubric:
+        - The option is declared alongside the other download options in
+          httpie/cli/definition.py with help text, and invalid combinations
+          are rejected in the parser (httpie/cli/argparser.py, in or next to
+          _process_download_options) - both --download-dir without --download
+          and --download-dir with --output produce a parser error, not a
+          crash or silent ignore.
+        - The directory is threaded through to the Downloader (constructed in
+          httpie/core.py program) and used in the auto-naming path
+          (_get_output_file_from_response in httpie/downloads.py) - the
+          resolved filename is joined with DIR before the uniqueness probe,
+          so get_unique_filename-style suffixing checks existence within DIR,
+          and the file is opened inside DIR.
+        - A non-existent DIR results in a clear user-facing error (parser
+          error or clean error exit), not an unhandled traceback, and DIR is
+          not silently created.
+        - With the flag absent, behaviour is unchanged - auto-named downloads
+          still land in the current working directory, and no other option's
+          semantics change; unrelated modules (sessions, output formatting,
+          plugin machinery) are not modified.
+
+  - id: ht-change-redact-auth-output
+    family: change
+    prompt: >-
+      HTTPie prints outgoing request headers with --verbose/--print=H,
+      including the Authorization header with its full credential value,
+      which makes shared transcripts leak secrets. Add an opt-in flag
+      (suggested name --redact-auth) to the http/https command: when enabled,
+      any rendered request output replaces the value of the Authorization
+      header with a fixed placeholder (for example <redacted>); the request
+      actually sent on the wire must be unaffected and must carry the real
+      header; response output is untouched. Default behaviour without the
+      flag must be byte-for-byte unchanged. The redaction must apply wherever
+      request headers are rendered (pretty-printed or raw, terminal or
+      redirected), not just in one formatter.
+    touches:
+      - httpie/cli/definition.py
+      - httpie/models.py
+      - httpie/output/models.py
+      - httpie#arg-parser
+      - httpie#output-pipeline
+    scoring:
+      method: rubric
+      rubric:
+        - A new opt-in flag is declared in httpie/cli/definition.py (default
+          off) and reaches the output path via the parsed namespace (for
+          example through ProcessingOptions in httpie/output/models.py or an
+          equivalent explicit mechanism), not via a global variable.
+        - With the flag enabled, the rendered request-header text (produced
+          from HTTPRequest.headers in httpie/models.py) shows the placeholder
+          instead of the Authorization value in every output mode - pretty and
+          non-pretty, tty and redirected - and the real credential string
+          appears nowhere in the rendered output.
+        - The PreparedRequest that is dispatched still carries the genuine
+          Authorization header - redaction is display-only, verified by the
+          fact that the redaction is applied only on the rendering side and
+          never mutates the outgoing requests message.
+        - With the flag absent, output is unchanged, and response rendering is
+          unaffected in both modes.
+
+  - id: ht-change-session-auth-plugin-error
+    family: change
+    prompt: >-
+      A stored session file can carry an auth entry whose type refers to an
+      auth plugin that is no longer installed (for example a session recorded
+      with a third-party auth plugin that was later uninstalled). Today,
+      reusing such a session dies with a bare KeyError raised from the plugin
+      lookup, surfaced to the user as an unhelpful "KeyError: '<type>'"
+      message. Improve this: reusing a session whose auth type has no
+      registered plugin must produce a clear, actionable error that names the
+      unknown auth type, identifies the session (file path or session id),
+      and hints that the corresponding auth plugin needs to be installed. The
+      run must terminate through the normal error path with a non-zero exit
+      status and no traceback (unless --traceback is given). Behaviour for
+      sessions with valid or absent auth must be unchanged, as must the
+      existing --auth-type validation for command-line auth.
+    touches:
+      - httpie/sessions.py
+      - httpie/plugins/manager.py
+      - httpie#session-manager
+      - httpie#plugin-manager
+    scoring:
+      method: rubric
+      rubric:
+        - The unknown-auth-type lookup for session auth (Session.auth in
+          httpie/sessions.py calling plugin_manager.get_auth_plugin) no longer
+          escapes as a raw KeyError - it is caught or replaced by a dedicated,
+          intentional error path (custom exception or explicit membership
+          check in httpie/plugins/manager.py or httpie/sessions.py).
+        - The resulting message names the missing auth type, identifies the
+          session file (path or id), and suggests installing the missing auth
+          plugin - all three elements present.
+        - The failure exits through the existing error handling with a
+          non-zero status and without a traceback by default (traceback still
+          available with --traceback); no unrelated behaviour changes - valid
+          session auth, sessions without auth, and command-line --auth-type
+          validation behave exactly as before.
+
+  # ---------------------------------------------------------- model-maintenance
+  - id: ht-mm-manager-session-store
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace for this repository
+      (.yarramate/workspace.yaml, with the document under
+      .yarramate/architecture/, evidence under .yarramate/evidence/,
+      projections under .yarramate/projections/, and a LikeC4 adapter mapping
+      under .yarramate/integrations/likec4/) models the maintenance CLI
+      (httpie#manager-cli) as only influencing the plugin manager. The code
+      shows it also touches stored session files: httpie/manager/tasks/sessions.py
+      implements `httpie cli sessions upgrade` and `upgrade-all`, loading each
+      session via get_httpie_session, rewriting it in place with
+      session.save(bump_version=True), and walking the sessions/ directory
+      under the config directory. Update the workspace to capture this
+      responsibility: add the missing relationship(s) between the maintenance
+      CLI and the session-files data object (a read-write access is the
+      natural fit), record supporting evidence observations with repo:
+      locators in the evidence overlay, and update the LikeC4 subject mapping
+      for any new subjects so the adapter export stays complete. When you are
+      done, the native workspace check and the LikeC4 adapter check must both
+      pass, with no contradicted claims and no new open catalogue questions
+      left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-not-worse
+          - likec4-check-pass
+
+  - id: ht-mm-update-checker
+    family: model-maintenance
+    prompt: >-
+      HTTPie ships a self-update warning subsystem that this repository's
+      committed .yarramate workspace does not yet model:
+      httpie/internal/update_warnings.py is invoked as check_updates from
+      raw_main in httpie/core.py on every run, periodically fetches
+      https://packages.httpie.io/latest.json (spawning a background daemon via
+      httpie/internal/daemons.py and httpie/internal/daemon_runner.py), and
+      persists fetch/warn state to a version_info.json file resolved by
+      Config.version_info_file in httpie/config.py. Extend the workspace
+      (.yarramate/workspace.yaml and the documents it references) to reflect
+      this: declare an update-checker application component composed into the
+      http/https command concept, declare a version-info data object for the
+      persisted state file, and relate the new component to the command that
+      triggers it and to the data object it reads and writes (plus any further
+      relationship you can ground in the cited code, such as the outbound
+      fetch). Add evidence observations with repo: locators for each new
+      claim, and update the LikeC4 subject mapping so every new subject is
+      mapped. Afterwards the native workspace check and the LikeC4 adapter
+      check must both pass, with no contradicted claims and no new open
+      catalogue questions left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-not-worse
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/miniflux.yaml
+++ b/docs/research/context-benchmark/tasks/miniflux.yaml
@@ -1,0 +1,258 @@
+# Frozen benchmark task suite for miniflux (context benchmark H1/H2/H3).
+# Ground truth verified against the source at the pinned commit; the gallery
+# model was used only to select targets, never as the authority.
+type: yarramate/benchmark-suite/v1
+suite: miniflux
+headline: true
+repository:
+  name: miniflux
+  source: https://github.com/miniflux/v2
+  commit: c4d54f87a81b30aa173fddf05d7ff83ae7da5796
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/miniflux
+
+tasks:
+  # ---------------------------------------------------------------- comprehension
+  - id: mf-comp-integration-dispatch
+    family: comprehension
+    prompt: >-
+      Miniflux can deliver entries to third-party services such as Wallabag,
+      Pinboard, and Telegram. Identify: (1) the Go package that implements this
+      fan-out delivery; (2) the two exported functions that are its only entry
+      points from the rest of the codebase; (3) for each of those functions,
+      every call site that invokes it — one path runs after a feed refresh has
+      persisted new entries, the other when a user saves a single entry from
+      the web UI or from the REST API. Give the package import path, the two
+      function names, and the file containing each call site.
+    groundTruth:
+      answer: >-
+        The package is internal/integration (miniflux.app/v2/internal/integration),
+        implemented in internal/integration/integration.go. Its two entry points
+        are SendEntry (integration.go:41) and PushEntries (integration.go:511).
+        PushEntries is invoked exactly once, as "go integration.PushEntries(...)"
+        from RefreshFeed in internal/reader/handler/handler.go:339, after
+        store.RefreshFeedEntries returns new entries and the user has integrations
+        configured. SendEntry is invoked from two call sites, both as
+        "go integration.SendEntry(...)": the web UI save handler in
+        internal/ui/entry_save.go:36 and the REST API saveEntryHandler in
+        internal/api/entry_handlers.go:273.
+      verifiedAgainst:
+        - internal/integration/integration.go:41
+        - internal/integration/integration.go:511
+        - internal/reader/handler/handler.go:339
+        - internal/ui/entry_save.go:36
+        - internal/api/entry_handlers.go:273
+    scoring:
+      method: ground-truth
+
+  - id: mf-comp-worker-pool-retirement
+    family: comprehension
+    prompt: >-
+      Suppose the background worker pool implemented in internal/worker were
+      deleted and nothing could enqueue refresh jobs any more, while everything
+      else stayed as-is. For each of the following operations, state whether it
+      would break or keep working, and cite the file that decides the answer:
+      (a) the periodic background refresh driven by the polling scheduler;
+      (b) "refresh all feeds" from the web UI;
+      (c) refreshing all feeds of one category from the web UI;
+      (d) PUT /v1/feeds/refresh (REST refresh-all);
+      (e) PUT /v1/categories/{categoryID}/refresh (REST category refresh);
+      (f) refreshing a single feed from the web UI;
+      (g) PUT /v1/feeds/{feedID}/refresh (REST single-feed refresh).
+    groundTruth:
+      answer: >-
+        (a)-(e) break: they all build a job batch and push it onto the pool.
+        (a) internal/cli/scheduler.go feedScheduler calls pool.Push(jobs);
+        (b) internal/ui/feed_refresh.go refreshAllFeeds calls go h.pool.Push(jobs);
+        (c) internal/ui/category_refresh.go refreshCategory calls go h.pool.Push(jobs);
+        (d) internal/api/feed_handlers.go refreshAllFeedsHandler calls go h.pool.Push(jobs) (line 97);
+        (e) internal/api/category_handlers.go calls go h.pool.Push(jobs) (line 191).
+        (f) and (g) keep working: single-feed refresh never touches the pool —
+        both call reader/handler RefreshFeed synchronously inside the HTTP
+        request: internal/ui/feed_refresh.go refreshFeed (line 21) and
+        internal/api/feed_handlers.go refreshFeedHandler (line 66).
+      verifiedAgainst:
+        - internal/cli/scheduler.go:36-49
+        - internal/worker/pool.go
+        - internal/ui/feed_refresh.go:21
+        - internal/ui/feed_refresh.go:61
+        - internal/ui/category_refresh.go:58
+        - internal/api/feed_handlers.go:66
+        - internal/api/feed_handlers.go:97
+        - internal/api/category_handlers.go:191
+    scoring:
+      method: ground-truth
+
+  - id: mf-comp-sql-ownership
+    family: comprehension
+    prompt: >-
+      For the Miniflux server: which Go package concentrates the application's
+      SQL data-access queries, which package owns schema migrations and
+      database connection setup, and which database engine or engines does the
+      server support? Name the database driver dependency from go.mod and the
+      file where the connection pool is opened.
+    groundTruth:
+      answer: >-
+        All SQL data-access queries live in internal/storage (feed.go, entry.go,
+        entry_query_builder.go, user.go, batch.go, integration.go, etc.).
+        Schema migrations and connection setup live in internal/database:
+        migrations.go holds the ordered migrations array (schemaVersion =
+        len(migrations)) applied by Migrate in database.go, and postgresql.go
+        opens the connection pool with sql.Open("postgres", dsn) in
+        NewConnectionPool. PostgreSQL is the only supported engine; the sole
+        driver dependency is github.com/lib/pq (go.mod).
+      verifiedAgainst:
+        - internal/storage/feed.go
+        - internal/storage/entry.go
+        - internal/storage/batch.go
+        - internal/database/database.go
+        - internal/database/migrations.go
+        - internal/database/postgresql.go
+        - go.mod:13
+    scoring:
+      method: ground-truth
+
+  # ---------------------------------------------------------------------- change
+  - id: mf-change-async-single-feed-refresh
+    family: change
+    prompt: >-
+      Single-feed refresh over HTTP currently runs the entire fetch/parse/store
+      cycle synchronously inside the request handler in two places: the web UI
+      (refreshFeed in internal/ui/feed_refresh.go) and the REST API
+      (refreshFeedHandler in internal/api/feed_handlers.go). Change both so the
+      refresh is enqueued onto the existing background worker queue instead of
+      running inline: the UI handler enqueues and redirects immediately as it
+      does today; the API handler validates that the feed exists (404 as today
+      when it does not), enqueues, and returns 204 No Content immediately.
+      The web UI's forceRefresh query parameter must keep working end to end,
+      which requires carrying a force-refresh flag on the queued job and
+      honoring it when the worker executes the job; jobs created by the
+      scheduler and by the existing refresh-all/category paths must keep
+      today's non-forced behavior. Reuse the existing job and pool types rather
+      than introducing a parallel mechanism.
+    touches:
+      - internal/ui/feed_refresh.go
+      - internal/api/feed_handlers.go
+      - internal/model/job.go
+      - internal/worker/worker.go
+      - miniflux#web-ui
+      - miniflux#rest-api
+      - miniflux#worker-pool
+    scoring:
+      method: rubric
+      rubric:
+        - Neither internal/ui/feed_refresh.go refreshFeed nor
+          internal/api/feed_handlers.go refreshFeedHandler calls
+          reader/handler.RefreshFeed inline any more; both enqueue a job for
+          the requested feed through the existing worker pool (Pool.Push).
+        - The force-refresh flag travels with the job (model.Job gains a field
+          or equivalent) and internal/worker/worker.go passes it through to
+          RefreshFeed, so a UI request with forceRefresh=true results in a
+          forced refresh when the worker runs the job.
+        - Scheduler, refresh-all, and category-refresh job producers are either
+          untouched or continue to produce non-forced jobs; no call path gains
+          forced refresh that did not have it.
+        - The API handler still returns 404 for a feed that does not belong to
+          the user, before anything is enqueued, and returns 204 immediately on
+          success; the UI handler still redirects to the feed entries page.
+        - No parallel queue, goroutine pool, or duplicate job type is
+          introduced; the change reuses the existing pool and job list types.
+
+  - id: mf-change-per-feed-integration-optout
+    family: change
+    prompt: >-
+      Add a per-feed setting that stops a feed's newly refreshed entries from
+      being pushed to the user's connected third-party services (Wallabag,
+      Telegram, webhooks, and the rest), while leaving manual "save this entry"
+      delivery untouched. Concretely: introduce a boolean feed option (for
+      example "disable_integrations", default false) that (1) is stored on the
+      feeds table via a new schema migration, (2) is part of the feed domain
+      type and of the feed creation and feed modification request payloads
+      accepted by the REST API, including partial updates, (3) is persisted and
+      loaded by the feed data-access code, and (4) is honored during feed
+      refresh: when set, new entries produced by a refresh of that feed must
+      not be dispatched to the user's third-party services. Saving an
+      individual entry by hand must still deliver it regardless of the new
+      option.
+    touches:
+      - internal/database/migrations.go
+      - internal/model/feed.go
+      - internal/storage/feed.go
+      - internal/reader/handler/handler.go
+      - miniflux#storage
+      - miniflux#feed-pipeline
+      - miniflux#integration-hub
+      - miniflux#rest-api
+    scoring:
+      method: rubric
+      rubric:
+        - A new migration is appended to the migrations array in
+          internal/database/migrations.go adding the column with a false
+          default; no existing migration entry is edited.
+        - internal/model/feed.go carries the field on the Feed struct, on
+          FeedCreationRequest, and on FeedModificationRequest (nullable/pointer
+          so partial updates work), and the modification patch logic applies
+          it.
+        - internal/storage/feed.go includes the new column in both the create
+          and update statements and in the feed row scanning, so the value
+          round-trips.
+        - In internal/reader/handler/handler.go RefreshFeed, when the option is
+          set on the refreshed feed, integration.PushEntries is not invoked for
+          that feed's new entries; when unset, behavior is unchanged.
+        - The manual save paths (internal/ui/entry_save.go and the REST
+          save-entry handler) still call integration.SendEntry unconditionally;
+          the new option does not gate them.
+
+  # ---------------------------------------------------------- model-maintenance
+  - id: mf-mm-add-metrics-component
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace for this repository
+      (.yarramate/workspace.yaml, with documents under .yarramate/architecture/,
+      evidence under .yarramate/evidence/, projections under
+      .yarramate/projections/, and a LikeC4 adapter mapping under
+      .yarramate/integrations/likec4/) deliberately omitted the Prometheus
+      metrics subsystem. It is now in scope. In the code: internal/metric
+      defines the collectors, the /metrics endpoint is registered in
+      internal/http/server/routes.go behind config.Opts.HasMetricsCollector(),
+      the daemon starts a storage-metrics collector goroutine in
+      internal/cli/daemon.go, and the background workers record refresh
+      durations via internal/metric in internal/worker/worker.go. Update the
+      workspace to declare a metrics collector component: compose it into the
+      miniflux-server concept alongside the other runtime parts, and relate it
+      to at least the worker pool (whose refresh durations it measures) and the
+      storage layer (whose metrics the daemon collector gathers). Keep the
+      whole workspace consistent: extend or add projections as appropriate, and
+      update the LikeC4 subject mapping so both the native check and the LikeC4
+      adapter check pass, with no contradicted claims and no new open catalogue
+      questions left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-not-worse
+
+  - id: mf-mm-remove-media-proxy
+    family: model-maintenance
+    prompt: >-
+      Miniflux maintainers have decided to drop the built-in media proxy:
+      internal/mediaproxy will be deleted, its rewriting will be removed from
+      the web UI, and browsers will load external media directly. Update this
+      repository's committed .yarramate workspace
+      (.yarramate/workspace.yaml and the documents it references) to reflect
+      that code-level change: remove the media proxy concept and every
+      relationship that references it, prune it from any projection that
+      renders it and from the evidence document's observations, and update the
+      LikeC4 subject mapping and project views under
+      .yarramate/integrations/likec4/ so that no orphaned mapping entries
+      remain. When you are done, the native workspace check and the LikeC4
+      adapter check must both pass.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/uptime-kuma.yaml
+++ b/docs/research/context-benchmark/tasks/uptime-kuma.yaml
@@ -1,0 +1,333 @@
+# Frozen benchmark task suite — uptime-kuma (headline repository).
+# Authored against commit ca5323c2dd1ed85c8b36b5227d2da6f6c28eeebc; every
+# groundTruth.answer was verified by reading the cited source files in that
+# commit. Code is the authority; the gallery model was used only to select
+# declared components worth targeting.
+type: yarramate/benchmark-suite/v1
+suite: uptime-kuma
+headline: true
+repository:
+  name: uptime-kuma
+  source: https://github.com/louislam/uptime-kuma
+  commit: ca5323c2dd1ed85c8b36b5227d2da6f6c28eeebc
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/uptime-kuma
+
+tasks:
+  # ------------------------------------------------------------------
+  # Comprehension
+  # ------------------------------------------------------------------
+  - id: uk-comp-alert-decision-dispatch
+    family: comprehension
+    prompt: >-
+      In this repository, when an actively checked monitor transitions from UP
+      to DOWN, an alert is delivered to the operator's configured channels
+      (Telegram, Slack, email, and so on). Explain the code path with
+      repo-relative file paths: (a) which file and function decide that the
+      heartbeat warrants sending notifications, (b) which file and function
+      resolve the concrete provider implementation that formats and delivers
+      the message for a given channel type, and (c) where the individual
+      per-channel provider implementations live and what contract they
+      implement.
+    groundTruth:
+      answer: >-
+        (a) The per-monitor check loop in server/model/monitor.js decides:
+        after each beat, Monitor.isImportantBeat marks the transition and
+        Monitor.isImportantForNotification (server/model/monitor.js:1420,
+        called at line 968) determines that UP->DOWN warrants notifications;
+        Monitor.sendNotification (server/model/monitor.js:1452) then builds
+        the message and iterates the monitor's configured notification list
+        (re-sends while still DOWN are driven by resendInterval at lines
+        989-1002). (b) Notification.send in server/notification.js (line 238)
+        resolves the provider by looking up notification.type in the
+        providerList registry that Notification.init (line 112) builds at
+        startup. (c) Each channel is a module under
+        server/notification-providers/ (99 modules) whose class extends
+        NotificationProvider (server/notification-providers/notification-provider.js),
+        sets a unique name, and implements send(notification, msg,
+        monitorJSON, heartbeatJSON), returning a success message or throwing
+        on failure.
+      verifiedAgainst:
+        - server/model/monitor.js:961
+        - server/model/monitor.js:1420
+        - server/model/monitor.js:1452
+        - server/notification.js:112
+        - server/notification.js:238
+        - server/notification-providers/notification-provider.js
+    scoring:
+      method: ground-truth
+
+  - id: uk-comp-push-vs-active
+    family: comprehension
+    prompt: >-
+      Push monitors in this repository are passive: an external system calls
+      an HTTP endpoint to report its own liveness instead of being probed.
+      Identify, with repo-relative file paths: (a) the exact route and the
+      file that implements it, (b) how the handler decides whether the
+      resulting heartbeat is UP, PENDING, or DOWN when retries are configured,
+      and (c) whether the handler reuses the periodic check loop that active
+      monitors run through or implements its own path — and, in the latter
+      case, what state it updates before responding (persistence, live
+      dashboard updates, statistics, alerting).
+    groundTruth:
+      answer: >-
+        (a) router.all("/api/push/:pushToken") in server/routers/api-router.js
+        (line 47). (b) A local determineStatus() helper in the same file
+        (lines 576-619) applies upside-down flipping and the
+        maxretries/PENDING escalation against the previous heartbeat.
+        (c) It does not go through the active check loop in
+        server/model/monitor.js — the route handler itself dispenses a
+        heartbeat bean, checks maintenance via Monitor.isUnderMaintenance
+        (forcing MAINTENANCE status), updates the per-monitor UptimeCalculator
+        (line 92), calls Monitor.sendNotification on important transitions and
+        re-sends while DOWN per resendInterval (lines 102-123), stores the
+        heartbeat row (line 125), emits the "heartbeat" Socket.IO event to the
+        owning user's room and pushes aggregate stats via Monitor.sendStats
+        (lines 127-129), and updates Prometheus metrics (line 132) before
+        responding with { ok: true }.
+      verifiedAgainst:
+        - server/routers/api-router.js:47
+        - server/routers/api-router.js:576
+        - server/routers/api-router.js:92
+        - server/routers/api-router.js:125
+        - server/model/monitor.js:1596
+    scoring:
+      method: ground-truth
+
+  - id: uk-comp-uptime-calc-retired
+    family: comprehension
+    prompt: >-
+      Suppose the module server/uptime-calculator.js were retired from this
+      repository without a replacement. Based on what actually imports and
+      calls it, list the user-facing capabilities that would break, naming the
+      consuming file (repo-relative path) responsible for each.
+    groundTruth:
+      answer: >-
+        Breakages by consumer: (1) server/model/monitor.js — the check loop's
+        uptime/response aggregation (uptimeCalculator.update at line 1053) and
+        the live dashboard statistics Monitor.sendStats emits (avgPing and
+        uptime Socket.IO events, lines 1315-1340); (2)
+        server/routers/api-router.js — the public SVG uptime and ping badges
+        (getDataByDuration at lines 257 and 317) and the push endpoint's
+        heartbeat end-time/uptime update (line 92); (3)
+        server/routers/status-page-router.js — the public status page's 24h
+        uptime figures (get24Hour at line 99); (4)
+        server/socket-handlers/chart-socket-handler.js — dashboard chart data
+        (getUptimeCalculator at line 16); (5) server/server.js — the
+        clear-statistics operations (UptimeCalculator.clearStatistics /
+        clearAllStatistics at lines 1683 and 1711); (6) server/database.js —
+        the aggregate-stats migration during database setup (new
+        UptimeCalculator at line 932). server/prometheus.js only references
+        the module's typedef in a comment, so metric export itself does not
+        depend on it at runtime.
+      verifiedAgainst:
+        - server/uptime-calculator.js:72
+        - server/model/monitor.js:1053
+        - server/model/monitor.js:1315
+        - server/routers/api-router.js:257
+        - server/routers/api-router.js:317
+        - server/routers/status-page-router.js:99
+        - server/socket-handlers/chart-socket-handler.js:16
+        - server/server.js:1683
+        - server/database.js:932
+        - server/prometheus.js:147
+    scoring:
+      method: ground-truth
+
+  # ------------------------------------------------------------------
+  # Change
+  # ------------------------------------------------------------------
+  - id: uk-change-add-notification-provider
+    family: change
+    prompt: >-
+      Add a new notification channel named "SimplePost" to this repository.
+      Behaviour: it performs an HTTP POST of the JSON body {"title", "msg",
+      "status"} to a user-configured URL, with an optional user-configured
+      token sent as an Authorization bearer header. Requirements: (1)
+      implement the server-side provider following the existing provider
+      conventions so both alert (DOWN) and recovery (UP) messages are
+      delivered through it; (2) register it so the server can dispatch to it
+      by notification type; (3) add the settings form to the web UI so an
+      operator can create a SimplePost notification from the notification
+      dialog (URL required, token optional). Follow the existing patterns in
+      the codebase and do not modify unrelated providers.
+    touches:
+      - notification-hub
+      - web-app
+      - server/notification.js
+      - server/notification-providers/
+      - src/components/notifications/index.js
+      - src/components/notifications/
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new module under server/notification-providers/ exports a class
+          extending NotificationProvider, sets a unique name, and implements
+          send() performing the POST with the JSON body and the optional
+          Authorization header, following the existing okMsg-on-success /
+          throw-on-failure convention.
+        - >-
+          The provider is imported and instantiated in the provider list
+          inside Notification.init() in server/notification.js, so
+          Notification.send() resolves it by type.
+        - >-
+          A form component is added under src/components/notifications/ and
+          registered in NotificationFormList in
+          src/components/notifications/index.js under a key matching the
+          server-side provider name, making the type selectable in the
+          notification dialog with a required URL input and an optional token
+          input.
+        - >-
+          No unrelated notification providers or monitor code paths are
+          modified.
+
+  - id: uk-change-add-monitor-type
+    family: change
+    prompt: >-
+      Add a new active check type "tcp-banner" to this repository. Behaviour:
+      it opens a TCP connection to a configured hostname and port, reads the
+      first line the remote end sends (the banner), and reports the check as
+      up only if the banner contains a configured keyword; otherwise the check
+      fails with a descriptive error message. Requirements: (1) implement the
+      check following the repository's pluggable check-type conventions; (2)
+      register the type so per-monitor checks of this type are dispatched to
+      your implementation; (3) expose the new type in the monitor edit form,
+      reusing the existing hostname, port, and keyword inputs. Follow the
+      existing patterns and do not modify other check types.
+    touches:
+      - monitor-engine
+      - server-core
+      - web-app
+      - server/monitor-types/
+      - server/uptime-kuma-server.js
+      - src/pages/EditMonitor.vue
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new module under server/monitor-types/ exports a class extending
+          MonitorType with name "tcp-banner" and an async check(monitor,
+          heartbeat, server) that sets heartbeat.status to UP with a message
+          on success and throws a descriptive Error on failure, per the
+          contract in server/monitor-types/monitor-type.js.
+        - >-
+          The type is registered as
+          UptimeKumaServer.monitorTypeList["tcp-banner"] in initMonitorTypes()
+          in server/uptime-kuma-server.js — the dispatch table the check loop
+          consults (server/model/monitor.js line ~871).
+        - >-
+          src/pages/EditMonitor.vue offers "tcp-banner" as a selectable
+          monitor type and shows the hostname, port, and keyword inputs for
+          it; the forms of other types are unchanged.
+        - >-
+          No existing check-type modules are modified.
+
+  - id: uk-change-skip-recovery-notification
+    family: change
+    prompt: >-
+      Add a per-monitor setting "Skip recovery notifications" to this
+      repository. When enabled for a monitor, DOWN alerts are still sent, but
+      the recovery (DOWN to UP) notification is suppressed for that monitor —
+      for both actively checked monitors and passive push monitors.
+      Requirements: (1) persist the setting on the monitor record with a
+      schema migration following the repository's migration conventions,
+      defaulting to off; (2) enforce the suppression wherever up/down
+      notifications are dispatched, without affecting DOWN alerts or the
+      still-down re-send behaviour; (3) expose a checkbox for the setting in
+      the monitor edit form; (4) ensure the setting round-trips through
+      monitor create and edit.
+    touches:
+      - monitor-engine
+      - server-core
+      - web-app
+      - monitor-config
+      - db/knex_migrations/
+      - server/model/monitor.js
+      - server/server.js
+      - src/pages/EditMonitor.vue
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new migration file under db/knex_migrations/ adds a boolean column
+          (defaulting to false/0) to the monitor table, matching the naming
+          and up/down structure of the existing migrations (e.g.
+          2025-09-02-0000-add-domain-expiry.js).
+        - >-
+          The guard is enforced on the shared dispatch path (e.g. in
+          Monitor.sendNotification or at its call sites in
+          server/model/monitor.js) such that UP-recovery notifications are
+          skipped when the flag is set while UP->DOWN alerts and
+          resendInterval re-sends still fire; because the push route in
+          server/routers/api-router.js also calls Monitor.sendNotification,
+          push monitors honour the same behaviour.
+        - >-
+          The field is included in Monitor.toJSON in server/model/monitor.js
+          and copied from the client payload in both the "add" and
+          "editMonitor" socket handlers in server/server.js, so it round-trips
+          through create and edit.
+        - >-
+          src/pages/EditMonitor.vue renders the checkbox, defaulting to
+          unchecked, and no unrelated monitor settings change behaviour.
+
+  # ------------------------------------------------------------------
+  # Model maintenance
+  # ------------------------------------------------------------------
+  - id: uk-mm-metrics-endpoint-removed
+    family: model-maintenance
+    prompt: >-
+      Scenario — assume this change has landed in the repository: the
+      Prometheus integration has been removed entirely. The
+      app.get("/metrics", apiAuth, ...) route is gone from server/server.js,
+      server/prometheus.js is deleted, and the prometheus-api-metrics
+      dependency has been dropped; no metrics endpoint exists any more.
+      Update the repository's committed .yarramate workspace
+      (.yarramate/workspace.yaml and the documents it references: the
+      architecture document, the evidence document, and the LikeC4 integration
+      mapping under .yarramate/integrations/likec4/) so it accurately reflects
+      the repository after this change. In particular, the metrics-scraper
+      concept and the core-serves-scraper relationship no longer describe
+      anything real, and evidence observations citing the /metrics endpoint
+      must not survive unchanged. Deliver an updated workspace that passes
+      `yarramate check` with no contradicted evidence results, and keep the
+      LikeC4 mapping consistent with the model so `yarramate-likec4 check`
+      passes.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-not-worse
+
+  - id: uk-mm-notification-worker-split
+    family: model-maintenance
+    prompt: >-
+      Scenario — assume this change has landed in the repository: notification
+      dispatch has been extracted out of the main server process. A new
+      entrypoint server/notification-worker.js runs as a second Node.js
+      process inside the same container, started by the container command
+      alongside server/server.js. The monitor engine no longer calls
+      Notification.send in-process; instead it enqueues dispatch requests into
+      a new notification_queue table in the application database, which the
+      worker polls and delivers through the existing provider modules under
+      server/notification-providers/. Update the repository's committed
+      .yarramate workspace (.yarramate/workspace.yaml and the documents it
+      references) to reflect this: the notification hub's process/deployment
+      placement inside the Docker runtime, the engine-to-hub interaction
+      becoming queue-mediated through the application database, and the new
+      queued dispatch-request data. Adjust evidence observations that the
+      scenario invalidates and keep the LikeC4 mapping in sync with the
+      revised concepts and relationships. Deliver an updated workspace that
+      passes `yarramate check` with no contradicted evidence results and a
+      passing `yarramate-likec4 check`.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-not-worse

--- a/docs/research/context-benchmark/tasks/yarramate-self.yaml
+++ b/docs/research/context-benchmark/tasks/yarramate-self.yaml
@@ -1,0 +1,266 @@
+# Frozen benchmark task suite: the YarraMate repository itself (self-model).
+# Excluded from pooled headline numbers as self-serving (DESIGN.md, "Task
+# suite"); reported separately. Authored against commit a96f770 before any
+# condition is run; do not edit after freezing.
+type: yarramate/benchmark-suite/v1
+suite: yarramate-self
+headline: false
+repository:
+  name: yarramate-self
+  source: https://github.com/yarrasys/yarramate
+  commit: a96f7703ea8be54912e9ce851fb4d66110dfe544
+  model: .yarramate
+tasks:
+  # ── Comprehension ────────────────────────────────────────────────────
+  - id: ym-mcp-tool-delegation
+    family: comprehension
+    prompt: |
+      This repository ships a Model Context Protocol server that speaks
+      JSON-RPC 2.0 over stdio.
+      (a) List the tools it exposes.
+      (b) Explain how a tools/call request is fulfilled: does the server
+      re-implement any engine behaviour itself, and can any of its tools
+      mutate repository files?
+      (c) How does a failure of the underlying operation surface in the
+      tool response?
+    groundTruth:
+      answer: |
+        (a) Four tools, defined in src/adapters/mcp-cli.ts: yarramate_status,
+        yarramate_check, yarramate_reconcile, and yarramate_context (the last
+        accepts either an authored projection path or globally qualified
+        --subject identities, plus an optional token budget).
+        (b) Each tool definition only maps its JSON input to a CLI argv array
+        (e.g. ['status', <workspace>, '--json']) and calls the exported
+        runCli() from src/cli.ts in-process. The adapter contains no domain
+        logic of its own, and every exposed command is read-only; the
+        initialize response's instructions state the server never mutates the
+        native documents.
+        (c) There is no JSON-RPC error for command failure: the response is a
+        normal result with isError: true and a single text content block
+        carrying the command's stdout (or stderr when stdout is empty),
+        driven by result.exitCode !== 0.
+      verifiedAgainst:
+        - src/adapters/mcp-cli.ts:29
+        - src/adapters/mcp-cli.ts:152
+        - src/cli.ts:885
+        - test/mcp-cli.test.ts:53
+    scoring:
+      method: ground-truth
+
+  - id: ym-status-one-call-orientation
+    family: comprehension
+    prompt: |
+      The CLI's status command prints a one-call orientation summary for a
+      workspace.
+      (a) Which other engine operations does it run internally to assemble
+      that summary?
+      (b) What exactly determines its exit code — in particular, can drift
+      findings reported in the summary alone make the exit code non-zero?
+      (c) What happens when status is pointed at a plain document instead
+      of a workspace manifest?
+    groundTruth:
+      answer: |
+        (a) src/status-command.ts re-runs the check command in JSON mode
+        (runCheckCommand([workspacePath, '--json'])) and embeds its verdict,
+        diagnostics, and counted block. When check passes it additionally
+        compiles the workspace (compileWorkspace) to recover document ids and
+        declared states, loads every projection definition to pick up titles,
+        and — when the manifest lists evidence documents — evaluates them
+        (evaluateEvidenceWorkspace) and embeds the reconciliation summary
+        (observations, confirmed, findings split into contradicted, unknown,
+        notObserved) via reconcileEvidenceReports.
+        (b) The exit code mirrors the check verdict only: result.ok is set
+        from the embedded check payload's ok, and stdout exits 0/1 on that
+        alone. Reconciliation findings (including contradicted claims) are
+        reported in the summary but never change the exit code.
+        (c) It refuses to run: unless the file's format is
+        yarramate/workspace/v1 it exits 2 with "status requires an explicit
+        workspace manifest"; a manifest that fails to load exits 1 with
+        diagnostics.
+      verifiedAgainst:
+        - src/status-command.ts:75
+        - src/status-command.ts:101
+        - src/status-command.ts:160
+        - src/status-command.ts:184
+        - src/status-command.ts:266
+        - src/check-command.ts:30
+        - src/cli-support.ts:42
+    scoring:
+      method: ground-truth
+
+  - id: ym-source-loader-blast-radius
+    family: comprehension
+    prompt: |
+      One module in this codebase centralizes schema-backed YAML loading:
+      parsing, JSON Schema validation, and construction of deterministic
+      source-located diagnostics (path, pointer, line, column).
+      (a) Which file is it, and what are its key exports?
+      (b) Which other modules depend on it, and on which exports?
+      (c) If the file were deleted outright, which CLI capabilities would
+      break?
+    groundTruth:
+      answer: |
+        (a) src/source-document.ts. Key exports: loadSourceDocument (parse +
+        Ajv validation returning a validated document or YM101/YM201
+        diagnostics), locateSourcePath (pointer → line/column),
+        diagnosticOrder (deterministic diagnostic sort key),
+        describeSchemaViolation, and closestCandidate (did-you-mean
+        suggestions).
+        (b) loadSourceDocument is used by the loaders in src/workspace.ts,
+        src/evidence.ts, src/core-contract.ts, src/adapter-mapping.ts,
+        src/projection.ts, and the adapter modules
+        src/adapters/likec4-kind-mapping.ts, src/adapters/likec4-prepare.ts,
+        and src/adapters/likec4-project.ts. src/compiler.ts depends on the
+        helper exports describeSchemaViolation and closestCandidate, and
+        src/adapters/likec4-export.ts on diagnosticOrder.
+        (c) Everything: the compiler and every schema-backed loader import
+        from it, so document/profile compilation and workspace, evidence,
+        contract, mapping, and projection loading all fail — which breaks
+        every CLI command (check, status, compile, context, view, compare,
+        evidence, reconcile, add, connect, new) as well as the bundled
+        adapter commands.
+      verifiedAgainst:
+        - src/source-document.ts:25
+        - src/source-document.ts:118
+        - src/compiler.ts:8
+        - src/workspace.ts:12
+        - src/evidence.ts:12
+        - src/core-contract.ts:8
+        - src/adapter-mapping.ts:12
+        - src/projection.ts:9
+        - src/adapters/likec4-kind-mapping.ts:8
+        - src/adapters/likec4-prepare.ts:22
+        - src/adapters/likec4-project.ts:4
+        - src/adapters/likec4-export.ts:9
+    scoring:
+      method: ground-truth
+
+  # ── Change ───────────────────────────────────────────────────────────
+  - id: ym-mcp-compare-tool
+    family: change
+    prompt: |
+      This repository ships a Model Context Protocol server speaking
+      JSON-RPC 2.0 over stdio that currently exposes four read-only tools.
+      Add a fifth read-only tool that exposes the existing state-comparison
+      CLI command (compare <from-state> <to-state> <workspace-manifest>).
+      Follow the server's existing tool-naming convention, declare a JSON
+      input schema requiring workspace, from, and to, and produce the
+      result by delegating to the CLI exactly the way the existing tools do
+      — do not re-implement comparison logic inside the server. Update the
+      server's test suite so the tool-listing expectation includes the new
+      tool, and add a test that calls it successfully against the
+      repository's own committed workspace using two states declared there.
+    touches:
+      - src/adapters/mcp-cli.ts
+      - test/mcp-cli.test.ts
+      - "yarramate-engine#compare-command"
+      - "yarramate-engine#state-comparison"
+    scoring:
+      method: rubric
+      rubric:
+        - tools/list returns exactly five tools; the new tool follows the
+          existing yarramate_<command> naming convention and its inputSchema
+          requires workspace, from, and to.
+        - The new tool's arguments mapping produces ['compare', <from>,
+          <to>, <workspace>] and the result comes from the exported runCli;
+          no comparison logic is implemented in the adapter and the four
+          existing tool definitions are behaviourally unchanged.
+        - A failing compare surfaces exactly like other tool failures — a
+          result with isError true carrying the command's stdout/stderr
+          text — not a JSON-RPC error.
+        - The updated test suite covers both the five-tool listing and one
+          successful compare call against the committed workspace, and the
+          tests command exits 0.
+      tests: pnpm build && pnpm vitest run test/mcp-cli.test.ts
+
+  - id: ym-check-counted-claims
+    family: change
+    prompt: |
+      The check command's machine-readable JSON result contains a counted
+      block reporting documents, concepts, relationships, and states, and
+      the status command embeds the same block in its own JSON output.
+      Extend the counted block with a claims field reporting the total
+      number of claims in the compiled semantic graph. Update the published
+      JSON Schemas for both result formats so that claims is a required
+      non-negative integer inside counted, keep the check command's
+      human-readable success line unchanged, and make sure the status
+      command's JSON output carries the new field through.
+    touches:
+      - src/check-command.ts
+      - src/cli-support.ts
+      - src/status-command.ts
+      - schema/yarramate-check-result.schema.json
+      - schema/yarramate-status-result.schema.json
+      - "yarramate-engine#check-result-schema"
+      - "yarramate-engine#status-command"
+    scoring:
+      method: rubric
+      rubric:
+        - Running check in JSON mode on the committed workspace emits
+          counted.claims equal to the compiled graph's total claim count
+          alongside the existing four counts, and the human-readable
+          success line is byte-identical to before the change.
+        - Both schema/yarramate-check-result.schema.json and
+          schema/yarramate-status-result.schema.json now require
+          counted.claims as an integer >= 0 with additionalProperties still
+          false, and the emitted JSON outputs validate against them.
+        - The status command's JSON output contains the same counted block
+          including claims, with no independent re-computation added to
+          src/status-command.ts.
+        - The tests command exits 0.
+      tests: pnpm vitest run test/cli.test.ts test/status-command.test.ts
+
+  # ── Model maintenance ────────────────────────────────────────────────
+  - id: ym-model-declare-mcp-adapter
+    family: model-maintenance
+    prompt: |
+      The repository recently gained a read-only MCP adapter
+      (src/adapters/mcp-cli.ts, commit "Add read-only MCP adapter over the
+      stable CLI"): a JSON-RPC-over-stdio server exposing status, check,
+      reconcile, and context as tools, each delegating to the stable CLI's
+      exported runCli rather than re-implementing engine behaviour. The
+      committed .yarramate workspace does not declare this adapter
+      anywhere. Update the .yarramate model to reflect it: declare the
+      adapter in the engine document at the granularity used for comparable
+      adapters (see the Graphify evidence adapter and the LikeC4 export
+      adapter), and relate it to the existing yarramate-engine#cli concept
+      it delegates to and to the command services it exposes
+      (yarramate-engine#status-command, yarramate-engine#check-command,
+      yarramate-engine#reconcile-command). Every workspace check must
+      remain green and reconciliation must report no contradicted findings
+      afterwards.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+
+  - id: ym-model-declare-context-and-new
+    family: model-maintenance
+    prompt: |
+      Two CLI capabilities shipped recently but are absent from the
+      committed .yarramate model, whose engine document declares command
+      services only for check, init, add, connect, compile, evidence,
+      reconcile, status, and compare:
+      (1) the context command (src/cli.ts), which renders a bounded slice
+      from an authored projection or an ad-hoc --subject neighbourhood and
+      supports a --budget flag for a compact token-budgeted rendering
+      (renderBudgetedContext in src/projection.ts);
+      (2) the new command (src/new-command.ts), which scaffolds a
+      projection definition through validated writes.
+      Update the .yarramate workspace so both appear as command services in
+      the engine document with relationships mirroring the granularity of
+      the existing command declarations (the CLI implements them; the
+      context service realizes or serves the machine-context capability in
+      the product document; the new command serves the agent harness).
+      Afterwards the workspace must still check green, reconciliation must
+      report no contradicted findings, and the bundled LikeC4 adapter path
+      must still pass its check.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass

--- a/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
+++ b/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarrasys.github.io/yarramate/research/yarramate-benchmark-suite.schema.json",
+  "title": "yarramate/benchmark-suite/v1 (research draft)",
+  "description": "Frozen task suite for one benchmark repository. Draft research artifact; not a normative contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "suite", "headline", "repository", "tasks"],
+  "properties": {
+    "type": { "const": "yarramate/benchmark-suite/v1" },
+    "suite": { "$ref": "#/$defs/slug" },
+    "headline": {
+      "type": "boolean",
+      "description": "false excludes this suite from pooled headline numbers (e.g. the self-serving yarramate self-model suite)."
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "source", "commit", "model"],
+      "properties": {
+        "name": { "$ref": "#/$defs/slug" },
+        "source": { "$ref": "#/$defs/nonEmptyText" },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "gallery": { "$ref": "#/$defs/nonEmptyText" },
+        "model": {
+          "type": "string",
+          "description": "Path of the committed .yarramate model used for condition B, relative to the gallery repository root (or this repository root when gallery is absent)."
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 6,
+      "items": { "$ref": "#/$defs/task" }
+    }
+  },
+  "$defs": {
+    "slug": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+    "nonEmptyText": { "type": "string", "minLength": 1 },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "family", "prompt", "scoring"],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "family": { "enum": ["comprehension", "change", "model-maintenance"] },
+        "prompt": {
+          "$ref": "#/$defs/nonEmptyText",
+          "description": "Frozen task text given verbatim to the agent. Must be condition-neutral: no mention of yarramate, models, projections, or any preferred context source."
+        },
+        "groundTruth": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["answer", "verifiedAgainst"],
+          "properties": {
+            "answer": { "$ref": "#/$defs/nonEmptyText" },
+            "verifiedAgainst": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/nonEmptyText" },
+              "description": "Source-code locations (repo-relative paths, optionally :line) the answer was verified against. Code is the authority, not the model."
+            }
+          }
+        },
+        "touches": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/nonEmptyText" },
+          "description": "Change tasks: repo-relative files or declared component ids the correct change is expected to touch; input to the wrong-file/wrong-component metric."
+        },
+        "scoring": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["method"],
+          "properties": {
+            "method": { "enum": ["ground-truth", "rubric", "deterministic"] },
+            "rubric": {
+              "type": "array",
+              "minItems": 2,
+              "items": { "$ref": "#/$defs/nonEmptyText" },
+              "description": "Human-adjudicated pass/fail criteria, one judgement per entry."
+            },
+            "deterministic": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["expect"],
+              "properties": {
+                "expect": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "enum": ["check-pass", "no-contradicted", "catalogue-not-worse", "likec4-check-pass"] }
+                }
+              }
+            },
+            "tests": {
+              "$ref": "#/$defs/nonEmptyText",
+              "description": "Optional shell command run in the task workdir; exit 0 counts toward success (change tasks)."
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "family": { "const": "comprehension" } } },
+          "then": {
+            "required": ["groundTruth"],
+            "properties": { "scoring": { "type": "object", "properties": { "method": { "const": "ground-truth" } } } }
+          }
+        },
+        {
+          "if": { "properties": { "family": { "const": "change" } } },
+          "then": {
+            "required": ["touches"],
+            "properties": { "scoring": { "type": "object", "properties": { "method": { "const": "rubric" }, "rubric": { "type": "array", "minItems": 2 } }, "required": ["rubric"] } }
+          }
+        },
+        {
+          "if": { "properties": { "family": { "const": "model-maintenance" } } },
+          "then": {
+            "properties": { "scoring": { "type": "object", "properties": { "method": { "const": "deterministic" } }, "required": ["deterministic"] } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "self:check:likec4:json": "pnpm build && node dist/adapters/likec4-cli.js check .yarramate/integrations/likec4/project.yaml --json .yarramate/workspace.yaml",
     "self:export:likec4": "pnpm build && node dist/adapters/likec4-cli.js export-project .yarramate/integrations/likec4/project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml",
     "validate": "pnpm self:export:likec4 && likec4 validate --no-layout .yarramate-out/likec4",
-    "verify": "pnpm typecheck && pnpm test && pnpm self:check && pnpm validate",
+    "verify": "pnpm typecheck && pnpm build && pnpm test && pnpm self:check && pnpm validate",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Delivers the implementation phase of the context benchmark (design frozen in `docs/research/context-benchmark/DESIGN.md`, PR #42). Everything lives under `docs/research/` — nothing is wired into the compiler, CLI, or package exports.

## Task suites (frozen at merge)

37 tasks across five repositories, authored by five independent agents with ground truth verified against code at pinned commits (never against the models):

| Suite | Tasks | Headline |
|---|---|---|
| uptime-kuma | 8 | yes |
| miniflux | 7 | yes |
| fastify | 7 | yes |
| httpie | 8 | yes |
| yarramate-self | 7 | no (self-serving, reported separately) |

Each suite passes `validate-suite.mjs`: schema conformance, unique ids, ≥2 tasks per family, and a lexical prompt-leakage check (condition-A prompts cannot name a context source).

## Runner

- `conditions.mjs` — A (prose only) / B (model + CLI) / C (stale model); B and C share one verbatim instruction string so staleness is undetectable from prompt text
- `inject-stale.mjs` — deterministic condition-C injection: rotates same-kind confirmed relationship targets and flips their evidence to `contradicted`; self-verifies (check stays green, reconcile reports ≥3 contradicted). Live-tested against the miniflux gallery model
- `run-benchmark.mjs` — tasks × conditions matrix, isolated pinned-commit workdirs, harness invocation via stdin with transcript capture, `--dry-run` matrix preview (smoke-tested: 16-run matrix on a synthetic suite, model-maintenance correctly excluded from A)
- `score.mjs` — deterministic scoring (check/reconcile/catalogue/likec4 + wrong-file edit rate from git diff vs `touches`) and a human adjudication queue for ground-truth/rubric verdicts — no LLM judging

## Caveats

- ⚠️ Headline pooling wants N≥5 external repos; the gallery has 4 — a fifth showcase is needed before publishing pooled numbers (README notes this)
- Live runs cost agent tokens and are user-triggered; nothing in this PR executes a harness
- Suite authoring surfaced minor gallery-model errata (overgeneralized miniflux refresh description, uptime-kuma pluggable-type overstatement, line-number drifts) — tracked for a gallery follow-up, deliberately not fixed here to keep suites honest against the published models

Verify green (typecheck, 226 tests, self-check, likec4 validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)