### PR TITLE
Release v0.5.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.4.0
+version: 0.5.0
 date-released: 2026-07-28
 url: "https://github.com/yarrasys/yarramate"
 repository-code: "https://github.com/yarrasys/yarramate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to 0.5.0 (package.json, CITATION.cff). Runbook validation: clean-slate verify green (240 tests / 24 files, self:check, likec4 validate), tarball 84 files with no source/test/dogfood leakage.

Ships since v0.4.0: harness-aware pointer delivery (ADR 0045, #57), YM404 repair hints + authoring docs (#60), asserted relationships in findings (ADR 0046, #61), **breaking** document-relative likec4 project paths + unmapped-diagnostic summary (#62), `--version` on all binaries (#59), verify build-order fix (#52), plus the context-benchmark research suite (#52/#53). Full notes land on the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)