### PR TITLE
Declare the MCP adapter, context, new, status, and next surface in the self-model

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -61,6 +61,12 @@ concepts:
     description: Converts explicitly mapped Graphify nodes into provider-neutral evidence without inferring architectural intent.
     status: current
     owner: yarramate-product#yarramate-maintainers
+  - id: mcp-adapter
+    kind: applicationComponent
+    name: MCP adapter
+    description: Exposes the read-only stable CLI surface over stdio Model Context Protocol without adding semantics of its own.
+    status: current
+    owner: yarramate-product#yarramate-maintainers
   - id: architecture-state-engine
     kind: compiler-module
     name: Architecture state engine
@@ -287,6 +293,18 @@ concepts:
     kind: applicationService
     name: Next command
     description: Reports planned subjects in a projection in declared dependency order with per-subject evidence coverage.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: context-command
+    kind: applicationService
+    name: Context command
+    description: Renders an authored or ad-hoc projection slice as agent-ready context within an optional token budget.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: new-command
+    kind: applicationService
+    name: New command
+    description: Scaffolds a projection document through a validated write that refuses to persist an invalid candidate.
     owner: yarramate-product#yarramate-maintainers
     status: current
   - id: native-document
@@ -994,3 +1012,19 @@ relationships:
     kind: serving
     from: next-command
     to: yarramate-product#agent-harness
+  - id: context-command-serves-agent-harness
+    kind: serving
+    from: context-command
+    to: yarramate-product#agent-harness
+  - id: new-command-serves-agent-harness
+    kind: serving
+    from: new-command
+    to: yarramate-product#agent-harness
+  - id: mcp-adapter-serves-agent-harness
+    kind: serving
+    from: mcp-adapter
+    to: yarramate-product#agent-harness
+  - id: mcp-adapter-uses-cli
+    kind: serving
+    from: cli
+    to: mcp-adapter

--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -63,6 +63,22 @@ concepts:
     kind: repository-file
     name: src/cli-support.ts
     status: current
+  - id: status-command-source
+    kind: repository-file
+    name: src/status-command.ts
+    status: current
+  - id: next-command-source
+    kind: repository-file
+    name: src/next-command.ts
+    status: current
+  - id: new-command-source
+    kind: repository-file
+    name: src/new-command.ts
+    status: current
+  - id: mcp-cli-source
+    kind: repository-file
+    name: src/adapters/mcp-cli.ts
+    status: current
   - id: projection-source
     kind: repository-file
     name: src/projection.ts
@@ -428,6 +444,22 @@ relationships:
     kind: realization
     from: cli-support-source
     to: yarramate-engine#cli
+  - id: status-command-source-realizes-command
+    kind: realization
+    from: status-command-source
+    to: yarramate-engine#status-command
+  - id: next-command-source-realizes-command
+    kind: realization
+    from: next-command-source
+    to: yarramate-engine#next-command
+  - id: new-command-source-realizes-command
+    kind: realization
+    from: new-command-source
+    to: yarramate-engine#new-command
+  - id: mcp-cli-source-realizes-adapter
+    kind: realization
+    from: mcp-cli-source
+    to: yarramate-engine#mcp-adapter
   - id: projection-source-realizes-context
     kind: realization
     from: projection-source

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1182,3 +1182,48 @@ mappings:
   - native: yarramate-engine#next-command-serves-agent-harness
     external: nextCommandServesAgentHarness
     type: relationship
+  - native: yarramate-engine#context-command
+    external: contextCommand
+    type: concept
+  - native: yarramate-engine#context-command-serves-agent-harness
+    external: contextCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#mcp-adapter
+    external: mcpAdapter
+    type: concept
+  - native: yarramate-engine#mcp-adapter-serves-agent-harness
+    external: mcpAdapterServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#mcp-adapter-uses-cli
+    external: mcpAdapterUsesCli
+    type: relationship
+  - native: yarramate-engine#new-command
+    external: newCommand
+    type: concept
+  - native: yarramate-engine#new-command-serves-agent-harness
+    external: newCommandServesAgentHarness
+    type: relationship
+  - native: yarramate-repository#mcp-cli-source
+    external: mcpCliSource
+    type: concept
+  - native: yarramate-repository#mcp-cli-source-realizes-adapter
+    external: mcpCliSourceRealizesAdapter
+    type: relationship
+  - native: yarramate-repository#new-command-source
+    external: newCommandSource
+    type: concept
+  - native: yarramate-repository#new-command-source-realizes-command
+    external: newCommandSourceRealizesCommand
+    type: relationship
+  - native: yarramate-repository#next-command-source
+    external: nextCommandSource
+    type: concept
+  - native: yarramate-repository#next-command-source-realizes-command
+    external: nextCommandSourceRealizesCommand
+    type: relationship
+  - native: yarramate-repository#status-command-source
+    external: statusCommandSource
+    type: concept
+  - native: yarramate-repository#status-command-source-realizes-command
+    external: statusCommandSourceRealizesCommand
+    type: relationship

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2405,8 +2405,8 @@ mappings:
               'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
             subject: 'yarramate-repository#likec4-export-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/16/kind',
-            line: 75,
+            pointer: '/concepts/20/kind',
+            line: 91,
             column: 11,
           },
           {
@@ -2416,8 +2416,8 @@ mappings:
               'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
             subject: 'yarramate-repository#likec4-prepare-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/19/kind',
-            line: 87,
+            pointer: '/concepts/23/kind',
+            line: 103,
             column: 11,
           },
           {
@@ -2427,8 +2427,8 @@ mappings:
               'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
             subject: 'yarramate-repository#likec4-project-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/20/kind',
-            line: 91,
+            pointer: '/concepts/24/kind',
+            line: 107,
             column: 11,
           },
           {
@@ -2439,8 +2439,8 @@ mappings:
             subject:
               'yarramate-repository#likec4-project-definition-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/21/kind',
-            line: 95,
+            pointer: '/concepts/25/kind',
+            line: 111,
             column: 11,
           },
           {
@@ -2451,8 +2451,8 @@ mappings:
             subject:
               'yarramate-repository#likec4-project-schema-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/48/kind',
-            line: 208,
+            pointer: '/concepts/52/kind',
+            line: 224,
             column: 11,
           },
           {
@@ -2463,8 +2463,8 @@ mappings:
             subject:
               'yarramate-repository#likec4-generated-project-v2-schema-source',
             path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/49/kind',
-            line: 212,
+            pointer: '/concepts/53/kind',
+            line: 228,
             column: 11,
           },
         ],


### PR DESCRIPTION
## Summary
The dogfooded self-model was behind its own code. Shipped-but-undeclared: the **MCP adapter** (ADR 0044) and the **`context`** (ADRs 0041/0042) and **`new`** (ADR 0043) commands. No repository-layer file pointed at the `status`, `next`, `new`, or MCP implementations either. Benchmark authoring originally surfaced this by grepping `.yarramate/` for surface that demonstrably exists.

- Engine: adds `mcp-adapter`, `context-command`, `new-command` concepts plus serving relationships to the agent harness (and CLI → MCP adapter).
- Repository: adds `status-command-source`, `next-command-source`, `new-command-source`, `mcp-cli-source` with their `realization` edges to the engine services they implement.
- LikeC4 subject mapping synced (`map --sync`, +15 entries).
- Model goes from 175 concepts / 214 relationships to **182 / 222**.

Nice dogfooding note: the relationship-mapping gate shipped in #76 is what caught the mapping drift here — the read-only check failed on the new relationships until `map --sync` ran, which is exactly the loop that PR describes.

## Test plan
- [x] `rm -rf dist && pnpm verify` exit 0 (273 tests).
- [x] `yarramate-likec4 check` green from a synced mapping.
- [x] Pinned positions in the LikeC4 export-path test updated to follow the inserted concepts — verified the diagnostic set is otherwise identical (same 6 subjects, same order, same code, same file; only pointer index and line shifted by the 4 inserted concepts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)