### PR TITLE
Release v0.6.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.5.0
-date-released: 2026-07-28
+version: 0.6.0
+date-released: 2026-07-30
 url: "https://github.com/yarrasys/yarramate"
 repository-code: "https://github.com/yarrasys/yarramate"
 license: MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Cuts v0.6.0. Bumps `package.json` and `CITATION.cff`; no functional change in this PR.

Everything since v0.5.0 (nine commits, seven feature/fix PRs) — six issues closed:

**New surface**
- `yarramate next <projection> <workspace>` — planned subjects in dependency order with evidence coverage (ADR 0048, closes #63); new `yarramate/next-result/v1` schema and package export.
- `yarramate check --strict` — opt-in gate failing on contradicted evidence as source-located `YM901` diagnostics (ADR 0047, closes #54); additive `strict` summary in `check-result/v1`.
- `yarramate-likec4 export-project --check` — deterministic fresh/stale/absent/modified freshness from recorded input digests (ADR 0050, closes #65).

**Behaviour changes worth reading before upgrading**
- ⚠️ `yarramate-likec4 check` now **fails** when a projected relationship has no mapping entry (`YMLC111`, ADR 0051, closes #33). This closes a real gate hole — `map --sync` always wrote these entries, so a green check previously did not mean "sync would change nothing". **If your CI check starts failing, run `yarramate-likec4 map --sync <mapping> <workspace>` once and commit the result.** Rendering is unaffected: `export`/`export-project` still accept a concept-only mapping.
- `export-project` no longer refuses a previously generated directory when the project has legitimately changed; the gate is now provenance + digest integrity (ADR 0050, closes #58). A reversed `--compare` regeneration is consequently allowed and re-recorded, where it was previously refused.

**Improved reporting**
- Reconciliation counts and lists `current` subjects with zero evidence (`subjectsWithoutEvidence`, `unobservedSubjects`; ADR 0049, closes #64) — the repo's own model surfaces 110 such subjects that were previously invisible. Surfaced in `status` too.
- `YM404` now enumerates the relationship kinds valid for the observed endpoint aspect pair, derived from the profile policy matrix, so extension kinds get actionable hints too (closes #66).

**Repository hygiene**
- vitest discovery scoped to `test/`; `.claude/worktrees/` ignored.

## Test plan
- [x] `rm -rf dist && pnpm verify` exit 0 — 273 tests across 27 files, self-check, self-export, LikeC4 validate.
- [x] `npm pack --dry-run`: 87 files, 76.2 kB. Contains runtime, normative schemas (incl. new `next-result`), consumer guide, agent skill, README, LICENSE. Excludes `src/`, `test/`, fixtures, `.yarramate/`, `docs/research/`, generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)