### PR TITLE
Carry repair hints on YM404 aspect violations

### DIFF
--- a/docs/adr/0039-diagnostics-carry-repair-information.md
+++ b/docs/adr/0039-diagnostics-carry-repair-information.md
@@ -11,10 +11,14 @@ Schema violations name the expected value: a `const` mismatch states the
 constant, and an `enum` mismatch lists the allowed values (capped at eight).
 Unknown concept and relationship kinds suggest the closest declared kind in
 the selected profile by edit distance, with a deterministic tie-break so
-diagnostic output stays reproducible. No new diagnostic codes are
-introduced, severities and locations are unchanged, and messages remain
-plain text within the existing check-result and diagnostic-result
-contracts.
+diagnostic output stays reproducible. Endpoint-aspect violations carry the
+violated policy's remedy: each constrained core relationship kind states the
+shapes that stay legal, such as `flow` between active-structure elements or
+a behavior concept joined by `assignment`; extension kinds declare
+constraints without remedies and keep the plain violation message. No new
+diagnostic codes are introduced, severities and locations are unchanged, and
+messages remain plain text within the existing check-result and
+diagnostic-result contracts.
 
 Suggestions are repair hints, never corrections: the compiler still rejects
 the input, and nothing is auto-fixed.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -67,6 +67,71 @@ Use `mode: read|write|read-write|unspecified` only with `access`. Use
 `content` only with `flow`. Prefer a precise relationship over `association`;
 use association when no stronger semantic meaning is justified.
 
+Every concept kind carries an aspect: `motivation`, `active-structure`
+(actors, roles, components, nodes, interfaces), `behavior` (processes,
+functions, interactions, services, events), `passive-structure` (objects,
+data, artifacts, material), or `composite`. Four relationship kinds constrain
+endpoint aspects, and the compiler rejects violations as `YM404`:
+
+```text
+assignment  source must be active-structure
+access      target must be passive-structure
+influence   target must be motivation
+triggering  source and target must be behavior
+```
+
+The other kinds accept endpoints of any aspect.
+
+## Invocation chains
+
+"User invokes command" and "component invokes component" fail `YM404` when
+written as `triggering` between active-structure elements. Name the invoked
+behavior, assign the performers, and trigger between behaviors:
+
+```yaml
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+  - id: cli
+    kind: applicationComponent
+    name: CLI
+  - id: run-check
+    kind: applicationProcess
+    name: Run check
+relationships:
+  - id: user-starts-run-check
+    kind: assignment
+    from: user
+    to: run-check
+    name: User invokes the check command
+  - id: cli-performs-run-check
+    kind: assignment
+    from: cli
+    to: run-check
+```
+
+Chain steps with `triggering` only between behavior concepts, for example
+`run-check` triggering a downstream process owned by another component.
+
+## Degrading a blocked kind
+
+When aspect policy blocks the kind you want—`triggering` between two
+components is the common case—keep the edge legal with `kind: flow` and carry
+the invocation semantics on the edge's `name` and `description`:
+
+```sh
+yarramate connect .yarramate/architecture/main.yaml \
+  --id cli-invokes-engine --kind flow \
+  --from cli --to engine \
+  --name "invokes" \
+  --description "The CLI invokes the engine once per check run"
+```
+
+Both fields compile to claims, so evidence can later confirm or contradict
+the recorded invocation semantics; the degradation loses no reviewable
+information.
+
 ## Ownership and constraints
 
 ```yaml

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -117,6 +117,7 @@ interface ResolvedRelationshipKind {
   readonly lineage: readonly string[]
   readonly sourceAspects?: readonly (typeof conceptKinds)[number]['aspect'][]
   readonly targetAspects?: readonly (typeof conceptKinds)[number]['aspect'][]
+  readonly repair?: string
 }
 
 interface ResolvedProfile {
@@ -228,6 +229,7 @@ function compileWorkspaceResolved(
       lineage: [`${coreProfile}#${policy.id}`],
       sourceAspects: policy.sourceAspects,
       targetAspects: policy.targetAspects,
+      repair: policy.repair,
     } satisfies ResolvedRelationshipKind
     coreRelationshipKinds.set(policy.id, resolved)
     relationshipKindByIdentity.set(resolved.identity, resolved)
@@ -1162,7 +1164,7 @@ function compileWorkspaceResolved(
             diagnostics.push({
               severity: 'error',
               code: 'YM404',
-              message: `Relationship "${relationship.kind}" requires a ${endpoint} with aspect ${allowed.map((aspect) => `"${aspect}"`).join(' or ')}; "${reference}" has aspect "${kind.aspect}"`,
+              message: `Relationship "${relationship.kind}" requires a ${endpoint} with aspect ${allowed.map((aspect) => `"${aspect}"`).join(' or ')}; "${reference}" has aspect "${kind.aspect}"${policy.repair === undefined ? '' : `; ${policy.repair}`}`,
               path: input.path,
               pointer,
               line: source.line,

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -157,6 +157,11 @@ export interface RelationshipPolicy {
   readonly intent: string
   readonly sourceAspects?: readonly Aspect[]
   readonly targetAspects?: readonly Aspect[]
+  /**
+   * Repair hint appended to endpoint-aspect diagnostics (YM404). A remedy,
+   * never a correction: the compiler still rejects the input.
+   */
+  readonly repair?: string
 }
 
 /**
@@ -171,6 +176,8 @@ export const relationshipPolicies: readonly RelationshipPolicy[] = [
     id: 'assignment',
     intent: 'Allocate an active structure to behavior or responsibility',
     sourceAspects: ['active-structure'],
+    repair:
+      'assign from an active-structure element (an actor, component, or node), or use "association"',
   },
   { id: 'realization', intent: 'Fulfil a more abstract concept' },
   { id: 'serving', intent: 'Make behavior or an interface available' },
@@ -178,11 +185,15 @@ export const relationshipPolicies: readonly RelationshipPolicy[] = [
     id: 'access',
     intent: 'Read, write, create, or use passive structure',
     targetAspects: ['passive-structure'],
+    repair:
+      'point "access" at passive structure (a business object, data object, or artifact), or use "association"',
   },
   {
     id: 'influence',
     intent: 'Affect a motivation concept',
     targetAspects: ['motivation'],
+    repair:
+      'point "influence" at a motivation concept (a goal, requirement, or principle), or use "association"',
   },
   { id: 'association', intent: 'Relevant connection with no stronger meaning' },
   {
@@ -190,6 +201,8 @@ export const relationshipPolicies: readonly RelationshipPolicy[] = [
     intent: 'Express temporal or causal precedence',
     sourceAspects: ['behavior'],
     targetAspects: ['behavior'],
+    repair:
+      'use "flow" between active-structure elements, or introduce a behavior concept and "assignment"',
   },
   { id: 'flow', intent: 'Transfer information, value, goods, or material' },
   { id: 'specialization', intent: 'Express a more specific form' },

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -904,7 +904,7 @@ relationships:
           severity: 'error',
           code: 'YM404',
           message:
-            'Relationship "assignment" requires a source with aspect "active-structure"; "intent" has aspect "motivation"',
+            'Relationship "assignment" requires a source with aspect "active-structure"; "intent" has aspect "motivation"; assign from an active-structure element (an actor, component, or node), or use "association"',
           path: 'incompatible.yaml',
           pointer: '/relationships/0/from',
           line: 14,
@@ -929,7 +929,7 @@ relationships:
           severity: 'error',
           code: 'YM404',
           message:
-            'Relationship "access" requires a target with aspect "passive-structure"; "intent" has aspect "motivation"',
+            'Relationship "access" requires a target with aspect "passive-structure"; "intent" has aspect "motivation"; point "access" at passive structure (a business object, data object, or artifact), or use "association"',
           path: 'incompatible-target.yaml',
           pointer: '/relationships/0/to',
           line: 15,

--- a/test/diagnostic-repair.test.ts
+++ b/test/diagnostic-repair.test.ts
@@ -71,4 +71,29 @@ describe('repair-oriented diagnostics', () => {
       'Document schema violation: must be equal to one of the allowed values: "planned", "current", "retired"',
     )
   })
+
+  it('carries the invocation-chain remedy on triggering aspect violations', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: cli\n    kind: applicationComponent\n    name: CLI\n  - id: engine\n    kind: applicationComponent\n    name: Engine\nrelationships:\n  - id: cli-invokes-engine\n    kind: triggering\n    from: cli\n    to: engine\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Relationship "triggering" requires a source with aspect "behavior"; "cli" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"',
+    )
+    expect(messages).toContain(
+      'Relationship "triggering" requires a target with aspect "behavior"; "engine" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"',
+    )
+  })
+
+  it('carries the motivation-target remedy on influence aspect violations', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: cli\n    kind: applicationComponent\n    name: CLI\n  - id: engine\n    kind: applicationComponent\n    name: Engine\nrelationships:\n  - id: cli-influences-engine\n    kind: influence\n    from: cli\n    to: engine\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Relationship "influence" requires a target with aspect "motivation"; "engine" has aspect "active-structure"; point "influence" at a motivation concept (a goal, requirement, or principle), or use "association"',
+    )
+  })
 })


### PR DESCRIPTION
## Summary

YM404 aspect constraints were undiscoverable and carried no repair hint: 3 of 4 independent discovery agents authored `triggering` between application components as their natural first draft and burned a full round-trip rediscovering the rule (yarrasys/yarramate-gallery#1).

- **Repair-carrying YM404** (ADR 0039 pattern): each constrained core relationship kind (`assignment`, `access`, `influence`, `triggering`) declares a `repair` clause on its `RelationshipPolicy`, appended to the diagnostic. Triggering now reads: `Relationship "triggering" requires a source with aspect "behavior"; "cli" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"`. Extension kinds declare constraints without remedies and keep the plain message. No new codes, severities, locations, or contract changes; nothing is auto-fixed. ADR 0039 records the extension.
- **Aspect rules documented** in `skills/yarramate-architecture/references/native-authoring.md` beside the relationship-kind list: a compact kind→aspect-requirement note, plus a worked invocation-chain example ("user invokes command", "component invokes component") under a new "Invocation chains" section.
- **Degradation idiom** ("Degrading a blocked kind"): when aspect policy blocks the kind you want, keep `kind: flow` for profile legality and carry invocation semantics on the edge's `name`/`description` (`yarramate connect --name --description`); both compile to claims that evidence can confirm or contradict.

## Test plan

- Updated the two native YM404 message assertions in `test/compiler.test.ts`; the extension-profile assertion is unchanged (locks the no-remedy behavior).
- Added two tests to `test/diagnostic-repair.test.ts` covering the triggering (both endpoints) and influence remedies.
- Verified the doc's worked example compiles clean and the failing invocation-chain shape emits the new message end-to-end via the built CLI.
- `rm -rf dist && pnpm verify` fully green (24 files, 232 tests, self:check and LikeC4 validate clean).

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)