### PR TITLE
Benchmark: model-bearing conditions mirror an adopted repository

### DIFF
--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -60,7 +60,14 @@ node runner/score.mjs --runs results/2026-07-29/runs.jsonl \
 The harness command receives the composed prompt (condition instruction +
 frozen task text) on stdin and runs with the isolated task workdir as cwd; the
 pinned toolchain is prepended to its PATH so `yarramate` resolves to the
-benchmark version. For the H2 tier sweep, repeat step 3 with a different
+benchmark version. Model-bearing workdirs (B/C) also carry the `AGENTS.md`
+pointer that `yarramate init` writes (ADR 0040) — appended to the repo's
+existing `AGENTS.md` when present — and the run record snapshots the
+workspace's open-catalogue count (`catalogueBaseline`) for the
+`catalogue-not-worse` scorer. Run harness agents from a hermetic path: the
+pilot showed user-level agent config (memory/plugin hooks) leaking into runs
+non-uniformly by tier when workdirs lived under the operator's own project
+tree. For the H2 tier sweep, repeat step 3 with a different
 `--model`/`--label` pair. Model-maintenance tasks are skipped under condition
 A (no workspace to maintain).
 

--- a/docs/research/context-benchmark/runner/catalogue.mjs
+++ b/docs/research/context-benchmark/runner/catalogue.mjs
@@ -1,0 +1,32 @@
+// Shared helper: open-question count of a workspace under the core-enrichment
+// catalogue, via the reference evaluator. Returns null (never throws) when the
+// workspace does not compile or the evaluator output is unrecognisable.
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const catalogueDir = join(repoRoot, 'docs/research/question-catalogue');
+
+export const catalogueOpen = (toolchainDir, workspaceDir, scratchDir, cataloguePath = join(catalogueDir, 'core-enrichment.yaml')) => {
+  try {
+    const compiled = execFileSync(join(toolchainDir, 'yarramate'), ['compile', join(workspaceDir, 'workspace.yaml')], {
+      encoding: 'utf8',
+      maxBuffer: 512 * 1024 * 1024,
+    });
+    const graphPath = join(scratchDir, 'compiled-graph.json');
+    writeFileSync(graphPath, compiled);
+    const evaluated = execFileSync('node', [
+      join(catalogueDir, 'evaluate-catalogue.mjs'),
+      join(catalogueDir, 'yarramate-question-catalogue.schema.json'),
+      cataloguePath,
+      graphPath,
+    ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+    const open = evaluated.match(/total open questions[^:]*:\s*(\d+)/i);
+    return open ? Number(open[1]) : null;
+  } catch {
+    return null;
+  }
+};

--- a/docs/research/context-benchmark/runner/conditions.mjs
+++ b/docs/research/context-benchmark/runner/conditions.mjs
@@ -4,6 +4,12 @@
 
 const BASE = 'Work in the repository at the current directory.';
 
+// Model-bearing workdirs additionally carry the AGENTS.md pointer that
+// `yarramate init` writes (ADR 0040): an adopted repository advertises its
+// workspace to agent harnesses, so B/C mirror an adopted repository rather
+// than a bare model drop. The pilot (2026-07-29) ran without the pointer and
+// the weak tier never discovered the workspace; the instruction text below is
+// unchanged so prompt neutrality is preserved.
 const MODEL_AVAILABLE =
   `${BASE} It contains a committed .yarramate architecture workspace; the ` +
   'yarramate CLI is installed and can query it (status, context, check).';

--- a/docs/research/context-benchmark/runner/run-benchmark.mjs
+++ b/docs/research/context-benchmark/runner/run-benchmark.mjs
@@ -22,6 +22,7 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CONDITIONS } from './conditions.mjs';
+import { catalogueOpen } from './catalogue.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..', '..', '..', '..');
@@ -94,6 +95,23 @@ if (!existsSync(cacheDir)) {
   execSync('git checkout -q FETCH_HEAD', { cwd: cacheDir });
 }
 
+// Model-bearing workdirs also get the AGENTS.md pointer that `yarramate init`
+// writes (ADR 0040): an adopted repository advertises its workspace to agent
+// harnesses, and condition B/C should look like an adopted repository. The
+// pointer text is captured once from a fresh init with the pinned toolchain.
+let pointerText = null;
+const agentsPointer = () => {
+  if (pointerText === null) {
+    const probeDir = join(outDir, 'cache', '.agents-probe');
+    if (!existsSync(join(probeDir, 'AGENTS.md'))) {
+      mkdirSync(probeDir, { recursive: true });
+      execFileSync(join(toolchain, 'yarramate'), ['init', '.'], { cwd: probeDir, stdio: 'ignore' });
+    }
+    pointerText = readFileSync(join(probeDir, 'AGENTS.md'), 'utf8');
+  }
+  return pointerText;
+};
+
 const runsPath = join(outDir, 'runs.jsonl');
 for (const [index, { conditionId, condition, task }] of matrix.entries()) {
   const runDir = join(outDir, suite.suite, label, conditionId, task.id);
@@ -104,6 +122,7 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
 
   const workspaceDir = join(workdir, '.yarramate');
   rmSync(workspaceDir, { recursive: true, force: true });
+  let catalogueBaseline = null;
   if (condition.model !== 'none') {
     cpSync(modelSourceDir(), workspaceDir, { recursive: true });
     if (condition.model === 'stale') {
@@ -114,6 +133,10 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
       ], { encoding: 'utf8' });
       writeFileSync(join(runDir, 'inject.json'), injected);
     }
+    const agentsPath = join(workdir, 'AGENTS.md');
+    const existing = existsSync(agentsPath) ? `${readFileSync(agentsPath, 'utf8').replace(/\n*$/, '')}\n\n` : '';
+    writeFileSync(agentsPath, `${existing}${agentsPointer()}`);
+    catalogueBaseline = catalogueOpen(toolchain, workspaceDir, runDir);
   }
   execSync('git add -A && git -c user.email=bench@local -c user.name=bench commit -qm baseline --allow-empty', { cwd: workdir });
 
@@ -156,6 +179,7 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
     exitCode: result.status,
     durationMs,
     metrics,
+    catalogueBaseline,
     runDir,
     finishedAt: new Date().toISOString(),
   })}\n`);

--- a/docs/research/context-benchmark/runner/score.mjs
+++ b/docs/research/context-benchmark/runner/score.mjs
@@ -16,6 +16,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { catalogueOpen } from './catalogue.mjs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -54,24 +55,7 @@ const cli = (bin, cmdArgs, cwd) => {
     return { out: `${error.stdout ?? ''}${error.stderr ?? ''}`, code: error.status ?? 1 };
   }
 };
-const catalogueOpen = (workspaceDir, cwd) => {
-  const compiled = cli('yarramate', ['compile', join(workspaceDir, 'workspace.yaml')], cwd);
-  if (compiled.code !== 0) return null;
-  const graphPath = join(cwd, 'compiled-graph.json');
-  writeFileSync(graphPath, compiled.out);
-  try {
-    const evaluated = execFileSync('node', [
-      join(repoRoot, 'docs/research/question-catalogue/evaluate-catalogue.mjs'),
-      join(repoRoot, 'docs/research/question-catalogue/yarramate-question-catalogue.schema.json'),
-      cataloguePath,
-      graphPath,
-    ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
-    const open = evaluated.match(/total open questions[^:]*:\s*(\d+)/i);
-    return open ? Number(open[1]) : null;
-  } catch {
-    return null;
-  }
-};
+const postCatalogueOpen = (workspaceDir, cwd) => catalogueOpen(toolchain, workspaceDir, cwd, cataloguePath);
 
 const records = readFileSync(runsPath, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
 for (const record of records) {
@@ -115,7 +99,7 @@ for (const record of records) {
         }
       } else if (expectation === 'catalogue-not-worse') {
         const baseline = record.catalogueBaseline ?? null;
-        const after = catalogueOpen(workspaceDir, workdir);
+        const after = postCatalogueOpen(workspaceDir, workdir);
         results[expectation] = baseline === null || after === null ? null : after <= baseline;
         score.catalogue = { baseline, after };
       }


### PR DESCRIPTION
Pilot finding (miniflux, A/B, haiku vs sonnet — 24 runs): the weak tier never discovered the workspace from the condition instruction alone (0/5 haiku B runs used the CLI; sonnet 5/5). Haiku's B cells were measuring discoverability failure, not workspace value.

- B/C workdirs now carry the `AGENTS.md` pointer that `yarramate init` writes (ADR 0040), appended to the repo's existing AGENTS.md when present — an adopted repository advertises its workspace; instruction text is unchanged so prompt neutrality holds
- Run records snapshot the placed workspace's open-catalogue count (`catalogueBaseline`), fixing the null `catalogue-not-worse` scores; the evaluator call is shared via `runner/catalogue.mjs`
- README records the harness-hygiene lesson from the pilot: run harness agents from hermetic paths — user-level memory/plugin hooks leaked into agents non-uniformly by tier when workdirs lived under the operator's project tree

Smoke-verified: pointer lands in the workdir (append + create paths), `catalogueBaseline: 21` recorded on the miniflux model, run green. Full A/B/C × 2-tier sweep is running on this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)