### PR TITLE
Render the asserted relationship inside claim findings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,10 +109,10 @@ runs:
         else
           summary "⚠️ Reconciliation: ${OBSERVATIONS} observations, ${CONFIRMED} confirmed, ${FINDINGS} findings (${CONTRADICTED} contradicted, ${UNKNOWN} unknown, ${NOT_OBSERVED} not observed)"
           summary ''
-          summary '| Result | Target | Provider | Evidence document |'
-          summary '| --- | --- | --- | --- |'
+          summary '| Result | Target | Model asserts | Provider | Evidence document |'
+          summary '| --- | --- | --- | --- | --- |'
           printf '%s' "$RECONCILE_JSON" \
-            | jq -r '.findings[] | "| \(.result) | `\(.target.id)` | \(.provider) | \(.evidenceDocument) |"' \
+            | jq -r '.findings[] | "| \(.result) | `\(.target.id)` | \(if .asserted then "`\(.asserted.from)` -\(.asserted.kind)-> `\(.asserted.to)`" + (if .asserted.name then " (\(.asserted.name))" else "" end) else "" end) | \(.provider) | \(.evidenceDocument) |"' \
             >> "$GITHUB_STEP_SUMMARY"
         fi
 

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -79,6 +79,33 @@ The summary counts all observations. The `findings` array contains only
 provider. Confirmed observations remain summarized rather than repeated so a
 reviewer or agent can focus on unresolved evidence.
 
+When a finding targets the primary claim of a declared relationship, it also
+carries an optional `asserted` object with the declared `from`, `to`, and
+`kind` (and `name` when present), so the disagreement between the model and
+the evidence is visible in the finding itself:
+
+```json
+{
+  "target": { "type": "claim", "id": "payments#payment-api-writes-ledger" },
+  "asserted": {
+    "from": "payments#payment-api",
+    "to": "payments#ledger",
+    "kind": "yarramate/core@0.1#access",
+    "name": "Records payments"
+  },
+  "result": "contradicted",
+  "provider": "repository-inspection",
+  "evidenceDocument": "payments-repository@1.0",
+  "evidence": {
+    "uri": "repo:src/payments.ts",
+    "message": "Payment API writes to the billing store, not the ledger"
+  }
+}
+```
+
+Subject-targeted findings and findings on relationship sub-claims (such as
+`…~name`) do not carry `asserted`.
+
 A finding is advisory evidence, not a proposed replacement claim, validation
 error, CI verdict, or authorization to modify the native model.
 

--- a/docs/adr/0046-findings-carry-the-asserted-relationship.md
+++ b/docs/adr/0046-findings-carry-the-asserted-relationship.md
@@ -1,0 +1,22 @@
+# Findings carry the asserted relationship
+
+Status: accepted
+
+A reconciliation finding used to name the disputed claim and quote the
+evidence locator, which describes what was observed — never what the model
+asserts. Reviewers and agents therefore read contradictions as reconciler
+false positives, because the disagreement itself was not visible in the
+finding.
+
+When a finding targets the primary claim of a declared relationship, the
+report now also renders that assertion: an optional `asserted` object with
+the declared `from`, `to`, and `kind`, plus `name` when present, taken
+verbatim from the compiled graph. Subject-targeted findings and relationship
+sub-claims (name, description, status, and similar) are unchanged, because a
+concept or attribute has no endpoint rendering that is equally cheap and
+coherent.
+
+The field is additive within `yarramate/reconciliation-report/v1`; existing
+consumers keep working. It restates declared intent for contrast and remains
+advisory: no replacement claim is proposed, no document is mutated, and no
+remediation is authorized (ADR 0032).

--- a/schema/yarramate-reconciliation-report.schema.json
+++ b/schema/yarramate-reconciliation-report.schema.json
@@ -66,6 +66,21 @@
         "message": { "type": "string", "minLength": 1 }
       }
     },
+    "subjectIdentity": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*#[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+    },
+    "assertedRelationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to", "kind"],
+      "properties": {
+        "from": { "$ref": "#/$defs/subjectIdentity" },
+        "to": { "$ref": "#/$defs/subjectIdentity" },
+        "kind": { "type": "string", "pattern": "^\\S+$" },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
     "finding": {
       "type": "object",
       "additionalProperties": false,
@@ -78,6 +93,7 @@
       ],
       "properties": {
         "target": { "$ref": "#/$defs/target" },
+        "asserted": { "$ref": "#/$defs/assertedRelationship" },
         "result": {
           "enum": ["contradicted", "unknown", "not-observed"]
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -389,6 +389,7 @@ const runReconciliation = (
         reconcileEvidenceReports(
           loadedWorkspace.workspace.id,
           evaluation.reports,
+          compilation.graph,
         ),
         null,
         2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from './evidence.js'
 export {
   reconcileEvidenceReports,
+  type AssertedRelationship,
   type ReconciliationFinding,
   type ReconciliationReport,
 } from './reconciliation.js'

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -1,14 +1,23 @@
+import type { SemanticGraph } from './compiler.js'
 import type {
   EvidenceLocator,
   EvidenceReport,
   EvidenceResult,
 } from './evidence.js'
 
+export interface AssertedRelationship {
+  readonly from: string
+  readonly to: string
+  readonly kind: string
+  readonly name?: string
+}
+
 export interface ReconciliationFinding {
   readonly target: {
     readonly type: 'subject' | 'claim'
     readonly id: string
   }
+  readonly asserted?: AssertedRelationship
   readonly result: Exclude<EvidenceResult, 'confirmed'>
   readonly provider: string
   readonly evidenceDocument: string
@@ -30,10 +39,44 @@ export interface ReconciliationReport {
   readonly findings: readonly ReconciliationFinding[]
 }
 
+const assertedRelationshipsByClaim = (
+  graph: SemanticGraph | undefined,
+): ReadonlyMap<string, AssertedRelationship> => {
+  const asserted = new Map<string, AssertedRelationship>()
+  if (graph === undefined) return asserted
+  const relationshipIds = new Set(
+    graph.subjects
+      .filter(({ type }) => type === 'relationship')
+      .map(({ id }) => id),
+  )
+  const names = new Map<string, string>()
+  for (const claim of graph.claims) {
+    if (
+      claim.predicate === 'yarramate/relationship/name' &&
+      'value' in claim.object
+    ) {
+      names.set(claim.subject, claim.object.value)
+    }
+  }
+  for (const claim of graph.claims) {
+    if (!relationshipIds.has(claim.id) || !('ref' in claim.object)) continue
+    const name = names.get(claim.id)
+    asserted.set(claim.id, {
+      from: claim.subject,
+      to: claim.object.ref,
+      kind: claim.predicate,
+      ...(name === undefined ? {} : { name }),
+    })
+  }
+  return asserted
+}
+
 export function reconcileEvidenceReports(
   workspace: string,
   reports: readonly EvidenceReport[],
+  graph?: SemanticGraph,
 ): ReconciliationReport {
+  const assertedByClaim = assertedRelationshipsByClaim(graph)
   const summary = {
     evidenceDocuments: reports.length,
     observations: 0,
@@ -56,10 +99,15 @@ export function reconcileEvidenceReports(
       } else {
         summary[observation.result] += 1
       }
+      const target =
+        'subject' in observation
+          ? ({ type: 'subject', id: observation.subject } as const)
+          : ({ type: 'claim', id: observation.claim } as const)
+      const asserted =
+        target.type === 'claim' ? assertedByClaim.get(target.id) : undefined
       findings.push({
-        target: 'subject' in observation
-          ? { type: 'subject', id: observation.subject }
-          : { type: 'claim', id: observation.claim },
+        target,
+        ...(asserted === undefined ? {} : { asserted }),
         result: observation.result,
         provider: report.provider,
         evidenceDocument: report.evidence,

--- a/src/status-command.ts
+++ b/src/status-command.ts
@@ -175,6 +175,7 @@ export function runStatusCommand(
             reconciliation = reconcileEvidenceReports(
               workspace.id,
               evaluation.reports,
+              compilation.graph,
             ).summary
           }
         }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -468,6 +468,78 @@ describe('YarraMate CLI', () => {
     })
   })
 
+  it('renders the asserted relationship inside contradicted claim findings', () => {
+    const schema = JSON.parse(
+      readFileSync(
+        join(
+          repositoryRoot,
+          'schema/yarramate-reconciliation-report.schema.json',
+        ),
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ allErrors: true }).compile(schema)
+    const result = runCli(
+      ['reconcile', 'test/fixtures/valid/payments.workspace.yaml'],
+      repositoryRoot,
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+    const report = JSON.parse(result.stdout)
+    expect(
+      validate(report),
+      JSON.stringify(validate.errors ?? []),
+    ).toBe(true)
+    expect(report).toEqual({
+      format: 'yarramate/reconciliation-report/v1',
+      workspace: 'payments',
+      summary: {
+        evidenceDocuments: 1,
+        observations: 3,
+        confirmed: 1,
+        findings: 2,
+        contradicted: 2,
+        unknown: 0,
+        notObserved: 0,
+      },
+      findings: [
+        {
+          target: {
+            type: 'subject',
+            id: 'payments#billing',
+          },
+          result: 'contradicted',
+          provider: 'repository-inspection',
+          evidenceDocument: 'payments-repository@1.0',
+          evidence: {
+            uri: 'repo:src/billing.ts',
+            message: 'No billing service was observed in the repository',
+          },
+        },
+        {
+          target: {
+            type: 'claim',
+            id: 'payments#payment-api-writes-ledger',
+          },
+          asserted: {
+            from: 'payments#payment-api',
+            to: 'payments#ledger',
+            kind: 'yarramate/core@0.1#access',
+            name: 'Records payments',
+          },
+          result: 'contradicted',
+          provider: 'repository-inspection',
+          evidenceDocument: 'payments-repository@1.0',
+          evidence: {
+            uri: 'repo:src/payments.ts',
+            message: 'Payment API writes to the billing store, not the ledger',
+          },
+        },
+      ],
+    })
+  })
+
   it('initializes a minimal native workspace without overwriting it', () => {
     const directory = mkdtempSync(join(tmpdir(), 'yarramate-init-'))
     try {

--- a/test/fixtures/valid/payments-evidence.yaml
+++ b/test/fixtures/valid/payments-evidence.yaml
@@ -1,0 +1,19 @@
+format: yarramate/evidence/v1
+id: payments-repository
+version: "1.0"
+provider: repository-inspection
+observations:
+  - claim: payments#payment-api-writes-ledger
+    result: contradicted
+    evidence:
+      uri: repo:src/payments.ts
+      message: Payment API writes to the billing store, not the ledger
+  - subject: payments#billing
+    result: contradicted
+    evidence:
+      uri: repo:src/billing.ts
+      message: No billing service was observed in the repository
+  - subject: payments#payment-api
+    result: confirmed
+    evidence:
+      uri: repo:src/payments.ts

--- a/test/fixtures/valid/payments.workspace.yaml
+++ b/test/fixtures/valid/payments.workspace.yaml
@@ -1,0 +1,9 @@
+format: yarramate/workspace/v1
+id: payments
+documents:
+  - payments.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence:
+  - payments-evidence.yaml

--- a/test/fixtures/valid/payments.yaml
+++ b/test/fixtures/valid/payments.yaml
@@ -1,0 +1,20 @@
+format: yarramate/v1
+id: payments
+profile: yarramate/core@0.1
+concepts:
+  - id: payment-api
+    kind: applicationService
+    name: Payment API
+  - id: ledger
+    kind: dataObject
+    name: Ledger
+  - id: billing
+    kind: applicationService
+    name: Billing
+relationships:
+  - id: payment-api-writes-ledger
+    kind: access
+    from: payment-api
+    to: ledger
+    name: Records payments
+    mode: write


### PR DESCRIPTION
Closes #55

## Problem

Contradicted reconciliation findings rendered the claim id plus the evidence locator/message — which describes the TRUE code — but never what the model actually asserts. In the benchmark sweep, agents at both capability tiers read contradictions as reconciler false positives and ignored them (verified across four repos: agents edited lines adjacent to a mutated relationship without noticing the lie).

## Fix

When a finding targets the primary claim of a declared relationship, the reconciliation report now carries an additive optional `asserted` object with the declared endpoints, taken verbatim from the compiled graph, so the model-vs-evidence disagreement is visible inside the finding itself:

```json
{
  "target": { "type": "claim", "id": "payments#payment-api-writes-ledger" },
  "asserted": {
    "from": "payments#payment-api",
    "to": "payments#ledger",
    "kind": "yarramate/core@0.1#access",
    "name": "Records payments"
  },
  "result": "contradicted",
  "provider": "repository-inspection",
  "evidenceDocument": "payments-repository@1.0",
  "evidence": {
    "uri": "repo:src/payments.ts",
    "message": "Payment API writes to the billing store, not the ledger"
  }
}
```

## Scope choice

`asserted` is scoped to claims that resolve to the primary claim of a declared relationship (`from`/`to`/`kind`, `name` when present). Subject-targeted findings (concepts) and relationship sub-claims (`…~name`, `…~status`, ownership, constraints, presence) do not carry it: a concept has no endpoint rendering that is equally cheap and coherent, and the compiled graph gives the relationship assertion for free (the primary claim IS the assertion). Recorded as ADR 0046, following the ADR 0032 boundary — the field restates declared intent for contrast and stays advisory (no replacement claim, no remediation).

## Changes

- `src/reconciliation.ts` — `reconcileEvidenceReports` accepts an optional third `graph` parameter and attaches `asserted` to relationship-claim findings; new exported `AssertedRelationship` type.
- `src/cli.ts`, `src/status-command.ts` — pass the compiled graph through (status output unchanged; it only surfaces the summary).
- `schema/yarramate-reconciliation-report.schema.json` — additive optional `asserted` (`from`/`to` pinned to subject identities, `kind` matching the graph v2 predicate shape, optional `name`). Format id, contract manifest (`.yarramate/contracts/yarramate-core-0.1.yaml`), and package export are untouched — the contract check (format const, valid 2020-12 schema, export mapping) stays green.
- `action.yml` — the drift Action's findings table gains a "Model asserts" column rendered from `asserted` (the human-readable path for this report).
- `docs/EVIDENCE.md` — documents the field with an example; `docs/adr/0046-findings-carry-the-asserted-relationship.md` records the decision.
- Tests: new `payments` fixture trio (document, evidence, workspace) where evidence contradicts a relationship claim; the new CLI test validates the report against the updated schema and pins the asserted endpoints in the finding, plus a subject finding without `asserted`. Existing reconcile tests (subject-targeted discovery fixture, journeys, package-consumer) are untouched and still pin the prior shape.

## Verification

`rm -rf dist && pnpm verify` fully green: 24 test files, 231 tests (+1 over baseline), self:check and LikeC4 validate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)