### PR TITLE
Context benchmark: first sweep results (adjudicated)

### DIFF
--- a/docs/research/context-benchmark/RESULTS-2026-07-29.md
+++ b/docs/research/context-benchmark/RESULTS-2026-07-29.md
@@ -1,0 +1,143 @@
+# Context benchmark — first sweep results (2026-07-29)
+
+Status: final, human-adjudicated. Protocol per [DESIGN.md](DESIGN.md), frozen
+before any run. Negative and null results are reported with the same
+prominence as positive ones.
+
+## Versions and provenance
+
+- Suite: the frozen v1 task files in [tasks/](tasks/) (37 tasks; the four
+  headline repositories only — the self-model suite was not swept).
+- Toolchain under test: `yarramate@0.4.0` (published npm dist). Note: the
+  sweep therefore predates the v0.5.0 fixes this sweep itself motivated.
+- Harness: Claude Code CLI 2.1.220, `claude -p --output-format json
+  --setting-sources project --permission-mode acceptEdits --allowedTools
+  "Bash,Edit,Write"`; hermetic tmp workdirs (see Threats); one run per cell,
+  sequential per tier.
+- Generator tiers: `haiku` (claude-haiku-4-5) and `sonnet` (claude-sonnet-5).
+- Runs: 164/164 completed, zero harness failures, total cost $104.76
+  (haiku ≈ $24, sonnet ≈ $81).
+- Verdicts: 132 comprehension/change runs human-adjudicated (adjudicator:
+  nabsha, 2026-07-30) from LLM-drafted advisory verdicts; model-maintenance
+  runs scored deterministically (check / reconcile / likec4 gates). Raw
+  transcripts, diffs, per-run records, and the full adjudication trail are
+  retained and available (publication pending).
+
+## Adjudication policy (set during the pass, binding for v2)
+
+1. Behavioral equivalence beats rubric letter; real behavioral gaps fail.
+2. A change that leaves the subject repo's own tests broken fails ("done"
+   includes green CI) — this cost the stronger tier its only fails.
+3. A wrong substantive claim on the asked question fails, tier-blind, even
+   inside an otherwise excellent answer.
+4. Environment-confounded runs (4 haiku refusals obeying uptime-kuma's
+   upstream anti-AI `CLAUDE.md`, auto-loaded by the harness) are excluded
+   and reported separately, not counted as fails.
+
+## Results
+
+Pass rates with 95% Wilson intervals; excluded runs removed from denominators.
+
+### Per tier × condition (A = repo only, B = repo + model + CLI, C = repo + deliberately falsified model)
+
+| | A | B | C |
+|---|---|---|---|
+| haiku | 76.2% (16/21) [54.9, 89.4] | 85.7% (18/21) [65.4, 95.0] | 80.0% (16/20) [58.4, 91.9] |
+| sonnet | 90.9% (20/22) [72.2, 97.5] | 100% (22/22) [85.1, 100.0] | 95.5% (21/22) [78.2, 99.2] |
+
+### Pooled across tiers
+
+| | A | B | C |
+|---|---|---|---|
+| all | 83.7% (36/43) [70.0, 91.9] | 93.0% (40/43) [81.4, 97.6] | 88.1% (37/42) [75.0, 94.8] |
+
+### Per repository (pass/fail/excluded, both tiers, all conditions)
+
+| repo | pass | fail | excluded |
+|---|---|---|---|
+| miniflux | 29 | 1 | 0 |
+| uptime-kuma | 31 | 1 | 4 |
+| fastify | 23 | 7 | 0 |
+| httpie | 30 | 6 | 0 |
+
+### Model-maintenance deterministic gates (not adjudicated)
+
+Hard gates (check-pass, no-contradicted, likec4-check-pass): haiku 33/42,
+sonnet 39/42. In condition B the tiers are effectively equal; the entire gap
+is condition-C repair (see H3). The `catalogue-not-worse` gate is excluded as
+miscalibrated for additive tasks (errata).
+
+## Hypothesis verdicts
+
+**H1 — context value: direction-consistent, underpowered.** Condition B is
+the best cell at both tiers (+9.5 pts haiku, +9.1 pts sonnet over A), and
+pooled B−A is +9.3 pts — but every interval overlaps; at n≈21 per cell each
+delta is roughly one binomial SE. Honest verdict: suggestive positive
+direction, not a significant effect. Contributing ceiling effects: all 24
+comprehension cells at sonnet passed regardless of condition, and the
+comprehension family is saturated at both tiers. H1 needs harder tasks and
+larger n before any claim.
+
+**H2 — capability flattening: supported where the loop is engaged, with a
+load-bearing wrinkle.** On the mechanized dimensions the weak tier matched
+the strong tier whenever the deterministic loop was actually exercised
+(condition-B maintenance gates tier-equal; haiku's adjudicated change fails
+are predominantly precision misses — a type signature, a pinned test count,
+one real one-line defect — not architectural misunderstandings). The wrinkle:
+engagement is itself tier-bound. Haiku consulted the workspace in ~1 of 34
+non-maintenance B/C runs even with the workspace named in the prompt; the
+verifier levels tiers only when the harness or task forces contact with it.
+The floor rises only if you stand on it.
+
+**H3 — trust sensitivity: unsupported at observed usage levels.** The
+deliberately falsified model never dragged either tier below its no-model
+baseline (C ≥ A in every cell). Mechanism, not resistance: agents mostly did
+not consult the model in C (avoidance), and when the strong tier did read
+falsified claims it noticed the contradicted findings and verified against
+source. Exactly one stale-influence event occurred in 40 C comprehension/
+change runs (haiku propagated an injected lie into a projection). Staleness
+costs concentrated in maintenance work: sabotage repair happened only where
+a task criterion explicitly demanded zero contradictions, and only the
+strong tier applied that criterion literally; the weak tier twice reported
+"no contradictions" after receiving "3 contradicted". H3 as designed is
+reframed: the risk today is not that stale models poison answers — it is
+that models are not consulted enough for staleness to reach answers, and
+that repair does not happen without an explicit gate.
+
+## Root causes and actions (all addressed post-sweep)
+
+1. `AGENTS.md` pointer never read by the harness (0/~120 sessions) →
+   harness-aware delivery, ADR 0045, shipped in v0.5.0.
+2. `check` passes over a contradicted model → decision open (#54).
+3. Findings hid the asserted endpoints → ADR 0046, shipped in v0.5.0.
+4. Subject-repo agent config leaks into runs tier-dependently → harness v2
+   (#56).
+
+## Threats to validity
+
+- **Small N everywhere**: 4 repositories, one run per cell, n≈21 per
+  tier×condition. All conclusions directional.
+- **Prior-knowledge contamination**: the subject repos are well-known OSS;
+  both tiers answered some comprehension questions from priors without
+  reading code. This inflates A and compresses A→B deltas.
+- **Comprehension saturation**: the v1 comprehension tasks do not
+  discriminate conditions or tiers.
+- **Environment confound (found and quarantined)**: an earlier pilot attempt
+  was invalidated by user-level agent config leaking into runs
+  tier-dependently; the sweep ran in hermetic workdirs, but uptime-kuma's
+  in-repo CLAUDE.md produced the four excluded refusals.
+- **Suite errata (frozen, corrected in v2 only)**: one incomplete ground
+  truth (agents graded against code), two incomplete `touches` lists, one
+  miscalibrated deterministic gate.
+- The sweep measured `yarramate@0.4.0`; v0.5.0 already changes two measured
+  failure modes (pointer delivery, findings rendering), so these numbers are
+  a baseline, not a current-version claim.
+
+## What v2 changes
+
+Harder, multi-hop comprehension tasks; a fifth repository (pooled N≥5);
+neutralized subject-repo agent config; corrected errata as a suite version
+bump; diff capture from the baseline commit; degenerate-run flagging; and a
+re-run on v0.5.0 to measure whether harness-aware pointer delivery moves
+weak-tier workspace engagement — the single variable this sweep identifies
+as decisive.


### PR DESCRIPTION
Adds `RESULTS-2026-07-29.md` — the write-up the frozen design promised: per-cell and pooled pass rates with 95% Wilson intervals, human-adjudicated verdicts (adjudication policy recorded and binding for v2), deterministic-gate results, hypothesis verdicts with negative/null results at full prominence, threats to validity, and the v2 plan.

Headline reads: H1 suggestive-but-underpowered (+9 pts A→B at both tiers, intervals overlap); H2 supported where the verifier loop is engaged — with engagement itself tier-bound as the load-bearing wrinkle; H3 unsupported at observed usage and reframed as an adoption problem. Numbers are a v0.4.0 baseline; v0.5.0 already ships fixes for two measured failure modes.

Transcripts/diffs/adjudication trail retained locally in yarramate-bench-results (publication decision pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)