### PR TITLE
Scope vitest discovery to the repository test tree

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+// Scope discovery to the repository's own test tree: agent worktrees under
+// .claude/worktrees/ carry full copies of test/ that default globs would run.
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary
- Adds a minimal `vitest.config.ts` pinning test discovery to `test/**/*.test.ts`. Without it, vitest's default globs also run the full test-tree copies inside `.claude/worktrees/` agent worktrees — the v0.5.0 release-prep incident (24 files ballooning to 120, running against stale worktree state), and this repo actively uses worktree agents.

## Test plan
- [x] With three live agent worktrees on disk: `pnpm vitest run` → 24 files / 240 tests (main's own tree only), exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)