### PR TITLE
Enumerate valid relationship kinds for the observed aspect pair in YM404

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -181,6 +181,35 @@ const compareById = <T extends { readonly id: string }>(left: T, right: T) =>
 const presenceClaimId = (subject: string, state: string) =>
   `${subject}~present-in-${Buffer.from(state, 'utf8').toString('hex')}`
 
+const describeAspect = (aspect: (typeof conceptKinds)[number]['aspect']) =>
+  aspect.replace('-', ' ')
+
+// Candidate order is the policy-matrix declaration order: the resolved kind
+// map inserts core policies first, then extension kinds as declared.
+const candidateKindHint = (
+  kinds: ReadonlyMap<string, ResolvedRelationshipKind>,
+  rejected: string,
+  sourceAspect: (typeof conceptKinds)[number]['aspect'],
+  targetAspect: (typeof conceptKinds)[number]['aspect'],
+) => {
+  const candidates = [...kinds]
+    .filter(
+      ([id, kind]) =>
+        id !== rejected &&
+        (kind.sourceAspects?.includes(sourceAspect) ?? true) &&
+        (kind.targetAspects?.includes(targetAspect) ?? true),
+    )
+    .map(([id]) => id)
+  if (candidates.length === 0) {
+    return ''
+  }
+  const observed =
+    sourceAspect === targetAspect
+      ? `both endpoints are ${describeAspect(sourceAspect)}`
+      : `source is ${describeAspect(sourceAspect)} and target is ${describeAspect(targetAspect)}`
+  return `; ${observed}; valid candidates: ${candidates.join(', ')}`
+}
+
 const diagnosticFailure = (
   diagnostics: readonly Diagnostic[],
 ): Extract<CompilationResult, { readonly ok: false }> => ({
@@ -1134,26 +1163,40 @@ function compileWorkspaceResolved(
       }
       const policy = selectedProfile.relationshipKinds.get(relationship.kind)
       if (policy !== undefined) {
-        for (const endpoint of ['source', 'target'] as const) {
-          const reference =
-            endpoint === 'source' ? relationship.from : relationship.to
+        const aspectOf = (reference: string) => {
           const resolvedConcept = conceptByQualifiedId.get(
             qualifyReference(value.id, reference),
           )
-          const kind =
-            resolvedConcept === undefined
-              ? undefined
-              : profiles
-                  .get(resolvedConcept.profile)
-                  ?.conceptKinds.get(resolvedConcept.concept.kind)
+          return resolvedConcept === undefined
+            ? undefined
+            : profiles
+                .get(resolvedConcept.profile)
+                ?.conceptKinds.get(resolvedConcept.concept.kind)?.aspect
+        }
+        const sourceAspect = aspectOf(relationship.from)
+        const targetAspect = aspectOf(relationship.to)
+        const candidates =
+          sourceAspect === undefined || targetAspect === undefined
+            ? ''
+            : candidateKindHint(
+                selectedProfile.relationshipKinds,
+                relationship.kind,
+                sourceAspect,
+                targetAspect,
+              )
+        for (const endpoint of ['source', 'target'] as const) {
+          const reference =
+            endpoint === 'source' ? relationship.from : relationship.to
+          const aspect =
+            endpoint === 'source' ? sourceAspect : targetAspect
           const allowed =
             endpoint === 'source'
               ? policy.sourceAspects
               : policy.targetAspects
           if (
-            kind !== undefined &&
+            aspect !== undefined &&
             allowed !== undefined &&
-            !allowed.includes(kind.aspect)
+            !allowed.includes(aspect)
           ) {
             const field = endpoint === 'source' ? 'from' : 'to'
             const pointer = `/relationships/${index}/${field}`
@@ -1164,7 +1207,7 @@ function compileWorkspaceResolved(
             diagnostics.push({
               severity: 'error',
               code: 'YM404',
-              message: `Relationship "${relationship.kind}" requires a ${endpoint} with aspect ${allowed.map((aspect) => `"${aspect}"`).join(' or ')}; "${reference}" has aspect "${kind.aspect}"${policy.repair === undefined ? '' : `; ${policy.repair}`}`,
+              message: `Relationship "${relationship.kind}" requires a ${endpoint} with aspect ${allowed.map((entry) => `"${entry}"`).join(' or ')}; "${reference}" has aspect "${aspect}"${policy.repair === undefined ? '' : `; ${policy.repair}`}${candidates}`,
               path: input.path,
               pointer,
               line: source.line,

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -904,7 +904,7 @@ relationships:
           severity: 'error',
           code: 'YM404',
           message:
-            'Relationship "assignment" requires a source with aspect "active-structure"; "intent" has aspect "motivation"; assign from an active-structure element (an actor, component, or node), or use "association"',
+            'Relationship "assignment" requires a source with aspect "active-structure"; "intent" has aspect "motivation"; assign from an active-structure element (an actor, component, or node), or use "association"; source is motivation and target is behavior; valid candidates: composition, aggregation, realization, serving, association, flow, specialization',
           path: 'incompatible.yaml',
           pointer: '/relationships/0/from',
           line: 14,
@@ -929,7 +929,7 @@ relationships:
           severity: 'error',
           code: 'YM404',
           message:
-            'Relationship "access" requires a target with aspect "passive-structure"; "intent" has aspect "motivation"; point "access" at passive structure (a business object, data object, or artifact), or use "association"',
+            'Relationship "access" requires a target with aspect "passive-structure"; "intent" has aspect "motivation"; point "access" at passive structure (a business object, data object, or artifact), or use "association"; source is active structure and target is motivation; valid candidates: composition, aggregation, assignment, realization, serving, influence, association, flow, specialization',
           path: 'incompatible-target.yaml',
           pointer: '/relationships/0/to',
           line: 15,
@@ -1285,7 +1285,7 @@ relationships:
           severity: 'error',
           code: 'YM404',
           message:
-            'Relationship "owns" requires a target with aspect "behavior"; "target" has aspect "motivation"',
+            'Relationship "owns" requires a target with aspect "behavior"; "target" has aspect "motivation"; source is active structure and target is motivation; valid candidates: composition, aggregation, assignment, realization, serving, influence, association, flow, specialization',
           path: 'architecture/constrained.yaml',
           pointer: '/relationships/0/to',
           line: 15,

--- a/test/diagnostic-repair.test.ts
+++ b/test/diagnostic-repair.test.ts
@@ -79,10 +79,10 @@ describe('repair-oriented diagnostics', () => {
       ),
     ])
     expect(messages).toContain(
-      'Relationship "triggering" requires a source with aspect "behavior"; "cli" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"',
+      'Relationship "triggering" requires a source with aspect "behavior"; "cli" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"; both endpoints are active structure; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization',
     )
     expect(messages).toContain(
-      'Relationship "triggering" requires a target with aspect "behavior"; "engine" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"',
+      'Relationship "triggering" requires a target with aspect "behavior"; "engine" has aspect "active-structure"; use "flow" between active-structure elements, or introduce a behavior concept and "assignment"; both endpoints are active structure; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization',
     )
   })
 
@@ -93,7 +93,69 @@ describe('repair-oriented diagnostics', () => {
       ),
     ])
     expect(messages).toContain(
-      'Relationship "influence" requires a target with aspect "motivation"; "engine" has aspect "active-structure"; point "influence" at a motivation concept (a goal, requirement, or principle), or use "association"',
+      'Relationship "influence" requires a target with aspect "motivation"; "engine" has aspect "active-structure"; point "influence" at a motivation concept (a goal, requirement, or principle), or use "association"; both endpoints are active structure; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization',
+    )
+  })
+
+  it('enumerates valid candidates for the observed aspect pair', () => {
+    const messages = messagesOf([
+      document(
+        'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: cli\n    kind: applicationComponent\n    name: CLI\n  - id: engine\n    kind: applicationComponent\n    name: Engine\nrelationships:\n  - id: cli-accesses-engine\n    kind: access\n    from: cli\n    to: engine\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Relationship "access" requires a target with aspect "passive-structure"; "engine" has aspect "active-structure"; point "access" at passive structure (a business object, data object, or artifact), or use "association"; both endpoints are active structure; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization',
+    )
+  })
+
+  it('derives candidates deterministically and never lists the rejected kind', () => {
+    const source = document(
+      'format: yarramate/v1\nid: example\nprofile: yarramate/core@0.1\nconcepts:\n  - id: cli\n    kind: applicationComponent\n    name: CLI\n  - id: engine\n    kind: applicationComponent\n    name: Engine\nrelationships:\n  - id: cli-accesses-engine\n    kind: access\n    from: cli\n    to: engine\n',
+    )
+    const first = messagesOf([source])
+    const second = messagesOf([source])
+    expect(second).toEqual(first)
+    const rejection = first.find((message) =>
+      message.includes('valid candidates: '),
+    )
+    expect(rejection).toBeDefined()
+    const candidates = (rejection ?? '')
+      .slice((rejection ?? '').indexOf('valid candidates: ') + 'valid candidates: '.length)
+      .split(', ')
+    expect(candidates).not.toContain('access')
+  })
+
+  it('derives candidates for extension kinds without curated remedies', () => {
+    const profile = {
+      path: 'profiles/platform.yaml',
+      source:
+        'format: yarramate/profile/v1\nid: example/platform\nversion: "1.0"\nextends: yarramate/core@0.1\nconceptKinds: []\nrelationshipKinds:\n  - id: owns\n    name: Owns\n    parent: yarramate/core@0.1#assignment\n    targetAspects: [behavior]\n',
+    }
+    const messages = messagesOf([
+      profile,
+      document(
+        'format: yarramate/v1\nid: example\nprofile: example/platform@1.0\nconcepts:\n  - id: team\n    kind: businessActor\n    name: Team\n  - id: north-star\n    kind: goal\n    name: North star\nrelationships:\n  - id: team-owns-north-star\n    kind: owns\n    from: team\n    to: north-star\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Relationship "owns" requires a target with aspect "behavior"; "north-star" has aspect "motivation"; source is active structure and target is motivation; valid candidates: composition, aggregation, assignment, realization, serving, influence, association, flow, specialization',
+    )
+  })
+
+  it('lists matching extension kinds after the core policy matrix', () => {
+    const profile = {
+      path: 'profiles/platform.yaml',
+      source:
+        'format: yarramate/profile/v1\nid: example/platform\nversion: "1.0"\nextends: yarramate/core@0.1\nconceptKinds: []\nrelationshipKinds:\n  - id: owns\n    name: Owns\n    parent: yarramate/core@0.1#assignment\n    targetAspects: [behavior]\n',
+    }
+    const messages = messagesOf([
+      profile,
+      document(
+        'format: yarramate/v1\nid: example\nprofile: example/platform@1.0\nconcepts:\n  - id: team\n    kind: businessActor\n    name: Team\n  - id: delivery\n    kind: businessProcess\n    name: Delivery\nrelationships:\n  - id: team-accesses-delivery\n    kind: access\n    from: team\n    to: delivery\n',
+      ),
+    ])
+    expect(messages).toContain(
+      'Relationship "access" requires a target with aspect "passive-structure"; "delivery" has aspect "behavior"; point "access" at passive structure (a business object, data object, or artifact), or use "association"; source is active structure and target is behavior; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization, owns',
     )
   })
 })


### PR DESCRIPTION
Follow-up to #48 / PR #60: YM404 diagnostics now derive and list the relationship kinds that ARE valid for the observed endpoint aspect pair, straight from the profile's policy matrix.

## Summary
- YM404 messages append the observed aspect pair and a derived candidate list, e.g. `; both endpoints are active structure; valid candidates: composition, aggregation, assignment, realization, serving, association, flow, specialization`.
- Candidates come from the resolved relationship-kind map (core policies plus profile-declared extension kinds), so the hint stays correct as profiles evolve: a kind qualifies when its `sourceAspects`/`targetAspects` constraints accept the observed pair; the rejected kind is excluded.
- Order is the policy-matrix declaration order (core `relationshipPolicies` first, then extension kinds as declared), which the resolved map's insertion order already guarantees — deterministic, not alphabetical.
- PR #60's curated `repair` remedies are kept verbatim; the derived clause is appended after them. Extension kinds, which carry no curated remedy, now get the derived hint too.
- When either endpoint fails to resolve (its aspect is unknown), the candidate clause is omitted and the message stays as before.
- Covered by ADR 0039 (diagnostics carry repair information); no docs quote the YM404 message verbatim, so none needed updating.

## Test plan
- [x] Candidate enumeration for an aspect-pair rejection (`access` between two active-structure components)
- [x] Determinism across compilations and rejected kind absent from the candidate list
- [x] Extension-kind rejection (`owns`, no curated remedy) receives derived candidates
- [x] Matching extension kinds are listed after the core matrix in declaration order
- [x] Existing curated-remedy assertions updated for the grown message (triggering, influence, assignment, access, extension `owns`)
- [x] `rm -rf dist && pnpm verify` exits 0 (typecheck, build, 244 tests, self:check, validate)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)