### PR TITLE
Add check --strict: contradicted evidence fails the gate (ADR 0047)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ node dist/cli.js reconcile .yarramate/workspace.yaml
 
 `init` creates `.yarramate/architecture/main.yaml` and
 `.yarramate/workspace.yaml`. Commands accept explicit source documents or one
-explicit workspace manifest.
+explicit workspace manifest. `check --strict` additionally fails when any
+evidence observation contradicts the model, for gates that want one knob.
 
 For a local consumer test, create a package artifact:
 

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -64,6 +64,13 @@ The typed API exposes `loadEvidence`, `evaluateEvidence`, and
 optional `evidence` category of a workspace manifest, in which case
 `yarramate check` validates them against the compiled graph.
 
+`yarramate check --strict` additionally fails the check (exit `1`) when any
+evidence observation is `contradicted`, rendering each contradiction as a
+source-located `YM901` diagnostic anchored at the declared claim. `unknown`
+and `not-observed` results stay advisory. A strict pass reports how many
+observations it evaluated, so a gate over zero evidence is visible rather
+than silently vacuous (ADR 0047).
+
 ## Reconciliation
 
 ```sh

--- a/docs/adr/0047-strict-check-gates-on-contradicted-evidence.md
+++ b/docs/adr/0047-strict-check-gates-on-contradicted-evidence.md
@@ -1,0 +1,29 @@
+# Strict check gates on contradicted evidence
+
+Status: accepted
+
+`yarramate check` deliberately verifies structure and references, not truth:
+reconciliation findings are advisory, and "checks pass" was satisfiable over
+a model whose confirmed claims the evidence contradicts. A benchmark sweep
+showed what that hole costs — agents gated on "checks must pass" saw three
+injected contradictions, reported success anyway, and repair only ever
+happened where an explicit zero-contradiction criterion existed.
+
+`check --strict` is the one-knob gate for consumers who want contradictions
+blocking: CI, benchmark harnesses, and skill acceptance criteria. When the
+base check passes, strict mode reconciles the workspace's evidence overlays
+and fails the check if any observation is `contradicted`. Each contradiction
+is rendered as an ordinary source-located diagnostic (`YM901`) anchored at
+the claim the model declares, restating the asserted relationship (ADR 0046)
+and the contradicting observation, so the failure is repairable where it is
+reported (ADR 0039). `unknown` and `not-observed` stay advisory: absence of
+evidence is not contradiction.
+
+The flag is opt-in and the default is unchanged, preserving the epistemic
+cut: a plain `check` still answers "is this a well-formed model", never "is
+this model true", and reconciliation itself still reports findings without
+remediation (ADR 0032). A strict pass also
+reports what it evaluated — including that zero evidence observations were
+available — because a vacuous gate that looks engaged is exactly the failure
+mode this flag exists to close. The machine result gains an additive
+optional `strict` summary within `yarramate/check-result/v1`.

--- a/schema/yarramate-check-result.schema.json
+++ b/schema/yarramate-check-result.schema.json
@@ -20,6 +20,9 @@
     },
     "counted": {
       "$ref": "#/$defs/counted"
+    },
+    "strict": {
+      "$ref": "#/$defs/strict"
     }
   },
   "allOf": [
@@ -50,6 +53,15 @@
     }
   ],
   "$defs": {
+    "strict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observations", "contradicted"],
+      "properties": {
+        "observations": { "type": "integer", "minimum": 0 },
+        "contradicted": { "type": "integer", "minimum": 0 }
+      }
+    },
     "counted": {
       "type": "object",
       "additionalProperties": false,

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -24,15 +24,38 @@ import {
   loadEvidence,
 } from './evidence.js'
 import { loadProjection } from './projection.js'
+import {
+  reconcileEvidenceReports,
+  type ReconciliationFinding,
+} from './reconciliation.js'
 
 const Ajv2020 = Ajv2020Module.default
+
+const strictFindingMessage = (finding: ReconciliationFinding): string => {
+  const observed =
+    finding.evidence.message === undefined
+      ? finding.evidence.uri
+      : `${finding.evidence.uri}: ${finding.evidence.message}`
+  const assertion =
+    finding.asserted === undefined
+      ? `Evidence contradicts ${finding.target.type} "${finding.target.id}"`
+      : `Evidence contradicts claim "${finding.target.id}": the model asserts ` +
+        `${finding.asserted.from} -> ${finding.asserted.to} (${finding.asserted.kind})`
+  return (
+    `${assertion}, but provider "${finding.provider}" observed otherwise ` +
+    `(${observed}); align the model or the evidence to pass --strict`
+  )
+}
 
 export function runCheckCommand(
   options: readonly string[],
   cwd: string,
 ): CliResult {
   const json = options.includes('--json')
-  const paths = options.filter((option) => option !== '--json')
+  const strict = options.includes('--strict')
+  const paths = options.filter(
+    (option) => option !== '--json' && option !== '--strict',
+  )
   const unknownOption = paths.find((path) => path.startsWith('-'))
   if (unknownOption !== undefined || paths.length === 0) {
     return { exitCode: 2, stdout: '', stderr: usage }
@@ -250,6 +273,65 @@ export function runCheckCommand(
       ? optionalDiagnostics
       : result.diagnostics
 
+    // Strict only tightens a passing check: base diagnostics already fail
+    // the gate, so contradictions are folded in only once everything else
+    // holds, and each one is anchored at the claim the model declares.
+    const strictEvaluation =
+      strict && result.ok && ok
+        ? (() => {
+            const reports =
+              evidenceEvaluation !== undefined && evidenceEvaluation.ok
+                ? evidenceEvaluation.reports
+                : []
+            const graph = result.graph
+            const contradicted = reconcileEvidenceReports(
+              'strict',
+              reports,
+              graph,
+            ).findings.filter(({ result: outcome }) => outcome === 'contradicted')
+            return {
+              observations: reports.reduce(
+                (total, report) => total + report.observations.length,
+                0,
+              ),
+              diagnostics: sortDiagnostics(
+                contradicted.map((finding) => {
+                  const anchor =
+                    graph.claims.find(({ id }) => id === finding.target.id) ??
+                    graph.claims.find(
+                      ({ subject, predicate }) =>
+                        subject === finding.target.id &&
+                        predicate === 'yarramate/concept/kind',
+                    ) ??
+                    graph.claims.find(
+                      ({ subject }) => subject === finding.target.id,
+                    )
+                  return {
+                    severity: 'error' as const,
+                    code: 'YM901',
+                    message: strictFindingMessage(finding),
+                    path: anchor?.source.path ?? finding.evidenceDocument,
+                    pointer: anchor?.source.pointer ?? '/',
+                    line: anchor?.source.line ?? 1,
+                    column: anchor?.source.column ?? 1,
+                  }
+                }),
+              ),
+            }
+          })()
+        : undefined
+    const strictSummary =
+      strictEvaluation === undefined
+        ? undefined
+        : {
+            observations: strictEvaluation.observations,
+            contradicted: strictEvaluation.diagnostics.length,
+          }
+    const strictOk = strictEvaluation === undefined
+      ? true
+      : strictEvaluation.diagnostics.length === 0
+    const finalOk = ok && strictOk
+
     const counted = result.ok
       ? (() => {
           const states = new Set(
@@ -275,12 +357,21 @@ export function runCheckCommand(
 
     if (json) {
       return {
-        exitCode: ok ? 0 : 1,
+        exitCode: finalOk ? 0 : 1,
         stdout: checkResultJson(
-          ok,
-          ok ? [] : diagnostics,
-          ok ? counted : undefined,
+          finalOk,
+          finalOk ? [] : ok ? strictEvaluation!.diagnostics : diagnostics,
+          finalOk ? counted : undefined,
+          strictSummary,
         ),
+        stderr: '',
+      }
+    }
+
+    if (ok && !strictOk) {
+      return {
+        exitCode: 1,
+        stdout: humanDiagnostics(strictEvaluation!.diagnostics),
         stderr: '',
       }
     }
@@ -321,6 +412,12 @@ export function runCheckCommand(
             ]
           : []),
       ].join(' and ')
+      const strictLine =
+        strictSummary === undefined
+          ? ''
+          : strictSummary.observations === 0
+            ? 'Strict: no evidence observations to evaluate\n'
+            : `Strict: ${strictSummary.observations} ${strictSummary.observations === 1 ? 'observation' : 'observations'}, 0 contradicted\n`
       return {
         exitCode: 0,
         stdout:
@@ -328,7 +425,8 @@ export function runCheckCommand(
           `${successfulCounts.concepts} ${successfulCounts.concepts === 1 ? 'concept' : 'concepts'}, ` +
           `${successfulCounts.relationships} ${successfulCounts.relationships === 1 ? 'relationship' : 'relationships'}, ` +
           `${successfulCounts.states} ${successfulCounts.states === 1 ? 'state' : 'states'}` +
-          '): no errors\n',
+          '): no errors\n' +
+          strictLine,
         stderr: '',
       }
     }

--- a/src/cli-support.ts
+++ b/src/cli-support.ts
@@ -38,7 +38,7 @@ export const versionResult = (binary: string): CliResult => ({
 })
 
 export const usage =
-  'Usage:\n  yarramate init <directory> [--no-pointer]\n  yarramate add <document.yaml> --id <id> --kind <kind> --name <name> [--status <status>] [--description <text>] [--owner <ref>] [--constraint <id>=<ref> ...] [--reference <id>=<ref> ...] [--present-in <state-ref> ...] [--source <source.yaml> ...]\n  yarramate connect <document.yaml> --id <id> --kind <kind> --from <ref> --to <ref> [--name <name>] [--description <text>] [--status <status>] [--mode <mode>] [--content <text>] [--reference <id>=<ref> ...] [--present-in <state-ref> ...] [--source <source.yaml> ...]\n  yarramate check <source.yaml> [source.yaml ...] [--json]\n  yarramate new projection <projection.yaml> --id <id> [--version <v>] [--title <text>] [--description <text>] [--document <id> ...] [--subject <ref> ...] [--kind <qualified-kind> ...] [--relationships <mode>]\n  yarramate status <workspace.yaml> [--json]\n  yarramate compile <source.yaml> [source.yaml ...]\n  yarramate context <projection.yaml> <source.yaml> [source.yaml ...] [--budget <tokens>]\n  yarramate context --subject <document-id>#<local-id> [--subject ...] <source.yaml> [source.yaml ...] [--budget <tokens>]\n  yarramate view <projection.yaml> <source.yaml> [source.yaml ...]\n  yarramate compare <from-state> <to-state> <source.yaml> [source.yaml ...]\n  yarramate evidence <evidence.yaml> <source.yaml> [source.yaml ...]\n  yarramate reconcile <workspace.yaml>\n'
+  'Usage:\n  yarramate init <directory> [--no-pointer]\n  yarramate add <document.yaml> --id <id> --kind <kind> --name <name> [--status <status>] [--description <text>] [--owner <ref>] [--constraint <id>=<ref> ...] [--reference <id>=<ref> ...] [--present-in <state-ref> ...] [--source <source.yaml> ...]\n  yarramate connect <document.yaml> --id <id> --kind <kind> --from <ref> --to <ref> [--name <name>] [--description <text>] [--status <status>] [--mode <mode>] [--content <text>] [--reference <id>=<ref> ...] [--present-in <state-ref> ...] [--source <source.yaml> ...]\n  yarramate check <source.yaml> [source.yaml ...] [--json] [--strict]\n  yarramate new projection <projection.yaml> --id <id> [--version <v>] [--title <text>] [--description <text>] [--document <id> ...] [--subject <ref> ...] [--kind <qualified-kind> ...] [--relationships <mode>]\n  yarramate status <workspace.yaml> [--json]\n  yarramate compile <source.yaml> [source.yaml ...]\n  yarramate context <projection.yaml> <source.yaml> [source.yaml ...] [--budget <tokens>]\n  yarramate context --subject <document-id>#<local-id> [--subject ...] <source.yaml> [source.yaml ...] [--budget <tokens>]\n  yarramate view <projection.yaml> <source.yaml> [source.yaml ...]\n  yarramate compare <from-state> <to-state> <source.yaml> [source.yaml ...]\n  yarramate evidence <evidence.yaml> <source.yaml> [source.yaml ...]\n  yarramate reconcile <workspace.yaml>\n'
 
 export const diagnosticJson = (diagnostics: unknown) =>
   `${JSON.stringify(
@@ -59,6 +59,10 @@ export const checkResultJson = (
     readonly relationships: number
     readonly states: number
   },
+  strict?: {
+    readonly observations: number
+    readonly contradicted: number
+  },
 ) =>
   `${JSON.stringify(
     {
@@ -66,6 +70,7 @@ export const checkResultJson = (
       ok,
       diagnostics,
       ...(counted === undefined ? {} : { counted }),
+      ...(strict === undefined ? {} : { strict }),
     },
     null,
     2,

--- a/test/check-strict.test.ts
+++ b/test/check-strict.test.ts
@@ -1,0 +1,243 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const checkResultSchema = JSON.parse(
+  readFileSync(
+    join(repositoryRoot, 'schema/yarramate-check-result.schema.json'),
+    'utf8',
+  ),
+) as object
+
+const document =
+  'format: yarramate/v1\n' +
+  'id: main\n' +
+  'profile: yarramate/core@0.1\n' +
+  'concepts:\n' +
+  '  - id: approve-order\n' +
+  '    kind: capability\n' +
+  '    name: Approve order\n' +
+  '  - id: approval-api\n' +
+  '    kind: applicationService\n' +
+  '    name: Approval API\n' +
+  'relationships:\n' +
+  '  - id: api-realizes-approval\n' +
+  '    kind: realization\n' +
+  '    from: approval-api\n' +
+  '    to: approve-order\n'
+
+const manifest = (evidence: readonly string[]) =>
+  'format: yarramate/workspace/v1\n' +
+  'id: strict-fixture\n' +
+  'documents:\n' +
+  '  - architecture/main.yaml\n' +
+  'profiles: []\n' +
+  'projections: []\n' +
+  'adapterMappings: []\n' +
+  (evidence.length === 0
+    ? 'evidence: []\n'
+    : `evidence:\n${evidence.map((path) => `  - ${path}`).join('\n')}\n`)
+
+const contradictedEvidence =
+  'format: yarramate/evidence/v1\n' +
+  'id: repository-scan\n' +
+  'version: "1.0"\n' +
+  'provider: import-audit\n' +
+  'observations:\n' +
+  '  - subject: main#approval-api\n' +
+  '    result: confirmed\n' +
+  '    evidence:\n' +
+  '      uri: repo:src/approval-api.ts\n' +
+  '  - claim: main#api-realizes-approval\n' +
+  '    result: contradicted\n' +
+  '    evidence:\n' +
+  '      uri: repo:src/approval-api.ts\n' +
+  '      message: no realization marker found in source\n'
+
+const confirmedEvidence = contradictedEvidence.replace(
+  'result: contradicted',
+  'result: confirmed',
+)
+
+describe('check --strict', () => {
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-strict-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(join(workspace, 'architecture/main.yaml'), document, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('keeps the default check passing over contradicted evidence', () => {
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['scan.evidence.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'scan.evidence.yaml'),
+      contradictedEvidence,
+      'utf8',
+    )
+
+    const result = runCli(['check', 'workspace.yaml'], workspace)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('no errors')
+    expect(result.stdout).not.toContain('Strict:')
+  })
+
+  it('fails strict checks with a source-located contradiction diagnostic', () => {
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['scan.evidence.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'scan.evidence.yaml'),
+      contradictedEvidence,
+      'utf8',
+    )
+
+    const result = runCli(['check', 'workspace.yaml', '--strict'], workspace)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain('error YM901')
+    expect(result.stdout).toContain(
+      'Evidence contradicts claim "main#api-realizes-approval"',
+    )
+    expect(result.stdout).toContain(
+      'the model asserts main#approval-api -> main#approve-order',
+    )
+    expect(result.stdout).toContain('provider "import-audit"')
+    expect(result.stdout).toContain('no realization marker found in source')
+    const [location] = result.stdout.split(' error ')
+    expect(location).toMatch(/^architecture\/main\.yaml:\d+:\d+$/)
+    const line = Number(location!.split(':')[1])
+    expect(line).toBeGreaterThan(11)
+  })
+
+  it('emits a schema-valid strict failure in JSON mode', () => {
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['scan.evidence.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'scan.evidence.yaml'),
+      contradictedEvidence,
+      'utf8',
+    )
+
+    const result = runCli(
+      ['check', 'workspace.yaml', '--strict', '--json'],
+      workspace,
+    )
+
+    expect(result.exitCode).toBe(1)
+    const payload = JSON.parse(result.stdout) as {
+      ok: boolean
+      diagnostics: readonly { code: string; path: string }[]
+      strict?: { observations: number; contradicted: number }
+    }
+    expect(payload.ok).toBe(false)
+    expect(payload.diagnostics).toHaveLength(1)
+    expect(payload.diagnostics[0]!.code).toBe('YM901')
+    expect(payload.diagnostics[0]!.path).toBe('architecture/main.yaml')
+    expect(payload.strict).toEqual({ observations: 2, contradicted: 1 })
+    const validate = new Ajv2020({ allErrors: true }).compile(
+      checkResultSchema,
+    )
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
+  })
+
+  it('passes strict checks and reports what it evaluated', () => {
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['scan.evidence.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'scan.evidence.yaml'),
+      confirmedEvidence,
+      'utf8',
+    )
+
+    const human = runCli(['check', 'workspace.yaml', '--strict'], workspace)
+    expect(human.exitCode).toBe(0)
+    expect(human.stdout).toContain('no errors')
+    expect(human.stdout).toContain('Strict: 2 observations, 0 contradicted')
+
+    const machine = runCli(
+      ['check', 'workspace.yaml', '--strict', '--json'],
+      workspace,
+    )
+    expect(machine.exitCode).toBe(0)
+    const payload = JSON.parse(machine.stdout) as {
+      ok: boolean
+      strict?: { observations: number; contradicted: number }
+    }
+    expect(payload.ok).toBe(true)
+    expect(payload.strict).toEqual({ observations: 2, contradicted: 0 })
+    const validate = new Ajv2020({ allErrors: true }).compile(
+      checkResultSchema,
+    )
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
+  })
+
+  it('announces a vacuous strict gate when no evidence is declared', () => {
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest([]), 'utf8')
+
+    const result = runCli(['check', 'workspace.yaml', '--strict'], workspace)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(
+      'Strict: no evidence observations to evaluate',
+    )
+  })
+
+  it('anchors subject-targeted contradictions at the concept declaration', () => {
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['scan.evidence.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'scan.evidence.yaml'),
+      'format: yarramate/evidence/v1\n' +
+        'id: repository-scan\n' +
+        'version: "1.0"\n' +
+        'provider: import-audit\n' +
+        'observations:\n' +
+        '  - subject: main#approval-api\n' +
+        '    result: contradicted\n' +
+        '    evidence:\n' +
+        '      uri: repo:src\n',
+      'utf8',
+    )
+
+    const result = runCli(['check', 'workspace.yaml', '--strict'], workspace)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      'Evidence contradicts subject "main#approval-api"',
+    )
+    expect(result.stdout).toMatch(/^architecture\/main\.yaml:\d+:\d+ error YM901/)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the decision recorded on #54: `check --strict` is an **opt-in** flag that folds reconciliation contradictions into the check exit code, for gates that want one knob (CI, benchmark harnesses, skill acceptance criteria). Default `check` behavior is byte-identical.
- When the base check passes, strict mode reconciles the workspace's evidence overlays and fails (exit 1) with one **YM901** diagnostic per `contradicted` observation — anchored at the declaring claim's source position, restating the asserted relationship (ADR 0046) and the contradicting observation with its evidence message, so the failure is repairable where it's reported (ADR 0039). `unknown`/`not-observed` stay advisory.
- A strict **pass** reports what it evaluated (`Strict: N observations, 0 contradicted`), including the vacuous case (`Strict: no evidence observations to evaluate`) — the sweep showed a gate that looks engaged but evaluated nothing is exactly the failure mode to close.
- `yarramate/check-result/v1` gains an additive optional `strict: {observations, contradicted}` summary; normative schema updated.
- ADR 0047 records the rationale, grounded in the benchmark sweep's sabotage-repair findings.

## Test plan
- [x] 6 new tests in `test/check-strict.test.ts`: default unchanged over contradicted evidence; strict human failure with source-located YM901 + asserted endpoints; schema-valid strict JSON failure and pass; vacuous-gate announcement; subject-targeted anchor.
- [x] `rm -rf dist && pnpm verify` exit 0 (246 tests).

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)