### PR TITLE
Let generated output update freely and declare its freshness (ADR 0050)

### DIFF
--- a/docs/ADAPTER-MAPPINGS.md
+++ b/docs/ADAPTER-MAPPINGS.md
@@ -168,23 +168,43 @@ Project export may add adapter-owned dynamic views as described below.
 
 `export-project` writes `model.likec4`, `specification.likec4`, and
 `likec4.config.json` into a project directory, plus a versioned
-`yarramate.generated.json` marker. A matching marker permits deterministic
+`yarramate.generated.json` marker. The marker permits deterministic
 regeneration of only those three declared files and preserves unrelated
-files. The complete marker is validated against its normative schema before
-ownership is trusted; unmarked, malformed, or differently owned directories
-are refused. The project directory, marker, and three owned files must also be
-physical directories/files rather than symbolic links or substituted file
-types, preventing regeneration from writing outside the marked project. The
-marker records SHA-256 digests for all three owned files. Once digests are
-present, any edit, deletion, or interrupted partial update is refused instead
-of silently overwritten; deleting the derived project and exporting it again
-is the recovery path. Regeneration stages every owned file in the destination
-directory, atomically replaces each complete file, and replaces the ownership
-marker last. A process interruption can therefore leave old and new complete
-files, but never a partially written file; the still-current marker digests
-make that mixed state detectable on the next run. Legacy v1 markers without
-digests are accepted once and upgraded on regeneration. Single-view marker v1
-is defined by `schema/yarramate-likec4-generated-project.schema.json`.
+files. The complete marker is validated against its normative schemas before
+regeneration is trusted: a directory carrying a valid marker of either format
+version whose recorded output digests are intact is entirely
+machine-generated, so it is updated in place even when the project, mapping,
+views, or comparison have since changed — the ownership fields document
+provenance without gating updates (ADR 0050). Unmarked or malformed
+directories are refused as not YarraMate-generated, and a hand-edited,
+deleted, or interrupted partially updated owned file is refused by name
+instead of silently overwritten; deleting the derived project and exporting
+it again is the recovery path for hand edits. The project directory, marker,
+and three owned files must also be physical directories/files rather than
+symbolic links or substituted file types, preventing regeneration from
+writing outside the marked project. Regeneration stages every owned file in
+the destination directory, atomically replaces each complete file, and
+replaces the ownership marker last. A process interruption can therefore
+leave old and new complete files, but never a partially written file; the
+still-current marker digests make that mixed state detectable on the next
+run. Legacy markers without digests are accepted once and upgraded on
+regeneration. Single-view marker v1 is defined by
+`schema/yarramate-likec4-generated-project.schema.json`.
+
+The marker also records `inputDigests`: the SHA-256 of every resolved input
+that fed the export — the project definition or projection, the subject
+mapping, the kind mapping when present, each referenced projection, and every
+workspace source document — keyed by the path used to reference it.
+`export-project --check` uses them to report generated-output freshness
+without writing anything: it recomputes the would-be export in memory and
+compares digests, printing `Generated LikeC4 output: fresh` (exit 0), or
+`stale` with one `Reason:` line per changed, added, or removed input plus
+`model source changed` when the rendered model differs, followed by
+`Safe to regenerate: yes` (exit 1). An absent output directory reports
+`absent` (exit 1), a hand-edited generated file reports `modified` with
+`Safe to regenerate: no` (exit 1), and markers written before input digests
+existed report stale with reason `marker predates input digests`. Freshness
+is a pure digest comparison, never a semantic judgement.
 
 For a multi-view project, pass an adapter-owned project definition in place of
 the projection and mapping arguments:
@@ -313,9 +333,9 @@ metadata without inventing LikeC4 relationship identities.
 Both comparison states must occur in the projection's `query.states`.
 `YMLC105` identifies a selected comparison state missing from the compiled
 workspace, and `YMLC106` identifies a compared state omitted from the
-projection. A generated project marker owns the ordered comparison in addition
-to its projection and mappings, preventing a directory from silently changing
-comparison meaning on regeneration.
+projection. A generated project marker records the ordered comparison in
+addition to its projection and mappings, so a regenerated directory documents
+which comparison produced it.
 
 In a multi-view project, direct comparison styles remain local to the selected
 view and marker v2 records its ordered comparison. Because model elements are

--- a/docs/adr/0050-generated-output-declares-its-freshness.md
+++ b/docs/adr/0050-generated-output-declares-its-freshness.md
@@ -1,0 +1,31 @@
+# Generated output declares its freshness
+
+Status: accepted
+
+`export-project` treated its ownership marker as an identity lock: any drift
+between the recorded project, mapping, views, or comparison and the requested
+export was refused with the same message as an unmarked directory. Adding a
+projection to a valid project therefore made safe regeneration
+indistinguishable from drift recovery, and nothing anywhere reported that an
+existing generated directory no longer matched the inputs it was generated
+from.
+
+A directory is now safely updatable exactly when its marker validates as a
+YarraMate generated-project marker of either format version and its recorded
+output digests are intact. That pair proves the directory is entirely
+machine-generated, so overwriting it loses nothing; how far its recorded
+ownership has drifted is irrelevant, because ownership drift is the normal
+regeneration-after-change case. The ownership fields remain in the marker to
+document provenance, refusals distinguish a foreign directory from a
+hand-edited generated file, and only a non-directory output path keeps the
+bare already-exists error.
+
+The marker additionally records `inputDigests`: the SHA-256 of every resolved
+input that fed the export, keyed by the path used to reference it.
+`export-project --check` recomputes the would-be export in memory and
+compares digests — the recorded inputs against the current ones and the
+recorded model digest against the would-be model source — reporting fresh,
+stale with one reason per differing input, modified for hand edits, or
+absent, without writing anything. Freshness is a pure digest comparison and
+never a semantic judgement; markers from releases before input digests are
+reported stale rather than guessed at.

--- a/schema/yarramate-likec4-generated-project-v2.schema.json
+++ b/schema/yarramate-likec4-generated-project-v2.schema.json
@@ -45,6 +45,12 @@
         }
       }
     },
+    "inputDigests": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/sha256"
+      }
+    },
     "files": {
       "const": [
         "likec4.config.json",

--- a/schema/yarramate-likec4-generated-project.schema.json
+++ b/schema/yarramate-likec4-generated-project.schema.json
@@ -51,6 +51,12 @@
         }
       }
     },
+    "inputDigests": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/sha256"
+      }
+    },
     "files": {
       "const": [
         "likec4.config.json",

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -110,8 +110,8 @@ const usage =
   '  yarramate-likec4 check <projection.yaml> <mapping.yaml> [--json] [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
   '  yarramate-likec4 check <likec4-project.yaml> [--json] <workspace-or-source...>\n' +
   '  yarramate-likec4 export <projection.yaml> <mapping.yaml> [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
-  '  yarramate-likec4 export-project <projection.yaml> <mapping.yaml> <output-dir> [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
-  '  yarramate-likec4 export-project <likec4-project.yaml> <output-dir> <workspace-or-source...>\n'
+  '  yarramate-likec4 export-project [--check] <projection.yaml> <mapping.yaml> <output-dir> [--kinds <kind-mapping.yaml>] [--compare <from-state> <to-state>] <workspace-or-source...>\n' +
+  '  yarramate-likec4 export-project [--check] <likec4-project.yaml> <output-dir> <workspace-or-source...>\n'
 
 const diagnosticJson = (
   diagnostics: readonly LikeC4PreparationDiagnostic[],
@@ -171,9 +171,6 @@ const summarizeUnmappedConcepts = (
     return [summary]
   })
 }
-
-const sameJson = (left: unknown, right: unknown) =>
-  JSON.stringify(left) === JSON.stringify(right)
 
 const lowerCamel = (value: string) =>
   value.replaceAll(/-([a-z0-9])/g, (_, character: string) =>
@@ -385,6 +382,40 @@ const runLikeC4MapSync = (
   }
 }
 
+// Ownership fields never gate updates: a marker of either format version
+// plus intact output digests proves the directory is entirely
+// machine-generated, so regenerating after the inputs changed loses nothing.
+const readGeneratedProjectMarker = (
+  markerPath: string,
+): Readonly<Record<string, unknown>> | undefined => {
+  let marker: unknown
+  try {
+    marker = JSON.parse(readFileSync(markerPath, 'utf8'))
+  } catch {
+    return undefined
+  }
+  return validateGeneratedProjectMarker(marker) ||
+    validateGeneratedProjectV2Marker(marker)
+    ? (marker as Readonly<Record<string, unknown>>)
+    : undefined
+}
+
+const changedGeneratedFile = (
+  projectPath: string,
+  marker: Readonly<Record<string, unknown>>,
+): string | undefined => {
+  // Markers written before output digests existed are accepted once and
+  // upgraded on regeneration.
+  if (marker['digests'] === undefined) return undefined
+  const digests = marker['digests'] as Readonly<Record<string, string>>
+  return generatedFileNames.find((file) => {
+    const path = resolve(projectPath, file)
+    return (
+      !existsSync(path) || sha256(readFileSync(path)) !== digests[file]
+    )
+  })
+}
+
 const publishGeneratedProject = (
   cwd: string,
   outputDirectory: string,
@@ -393,7 +424,7 @@ const publishGeneratedProject = (
     readonly title: string
     readonly modelSource: string
     readonly ownership: Readonly<Record<string, unknown>>
-    readonly validateMarker: (value: unknown) => boolean
+    readonly inputDigests: Readonly<Record<string, string>>
   },
 ): CliResult => {
   const projectPath = resolve(cwd, outputDirectory)
@@ -423,45 +454,20 @@ const publishGeneratedProject = (
         stderr: `Generated project contains an unsafe file: ${unsafeFile}\n`,
       }
     }
-    let marker: unknown
-    try {
-      marker = JSON.parse(readFileSync(markerPath, 'utf8'))
-    } catch {
-      marker = undefined
-    }
-    if (
-      !input.validateMarker(marker) ||
-      typeof marker !== 'object' ||
-      marker === null ||
-      Object.entries(input.ownership).some(
-        ([key, value]) =>
-          !sameJson(
-            (marker as Record<string, unknown>)[key],
-            value,
-          ),
-      )
-    ) {
+    const marker = readGeneratedProjectMarker(markerPath)
+    if (marker === undefined) {
       return {
         exitCode: 2,
         stdout: '',
-        stderr: `Output directory already exists: ${projectPath}\n`,
+        stderr: `Output directory exists but is not a YarraMate-generated project: ${projectPath}\n`,
       }
     }
-    if ('digests' in marker && marker.digests !== undefined) {
-      const digests = marker.digests as Record<string, string>
-      const changedFile = generatedFileNames.find((file) => {
-        const path = resolve(projectPath, file)
-        return (
-          !existsSync(path) ||
-          sha256(readFileSync(path)) !== digests[file]
-        )
-      })
-      if (changedFile !== undefined) {
-        return {
-          exitCode: 2,
-          stdout: '',
-          stderr: `Generated project file has changed: ${resolve(projectPath, changedFile)}\n`,
-        }
+    const changedFile = changedGeneratedFile(projectPath, marker)
+    if (changedFile !== undefined) {
+      return {
+        exitCode: 2,
+        stdout: '',
+        stderr: `Generated project file has changed: ${resolve(projectPath, changedFile)}\n`,
       }
     }
   } else {
@@ -497,6 +503,7 @@ const publishGeneratedProject = (
         'model.likec4': sha256(input.modelSource),
         'specification.likec4': sha256(specificationSource),
       },
+      inputDigests: input.inputDigests,
     },
     null,
     2,
@@ -525,6 +532,106 @@ const publishGeneratedProject = (
   }
 }
 
+// Freshness is a pure digest comparison between the marker and the would-be
+// export; nothing on disk is written or semantically judged.
+const checkGeneratedProject = (
+  cwd: string,
+  outputDirectory: string,
+  input: {
+    readonly modelSource: string
+    readonly inputDigests: Readonly<Record<string, string>>
+  },
+): CliResult => {
+  const projectPath = resolve(cwd, outputDirectory)
+  if (!existsSync(projectPath)) {
+    return {
+      exitCode: 1,
+      stdout: 'Generated LikeC4 output: absent\n',
+      stderr: '',
+    }
+  }
+  const marker = readGeneratedProjectMarker(
+    resolve(projectPath, 'yarramate.generated.json'),
+  )
+  if (marker === undefined) {
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: `Output directory exists but is not a YarraMate-generated project: ${projectPath}\n`,
+    }
+  }
+  const changedFile = changedGeneratedFile(projectPath, marker)
+  if (changedFile !== undefined) {
+    return {
+      exitCode: 1,
+      stdout:
+        'Generated LikeC4 output: modified\n' +
+        'Reason:\n' +
+        `- generated file changed: ${resolve(projectPath, changedFile)}\n` +
+        'Safe to regenerate: no\n',
+      stderr: '',
+    }
+  }
+  const recordedInputs = marker['inputDigests'] as
+    | Readonly<Record<string, string>>
+    | undefined
+  const reasons: string[] = []
+  if (recordedInputs === undefined) {
+    reasons.push('marker predates input digests')
+  } else {
+    const inputPaths = [
+      ...new Set([
+        ...Object.keys(recordedInputs),
+        ...Object.keys(input.inputDigests),
+      ]),
+    ].sort()
+    for (const path of inputPaths) {
+      const recorded = recordedInputs[path]
+      const current = input.inputDigests[path]
+      if (recorded === undefined) reasons.push(`input added: ${path}`)
+      else if (current === undefined) {
+        reasons.push(`input removed: ${path}`)
+      } else if (recorded !== current) {
+        reasons.push(`input changed: ${path}`)
+      }
+    }
+  }
+  const digests = marker['digests'] as
+    | Readonly<Record<string, string>>
+    | undefined
+  if (
+    digests !== undefined &&
+    sha256(input.modelSource) !== digests['model.likec4']
+  ) {
+    reasons.push('model source changed')
+  }
+  if (reasons.length === 0) {
+    return {
+      exitCode: 0,
+      stdout: 'Generated LikeC4 output: fresh\n',
+      stderr: '',
+    }
+  }
+  return {
+    exitCode: 1,
+    stdout:
+      'Generated LikeC4 output: stale\n' +
+      'Reason:\n' +
+      reasons.map((reason) => `- ${reason}\n`).join('') +
+      'Safe to regenerate: yes\n',
+    stderr: '',
+  }
+}
+
+const inputDigestsOf = (
+  inputs: readonly { readonly path: string; readonly source: string }[],
+): Readonly<Record<string, string>> =>
+  Object.fromEntries(
+    inputs
+      .map(({ path, source }) => [path, sha256(source)] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  )
+
 export function runLikeC4Cli(
   args: readonly string[],
   cwd: string = process.cwd(),
@@ -535,7 +642,11 @@ export function runLikeC4Cli(
   if (args[0] === 'map') {
     return runLikeC4MapSync(args.slice(1), cwd)
   }
-  const [command, projectionPath, mappingPath, ...options] = args
+  const checkFreshness =
+    args[0] === 'export-project' && args.includes('--check')
+  const [command, projectionPath, mappingPath, ...options] = checkFreshness
+    ? args.filter((argument) => argument !== '--check')
+    : args
   let projectDefinitionMode = false
   if (
     (command === 'check' || command === 'export-project') &&
@@ -1065,6 +1176,17 @@ export function runLikeC4Cli(
           ? undefined
           : `${first.prepared.kindMapping.id}@${first.prepared.kindMapping.version}`
       const projectIdentity = `${loadedProject.document.value.id}@${loadedProject.document.value.version}`
+      const inputDigests = inputDigestsOf([
+        projectSource,
+        ...sources,
+        ...referencedSources.values(),
+      ])
+      if (checkFreshness) {
+        return checkGeneratedProject(cwd, outputDirectory!, {
+          modelSource: exported.source,
+          inputDigests,
+        })
+      }
       return publishGeneratedProject(cwd, outputDirectory!, {
         projectName: `yarramate-${projectIdentity}`.replaceAll(
           /[^A-Za-z0-9_-]/g,
@@ -1087,31 +1209,31 @@ export function runLikeC4Cli(
               : { comparison }),
           })),
         },
-        validateMarker: (value) =>
-          validateGeneratedProjectV2Marker(value),
+        inputDigests,
       })
     }
+    const projectionSource = {
+      path: projectionPath,
+      source: readFileSync(resolve(cwd, projectionPath), 'utf8'),
+    }
+    const mappingSource = {
+      path: mappingPath!,
+      source: readFileSync(resolve(cwd, mappingPath!), 'utf8'),
+    }
+    const kindMappingSource =
+      kindMappingPath === undefined
+        ? undefined
+        : {
+            path: kindMappingPath,
+            source: readFileSync(resolve(cwd, kindMappingPath), 'utf8'),
+          }
     const prepared = prepareLikeC4Export({
       sources,
-      projection: {
-        path: projectionPath,
-        source: readFileSync(resolve(cwd, projectionPath), 'utf8'),
-      },
-      subjectMapping: {
-        path: mappingPath!,
-        source: readFileSync(resolve(cwd, mappingPath!), 'utf8'),
-      },
-      ...(kindMappingPath === undefined
+      projection: projectionSource,
+      subjectMapping: mappingSource,
+      ...(kindMappingSource === undefined
         ? {}
-        : {
-            kindMapping: {
-              path: kindMappingPath,
-              source: readFileSync(
-                resolve(cwd, kindMappingPath),
-                'utf8',
-              ),
-            },
-          }),
+        : { kindMapping: kindMappingSource }),
       ...(comparison === undefined ? {} : { comparison }),
       vocabulary: command === 'export' ? 'consumer' : 'bundled',
     })
@@ -1142,6 +1264,18 @@ export function runLikeC4Cli(
         ? undefined
         : `${prepared.kindMapping.id}@${prepared.kindMapping.version}`
     const comparisonIdentity = comparison
+    const inputDigests = inputDigestsOf([
+      projectionSource,
+      mappingSource,
+      ...(kindMappingSource === undefined ? [] : [kindMappingSource]),
+      ...sources,
+    ])
+    if (checkFreshness) {
+      return checkGeneratedProject(cwd, outputDirectory!, {
+        modelSource: prepared.source,
+        inputDigests,
+      })
+    }
     return publishGeneratedProject(cwd, outputDirectory!, {
       projectName: ['yarramate', projectionIdentity]
         .join('-')
@@ -1161,7 +1295,7 @@ export function runLikeC4Cli(
           ? {}
           : { comparison: comparisonIdentity }),
       },
-      validateMarker: (value) => validateGeneratedProjectMarker(value),
+      inputDigests,
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -672,7 +672,7 @@ mappings:
           to: 'system#target',
         },
       })
-      const conflicting = runLikeC4Cli(
+      const reversed = runLikeC4Cli(
         [
           'export-project',
           'comparison.projection.yaml',
@@ -685,10 +685,23 @@ mappings:
         ],
         parent,
       )
-      expect(conflicting).toEqual({
-        exitCode: 2,
-        stdout: '',
-        stderr: `Output directory already exists: ${project}\n`,
+      expect(reversed).toEqual({
+        exitCode: 0,
+        stdout: `Updated LikeC4 project at ${project}\n`,
+        stderr: '',
+      })
+      expect(
+        JSON.parse(
+          readFileSync(
+            join(project, 'yarramate.generated.json'),
+            'utf8',
+          ),
+        ),
+      ).toMatchObject({
+        comparison: {
+          from: 'system#target',
+          to: 'system#baseline',
+        },
       })
     } finally {
       rmSync(parent, { recursive: true, force: true })
@@ -835,6 +848,14 @@ mappings:
         'likec4.config.json': expect.stringMatching(/^[a-f0-9]{64}$/),
         'model.likec4': expect.stringMatching(/^[a-f0-9]{64}$/),
         'specification.likec4': expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+      expect(marker.inputDigests).toEqual({
+        'test/fixtures/valid/governed-change.projection.yaml':
+          expect.stringMatching(/^[a-f0-9]{64}$/),
+        'test/fixtures/valid/governed-change.likec4-mapping.yaml':
+          expect.stringMatching(/^[a-f0-9]{64}$/),
+        'test/fixtures/valid/governed-change.yaml':
+          expect.stringMatching(/^[a-f0-9]{64}$/),
       })
       const markerSchema = JSON.parse(
         readFileSync(
@@ -1080,6 +1101,14 @@ views:
           { projection: 'empty@1.0' },
         ],
       })
+      expect(Object.keys(marker.inputDigests)).toEqual([
+        'architecture.yaml',
+        'baseline.projection.yaml',
+        'empty.projection.yaml',
+        'likec4.mapping.yaml',
+        'target.projection.yaml',
+        'yarramate.likec4.yaml',
+      ])
       const markerSchema = JSON.parse(
         readFileSync(
           join(
@@ -1671,6 +1700,312 @@ views:
     }
   })
 
+  it('safely re-exports after the project definition gains a projection', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-grown-project-'),
+    )
+    const project = join(parent, 'generated')
+    const args = [
+      'export-project',
+      'yarramate.likec4.yaml',
+      project,
+      'architecture.yaml',
+    ]
+    try {
+      writeFileSync(
+        join(parent, 'architecture.yaml'),
+        `format: yarramate/v1
+id: system
+profile: yarramate/core@0.1
+concepts:
+  - id: service
+    kind: applicationComponent
+    name: Service
+relationships: []
+`,
+      )
+      writeFileSync(
+        join(parent, 'first.projection.yaml'),
+        `format: yarramate/projection/v1
+id: first
+version: "1.0"
+query: {}
+`,
+      )
+      writeFileSync(
+        join(parent, 'likec4.mapping.yaml'),
+        `format: yarramate/adapter-mapping/v1
+id: system-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: system#service
+    external: service
+    type: concept
+`,
+      )
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.0"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: first.projection.yaml
+`,
+      )
+      expect(runLikeC4Cli(args, parent)).toEqual({
+        exitCode: 0,
+        stdout: `Wrote LikeC4 project to ${project}\n`,
+        stderr: '',
+      })
+
+      writeFileSync(
+        join(parent, 'second.projection.yaml'),
+        `format: yarramate/projection/v1
+id: second
+version: "1.0"
+query: {}
+`,
+      )
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.1"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: first.projection.yaml
+  - projection: second.projection.yaml
+`,
+      )
+
+      expect(runLikeC4Cli(args, parent)).toEqual({
+        exitCode: 0,
+        stdout: `Updated LikeC4 project at ${project}\n`,
+        stderr: '',
+      })
+      expect(
+        readFileSync(join(project, 'model.likec4'), 'utf8'),
+      ).toContain('view second')
+      expect(
+        JSON.parse(
+          readFileSync(
+            join(project, 'yarramate.generated.json'),
+            'utf8',
+          ),
+        ),
+      ).toMatchObject({
+        project: 'system@1.1',
+        views: [
+          { id: 'index', projection: 'first@1.0' },
+          { projection: 'second@1.0' },
+        ],
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports generated-output freshness without writing anything', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-check-'))
+    const project = join(parent, 'generated')
+    const exportArgs = [
+      'export-project',
+      'yarramate.likec4.yaml',
+      project,
+      'architecture.yaml',
+    ]
+    const checkArgs = ['export-project', '--check', ...exportArgs.slice(1)]
+    try {
+      writeFileSync(
+        join(parent, 'architecture.yaml'),
+        `format: yarramate/v1
+id: system
+profile: yarramate/core@0.1
+concepts:
+  - id: service
+    kind: applicationComponent
+    name: Service
+relationships: []
+`,
+      )
+      writeFileSync(
+        join(parent, 'first.projection.yaml'),
+        `format: yarramate/projection/v1
+id: first
+version: "1.0"
+query: {}
+`,
+      )
+      writeFileSync(
+        join(parent, 'likec4.mapping.yaml'),
+        `format: yarramate/adapter-mapping/v1
+id: system-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: system#service
+    external: service
+    type: concept
+`,
+      )
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.0"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: first.projection.yaml
+`,
+      )
+
+      expect(runLikeC4Cli(checkArgs, parent)).toEqual({
+        exitCode: 1,
+        stdout: 'Generated LikeC4 output: absent\n',
+        stderr: '',
+      })
+      expect(existsSync(project)).toBe(false)
+
+      expect(runLikeC4Cli(exportArgs, parent).exitCode).toBe(0)
+      expect(runLikeC4Cli(checkArgs, parent)).toEqual({
+        exitCode: 0,
+        stdout: 'Generated LikeC4 output: fresh\n',
+        stderr: '',
+      })
+
+      writeFileSync(
+        join(parent, 'second.projection.yaml'),
+        `format: yarramate/projection/v1
+id: second
+version: "1.0"
+query: {}
+`,
+      )
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.1"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: first.projection.yaml
+  - projection: second.projection.yaml
+`,
+      )
+      const before = readFileSync(join(project, 'model.likec4'), 'utf8')
+
+      expect(runLikeC4Cli(checkArgs, parent)).toEqual({
+        exitCode: 1,
+        stdout:
+          'Generated LikeC4 output: stale\n' +
+          'Reason:\n' +
+          '- input added: second.projection.yaml\n' +
+          '- input changed: yarramate.likec4.yaml\n' +
+          '- model source changed\n' +
+          'Safe to regenerate: yes\n',
+        stderr: '',
+      })
+      expect(readFileSync(join(project, 'model.likec4'), 'utf8')).toBe(
+        before,
+      )
+
+      expect(runLikeC4Cli(exportArgs, parent).exitCode).toBe(0)
+      expect(runLikeC4Cli(checkArgs, parent)).toEqual({
+        exitCode: 0,
+        stdout: 'Generated LikeC4 output: fresh\n',
+        stderr: '',
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a hand-edited generated file as modified in --check', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-check-modified-'),
+    )
+    const project = join(parent, 'governed-change')
+    const exportArgs = [
+      'export-project',
+      'test/fixtures/valid/governed-change.projection.yaml',
+      'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+      project,
+      'test/fixtures/valid/governed-change.workspace.yaml',
+    ]
+    const checkArgs = ['export-project', '--check', ...exportArgs.slice(1)]
+    try {
+      expect(runLikeC4Cli(exportArgs, repositoryRoot).exitCode).toBe(0)
+      expect(runLikeC4Cli(checkArgs, repositoryRoot)).toEqual({
+        exitCode: 0,
+        stdout: 'Generated LikeC4 output: fresh\n',
+        stderr: '',
+      })
+      const modelPath = join(project, 'model.likec4')
+      writeFileSync(
+        modelPath,
+        `${readFileSync(modelPath, 'utf8')}// edited\n`,
+      )
+
+      expect(runLikeC4Cli(checkArgs, repositoryRoot)).toEqual({
+        exitCode: 1,
+        stdout:
+          'Generated LikeC4 output: modified\n' +
+          'Reason:\n' +
+          `- generated file changed: ${modelPath}\n` +
+          'Safe to regenerate: no\n',
+        stderr: '',
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a marker predating input digests as stale in --check', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-check-legacy-'),
+    )
+    const project = join(parent, 'governed-change')
+    const exportArgs = [
+      'export-project',
+      'test/fixtures/valid/governed-change.projection.yaml',
+      'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+      project,
+      'test/fixtures/valid/governed-change.workspace.yaml',
+    ]
+    const checkArgs = ['export-project', '--check', ...exportArgs.slice(1)]
+    try {
+      expect(runLikeC4Cli(exportArgs, repositoryRoot).exitCode).toBe(0)
+      const markerPath = join(project, 'yarramate.generated.json')
+      const { inputDigests, ...legacyMarker } = JSON.parse(
+        readFileSync(markerPath, 'utf8'),
+      ) as Record<string, unknown>
+      expect(inputDigests).toBeDefined()
+      writeFileSync(markerPath, `${JSON.stringify(legacyMarker, null, 2)}\n`)
+
+      expect(runLikeC4Cli(checkArgs, repositoryRoot)).toEqual({
+        exitCode: 1,
+        stdout:
+          'Generated LikeC4 output: stale\n' +
+          'Reason:\n' +
+          '- marker predates input digests\n' +
+          'Safe to regenerate: yes\n',
+        stderr: '',
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('atomically replaces each owned file during regeneration', () => {
     const parent = mkdtempSync(
       join(tmpdir(), 'yarramate-likec4-atomic-update-'),
@@ -1798,7 +2133,7 @@ mappings:
       expect(result).toEqual({
         exitCode: 2,
         stdout: '',
-        stderr: `Output directory already exists: ${project}\n`,
+        stderr: `Output directory exists but is not a YarraMate-generated project: ${project}\n`,
       })
     } finally {
       rmSync(parent, { recursive: true, force: true })
@@ -1837,26 +2172,46 @@ mappings:
     }
   })
 
-  it('refuses to overwrite an existing project directory', () => {
+  it('refuses an existing directory that is not YarraMate-generated', () => {
     const project = mkdtempSync(
       join(tmpdir(), 'yarramate-likec4-existing-'),
     )
+    const args = [
+      'export-project',
+      'test/fixtures/valid/governed-change.projection.yaml',
+      'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+      project,
+      'test/fixtures/valid/governed-change.workspace.yaml',
+    ]
     try {
-      const result = runLikeC4Cli(
-        [
-          'export-project',
-          'test/fixtures/valid/governed-change.projection.yaml',
-          'test/fixtures/valid/governed-change.likec4-mapping.yaml',
-          project,
-          'test/fixtures/valid/governed-change.workspace.yaml',
-        ],
-        repositoryRoot,
-      )
+      const result = runLikeC4Cli(args, repositoryRoot)
 
       expect(result).toEqual({
         exitCode: 2,
         stdout: '',
-        stderr: `Output directory already exists: ${project}\n`,
+        stderr: `Output directory exists but is not a YarraMate-generated project: ${project}\n`,
+      })
+      expect(
+        runLikeC4Cli(
+          ['export-project', '--check', ...args.slice(1)],
+          repositoryRoot,
+        ),
+      ).toEqual({
+        exitCode: 2,
+        stdout: '',
+        stderr: `Output directory exists but is not a YarraMate-generated project: ${project}\n`,
+      })
+      const occupied = join(project, 'occupied')
+      writeFileSync(occupied, 'not a directory\n')
+      expect(
+        runLikeC4Cli(
+          [...args.slice(0, 3), occupied, ...args.slice(4)],
+          repositoryRoot,
+        ),
+      ).toEqual({
+        exitCode: 2,
+        stdout: '',
+        stderr: `Output directory already exists: ${occupied}\n`,
       })
     } finally {
       rmSync(project, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- **#58 — safe regeneration:** `export-project` no longer refuses its own output after ownership drift. The update gate is now: marker validates as a YarraMate generated-project marker (either format version) **and** recorded output digests are intact — that pair proves the directory is entirely machine-generated, so regenerating after the project gained a projection (or the mapping/views/comparison changed) loses nothing. Ownership fields are still written to the marker as provenance.
- **Distinct refusals:** foreign/malformed directory → `Output directory exists but is not a YarraMate-generated project: <path>` (exit 2); hand-edited generated file → `Generated project file has changed: <path>` (exit 2, unchanged); bare `Output directory already exists` remains only for non-directory/symlink output paths. Markers from older releases without `digests` are still accepted once and upgraded.
- **#65 — freshness reporting:** markers now record `inputDigests` (sha256 of every resolved input keyed by the path used to reference it: project definition/projection, subject mapping, kind mapping, referenced projections, workspace source documents). New `export-project --check` mode recomputes the would-be export in memory and reports deterministically without writing: `fresh` (exit 0), `stale` with one `Reason:` bullet per changed/added/removed input plus `model source changed` (exit 1, `Safe to regenerate: yes`), `absent` (exit 1), `modified` for hand edits (exit 1, `Safe to regenerate: no`), and `marker predates input digests` for pre-inputDigests markers.
- Both generated-project marker schemas gain the optional `inputDigests` property; usage string, `docs/ADAPTER-MAPPINGS.md`, and new `docs/adr/0050-generated-output-declares-its-freshness.md` cover both decisions.

## Test plan

- [x] Re-export succeeds after the project definition gains a projection (exact #58 repro, marker updated to new views)
- [x] Reversed `--compare` re-export updates in place and re-records the comparison (previously refused)
- [x] Foreign directory and malformed marker refusals use the new distinct message; non-directory path keeps `Output directory already exists`
- [x] Hand-edited generated file still refused with `Generated project file has changed`
- [x] `--check`: absent / fresh / stale-with-exact-reasons / modified paths, plus fresh-after-regeneration, with exact stdout pinned
- [x] Marker without `inputDigests` → stale with reason `marker predates input digests`
- [x] Marker content and schema validation extended for `inputDigests` in both v1 and v2 export forms
- [x] `rm -rf dist && pnpm verify` exits 0 (typecheck, build, 244 tests, self-check, self-export + `likec4 validate`)

Closes #58
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)