### PR TITLE
Count current subjects without evidence in reconciliation (ADR 0049)

### DIFF
--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -106,6 +106,14 @@ the evidence is visible in the finding itself:
 Subject-targeted findings and findings on relationship sub-claims (such as
 `…~name`) do not carry `asserted`.
 
+The summary also counts `current` concepts that appear in no observation at
+all — neither targeted directly, nor through a claim they own, nor as an
+endpoint of an observed relationship claim — as `subjectsWithoutEvidence`.
+When the count is positive the report lists them in a top-level
+`unobservedSubjects` array, sorted lexicographically. This is not a finding:
+no provider looked and disagreed; reconciliation simply has no opinion, and
+the report says so instead of letting the gap pass as verified.
+
 A finding is advisory evidence, not a proposed replacement claim, validation
 error, CI verdict, or authorization to modify the native model.
 

--- a/docs/adr/0049-reconciliation-counts-the-unobserved.md
+++ b/docs/adr/0049-reconciliation-counts-the-unobserved.md
@@ -1,0 +1,28 @@
+# Reconciliation counts the unobserved
+
+Status: accepted
+
+A reconciliation summary used to count only the observations that evidence
+providers made. Subjects with no observation at all were absent from the
+denominator, so after a dogfooded slice marked its new concepts `current`,
+the summary read as fully verified while those concepts had never been
+looked at. `not-observed` is a provider's opinion that something is missing;
+no observation is the absence of any opinion, and the two were
+indistinguishable at summary level.
+
+The report now computes, from the compiled graph, the concepts whose
+lifecycle status is `current` yet which appear in no observation — neither
+targeted directly, nor through a claim they own, nor as an endpoint of an
+observed relationship claim. The summary always carries a
+`subjectsWithoutEvidence` counter, and when the count is positive the report
+lists the subjects in a top-level `unobservedSubjects` array, sorted
+lexicographically. The filter is deliberate: `current` is where the claim
+"this exists" is being made without support, while `planned` and `retired`
+subjects make no such claim.
+
+Absence of evidence is reported as absence, never as a finding: findings
+carry a provider and an evidence locator, and no provider produced anything
+here, so shoehorning the gap into `findings` would fabricate an accusation.
+The change is additive within `yarramate/reconciliation-report/v1`, the same
+pattern as ADR 0046; existing consumers keep working, and `unobservedSubjects`
+is omitted when the graph is unavailable or the list is empty.

--- a/schema/yarramate-reconciliation-report.schema.json
+++ b/schema/yarramate-reconciliation-report.schema.json
@@ -18,7 +18,8 @@
         "findings",
         "contradicted",
         "unknown",
-        "notObserved"
+        "notObserved",
+        "subjectsWithoutEvidence"
       ],
       "properties": {
         "evidenceDocuments": { "type": "integer", "minimum": 0 },
@@ -27,12 +28,17 @@
         "findings": { "type": "integer", "minimum": 0 },
         "contradicted": { "type": "integer", "minimum": 0 },
         "unknown": { "type": "integer", "minimum": 0 },
-        "notObserved": { "type": "integer", "minimum": 0 }
+        "notObserved": { "type": "integer", "minimum": 0 },
+        "subjectsWithoutEvidence": { "type": "integer", "minimum": 0 }
       }
     },
     "findings": {
       "type": "array",
       "items": { "$ref": "#/$defs/finding" }
+    },
+    "unobservedSubjects": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/subjectIdentity" }
     }
   },
   "$defs": {

--- a/schema/yarramate-status-result.schema.json
+++ b/schema/yarramate-status-result.schema.json
@@ -79,7 +79,8 @@
         "findings",
         "contradicted",
         "unknown",
-        "notObserved"
+        "notObserved",
+        "subjectsWithoutEvidence"
       ],
       "properties": {
         "evidenceDocuments": {
@@ -107,6 +108,10 @@
           "minimum": 0
         },
         "notObserved": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "subjectsWithoutEvidence": {
           "type": "integer",
           "minimum": 0
         }

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -35,8 +35,10 @@ export interface ReconciliationReport {
     readonly contradicted: number
     readonly unknown: number
     readonly notObserved: number
+    readonly subjectsWithoutEvidence: number
   }
   readonly findings: readonly ReconciliationFinding[]
+  readonly unobservedSubjects?: readonly string[]
 }
 
 const assertedRelationshipsByClaim = (
@@ -71,12 +73,57 @@ const assertedRelationshipsByClaim = (
   return asserted
 }
 
+const unobservedCurrentConcepts = (
+  graph: SemanticGraph | undefined,
+  reports: readonly EvidenceReport[],
+): readonly string[] => {
+  if (graph === undefined) return []
+  const relationshipIds = new Set(
+    graph.subjects
+      .filter(({ type }) => type === 'relationship')
+      .map(({ id }) => id),
+  )
+  const claimsById = new Map(graph.claims.map((claim) => [claim.id, claim]))
+  const observed = new Set<string>()
+  for (const report of reports) {
+    for (const observation of report.observations) {
+      if ('subject' in observation) {
+        observed.add(observation.subject)
+        continue
+      }
+      const claim = claimsById.get(observation.claim)
+      if (claim === undefined) continue
+      observed.add(claim.subject)
+      if (relationshipIds.has(claim.id) && 'ref' in claim.object) {
+        observed.add(claim.object.ref)
+      }
+    }
+  }
+  const conceptIds = new Set(
+    graph.subjects
+      .filter(({ type }) => type === 'concept')
+      .map(({ id }) => id),
+  )
+  return graph.claims
+    .filter(
+      (claim) =>
+        claim.predicate === 'yarramate/lifecycle/status' &&
+        'value' in claim.object &&
+        claim.object.value === 'current' &&
+        conceptIds.has(claim.subject) &&
+        !observed.has(claim.subject),
+    )
+    .map(({ subject }) => subject)
+    .sort((left, right) => left.localeCompare(right))
+}
+
 export function reconcileEvidenceReports(
   workspace: string,
   reports: readonly EvidenceReport[],
   graph?: SemanticGraph,
 ): ReconciliationReport {
   const assertedByClaim = assertedRelationshipsByClaim(graph)
+  const unobservedSubjects = unobservedCurrentConcepts(graph, reports)
   const summary = {
     evidenceDocuments: reports.length,
     observations: 0,
@@ -85,6 +132,7 @@ export function reconcileEvidenceReports(
     contradicted: 0,
     unknown: 0,
     notObserved: 0,
+    subjectsWithoutEvidence: unobservedSubjects.length,
   }
   const findings: ReconciliationFinding[] = []
   for (const report of reports) {
@@ -127,5 +175,6 @@ export function reconcileEvidenceReports(
     workspace,
     summary,
     findings,
+    ...(unobservedSubjects.length === 0 ? {} : { unobservedSubjects }),
   }
 }

--- a/src/status-command.ts
+++ b/src/status-command.ts
@@ -238,6 +238,9 @@ export function runStatusCommand(
             ? ` (${result.reconciliation.contradicted} contradicted, ` +
               `${result.reconciliation.unknown} unknown, ` +
               `${result.reconciliation.notObserved} not observed)`
+            : '') +
+          (result.reconciliation.subjectsWithoutEvidence > 0
+            ? `, ${plural(result.reconciliation.subjectsWithoutEvidence, 'current subject')} without evidence`
             : ''),
       )
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -463,7 +463,9 @@ describe('YarraMate CLI', () => {
         contradicted: 1,
         unknown: 0,
         notObserved: 0,
+        subjectsWithoutEvidence: 1,
       },
+      unobservedSubjects: ['orders-project#order-service'],
       findings: [
         {
           target: {
@@ -516,6 +518,7 @@ describe('YarraMate CLI', () => {
         contradicted: 2,
         unknown: 0,
         notObserved: 0,
+        subjectsWithoutEvidence: 0,
       },
       findings: [
         {

--- a/test/reconciliation-unobserved.test.ts
+++ b/test/reconciliation-unobserved.test.ts
@@ -1,0 +1,206 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const reconciliationSchema = JSON.parse(
+  JSON.stringify(
+    await import('../schema/yarramate-reconciliation-report.schema.json', {
+      with: { type: 'json' },
+    }).then((module) => module.default),
+  ),
+) as object
+
+const writeFixture = () => {
+  const parent = mkdtempSync(join(tmpdir(), 'yarramate-unobserved-'))
+  mkdirSync(join(parent, 'architecture'))
+  mkdirSync(join(parent, 'evidence'))
+  writeFileSync(
+    join(parent, 'workspace.yaml'),
+    'format: yarramate/workspace/v1\n' +
+      'id: shop\n' +
+      'documents:\n' +
+      '  - architecture/*.yaml\n' +
+      'profiles: []\n' +
+      'projections: []\n' +
+      'adapterMappings: []\n' +
+      'evidence:\n' +
+      '  - evidence/*.yaml\n',
+  )
+  writeFileSync(
+    join(parent, 'architecture', 'shop.yaml'),
+    'format: yarramate/v1\n' +
+      'id: shop\n' +
+      'profile: yarramate/core@0.1\n' +
+      'concepts:\n' +
+      '  - id: zeta-service\n' +
+      '    kind: applicationService\n' +
+      '    name: Zeta\n' +
+      '    status: current\n' +
+      '  - id: checkout\n' +
+      '    kind: applicationService\n' +
+      '    name: Checkout\n' +
+      '    status: current\n' +
+      '  - id: basket\n' +
+      '    kind: dataObject\n' +
+      '    name: Basket\n' +
+      '    status: current\n' +
+      '  - id: alpha-service\n' +
+      '    kind: applicationService\n' +
+      '    name: Alpha\n' +
+      '    status: current\n' +
+      '  - id: catalog\n' +
+      '    kind: applicationService\n' +
+      '    name: Catalog\n' +
+      '    status: current\n' +
+      '  - id: search\n' +
+      '    kind: applicationService\n' +
+      '    name: Search\n' +
+      '    status: planned\n' +
+      '  - id: legacy-cart\n' +
+      '    kind: applicationService\n' +
+      '    name: Legacy cart\n' +
+      '    status: retired\n' +
+      'relationships:\n' +
+      '  - id: checkout-accesses-basket\n' +
+      '    kind: access\n' +
+      '    from: checkout\n' +
+      '    to: basket\n' +
+      '    mode: write\n' +
+      '  - id: catalog-accesses-basket\n' +
+      '    kind: access\n' +
+      '    from: catalog\n' +
+      '    to: basket\n' +
+      '    mode: read\n' +
+      '    status: current\n',
+  )
+  writeFileSync(
+    join(parent, 'evidence', 'repository.yaml'),
+    'format: yarramate/evidence/v1\n' +
+      'id: shop-repository\n' +
+      'version: "1.0"\n' +
+      'provider: repository-inspection\n' +
+      'observations:\n' +
+      '  - claim: shop#checkout-accesses-basket\n' +
+      '    result: confirmed\n' +
+      '    evidence:\n' +
+      '      uri: repo:src/checkout.ts\n',
+  )
+  return parent
+}
+
+describe('reconciliation of current subjects without evidence', () => {
+  it('lists and counts current concepts that no observation touches', () => {
+    const parent = writeFixture()
+    try {
+      const result = runCli(['reconcile', 'workspace.yaml'], parent)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).toBe('')
+      const report = JSON.parse(result.stdout)
+      expect(report.summary.subjectsWithoutEvidence).toBe(3)
+      expect(report.unobservedSubjects).toEqual([
+        'shop#alpha-service',
+        'shop#catalog',
+        'shop#zeta-service',
+      ])
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('skips planned and retired concepts and relationship subjects', () => {
+    const parent = writeFixture()
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', 'workspace.yaml'], parent).stdout,
+      )
+      expect(report.unobservedSubjects).not.toContain('shop#search')
+      expect(report.unobservedSubjects).not.toContain('shop#legacy-cart')
+      expect(report.unobservedSubjects).not.toContain(
+        'shop#catalog-accesses-basket',
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('treats relationship-claim endpoints as observed', () => {
+    const parent = writeFixture()
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', 'workspace.yaml'], parent).stdout,
+      )
+      expect(report.unobservedSubjects).not.toContain('shop#checkout')
+      expect(report.unobservedSubjects).not.toContain('shop#basket')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('emits the same sorted report on repeated runs', () => {
+    const parent = writeFixture()
+    try {
+      const first = runCli(['reconcile', 'workspace.yaml'], parent)
+      const second = runCli(['reconcile', 'workspace.yaml'], parent)
+      expect(first.stdout).toBe(second.stdout)
+      const report = JSON.parse(first.stdout)
+      expect(report.unobservedSubjects).toEqual(
+        [...report.unobservedSubjects].sort((left: string, right: string) =>
+          left.localeCompare(right),
+        ),
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('remains valid against the normative reconciliation schema', () => {
+    const parent = writeFixture()
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', 'workspace.yaml'], parent).stdout,
+      )
+      const validate = new Ajv2020({ allErrors: true }).compile(
+        reconciliationSchema,
+      )
+      expect(validate(report), JSON.stringify(validate.errors)).toBe(true)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('surfaces the count on the human status line', () => {
+    const parent = writeFixture()
+    try {
+      const result = runCli(['status', 'workspace.yaml'], parent)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain(
+        '3 current subjects without evidence',
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('omits unobservedSubjects when nothing current lacks evidence', () => {
+    const result = runCli(
+      ['reconcile', 'test/fixtures/valid/payments.workspace.yaml'],
+      repositoryRoot,
+    )
+    const report = JSON.parse(result.stdout)
+    expect(report.summary.subjectsWithoutEvidence).toBe(0)
+    expect('unobservedSubjects' in report).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Reconciliation now computes the set of `current` concepts that appear in no evidence observation — neither subject-targeted, nor via a claim they own, nor as an endpoint of an observed relationship claim — so absence of evidence is visible instead of passing as verified (issue #64, from the yarradev-ai dogfood).
- `yarramate/reconciliation-report/v1` gains an always-present `summary.subjectsWithoutEvidence` counter and, when positive, a top-level `unobservedSubjects` array sorted lexicographically. Additive, same pattern as ADR 0046; the gap is never rendered as a finding because findings carry provider/evidence locators that do not exist here.
- Normative schemas updated: `schema/yarramate-reconciliation-report.schema.json` (counter required, `unobservedSubjects` optional) and `schema/yarramate-status-result.schema.json` (embedded reconciliation summary accepts and requires the counter).
- `yarramate status` appends `, N current subjects without evidence` to the human `Reconciliation:` line when N > 0; the JSON status carries the counter via the embedded summary.
- ADR 0049 records the decision; docs/EVIDENCE.md documents the new fields. On the repo's own workspace, reconcile now reports 109 current subjects without evidence — previously invisible.

## Test plan
- [x] `test/reconciliation-unobserved.test.ts`: unobserved current concept is listed and counted; planned/retired concepts and relationship subjects are skipped; endpoints of an observed relationship claim count as observed; repeated runs emit identical sorted output; emitted report validates against the updated schema (Ajv 2020); human status line shows the count; `unobservedSubjects` omitted when nothing current lacks evidence.
- [x] Updated pinned reconcile expectations in `test/cli.test.ts` (discovery fixture now reports `orders-project#order-service`; payments reports zero).
- [x] `rm -rf dist && pnpm verify` exits 0 (typecheck, build, 247 tests, self-check, LikeC4 validate).

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)