### PR TITLE
Gate mapping coverage for projected relationships in the adapter check (ADR 0051)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ graphify-out/
 .env
 .env.*
 !.env.example
+
+# Agent worktrees are ephemeral checkouts of this repository
+.claude/worktrees/

--- a/docs/ADAPTER-MAPPINGS.md
+++ b/docs/ADAPTER-MAPPINGS.md
@@ -83,6 +83,14 @@ after a native subject is renamed: the retired external identity is released,
 so the replacement can receive its deterministic identity without an
 unnecessary collision suffix.
 
+Because `map --sync` writes, it is an authoring command; the read-only
+`check` is the gate. The two agree on coverage: `check` reports every
+projected subject without a mapping entry, relationships (`YMLC111`)
+as well as concepts (`YMLC102`), so a green check means a later sync would
+add nothing. Rendering is deliberately more permissive — a view selects a
+relationship by metadata, not by external identity, so `export` and
+`export-project` still succeed on a concept-only mapping (ADR 0051).
+
 The governed-change test fixture has a native document and explicit mapping:
 
 ```sh
@@ -128,6 +136,7 @@ the authored value that can correct the failure:
 | `YMLC108` | A dynamic step does not select a relationship. | Project dynamic-step relationship. |
 | `YMLC109` | A deployment identity, parent, or projected subject is invalid. | The corresponding project deployment field. |
 | `YMLC110` | A project mapping, kind mapping, or projection is missing or unreadable. | The referencing project field. |
+| `YMLC111` | A projected relationship has no LikeC4 mapping. Reported by `check` only. | The relationship in its native document. |
 
 Schema and source parsing failures retain their existing Core diagnostic
 codes in the same envelope. Mixed Core and adapter failures use the shared

--- a/docs/adr/0051-the-adapter-check-gates-mapping-coverage.md
+++ b/docs/adr/0051-the-adapter-check-gates-mapping-coverage.md
@@ -1,0 +1,24 @@
+# The adapter check gates mapping coverage, not renderability
+
+Status: accepted
+
+`yarramate-likec4 map --sync` writes a mapping entry for every projected
+subject, concepts and relationships alike, while the read-only check only
+walked concepts. A mapping missing relationship entries therefore passed the
+check and was silently rewritten by the next sync. Guidance that makes the
+read-only check the CI gate and sync an authoring command inherited that
+hole: in CI the repair is discarded with the runner, so the drift recurs
+every run and is never reported.
+
+The check now reports a projected relationship with no mapping entry as
+`YMLC111`, located at the relationship in its native document and summarized
+like its concept sibling when many are missing. A green check therefore means
+what the guidance already claimed: a later sync would add nothing.
+
+Rendering stays permissive. A generated view selects a relationship through
+its `yarramateId` metadata rather than an external identity, so a concept-only
+mapping still exports correctly, and `export` and `export-project` continue to
+accept one. The asymmetry is the point — the check answers "is this mapping
+complete", which is a question about synchronization, while the exporters
+answer "can this be rendered". Only the first is a gate, so only the first
+fails.

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -141,36 +141,45 @@ const checkJson = (
 
 const unmappedSubjectPreviewLength = 3
 
-const summarizeUnmappedConcepts = (
+const summarizeUnmappedSubjects = (
   diagnostics: readonly LikeC4PreparationDiagnostic[],
-): readonly LikeC4PreparationDiagnostic[] => {
-  const unmapped = diagnostics.filter(
-    (diagnostic) => diagnostic.code === 'YMLC102',
+): readonly LikeC4PreparationDiagnostic[] =>
+  (
+    [
+      ['YMLC102', 'concepts'],
+      ['YMLC111', 'relationships'],
+    ] as const
+  ).reduce<readonly LikeC4PreparationDiagnostic[]>(
+    (current, [code, noun]) => {
+      const unmapped = current.filter(
+        (diagnostic) => diagnostic.code === code,
+      )
+      if (unmapped.length <= unmappedSubjectPreviewLength) return current
+      const preview = unmapped
+        .slice(0, unmappedSubjectPreviewLength)
+        .map((diagnostic) =>
+          'subject' in diagnostic && diagnostic.subject !== undefined
+            ? `"${diagnostic.subject}"`
+            : `"${diagnostic.path}:${diagnostic.line}"`,
+        )
+        .join(', ')
+      const summary: LikeC4PreparationDiagnostic = {
+        ...unmapped[0]!,
+        message:
+          `${unmapped.length} projected ${noun} have no LikeC4 mapping ` +
+          `(first: ${preview}); run "yarramate-likec4 map --sync" to add ` +
+          'the missing mappings',
+      }
+      let summarized = false
+      return current.flatMap((diagnostic) => {
+        if (diagnostic.code !== code) return [diagnostic]
+        if (summarized) return []
+        summarized = true
+        return [summary]
+      })
+    },
+    diagnostics,
   )
-  if (unmapped.length <= unmappedSubjectPreviewLength) return diagnostics
-  const preview = unmapped
-    .slice(0, unmappedSubjectPreviewLength)
-    .map((diagnostic) =>
-      'subject' in diagnostic && diagnostic.subject !== undefined
-        ? `"${diagnostic.subject}"`
-        : `"${diagnostic.path}:${diagnostic.line}"`,
-    )
-    .join(', ')
-  const summary: LikeC4PreparationDiagnostic = {
-    ...unmapped[0]!,
-    message:
-      `${unmapped.length} projected concepts have no LikeC4 mapping ` +
-      `(first: ${preview}); run "yarramate-likec4 map --sync" to add ` +
-      'the missing mappings',
-  }
-  let summarized = false
-  return diagnostics.flatMap((diagnostic) => {
-    if (diagnostic.code !== 'YMLC102') return [diagnostic]
-    if (summarized) return []
-    summarized = true
-    return [summary]
-  })
-}
 
 const lowerCamel = (value: string) =>
   value.replaceAll(/-([a-z0-9])/g, (_, character: string) =>
@@ -749,7 +758,7 @@ export function runLikeC4Cli(
       ? checkJson(false, diagnostics)
       : diagnosticJson(
           command === 'check'
-            ? summarizeUnmappedConcepts(diagnostics)
+            ? summarizeUnmappedSubjects(diagnostics)
             : diagnostics,
         )
 
@@ -881,6 +890,7 @@ export function runLikeC4Cli(
               ? {}
               : { comparison: view.compare }),
             vocabulary: 'bundled',
+            requireMappedRelationships: command === 'check',
           }),
         }),
       )
@@ -1236,6 +1246,7 @@ export function runLikeC4Cli(
         : { kindMapping: kindMappingSource }),
       ...(comparison === undefined ? {} : { comparison }),
       vocabulary: command === 'export' ? 'consumer' : 'bundled',
+      requireMappedRelationships: command === 'check',
     })
     if (!prepared.ok) {
       return {

--- a/src/adapters/likec4-export.ts
+++ b/src/adapters/likec4-export.ts
@@ -21,6 +21,7 @@ export interface LikeC4ExportDiagnostic {
     | 'YMLC107'
     | 'YMLC108'
     | 'YMLC109'
+    | 'YMLC111'
   readonly message: string
   readonly subject?: string
   readonly path: string

--- a/src/adapters/likec4-prepare.ts
+++ b/src/adapters/likec4-prepare.ts
@@ -40,6 +40,12 @@ export interface LikeC4PreparationInput {
     readonly to: string
   }
   readonly vocabulary: 'bundled' | 'consumer'
+  /**
+   * Gate mode. Rendering a relationship needs no external identity — views
+   * select it by metadata — but `map --sync` still writes one, so only a
+   * check answering "would sync change anything" requires the entry.
+   */
+  readonly requireMappedRelationships?: boolean
 }
 
 export type LikeC4PreparationDiagnostic =
@@ -149,6 +155,39 @@ const unsupportedBundledKinds = (
   return diagnostics.sort(diagnosticOrder)
 }
 
+const unmappedProjectedRelationships = (
+  projection: ProjectionResult,
+  mapping: AdapterMapping,
+): readonly LikeC4ExportDiagnostic[] => {
+  const mapped = new Set(
+    mapping.mappings
+      .filter(({ type }) => type === 'relationship')
+      .map(({ native }) => native),
+  )
+  return projection.subjects
+    .filter(({ type, id }) => type === 'relationship' && !mapped.has(id))
+    .flatMap(({ id }) => {
+      const source = projection.claims.find(
+        (claim) => claim.id === id,
+      )?.source
+      return source === undefined
+        ? []
+        : [
+            {
+              severity: 'error' as const,
+              code: 'YMLC111' as const,
+              message: `Projected relationship "${id}" has no LikeC4 mapping`,
+              subject: id,
+              path: source.path,
+              pointer: source.pointer,
+              line: source.line,
+              column: source.column,
+            },
+          ]
+    })
+    .sort(diagnosticOrder)
+}
+
 export function prepareLikeC4Export(
   input: LikeC4PreparationInput,
 ): LikeC4PreparationResult {
@@ -235,6 +274,13 @@ export function prepareLikeC4Export(
     )
     if (diagnostics.length > 0) return { ok: false, diagnostics }
   }
+  const unmappedRelationships =
+    input.requireMappedRelationships === true
+      ? unmappedProjectedRelationships(
+          projectionResult,
+          subjectMapping.mapping,
+        )
+      : []
   const exported = exportLikeC4(
     projectionResult,
     subjectMapping.mapping,
@@ -243,7 +289,18 @@ export function prepareLikeC4Export(
       ? undefined
       : { comparison: comparison.comparison },
   )
-  if (!exported.ok) return exported
+  if (!exported.ok) {
+    return {
+      ok: false,
+      diagnostics: [
+        ...exported.diagnostics,
+        ...unmappedRelationships,
+      ].sort(diagnosticOrder),
+    }
+  }
+  if (unmappedRelationships.length > 0) {
+    return { ok: false, diagnostics: unmappedRelationships }
+  }
   return {
     ok: true,
     source: exported.source,

--- a/test/adapter-mapping.test.ts
+++ b/test/adapter-mapping.test.ts
@@ -255,7 +255,13 @@ describe('adapter mapping documents', () => {
     expect(validateAdapterMapping(compilation.graph, loaded.mapping).ok).toBe(
       true,
     )
-    expect(loaded.mapping.mappings).toHaveLength(29)
+    expect(loaded.mapping.mappings).toHaveLength(56)
+    expect(
+      loaded.mapping.mappings.filter(({ type }) => type === 'concept'),
+    ).toHaveLength(29)
+    expect(
+      loaded.mapping.mappings.filter(({ type }) => type === 'relationship'),
+    ).toHaveLength(27)
   })
 
   it('rejects duplicate versioned mapping identities across a workspace', () => {

--- a/test/fixtures/valid/governed-change.likec4-mapping.yaml
+++ b/test/fixtures/valid/governed-change.likec4-mapping.yaml
@@ -90,3 +90,84 @@ mappings:
   - native: governed-change#conformance-suite
     external: conformanceSuite
     type: concept
+  - native: governed-change#adoption-realizes-suite
+    external: adoptionRealizesSuite
+    type: relationship
+  - native: governed-change#approval-supports-integrity
+    external: approvalSupportsIntegrity
+    type: relationship
+  - native: governed-change#artifact-realizes-record
+    external: artifactRealizesRecord
+    type: relationship
+  - native: governed-change#constraint-enforces-approval
+    external: constraintEnforcesApproval
+    type: relationship
+  - native: governed-change#control-plane-assigned-to-edge
+    external: controlPlaneAssignedToEdge
+    type: relationship
+  - native: governed-change#control-plane-performs-verification
+    external: controlPlanePerformsVerification
+    type: relationship
+  - native: governed-change#control-plane-realizes-intent-match
+    external: controlPlaneRealizesIntentMatch
+    type: relationship
+  - native: governed-change#decision-gate-realizes-capability
+    external: decisionGateRealizesCapability
+    type: relationship
+  - native: governed-change#decision-serves-process
+    external: decisionServesProcess
+    type: relationship
+  - native: governed-change#drift-threatens-integrity
+    external: driftThreatensIntegrity
+    type: relationship
+  - native: governed-change#edge-composes-runtime
+    external: edgeComposesRuntime
+    type: relationship
+  - native: governed-change#intent-match-fulfills-integrity
+    external: intentMatchFulfillsIntegrity
+    type: relationship
+  - native: governed-change#interface-serves-member
+    external: interfaceServesMember
+    type: relationship
+  - native: governed-change#journey-realizes-capability
+    external: journeyRealizesCapability
+    type: relationship
+  - native: governed-change#member-performs-process
+    external: memberPerformsProcess
+    type: relationship
+  - native: governed-change#owner-concerned-with-integrity
+    external: ownerConcernedWithIntegrity
+    type: relationship
+  - native: governed-change#process-realizes-publication
+    external: processRealizesPublication
+    type: relationship
+  - native: governed-change#process-writes-record
+    external: processWritesRecord
+    type: relationship
+  - native: governed-change#publication-serves-member
+    external: publicationServesMember
+    type: relationship
+  - native: governed-change#request-triggers-verification
+    external: requestTriggersVerification
+    type: relationship
+  - native: governed-change#risk-causes-drift
+    external: riskCausesDrift
+    type: relationship
+  - native: governed-change#runtime-realizes-execution
+    external: runtimeRealizesExecution
+    type: relationship
+  - native: governed-change#suite-realizes-traceability
+    external: suiteRealizesTraceability
+    type: relationship
+  - native: governed-change#traceability-associated-with-foundation
+    external: traceabilityAssociatedWithFoundation
+    type: relationship
+  - native: governed-change#verification-reads-digest
+    external: verificationReadsDigest
+    type: relationship
+  - native: governed-change#verification-reads-proposal
+    external: verificationReadsProposal
+    type: relationship
+  - native: governed-change#verification-realizes-decision
+    external: verificationRealizesDecision
+    type: relationship

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -270,6 +270,116 @@ mappings:
     })
   })
 
+  it('fails the check when a projected relationship has no mapping', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-gate-'))
+    try {
+      const mapping = readFileSync(
+        join(
+          repositoryRoot,
+          'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+        ),
+        'utf8',
+      )
+      const conceptOnly = mapping
+        .split('  - native: ')
+        .filter((entry, index) => index === 0 || !entry.includes('type: relationship'))
+        .join('  - native: ')
+      writeFileSync(join(parent, 'concept-only.mapping.yaml'), conceptOnly)
+
+      const gated = runLikeC4Cli(
+        [
+          'check',
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.projection.yaml',
+          ),
+          join(parent, 'concept-only.mapping.yaml'),
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.workspace.yaml',
+          ),
+        ],
+        repositoryRoot,
+      )
+
+      expect(gated.exitCode).toBe(1)
+      expect(gated.stdout).toContain('YMLC111')
+      expect(gated.stdout).toContain('no LikeC4 mapping')
+
+      // The same incomplete mapping still renders: a view selects a
+      // relationship by metadata, not by external identity.
+      const exported = runLikeC4Cli(
+        [
+          'export',
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.projection.yaml',
+          ),
+          join(parent, 'concept-only.mapping.yaml'),
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.workspace.yaml',
+          ),
+        ],
+        repositoryRoot,
+      )
+
+      expect(exported.exitCode).toBe(0)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('summarizes a flood of unmapped relationships for the check gate', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-flood-'))
+    try {
+      const mapping = readFileSync(
+        join(
+          repositoryRoot,
+          'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+        ),
+        'utf8',
+      )
+      const conceptOnly = mapping
+        .split('  - native: ')
+        .filter((entry, index) => index === 0 || !entry.includes('type: relationship'))
+        .join('  - native: ')
+      writeFileSync(join(parent, 'concept-only.mapping.yaml'), conceptOnly)
+
+      const gated = runLikeC4Cli(
+        [
+          'check',
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.projection.yaml',
+          ),
+          join(parent, 'concept-only.mapping.yaml'),
+          join(
+            repositoryRoot,
+            'test/fixtures/valid/governed-change.workspace.yaml',
+          ),
+        ],
+        repositoryRoot,
+      )
+
+      const payload = JSON.parse(gated.stdout) as {
+        diagnostics: readonly { code: string; message: string }[]
+      }
+      const relationshipDiagnostics = payload.diagnostics.filter(
+        ({ code }) => code === 'YMLC111',
+      )
+      expect(relationshipDiagnostics).toHaveLength(1)
+      expect(relationshipDiagnostics[0]!.message).toMatch(
+        /^\d+ projected relationships have no LikeC4 mapping \(first: /,
+      )
+      expect(relationshipDiagnostics[0]!.message).toContain(
+        'yarramate-likec4 map --sync',
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('emits schema-valid machine results for successful and failing checks', () => {
     const schema = JSON.parse(
       readFileSync(
@@ -977,6 +1087,12 @@ mappings:
   - native: system#shared
     external: shared
     type: concept
+  - native: system#legacy-uses-shared
+    external: legacyUsesShared
+    type: relationship
+  - native: system#modern-uses-shared
+    external: modernUsesShared
+    type: relationship
 `,
       )
       writeFileSync(

--- a/test/likec4-prepare.test.ts
+++ b/test/likec4-prepare.test.ts
@@ -551,4 +551,133 @@ mappings:
       ),
     ).toEqual(['system#zeta', 'system#alpha'])
   })
+  const relationshipSources = [
+    {
+      path: 'system.yaml',
+      source: `format: yarramate/v1
+id: system
+profile: yarramate/core@0.1
+concepts:
+  - id: service
+    kind: applicationComponent
+    name: Service
+  - id: gateway
+    kind: applicationComponent
+    name: Gateway
+relationships:
+  - id: gateway-serves-service
+    kind: serving
+    from: gateway
+    to: service
+`,
+    },
+  ]
+  const relationshipProjection = {
+    path: 'system.projection.yaml',
+    source: `format: yarramate/projection/v1
+id: system
+version: "1.0"
+query: {}
+`,
+  }
+  const conceptOnlyMapping = {
+    path: 'system.mapping.yaml',
+    source: `format: yarramate/adapter-mapping/v1
+id: system-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: system#service
+    external: service
+    type: concept
+  - native: system#gateway
+    external: gateway
+    type: concept
+`,
+  }
+
+  it('renders a projected relationship that carries no mapping entry', () => {
+    const result = prepareLikeC4Export({
+      sources: relationshipSources,
+      projection: relationshipProjection,
+      subjectMapping: conceptOnlyMapping,
+      vocabulary: 'bundled',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source).toContain('gateway -[serving]-> service')
+  })
+
+  it('gates a projected relationship that carries no mapping entry', () => {
+    const result = prepareLikeC4Export({
+      sources: relationshipSources,
+      projection: relationshipProjection,
+      subjectMapping: conceptOnlyMapping,
+      vocabulary: 'bundled',
+      requireMappedRelationships: true,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics).toEqual([
+      {
+        severity: 'error',
+        code: 'YMLC111',
+        message:
+          'Projected relationship "system#gateway-serves-service" has no LikeC4 mapping',
+        subject: 'system#gateway-serves-service',
+        path: 'system.yaml',
+        pointer: '/relationships/0',
+        line: 12,
+        column: 5,
+      },
+    ])
+  })
+
+  it('accepts a gated projection once the relationship is mapped', () => {
+    const result = prepareLikeC4Export({
+      sources: relationshipSources,
+      projection: relationshipProjection,
+      subjectMapping: {
+        path: conceptOnlyMapping.path,
+        source: `${conceptOnlyMapping.source}  - native: system#gateway-serves-service
+    external: gatewayServesService
+    type: relationship
+`,
+      },
+      vocabulary: 'bundled',
+      requireMappedRelationships: true,
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports unmapped concepts and relationships together when gated', () => {
+    const result = prepareLikeC4Export({
+      sources: relationshipSources,
+      projection: relationshipProjection,
+      subjectMapping: {
+        path: conceptOnlyMapping.path,
+        source: `format: yarramate/adapter-mapping/v1
+id: system-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: system#service
+    external: service
+    type: concept
+`,
+      },
+      vocabulary: 'bundled',
+      requireMappedRelationships: true,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map(({ code }) => code)).toEqual([
+      'YMLC102',
+      'YMLC111',
+    ])
+  })
 })


### PR DESCRIPTION
## Summary
- Closes #33. `yarramate-likec4 map --sync` writes a mapping entry for **every** projected subject, but the read-only `check` only walked concepts — so a mapping missing relationship entries passed the gate and was silently rewritten by the next sync. In CI that repair is discarded with the runner, so the drift recurs every run and is never reported. This is the hole in the gate that #30's guidance points consumers at.
- `check` now reports an unmapped projected relationship as **`YMLC111`**, located at the relationship in its native document, and summarized like its concept sibling (`YMLC102`) when many are missing — including the `map --sync` remediation in the summary text.
- **Rendering stays permissive, deliberately.** A generated view selects a relationship through its `yarramateId` metadata, not an external identity, so a concept-only mapping still exports correctly and `export`/`export-project` continue to accept one. The check answers *"is this mapping complete"* (a synchronization question — the gate); the exporters answer *"can this be rendered"*. Only the first fails. ADR 0051 records the asymmetry.
- The `governed-change` fixture mapping was itself concept-only — i.e. the repo carried an instance of exactly this drift. It is synchronized here using `map --sync` (+27 relationship entries), which is the remediation the diagnostic names.
- Also adds `.claude/worktrees/` to `.gitignore` (ephemeral agent checkouts of this repo).

## Verification of the reported scenario
Removing one relationship entry from the repo's own mapping, then running the read-only check:

```
YMLC111  Projected relationship "yarramate-engine#status-command-serves-agent-harness" has no LikeC4 mapping
         .yarramate/architecture/engine.yaml:989:5
check exit: 1        # was 0 before this change
export-project       # still succeeds — renderability unaffected
```

## Test plan
- [x] 4 new tests in `test/likec4-prepare.test.ts`: renders without the entry when ungated; gates with an exact source-located YMLC111; accepts once mapped; reports unmapped concepts and relationships together.
- [x] 2 new tests in `test/likec4-cli.test.ts`: check fails while the same mapping still exports; flood summarization for relationships.
- [x] Pinned fixture expectations updated deliberately (`adapter-mapping.test.ts` now asserts coverage by type: 29 concepts + 27 relationships).
- [x] `rm -rf dist && pnpm verify` exit 0 (273 tests).

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)