### PR TITLE
Link published benchmark artifacts from the results write-up

### DIFF
--- a/docs/research/context-benchmark/RESULTS-2026-07-29.md
+++ b/docs/research/context-benchmark/RESULTS-2026-07-29.md
@@ -21,7 +21,7 @@ prominence as positive ones.
   nabsha, 2026-07-30) from LLM-drafted advisory verdicts; model-maintenance
   runs scored deterministically (check / reconcile / likec4 gates). Raw
   transcripts, diffs, per-run records, and the full adjudication trail are
-  retained and available (publication pending).
+  published at https://github.com/yarrasys/yarramate-bench-results.
 
 ## Adjudication policy (set during the pass, binding for v2)
 


### PR DESCRIPTION
yarrasys/yarramate-bench-results is now public (transcripts, diffs, scores, adjudication trail); the results doc's "publication pending" becomes the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)