### PR TITLE
Benchmark harness v2: neutralize subject-repo agent config, fix diff capture, suite v2 errata

### DIFF
--- a/docs/research/context-benchmark/DESIGN.md
+++ b/docs/research/context-benchmark/DESIGN.md
@@ -38,7 +38,11 @@ the drift signal is load-bearing, not hygiene theatre.
      components — scored by tests passing plus rubric review;
   3. **Model maintenance** — extend the model for a described change —
      scored by check pass, reconciliation results, and catalogue coverage.
-- Tasks are authored before any condition is run and frozen.
+- Tasks are authored before any condition is run and frozen. Errata found
+  after a sweep are corrected as a new suite version (`type:
+  yarramate/benchmark-suite/vN`) beside the old file, never as an edit to a
+  version that has been run: published numbers stay pinned to the text that
+  produced them. Suites at different versions are not pooled.
 
 ### Conditions
 
@@ -51,6 +55,13 @@ the drift signal is load-bearing, not hygiene theatre.
 Same agent harness, same prompts apart from the context instruction, fixed
 model per run. For H2, repeat A and B across ≥ 2 capability tiers.
 
+Prepared workdirs carry no agent configuration except the harness's own. The
+subject repository's `CLAUDE.md`, `AGENTS.md`, `.claude/` and `.mcp.json` are
+moved out of the workdir before the run and the run record lists what was
+moved; only then do model-bearing conditions receive YarraMate's pointer
+(ADR 0045) under those names. Keeping the subject's configuration is available
+as an explicit realism choice and is recorded as such.
+
 ### Metrics
 
 - Task success (primary; binary per task, human-adjudicated rubric for
@@ -59,6 +70,24 @@ model per run. For H2, repeat A and B across ≥ 2 capability tiers.
 - Wrong-file/wrong-component edit rate (a proxy for misorientation);
 - For model-maintenance tasks: check verdict, contradicted count, open
   catalogue questions before/after.
+
+What an agent changed is captured by staging the whole working tree and
+diffing it against the run's pinned baseline commit, so a file the agent
+created and a change the agent committed both appear — in the changed-file
+list and in the saved patch. A working-tree-only diff against `HEAD` sees
+neither, and both are ordinary agent behaviour.
+
+Open catalogue questions are counted once per matching subject, so declaring a
+concept mechanically opens more of them and at least one (`owner-missing`,
+human authority) cannot be answered for a third-party repository at all. Tasks
+that add concepts are therefore gated on open questions *per concept*, not on
+the absolute count; tasks that only remove or restructure keep the absolute
+comparison.
+
+Change and model-maintenance runs that finish in fewer than three turns are
+flagged for review rather than scored on their exit code: a clean exit that
+did no work is invisible to the harness-failure counter and reaches the
+adjudicator looking like an ordinary attempt.
 
 ### Reporting
 
@@ -77,6 +106,11 @@ the roadmap speaking.
   catalogue before freezing.
 - **Prompt leakage.** Condition instructions must not hint that one
   context source is preferred; phrasing review before freezing.
+- **Subject-repository agent configuration.** Coding harnesses auto-load
+  instruction files the subject repository ships, and tiers obey them
+  unequally — uptime-kuma's upstream anti-AI `CLAUDE.md` cost the weak tier
+  four one-turn refusals in the 2026-07-29 sweep and the strong tier none.
+  Left in place it measures instruction-following, not context value.
 - **Small N.** Early runs will be underpowered; report intervals, never
   bare point estimates.
 

--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -7,11 +7,15 @@ directory adds the task suites and the runner that make it executable.
 ```text
 context-benchmark/
   DESIGN.md                              # frozen protocol: hypotheses, conditions, metrics
-  yarramate-benchmark-suite.schema.json  # draft schema for yarramate/benchmark-suite/v1
+  yarramate-benchmark-suite.schema.json  # draft schema for yarramate/benchmark-suite v1-v2
   tasks/                                 # frozen task suites, one per repository
+    v2/                                  # errata-corrected suites (see "Suite versions")
   runner/
     validate-suite.mjs                   # schema + cross-checks (ids, family minimums, prompt leakage)
     conditions.mjs                       # condition A/B/C instructions (B and C verbatim-identical)
+    agent-config.mjs                     # subject-repo agent-config quarantine + pointer placement
+    agent-config.test.mjs                # self-test for the two above, ordering included
+    degenerate.mjs                       # <3-turn change/maintenance runs, flagged for review
     inject-stale.mjs                     # condition C: deterministic contradicted-claim injection
     run-benchmark.mjs                    # tasks x conditions matrix, workdir isolation, transcripts
     score.mjs                            # deterministic metrics + human adjudication queue
@@ -24,6 +28,27 @@ Task suites are frozen at merge, before any condition is run (DESIGN.md,
 file instead. Ground-truth answers cite the code locations they were verified
 against — the source repository at the pinned commit is the authority, never
 the model.
+
+## Suite versions
+
+The `type:` field is the suite version, and a suite is frozen per version.
+
+- **v1** — `tasks/*.yaml`. The suite the 2026-07-29 sweep ran
+  ([RESULTS-2026-07-29.md](RESULTS-2026-07-29.md)); byte-frozen, so those
+  numbers stay reproducible from the text that produced them.
+- **v2** — `tasks/v2/*.yaml`. The same tasks with the sweep's errata
+  corrected: one incomplete ground truth, two incomplete `touches` lists, and
+  the additive form of the catalogue gate. Each file's header lists its own
+  errata. `yarramate-self.yaml` has no v2 — no erratum applies to it.
+
+Never pool results across versions, and give each version its own `--out`
+directory: run directories are keyed on the suite slug, which does not change
+with the version.
+
+⚠️ v2 is errata only. The sweep's other finding — the comprehension family is
+saturated at both tiers on all four repositories, so H1 cannot be measured
+from it — needs new multi-hop, cross-component tasks authored against the
+subject repos. That authoring is still outstanding (#56).
 
 ## Corpus
 
@@ -40,36 +65,78 @@ before publishing pooled numbers.
 cd docs/research/context-benchmark
 
 # 1. validate every suite
-node runner/validate-suite.mjs yarramate-benchmark-suite.schema.json tasks/*.yaml
+node runner/validate-suite.mjs yarramate-benchmark-suite.schema.json \
+  tasks/*.yaml tasks/v2/*.yaml
 
-# 2. inspect the matrix (no side effects, no cost)
-node runner/run-benchmark.mjs --suite tasks/miniflux.yaml --out /tmp/bench --dry-run
+# 2. self-test the runner's workdir rules (fast, no cost)
+node --test 'runner/*.test.mjs'
 
-# 3. live run — one suite, one condition, one capability tier (costs agent tokens)
-node runner/run-benchmark.mjs --suite tasks/miniflux.yaml \
+# 3. inspect the matrix (no side effects, no cost)
+node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml --out /tmp/bench --dry-run
+
+# 4. live run — one suite, one condition, one capability tier (costs agent tokens)
+node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml \
   --gallery ~/work/yarrasys/projects/yarramate-gallery \
   --toolchain <dir>/node_modules/.bin \
   --out results/2026-07-29 --conditions B --label sonnet \
   --harness 'claude -p --output-format json --model sonnet'
 
-# 4. deterministic scoring + adjudication queue
+# 5. deterministic scoring + adjudication queue
 node runner/score.mjs --runs results/2026-07-29/runs.jsonl \
-  --suite tasks/miniflux.yaml --toolchain <dir>/node_modules/.bin
+  --suite tasks/v2/miniflux.yaml --toolchain <dir>/node_modules/.bin
 ```
 
 The harness command receives the composed prompt (condition instruction +
 frozen task text) on stdin and runs with the isolated task workdir as cwd; the
 pinned toolchain is prepended to its PATH so `yarramate` resolves to the
-benchmark version. Model-bearing workdirs (B/C) also carry the `AGENTS.md`
-pointer that `yarramate init` writes (ADR 0040) — appended to the repo's
-existing `AGENTS.md` when present — and the run record snapshots the
-workspace's open-catalogue count (`catalogueBaseline`) for the
-`catalogue-not-worse` scorer. Run harness agents from a hermetic path: the
-pilot showed user-level agent config (memory/plugin hooks) leaking into runs
-non-uniformly by tier when workdirs lived under the operator's own project
-tree. For the H2 tier sweep, repeat step 3 with a different
-`--model`/`--label` pair. Model-maintenance tasks are skipped under condition
-A (no workspace to maintain).
+benchmark version. Model-bearing workdirs (B/C) also carry the pointer that
+`yarramate init` writes (ADR 0040), delivered to every file that toolchain's
+`init` writes it to (ADR 0045), and the run record snapshots the workspace's
+open-catalogue count and concept count (`catalogueBaseline`) for the catalogue
+scorers. Run harness agents from a hermetic path: the pilot showed user-level
+agent config (memory/plugin hooks) leaking into runs non-uniformly by tier when
+workdirs lived under the operator's own project tree. For the H2 tier sweep,
+repeat step 4 with a different `--model`/`--label` pair. Model-maintenance
+tasks are skipped under condition A (no workspace to maintain).
+
+## What the workdir does and does not carry
+
+The subject repository's own agent configuration — `AGENTS.md`, `AGENT.md`,
+`CLAUDE.md`, `CLAUDE.local.md`, `.claude/`, `.mcp.json`, at any depth — is
+moved to `<runDir>/.benchmark-quarantined/` before the run, outside the
+workdir so the agent cannot read it either. It is a tier-dependent confound,
+not a property of the condition: uptime-kuma's upstream anti-AI `CLAUDE.md`
+produced four weak-tier one-turn refusals in the 2026-07-29 sweep and no
+strong-tier ones. Every run record carries `agentConfig: { policy,
+neutralized }` naming what was moved.
+
+Quarantine runs *before* the pointer is written, and the two overlap by name:
+conditions B and C deliberately place YarraMate's own pointer into `AGENTS.md`
+and `CLAUDE.md`. `runner/agent-config.test.mjs` pins that ordering.
+
+`--keep-subject-agent-config` keeps the subject's files, as an explicit
+realism choice ("does an adopted repository's own instructions help or hurt?");
+the record then reads `policy: "keep"`.
+
+## Capture and flags
+
+`score.mjs` stages the whole working tree (`git add -A`) and diffs it against
+the run's pinned `baselineCommit`, writing `<runDir>/diff.patch` and the
+changed-file list for the wrong-file metric. Both a file the agent created and
+a change the agent committed are captured; the earlier working-tree diff
+against `HEAD` saw neither.
+
+Change and model-maintenance runs finishing in fewer than three turns are
+flagged `degenerate` in the run record, in `scores.jsonl`, in the adjudication
+queue, and on the scorer's console — a clean exit that did nothing otherwise
+looks like an ordinary attempt.
+
+`catalogue-not-worse` compares absolute open-question counts and suits only
+tasks that do not add concepts. `catalogue-density-not-worse` compares open
+questions per concept and is the form additive tasks use: the evaluator counts
+subject-scoped questions once per subject, so a new concept mechanically opens
+more of them, and `owner-missing` (human authority) cannot honestly be closed
+for a third-party repository at all.
 
 ## What stays human
 

--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -14,7 +14,7 @@ context-benchmark/
     validate-suite.mjs                   # schema + cross-checks (ids, family minimums, prompt leakage)
     conditions.mjs                       # condition A/B/C instructions (B and C verbatim-identical)
     agent-config.mjs                     # subject-repo agent-config quarantine + pointer placement
-    agent-config.test.mjs                # self-test for the two above, ordering included
+    agent-config.test.mjs                # self-test for agent-config.mjs, ordering included
     degenerate.mjs                       # <3-turn change/maintenance runs, flagged for review
     inject-stale.mjs                     # condition C: deterministic contradicted-claim injection
     run-benchmark.mjs                    # tasks x conditions matrix, workdir isolation, transcripts
@@ -141,7 +141,8 @@ for a third-party repository at all.
 ## What stays human
 
 Comprehension and change verdicts: `score.mjs` emits
-`adjudication-queue.jsonl` with the transcript path, ground truth or rubric,
-and the computed wrong-file edits; a human records pass/fail. Pooled deltas
-and confidence intervals are computed only after adjudication — report
-negative results with the same prominence as positive ones.
+`adjudication-queue.jsonl` with the transcript and patch paths, ground truth or
+rubric, the computed wrong-file edits, and the degenerate flag; a human records
+pass/fail. Pooled deltas and confidence intervals are computed only after
+adjudication — report negative results with the same prominence as positive
+ones.

--- a/docs/research/context-benchmark/runner/agent-config.mjs
+++ b/docs/research/context-benchmark/runner/agent-config.mjs
@@ -1,0 +1,69 @@
+// Agent configuration in a prepared workdir: the subject repository's own, and
+// the pointer the harness deliberately places.
+//
+// Subject repositories ship agent configuration that coding harnesses auto-load
+// (uptime-kuma's upstream CLAUDE.md instructs agents to refuse the work; the
+// 2026-07-29 sweep lost four weak-tier runs to it and no strong-tier ones). That
+// makes it a tier-dependent confound, not a property of the condition under
+// test, so the runner moves it out of the workdir before the run and records
+// what it moved. Keeping it is an explicit realism choice, not the default.
+//
+// Ordering is load-bearing: quarantine strips the *subject's* files first, then
+// the harness writes YarraMate's own pointer into the same names for
+// model-bearing conditions (ADR 0045 delivers it to every file a harness
+// auto-loads). Reversing the two would quarantine the pointer.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// Paths a coding harness reads without being asked. Files and directories both;
+// matched by name at any depth, because nested CLAUDE.md files load when the
+// agent works in that subtree.
+export const SUBJECT_AGENT_CONFIG = ['AGENTS.md', 'AGENT.md', 'CLAUDE.md', 'CLAUDE.local.md', '.claude', '.mcp.json'];
+
+// ADR 0045: `init` delivers one identical pointer section to every file a
+// harness auto-loads. The delivery list is read back from a probe init rather
+// than hardcoded, so a pinned toolchain that predates ADR 0045 places exactly
+// what that toolchain would have placed.
+export const POINTER_FILES = ['AGENTS.md', 'CLAUDE.md'];
+
+const walk = (root, relative, found) => {
+  for (const entry of readdirSync(join(root, relative), { withFileTypes: true })) {
+    if (entry.name === '.git') continue;
+    const path = relative ? join(relative, entry.name) : entry.name;
+    if (SUBJECT_AGENT_CONFIG.includes(entry.name)) {
+      found.push(path);
+      continue;
+    }
+    if (entry.isDirectory()) walk(root, path, found);
+  }
+  return found;
+};
+
+// Moves (never deletes) the subject repository's agent configuration out of the
+// workdir, preserving its relative layout under quarantineDir for audit.
+// Returns the workdir-relative paths that were moved, sorted.
+export const quarantineAgentConfig = (workdir, quarantineDir) => {
+  const found = walk(workdir, '', []).sort();
+  for (const relative of found) {
+    const target = join(quarantineDir, relative);
+    mkdirSync(dirname(target), { recursive: true });
+    renameSync(join(workdir, relative), target);
+  }
+  return found;
+};
+
+export const readPointerFiles = (probeDir) =>
+  POINTER_FILES.filter((name) => existsSync(join(probeDir, name)))
+    .map((name) => [name, readFileSync(join(probeDir, name), 'utf8')]);
+
+// Appends to whatever the workdir already has, matching `init`'s own safety
+// rule. After quarantine there is nothing to append to, which is the point.
+export const placePointerFiles = (workdir, pointers) => {
+  for (const [name, text] of pointers) {
+    const path = join(workdir, name);
+    const existing = existsSync(path) ? `${readFileSync(path, 'utf8').replace(/\n*$/, '')}\n\n` : '';
+    writeFileSync(path, `${existing}${text}`);
+  }
+  return pointers.map(([name]) => name);
+};

--- a/docs/research/context-benchmark/runner/agent-config.test.mjs
+++ b/docs/research/context-benchmark/runner/agent-config.test.mjs
@@ -1,0 +1,85 @@
+// Self-test for the workdir agent-configuration rules. Not part of `pnpm test`
+// (this directory is a research artifact, outside the package test tree):
+//   node --test 'docs/research/context-benchmark/runner/*.test.mjs'
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { placePointerFiles, quarantineAgentConfig, readPointerFiles } from './agent-config.mjs';
+
+const POINTER = '## YarraMate architecture workspace\n\nThis repository has one.\n';
+
+const subjectRepo = () => {
+  const root = mkdtempSync(join(tmpdir(), 'bench-agent-config-'));
+  const workdir = join(root, 'repo');
+  mkdirSync(join(workdir, 'server', '.claude'), { recursive: true });
+  mkdirSync(join(workdir, '.git'), { recursive: true });
+  writeFileSync(join(workdir, 'CLAUDE.md'), 'Do not use AI assistants on this repository.\n');
+  writeFileSync(join(workdir, 'AGENTS.md'), 'Subject repo agent notes.\n');
+  writeFileSync(join(workdir, 'server', 'CLAUDE.md'), 'Nested refusal.\n');
+  writeFileSync(join(workdir, 'server', '.claude', 'settings.json'), '{}\n');
+  writeFileSync(join(workdir, '.git', 'CLAUDE.md'), 'git internals, never touched.\n');
+  writeFileSync(join(workdir, 'README.md'), 'Subject repo readme.\n');
+  return { root, workdir, quarantine: join(root, '.benchmark-quarantined') };
+};
+
+test('quarantine moves every auto-loaded agent config out of the workdir', (t) => {
+  const { root, workdir, quarantine } = subjectRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const moved = quarantineAgentConfig(workdir, quarantine);
+
+  assert.deepEqual(moved, ['AGENTS.md', 'CLAUDE.md', 'server/.claude', 'server/CLAUDE.md']);
+  for (const relative of moved) {
+    assert.equal(existsSync(join(workdir, relative)), false, `${relative} still in workdir`);
+    assert.equal(existsSync(join(quarantine, relative)), true, `${relative} not preserved`);
+  }
+  assert.equal(readFileSync(join(quarantine, 'server', '.claude', 'settings.json'), 'utf8'), '{}\n');
+  assert.equal(existsSync(join(workdir, 'README.md')), true, 'unrelated files must survive');
+  assert.equal(existsSync(join(workdir, '.git', 'CLAUDE.md')), true, 'git internals are not agent config');
+});
+
+test('quarantine runs before pointer placement, so B/C carry only the harness pointer', (t) => {
+  const { root, workdir, quarantine } = subjectRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const probeDir = join(root, 'probe');
+  mkdirSync(probeDir, { recursive: true });
+  writeFileSync(join(probeDir, 'AGENTS.md'), POINTER);
+  writeFileSync(join(probeDir, 'CLAUDE.md'), POINTER);
+
+  quarantineAgentConfig(workdir, quarantine);
+  const placed = placePointerFiles(workdir, readPointerFiles(probeDir));
+
+  assert.deepEqual(placed, ['AGENTS.md', 'CLAUDE.md']);
+  for (const name of placed) {
+    assert.equal(readFileSync(join(workdir, name), 'utf8'), POINTER, `${name} must be the pointer alone`);
+  }
+});
+
+test('quarantining after pointer placement would take the pointer with it', (t) => {
+  const { root, workdir, quarantine } = subjectRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const probeDir = join(root, 'probe');
+  mkdirSync(probeDir, { recursive: true });
+  writeFileSync(join(probeDir, 'AGENTS.md'), POINTER);
+
+  quarantineAgentConfig(workdir, quarantine);
+  placePointerFiles(workdir, readPointerFiles(probeDir));
+
+  // The pointer is written after quarantine; re-running quarantine would take
+  // it away, which is exactly the ordering bug the runner must not have.
+  assert.deepEqual(quarantineAgentConfig(workdir, join(root, 'second-pass')), ['AGENTS.md']);
+  assert.equal(existsSync(join(workdir, 'AGENTS.md')), false);
+});
+
+test('a repository with no agent config quarantines nothing', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'bench-agent-config-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const workdir = join(root, 'repo');
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(join(workdir, 'README.md'), 'Nothing to see.\n');
+
+  assert.deepEqual(quarantineAgentConfig(workdir, join(root, '.benchmark-quarantined')), []);
+});

--- a/docs/research/context-benchmark/runner/catalogue.mjs
+++ b/docs/research/context-benchmark/runner/catalogue.mjs
@@ -1,6 +1,12 @@
-// Shared helper: open-question count of a workspace under the core-enrichment
-// catalogue, via the reference evaluator. Returns null (never throws) when the
+// Shared helper: catalogue snapshot of a workspace — open questions under the
+// core-enrichment catalogue (via the reference evaluator) alongside the number
+// of concepts they were counted over. Returns null (never throws) when the
 // workspace does not compile or the evaluator output is unrecognisable.
+//
+// The concept count exists because the evaluator counts subject-scoped
+// questions once per matching subject: an absolute open-question total is not
+// comparable across workspaces of different size (score.mjs,
+// catalogue-density-not-worse).
 
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
@@ -10,7 +16,16 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
 const catalogueDir = join(repoRoot, 'docs/research/question-catalogue');
 
-export const catalogueOpen = (toolchainDir, workspaceDir, scratchDir, cataloguePath = join(catalogueDir, 'core-enrichment.yaml')) => {
+// Enrichment targets, as evaluate-catalogue.mjs defines them: concept subjects
+// minus the architecture-state subjects, which carry no catalogue questions.
+const conceptCount = (graph) => {
+  const states = new Set((graph.claims ?? [])
+    .filter((claim) => claim.predicate === 'yarramate/state/type')
+    .map((claim) => claim.subject));
+  return (graph.subjects ?? []).filter((subject) => subject.type === 'concept' && !states.has(subject.id)).length;
+};
+
+export const catalogueSnapshot = (toolchainDir, workspaceDir, scratchDir, cataloguePath = join(catalogueDir, 'core-enrichment.yaml')) => {
   try {
     const compiled = execFileSync(join(toolchainDir, 'yarramate'), ['compile', join(workspaceDir, 'workspace.yaml')], {
       encoding: 'utf8',
@@ -25,7 +40,7 @@ export const catalogueOpen = (toolchainDir, workspaceDir, scratchDir, catalogueP
       graphPath,
     ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
     const open = evaluated.match(/total open questions[^:]*:\s*(\d+)/i);
-    return open ? Number(open[1]) : null;
+    return open ? { open: Number(open[1]), concepts: conceptCount(JSON.parse(compiled)) } : null;
   } catch {
     return null;
   }

--- a/docs/research/context-benchmark/runner/degenerate.mjs
+++ b/docs/research/context-benchmark/runner/degenerate.mjs
@@ -1,0 +1,18 @@
+// Degenerate-run detection.
+//
+// A change or model-maintenance run that exits cleanly after one or two turns
+// did not do the work — it acknowledged the prompt and stopped. The harness
+// records exit code 0, so the harness-failure counter never sees it and the
+// adjudicator meets it as an ordinary fail. Flagging is evidence, not a
+// verdict: the run still gets scored and adjudicated normally.
+
+export const DEGENERATE_MIN_TURNS = 3;
+
+const REVIEWED_FAMILIES = new Set(['change', 'model-maintenance']);
+
+// true / false / null when the turn count is unknown (unparseable transcript).
+export const isDegenerateRun = (family, metrics) => {
+  if (!REVIEWED_FAMILIES.has(family)) return false;
+  const turns = metrics?.numTurns ?? null;
+  return turns === null ? null : turns < DEGENERATE_MIN_TURNS;
+};

--- a/docs/research/context-benchmark/runner/run-benchmark.mjs
+++ b/docs/research/context-benchmark/runner/run-benchmark.mjs
@@ -11,7 +11,8 @@
 //   node run-benchmark.mjs --suite tasks/<name>.yaml --gallery <gallery-repo-dir> \
 //     --toolchain <dir with yarramate bins> --out <results-dir> \
 //     [--conditions A,B,C] [--tasks id,id] [--label tier-name] \
-//     [--harness 'claude -p --output-format json'] [--dry-run]
+//     [--harness 'claude -p --output-format json'] [--keep-subject-agent-config] \
+//     [--dry-run]
 //
 // The harness command receives the composed prompt on stdin and runs with the
 // task workdir as cwd. Anything printed to stdout is captured as the transcript.
@@ -22,7 +23,9 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CONDITIONS } from './conditions.mjs';
-import { catalogueOpen } from './catalogue.mjs';
+import { catalogueSnapshot } from './catalogue.mjs';
+import { placePointerFiles, quarantineAgentConfig, readPointerFiles } from './agent-config.mjs';
+import { isDegenerateRun } from './degenerate.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..', '..', '..', '..');
@@ -39,7 +42,7 @@ const flag = (name) => args.includes(`--${name}`);
 const suitePath = opt('suite');
 const outDir = opt('out');
 if (!suitePath || !outDir) {
-  console.error('usage: run-benchmark.mjs --suite <suite.yaml> --out <dir> [--gallery <dir>] [--toolchain <bin-dir>] [--conditions A,B,C] [--tasks id,id] [--label tier] [--harness <cmd>] [--dry-run]');
+  console.error('usage: run-benchmark.mjs --suite <suite.yaml> --out <dir> [--gallery <dir>] [--toolchain <bin-dir>] [--conditions A,B,C] [--tasks id,id] [--label tier] [--harness <cmd>] [--keep-subject-agent-config] [--dry-run]');
   process.exit(2);
 }
 const suite = YAML.parse(readFileSync(suitePath, 'utf8'));
@@ -50,6 +53,7 @@ const label = opt('label', 'default');
 const conditionIds = opt('conditions', 'A,B,C').split(',');
 const onlyTasks = opt('tasks') ? new Set(opt('tasks').split(',')) : null;
 const dryRun = flag('dry-run');
+const agentConfigPolicy = flag('keep-subject-agent-config') ? 'keep' : 'neutralize';
 
 const modelSourceDir = () => {
   if (suite.repository.gallery && !galleryDir) {
@@ -76,7 +80,7 @@ for (const conditionId of conditionIds) {
 }
 
 if (dryRun) {
-  console.log(`suite=${suite.suite} label=${label} harness=${JSON.stringify(harness)} runs=${matrix.length}`);
+  console.log(`suite=${suite.suite} type=${suite.type} label=${label} harness=${JSON.stringify(harness)} agent-config=${agentConfigPolicy} runs=${matrix.length}`);
   for (const { conditionId, task } of matrix) console.log(`  ${conditionId} ${task.family.padEnd(17)} ${task.id}`);
   process.exit(0);
 }
@@ -95,21 +99,23 @@ if (!existsSync(cacheDir)) {
   execSync('git checkout -q FETCH_HEAD', { cwd: cacheDir });
 }
 
-// Model-bearing workdirs also get the AGENTS.md pointer that `yarramate init`
-// writes (ADR 0040): an adopted repository advertises its workspace to agent
-// harnesses, and condition B/C should look like an adopted repository. The
-// pointer text is captured once from a fresh init with the pinned toolchain.
-let pointerText = null;
-const agentsPointer = () => {
-  if (pointerText === null) {
+// Model-bearing workdirs also get the pointer that `yarramate init` writes
+// (ADR 0040, delivered per ADR 0045): an adopted repository advertises its
+// workspace to agent harnesses, and condition B/C should look like an adopted
+// repository. Both the delivery list and the text are captured once from a
+// fresh init with the pinned toolchain, so the runner places what that
+// toolchain places and nothing else.
+let pointers = null;
+const pointerFiles = () => {
+  if (pointers === null) {
     const probeDir = join(outDir, 'cache', '.agents-probe');
     if (!existsSync(join(probeDir, 'AGENTS.md'))) {
       mkdirSync(probeDir, { recursive: true });
       execFileSync(join(toolchain, 'yarramate'), ['init', '.'], { cwd: probeDir, stdio: 'ignore' });
     }
-    pointerText = readFileSync(join(probeDir, 'AGENTS.md'), 'utf8');
+    pointers = readPointerFiles(probeDir);
   }
-  return pointerText;
+  return pointers;
 };
 
 const runsPath = join(outDir, 'runs.jsonl');
@@ -119,6 +125,14 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
   rmSync(runDir, { recursive: true, force: true });
   mkdirSync(runDir, { recursive: true });
   cpSync(cacheDir, workdir, { recursive: true });
+
+  // Before anything the harness places: the subject's own agent config is a
+  // tier-dependent confound (agent-config.mjs). Quarantined outside the
+  // workdir so the agent cannot read it either, and always before the pointer
+  // is written into the same file names.
+  const neutralized = agentConfigPolicy === 'keep'
+    ? null
+    : quarantineAgentConfig(workdir, join(runDir, '.benchmark-quarantined'));
 
   const workspaceDir = join(workdir, '.yarramate');
   rmSync(workspaceDir, { recursive: true, force: true });
@@ -133,12 +147,11 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
       ], { encoding: 'utf8' });
       writeFileSync(join(runDir, 'inject.json'), injected);
     }
-    const agentsPath = join(workdir, 'AGENTS.md');
-    const existing = existsSync(agentsPath) ? `${readFileSync(agentsPath, 'utf8').replace(/\n*$/, '')}\n\n` : '';
-    writeFileSync(agentsPath, `${existing}${agentsPointer()}`);
-    catalogueBaseline = catalogueOpen(toolchain, workspaceDir, runDir);
+    placePointerFiles(workdir, pointerFiles());
+    catalogueBaseline = catalogueSnapshot(toolchain, workspaceDir, runDir);
   }
   execSync('git add -A && git -c user.email=bench@local -c user.name=bench commit -qm baseline --allow-empty', { cwd: workdir });
+  const baselineCommit = execSync('git rev-parse HEAD', { cwd: workdir, encoding: 'utf8' }).trim();
 
   const prompt = `${condition.instruction}\n\n${task.prompt}`;
   writeFileSync(join(runDir, 'prompt.txt'), prompt);
@@ -171,6 +184,7 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
 
   appendFileSync(runsPath, `${JSON.stringify({
     suite: suite.suite,
+    suiteType: suite.type,
     headline: suite.headline,
     label,
     condition: conditionId,
@@ -179,7 +193,10 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
     exitCode: result.status,
     durationMs,
     metrics,
+    degenerate: isDegenerateRun(task.family, metrics),
+    agentConfig: { policy: agentConfigPolicy, neutralized },
     catalogueBaseline,
+    baselineCommit,
     runDir,
     finishedAt: new Date().toISOString(),
   })}\n`);

--- a/docs/research/context-benchmark/runner/score.mjs
+++ b/docs/research/context-benchmark/runner/score.mjs
@@ -4,11 +4,13 @@
 // free-form agent output.
 //
 // Per run record from runs.jsonl:
+// - every run with a workdir: stage the working tree and write diff.patch
+//   against the pinned baseline commit;
 // - model-maintenance: run the pinned CLI against the post-run workspace and
 //   evaluate the task's `expect` list (check-pass, no-contradicted,
-//   catalogue-not-worse, likec4-check-pass);
+//   catalogue-not-worse, catalogue-density-not-worse, likec4-check-pass);
 // - change: compute the wrong-file edit rate (files changed vs the task's
-//   `touches` paths) from the workdir's git diff against the baseline commit;
+//   `touches` paths) from the same staged diff;
 // - comprehension/change verdicts: append to adjudication-queue.jsonl with the
 //   ground truth or rubric attached.
 //
@@ -16,7 +18,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { catalogueOpen } from './catalogue.mjs';
+import { catalogueSnapshot } from './catalogue.mjs';
+import { DEGENERATE_MIN_TURNS, isDegenerateRun } from './degenerate.mjs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -55,25 +58,65 @@ const cli = (bin, cmdArgs, cwd) => {
     return { out: `${error.stdout ?? ''}${error.stderr ?? ''}`, code: error.status ?? 1 };
   }
 };
-const postCatalogueOpen = (workspaceDir, cwd) => catalogueOpen(toolchain, workspaceDir, cwd, cataloguePath);
+const postCatalogueSnapshot = (workspaceDir, cwd) => catalogueSnapshot(toolchain, workspaceDir, cwd, cataloguePath);
+const git = (cmdArgs, cwd) => execFileSync('git', cmdArgs, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+// `git diff HEAD` saw neither the files an agent added (add-provider tasks
+// create whole modules) nor the work it committed. Staging everything and
+// diffing the index against the run's pinned baseline commit captures both.
+const baselineOf = (record, workdir) => {
+  if (record.baselineCommit) return record.baselineCommit;
+  // Sweeps that predate the recorded sha: "baseline" is the only commit the
+  // runner authors, so its message identifies it.
+  return git(['rev-list', '-1', '--grep=^baseline$', 'HEAD'], workdir).trim() || 'HEAD';
+};
+
+// Sweeps that predate the concept count store a bare open-question number.
+const asSnapshot = (value) => (typeof value === 'number' ? { open: value, concepts: null } : value ?? null);
+
+const catalogueVerdict = (expectation, baseline, after) => {
+  if (baseline === null || after === null) return null;
+  if (expectation === 'catalogue-not-worse') return after.open <= baseline.open;
+  if (baseline.concepts === null || after.concepts === null) return null;
+  // Open questions are counted once per matching subject, so declaring the
+  // concept an additive task asks for mechanically opens more of them — and
+  // owner-missing (authority: human) cannot honestly be closed for a
+  // third-party repository at all. Density keeps the intent, that new
+  // inventory is enriched to the standard of the model it joins, without
+  // punishing the requested behaviour. Cross-multiplied to stay in integers.
+  return after.open * baseline.concepts <= baseline.open * after.concepts;
+};
 
 const records = readFileSync(runsPath, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+const degenerate = [];
 for (const record of records) {
   const task = tasksById.get(record.task);
   if (!task) continue;
   const workdir = join(record.runDir, 'repo');
   const workspaceDir = join(workdir, '.yarramate');
-  const score = { ...record, deterministic: null, wrongFiles: null, adjudication: false };
+  const score = {
+    ...record,
+    degenerate: record.degenerate ?? isDegenerateRun(record.family, record.metrics),
+    deterministic: null,
+    wrongFiles: null,
+    adjudication: false,
+  };
 
-  if (task.family === 'change' && existsSync(workdir)) {
-    const changed = execFileSync('git', ['diff', '--name-only', 'HEAD'], { cwd: workdir, encoding: 'utf8' })
-      .trim().split('\n').filter(Boolean).filter((f) => !f.startsWith('.yarramate'));
-    const expected = task.touches.filter((t) => t.includes('/') || t.includes('.'));
-    score.wrongFiles = {
-      changed,
-      expected,
-      unexpected: changed.filter((f) => !expected.some((e) => f === e || f.startsWith(e))),
-    };
+  if (existsSync(join(workdir, '.git'))) {
+    const baseline = baselineOf(record, workdir);
+    git(['add', '-A'], workdir);
+    writeFileSync(join(record.runDir, 'diff.patch'), git(['diff', '--cached', baseline], workdir));
+
+    if (task.family === 'change') {
+      const changed = git(['diff', '--cached', '--name-only', baseline], workdir)
+        .trim().split('\n').filter(Boolean).filter((f) => !f.startsWith('.yarramate'));
+      const expected = task.touches.filter((t) => t.includes('/') || t.includes('.'));
+      score.wrongFiles = {
+        changed,
+        expected,
+        unexpected: changed.filter((f) => !expected.some((e) => f === e || f.startsWith(e))),
+      };
+    }
   }
 
   if (task.family === 'model-maintenance' && existsSync(workspaceDir)) {
@@ -97,10 +140,10 @@ for (const record of records) {
         } else {
           results[expectation] = null;
         }
-      } else if (expectation === 'catalogue-not-worse') {
-        const baseline = record.catalogueBaseline ?? null;
-        const after = postCatalogueOpen(workspaceDir, workdir);
-        results[expectation] = baseline === null || after === null ? null : after <= baseline;
+      } else if (expectation === 'catalogue-not-worse' || expectation === 'catalogue-density-not-worse') {
+        const baseline = asSnapshot(record.catalogueBaseline);
+        const after = postCatalogueSnapshot(workspaceDir, workdir);
+        results[expectation] = catalogueVerdict(expectation, baseline, after);
         score.catalogue = { baseline, after };
       }
     }
@@ -119,11 +162,17 @@ for (const record of records) {
       groundTruth: task.groundTruth ?? null,
       rubric: task.scoring.rubric ?? null,
       transcript: join(record.runDir, 'transcript.json'),
+      diff: join(record.runDir, 'diff.patch'),
       wrongFiles: score.wrongFiles,
+      degenerate: score.degenerate,
     })}\n`);
   }
 
   appendFileSync(scoresPath, `${JSON.stringify(score)}\n`);
+  if (score.degenerate) degenerate.push(`${record.label}/${record.condition}/${record.task}`);
 }
 
 console.log(`scored ${records.length} runs -> ${scoresPath}; adjudication queue -> ${queuePath}`);
+if (degenerate.length > 0) {
+  console.log(`degenerate (< ${DEGENERATE_MIN_TURNS} turns, review before scoring): ${degenerate.join(', ')}`);
+}

--- a/docs/research/context-benchmark/tasks/v2/fastify.yaml
+++ b/docs/research/context-benchmark/tasks/v2/fastify.yaml
@@ -1,0 +1,295 @@
+# Frozen benchmark task suite: fastify (yarramate/benchmark-suite/v2).
+# Authored before any condition run (DESIGN.md "Task suite"); ground truth was
+# verified by reading the source at the pinned commit — the code, not the
+# gallery model, is the authority. Comprehension and change prompts are
+# condition-neutral; model-maintenance prompts necessarily reference the
+# committed workspace and only run under model-present conditions.
+#
+# v2 errata against ../fastify.yaml (frozen; swept 2026-07-29):
+# - ff-ctp-remove-unknown-error: test/internals/errors.test.js pins
+#   `expectedErrors = 94`, so adding a code must move it — `touches` lists it.
+# - ff-model-log-controller: catalogue-density-not-worse, the additive form of
+#   the gate (see ../../runner/score.mjs).
+type: yarramate/benchmark-suite/v2
+suite: fastify
+headline: true
+repository:
+  name: fastify
+  source: https://github.com/fastify/fastify
+  commit: 812608e5c9cb0b643b3eb186c2e9e84bbb7ed8ee
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/fastify
+
+tasks:
+  # --- Comprehension -------------------------------------------------------
+  - id: ff-encapsulation-child-state
+    family: comprehension
+    prompt: >-
+      When fastify.register(plugin) runs a plugin in its own encapsulated
+      context, the framework produces a child instance for that plugin.
+      Answer precisely, citing the relevant source files: (a) which file and
+      function create the child instance, and what is the object relationship
+      between the child and its parent instance; (b) which pieces of
+      per-instance state are freshly rebuilt or copied onto the child at
+      creation time, rather than reached through the parent via the prototype
+      chain; (c) three hook arrays are deliberately reset to empty on the
+      child instead of being copied from the parent — name all three and
+      explain why they must not be copied.
+    groundTruth:
+      answer: >-
+        (a) lib/plugin-override.js exports override(), installed as avvio's
+        override hook in fastify.js (avvio.override = override,
+        fastify.js:377). The child is created with Object.create(old), so it
+        prototype-inherits from the parent, and is pushed onto the parent's
+        kChildren list. (b) Rebuilt/copied onto the child: Reply and Request
+        constructors (Reply.buildReply / Request.buildRequest), the
+        content-type parser (buildContentTypeParser), the hook store
+        (buildHooks, which slices each hook array), the route prefix
+        (buildRoutePrefix with opts.prefix), log level, a new schema
+        controller layered on the parent's (SchemaController.
+        buildSchemaController(old[kSchemaController])) with rebound
+        getSchema/getSchemas, a fresh kChildren array, a rebound ready
+        (kAvvioBoot), a derived registered-plugins tracker and plugin name
+        chain, kErrorHandlerAlreadySet = false, merged log serializers, and —
+        when opts.prefix is set — a re-arranged 404 level
+        (kFourOhFour.arrange404). (c) onReady, onListen and preClose are
+        reset to [] in buildHooks (lib/hooks.js:87-89). Application hooks are
+        executed by walking each instance's kChildren tree
+        (hookRunnerApplication and onListenHookRunner recurse into children),
+        so copying the parent's entries into every child would run those
+        boot/shutdown hooks once per descendant instead of once.
+      verifiedAgainst:
+        - lib/plugin-override.js:28-74
+        - lib/hooks.js:73-91
+        - lib/hooks.js:93-150
+        - lib/hooks.js:183-207
+        - fastify.js:360-381
+    scoring:
+      method: ground-truth
+
+  - id: ff-body-parser-selection
+    family: comprehension
+    prompt: >-
+      Consider a POST route on a fastify server built with default options
+      and no custom content-type parsers registered beyond the built-ins.
+      For each of the following three incoming requests, state which internal
+      module decides what happens to the request body, what the outcome is,
+      and — where the request is rejected — the HTTP status code and the
+      coded error used: (1) the request carries the header "Content-Type:
+      application/vnd.foo+toml" (syntactically valid, but no parser and no
+      catch-all parser is registered for it); (2) the request has no
+      Content-Type header and no body (no content-length or
+      transfer-encoding); (3) the request has no Content-Type header but
+      does carry a non-empty body. Cite the files involved.
+    groundTruth:
+      answer: >-
+        Dispatch happens in lib/handle-request.js handleRequest(). (1) The
+        header is present and valid, so the route context's content-type
+        parser runs (lib/handle-request.js:87). ContentTypeParser.prototype.
+        run (lib/content-type-parser.js:187-199) resolves the parser via
+        getParser (exact match, then media-type, then regexp list, then the
+        '' catch-all); all miss because the defaults only register
+        application/json and text/plain (lib/content-type-parser.js:33-42),
+        so run() sends FST_ERR_CTP_INVALID_MEDIA_TYPE — HTTP 415 Unsupported
+        Media Type (lib/errors.js:111-115). (2) isEmptyBody()
+        (lib/handle-request.js:112-117) is true, so body parsing is skipped
+        entirely and the request proceeds to preValidation/validation/handler
+        with request.body undefined (lib/handle-request.js:66-70). (3) The
+        catch-all parser is attempted via contentTypeParser.run('', ...)
+        (lib/handle-request.js:73); no catch-all is registered by default, so
+        getParser returns undefined and the same 415
+        FST_ERR_CTP_INVALID_MEDIA_TYPE is sent. Special case verified in
+        code: requests dispatched to a 404 context skip parsing and go
+        straight to the handler (lib/content-type-parser.js:191-194).
+      verifiedAgainst:
+        - lib/handle-request.js:25-117
+        - lib/content-type-parser.js:33-42
+        - lib/content-type-parser.js:119-156
+        - lib/content-type-parser.js:187-233
+        - lib/errors.js:111-115
+    scoring:
+      method: ground-truth
+
+  - id: ff-retire-avvio
+    family: comprehension
+    prompt: >-
+      fastify declares a runtime dependency on the third-party package avvio.
+      Suppose avvio were retired from the codebase with no replacement.
+      (a) Which public instance methods would stop working because avvio
+      itself provides or backs them? (b) Beyond those methods, name two
+      framework behaviors that would break because they are wired through
+      avvio callbacks, and cite the file(s) where each is wired in.
+    groundTruth:
+      answer: >-
+        (a) register (avvio's use, exposed under the name register via
+        expose: { use: 'register' }), after, ready (avvio's ready is cached
+        as kAvvioBoot and wrapped by fastify's own ready), onClose, close,
+        and printPlugins (bound to avvio.prettyPrint). fastify.js initializes
+        these to null with the comment "initialized by Avvio"
+        (fastify.js:248-254) and avvio fills them in (fastify.js:360-381).
+        addHook('onClose', fn) also delegates to avvio's onClose
+        (fastify.js:603-604 region: name === 'onClose' branch). (b) Two
+        avvio-callback-wired behaviors: plugin encapsulation — avvio calls
+        the override assigned at fastify.js:377 (lib/plugin-override.js) to
+        create each child instance; and boot/shutdown application-hook
+        ordering — hookRunnerApplication threads onReady and preClose hooks
+        through the avvio boot callback (fastify[kAvvioBoot]) including
+        per-child recursion and AVVIO_ERRORS_MAP/plugin-timeout translation
+        (lib/hooks.js:93-181, fastify.js:368-390). Without avvio neither
+        plugin isolation nor ordered ready/close execution exists.
+      verifiedAgainst:
+        - fastify.js:248-254
+        - fastify.js:360-390
+        - fastify.js:577-618
+        - lib/plugin-override.js:28-74
+        - lib/hooks.js:93-181
+    scoring:
+      method: ground-truth
+
+  # --- Change --------------------------------------------------------------
+  - id: ff-add-has-hook
+    family: change
+    prompt: >-
+      Add a public instance method hasHook(hookName) to fastify. Behavior:
+      it returns true when at least one handler is registered for hookName
+      in the calling instance's own hook store (its encapsulation context,
+      including hooks copied into a child context at registration time), and
+      false otherwise. It must cover the request/reply lifecycle hooks (e.g.
+      onRequest, preHandler, onSend) and the application hooks kept in the
+      instance hook store (e.g. onRoute, onReady, preClose). For a hook name
+      the store does not support (e.g. "onFoo", or onClose, which is managed
+      by the boot orchestrator rather than the store), it must throw the
+      existing coded error FST_ERR_HOOK_NOT_SUPPORTED rather than a plain
+      Error. Derive hook-name support from the canonical hook definitions in
+      lib/hooks.js instead of introducing a second hard-coded list, and
+      update the TypeScript declarations so the method is part of the typed
+      instance surface. Do not change the behavior of addHook.
+    touches:
+      - fastify.js
+      - lib/hooks.js
+      - types/instance.d.ts
+      - hook-system
+      - public-api
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          hasHook is exposed on the fastify instance and returns correct
+          booleans by consulting the instance's own hook store (kHooks) for
+          both lifecycle hooks and store-kept application hooks; it does not
+          maintain a separate registry.
+        - >-
+          Unsupported hook names (including onClose) throw the existing
+          FST_ERR_HOOK_NOT_SUPPORTED coded error; no new bare Error or new
+          error code is introduced for this case.
+        - >-
+          Hook-name support is derived from lib/hooks.js (the Hooks store
+          and/or its exported hook lists); no duplicated hard-coded hook-name
+          list is added in fastify.js or elsewhere.
+        - >-
+          types/instance.d.ts declares hasHook with hook-name typing
+          consistent with the existing addHook overloads, and addHook
+          behavior is unchanged.
+
+  - id: ff-ctp-remove-unknown-error
+    family: change
+    prompt: >-
+      Today fastify.removeContentTypeParser("application/xml") silently does
+      nothing when no parser is registered for that content type. Change
+      this: removing a content type (string or RegExp) that has no registered
+      parser must fail with a new coded error FST_ERR_CTP_PARSER_NOT_FOUND,
+      created and exported following the framework's existing coded-error
+      conventions (the createError factory in lib/errors.js, FST_ERR_CTP_
+      prefix, an appropriate status code). The array form of
+      removeContentTypeParser must fail the same way if any listed content
+      type has no registered parser. The existing guard that throws
+      FST_ERR_CTP_INSTANCE_ALREADY_STARTED when the instance has already
+      started must keep taking precedence. Document the new error code in
+      docs/Reference/Errors.md and add it to the error-code union in
+      types/errors.d.ts. Successful removals of registered parsers must keep
+      working exactly as before.
+    touches:
+      - lib/content-type-parser.js
+      - lib/errors.js
+      - docs/Reference/Errors.md
+      - types/errors.d.ts
+      - test/internals/errors.test.js
+      - content-type-parser
+      - error-handling
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          FST_ERR_CTP_PARSER_NOT_FOUND is defined in lib/errors.js via the
+          existing createError factory with the FST_ERR_CTP_ prefix and is
+          exported alongside the other codes.
+        - >-
+          removeContentTypeParser throws the new error for unregistered
+          content types in both the single and array forms, while removal of
+          registered parsers (string and RegExp) still succeeds and actually
+          deregisters the parser.
+        - >-
+          The FST_ERR_CTP_INSTANCE_ALREADY_STARTED guard still fires first
+          when the instance has started, and no silent no-op path remains
+          reachable through the public removeContentTypeParser API for
+          unknown types.
+        - >-
+          The new code is documented in docs/Reference/Errors.md and added to
+          the error-code union in types/errors.d.ts.
+
+  # --- Model maintenance ---------------------------------------------------
+  - id: ff-model-log-controller
+    family: model-maintenance
+    prompt: >-
+      A code-level change has landed in fastify that the committed .yarramate
+      workspace predates: per-request logging is now mediated by an internal
+      LogController. The class lives in lib/log-controller.js,
+      createLogController builds it from the server options (re-exported
+      through lib/logger-factory.js and wired into the instance in
+      fastify.js), it gates per-request log lines via disableRequestLogging /
+      isLogDisabled and carries requestIdLogLabel, and the 404 path reports
+      route-not-found through it (basic404 in lib/four-oh-four.js calls
+      routeNotFound on it). The workspace's logging concept still cites only
+      lib/logger-factory.js and lib/logger-pino.js. Update the .yarramate
+      workspace so the logging subsystem accurately reflects the
+      LogController: amend the logging concept (or add a dedicated concept
+      under the framework grouping) with descriptions and evidence pointing
+      at the files above, and add or adjust relationships where the code
+      shows them (for example the 404/not-found path consuming the
+      LogController for its route-not-found log line). The workspace must
+      still pass its checks and must not contradict the code as it stands.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-density-not-worse
+
+  - id: ff-model-schema-split-target
+    family: model-maintenance
+    prompt: >-
+      The fastify maintainers plan to split the schema subsystem that
+      lib/schema-controller.js currently owns end-to-end: request-side
+      validation (the shared schema bucket plus validator compilation backed
+      by @fastify/ajv-compiler, applied in lib/validation.js) will remain
+      with the schema controller, while response-side serialization
+      (serializer compilation backed by
+      @fastify/fast-json-stringify-compiler and the reply's serializer
+      resolution) will move to a new dedicated serializer controller module.
+      Update the .yarramate workspace to represent this as a planned target
+      state without misrepresenting the present: introduce a serialization
+      concept, move the serving relationship from the
+      "@fastify/fast-json-stringify-compiler (external)" dependency (dep-fjs)
+      and the serving relationship toward the Request/Reply layer
+      (schema-serves-reply) to that concept in the target structure, and keep
+      the currently observed single schema-engine arrangement accurate for
+      the as-is state (the split does not exist in the code today, so no
+      claim may assert it as observed). The workspace must still pass its
+      checks and the generated LikeC4 export must remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/v2/httpie.yaml
+++ b/docs/research/context-benchmark/tasks/v2/httpie.yaml
@@ -1,0 +1,345 @@
+# Frozen benchmark task suite for httpie (context benchmark H1/H2/H3).
+# Ground truth verified against the source at the pinned commit; the gallery
+# model was used only to select targets, never as the authority.
+#
+# v2 errata against ../httpie.yaml (frozen; swept 2026-07-29):
+# - ht-mm-manager-session-store, ht-mm-update-checker:
+#   catalogue-density-not-worse, the additive form of the gate (see
+#   ../../runner/score.mjs). No task text changes.
+type: yarramate/benchmark-suite/v2
+suite: httpie
+headline: true
+repository:
+  name: httpie
+  source: https://github.com/httpie/cli
+  commit: 5b604c37c6c67e18e7c3e9aee6c88a8c22b98345
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/httpie
+
+tasks:
+  # ---------------------------------------------------------------- comprehension
+  - id: ht-comp-download-filename
+    family: comprehension
+    prompt: >-
+      When a response body is saved with --download and no explicit --output
+      file is given, HTTPie picks the target filename automatically. Identify:
+      (1) the module that owns this filename-resolution logic; (2) the function
+      that extracts a filename from the Content-Disposition response header;
+      (3) the function that derives a fallback filename from the URL and the
+      response Content-Type; (4) how collisions with files that already exist
+      on disk are avoided (name the function and describe the scheme); and
+      (5) the method that ties these steps together to open the output file.
+    groundTruth:
+      answer: >-
+        httpie/downloads.py owns all of it. filename_from_content_disposition
+        (downloads.py:85) parses the Content-Disposition header via
+        mailbox.Message.get_filename and sanitises the result (basename,
+        lstrip('.'), strip). filename_from_url (downloads.py:106) falls back to
+        the last URL path segment (or 'index'), appending an extension guessed
+        from the Content-Type via mimetypes.guess_extension (with special
+        cases: text/plain -> .txt, .htm -> .html). get_unique_filename
+        (downloads.py:151) avoids collisions by probing with os.path.exists
+        and appending numeric suffixes -1, -2, ... until an unused name is
+        found, trimming the name first via trim_filename_if_needed so it stays
+        within the filesystem's max filename length. The static method
+        Downloader._get_output_file_from_response (downloads.py:288) ties them
+        together: prefer Content-Disposition, else URL-derived, then uniquify
+        and open the file in mode 'a+b'. It is called from Downloader.start
+        only when no --output file was provided.
+      verifiedAgainst:
+        - httpie/downloads.py:85-103
+        - httpie/downloads.py:106-123
+        - httpie/downloads.py:126-159
+        - httpie/downloads.py:288-304
+        - httpie/downloads.py:226-230
+    scoring:
+      method: ground-truth
+
+  - id: ht-comp-plugin-registry-retire
+    family: comprehension
+    prompt: >-
+      Suppose the file httpie/plugins/registry.py were deleted from this
+      repository with no other changes. State what that file provides, list
+      every module that imports from it, explain what each importer uses it
+      for, and summarise which user-facing capabilities of the http/https
+      command and of the httpie maintenance command would break.
+    groundTruth:
+      answer: >-
+        registry.py instantiates the process-wide singleton
+        plugin_manager = PluginManager() and registers the seven built-in
+        plugins (BasicAuthPlugin, DigestAuthPlugin, BearerAuthPlugin,
+        HeadersFormatter, JSONFormatter, XMLFormatter, ColorFormatter).
+        Importers: httpie/core.py (raw_main calls
+        plugin_manager.load_installed_plugins(env.config.plugins_dir) at
+        startup and --debug prints repr(plugin_manager)); httpie/cli/argparser.py
+        (_process_auth resolves the default auth plugin via
+        get_auth_plugins()[0] and looks up --auth-type via get_auth_plugin);
+        httpie/cli/definition.py (--auth-type lazy choices via
+        getter=plugin_manager.get_auth_plugin_mapping); httpie/client.py
+        (build_requests_session mounts adapters from get_transport_plugins);
+        httpie/output/processing.py (Conversion uses get_converters, Formatting
+        uses get_formatters_grouped); httpie/sessions.py (Session.auth
+        reconstructs stored session auth via get_auth_plugin);
+        httpie/manager/tasks/plugins.py (the httpie plugins list task iterates
+        plugin_manager.iter_entry_points). Breakage: both console commands fail
+        at import time, taking down all authentication (-a/--auth,
+        --auth-type, netrc, session-stored auth), third-party plugin loading,
+        transport adapter mounting, pretty-printing (headers/JSON/XML/colors
+        formatters), mime converters, and httpie plugins list.
+      verifiedAgainst:
+        - httpie/plugins/registry.py
+        - httpie/core.py:24
+        - httpie/core.py:46
+        - httpie/core.py:281
+        - httpie/cli/argparser.py:28
+        - httpie/cli/argparser.py:285
+        - httpie/cli/argparser.py:304
+        - httpie/cli/definition.py:23
+        - httpie/cli/definition.py:689
+        - httpie/client.py:23
+        - httpie/client.py:177
+        - httpie/output/processing.py:5
+        - httpie/output/processing.py:21
+        - httpie/output/processing.py:36
+        - httpie/sessions.py:21
+        - httpie/sessions.py:278
+        - httpie/manager/tasks/plugins.py:197-201
+    scoring:
+      method: ground-truth
+
+  - id: ht-comp-session-lifecycle
+    family: comprehension
+    prompt: >-
+      For an invocation like `http --session=api example.org/endpoint`,
+      explain: (a) which module loads the named session and where on disk the
+      session file lives, including how the path differs when the session name
+      contains a path separator; (b) at which points in the request pipeline
+      the session's stored headers, cookies, and auth are applied to the
+      outgoing request, including the precedence between session headers and
+      command-line headers, and between session auth and -a/--auth given on
+      the command line; and (c) under exactly which conditions the session
+      file is written back to disk at the end of the run.
+    groundTruth:
+      answer: >-
+        (a) httpie/client.py collect_messages calls get_httpie_session
+        (httpie/sessions.py:92) when --session/--session-read-only is set. For
+        a plain name the path is <config_dir>/sessions/<host>/<name>.json
+        (session_hostname_to_dirname, sessions.py:46; ':' in host:port becomes
+        '_'); if the name contains os.path.sep it is an "anonymous" session and
+        is treated as an explicit file path (is_anonymous_session,
+        sessions.py:42, os.path.expanduser at sessions.py:107).
+        (b) All inside collect_messages (httpie/client.py:43-101): session
+        headers are passed as base_headers into make_request_kwargs, where
+        precedence is defaults < session headers < CLI headers
+        (client.py:343-346: make_default_headers, then update(base_headers),
+        then update(args.headers)); cookies are applied by assigning
+        requests_session.cookies = httpie_session.cookies (client.py:76); for
+        auth, CLI auth wins - if args.auth_plugin is set the CLI auth is
+        written INTO the session (client.py:77-82), otherwise stored session
+        auth is applied as request_kwargs['auth'] (client.py:83-85, rebuilt via
+        Session.auth, sessions.py:272-299). In the other direction,
+        update_headers (client.py:75, sessions.py:230) merges request headers
+        back into the session, skipping Content-*/If-* prefixes and the
+        default HTTPie/ User-Agent, and folding a Cookie header into the
+        cookie jar.
+        (c) After the request/response loop (client.py:136-140): saved when
+        the session file is new OR --session (read-write) was used; an
+        existing session opened with --session-read-only is not written.
+        Before saving, cookies are refreshed from the requests session and
+        expired cookies are removed.
+      verifiedAgainst:
+        - httpie/client.py:43-101
+        - httpie/client.py:136-140
+        - httpie/client.py:325-374
+        - httpie/sessions.py:29-57
+        - httpie/sessions.py:92-121
+        - httpie/sessions.py:200-262
+        - httpie/sessions.py:272-304
+    scoring:
+      method: ground-truth
+
+  # ---------------------------------------------------------------------- change
+  - id: ht-change-download-dir
+    family: change
+    prompt: >-
+      Add a --download-dir DIR option to the http/https command. Semantics:
+      it is only meaningful together with --download, and only when the
+      filename is chosen automatically - using it without --download, or
+      combining it with an explicit --output FILE, must be rejected with a
+      clear parser error (like the existing --continue validations). When
+      active, automatically named downloads (name derived from
+      Content-Disposition or from the URL) are created inside DIR instead of
+      the current working directory, and the existing unique-suffix collision
+      avoidance must test for existing files inside DIR. If DIR does not
+      exist, fail with a clear error rather than creating it implicitly.
+      Behaviour when the new flag is absent must be completely unchanged.
+      Include help text consistent with the neighbouring download options.
+    touches:
+      - httpie/cli/definition.py
+      - httpie/cli/argparser.py
+      - httpie/core.py
+      - httpie/downloads.py
+      - httpie#arg-parser
+      - httpie#download-manager
+    scoring:
+      method: rubric
+      rubric:
+        - The option is declared alongside the other download options in
+          httpie/cli/definition.py with help text, and invalid combinations
+          are rejected in the parser (httpie/cli/argparser.py, in or next to
+          _process_download_options) - both --download-dir without --download
+          and --download-dir with --output produce a parser error, not a
+          crash or silent ignore.
+        - The directory is threaded through to the Downloader (constructed in
+          httpie/core.py program) and used in the auto-naming path
+          (_get_output_file_from_response in httpie/downloads.py) - the
+          resolved filename is joined with DIR before the uniqueness probe,
+          so get_unique_filename-style suffixing checks existence within DIR,
+          and the file is opened inside DIR.
+        - A non-existent DIR results in a clear user-facing error (parser
+          error or clean error exit), not an unhandled traceback, and DIR is
+          not silently created.
+        - With the flag absent, behaviour is unchanged - auto-named downloads
+          still land in the current working directory, and no other option's
+          semantics change; unrelated modules (sessions, output formatting,
+          plugin machinery) are not modified.
+
+  - id: ht-change-redact-auth-output
+    family: change
+    prompt: >-
+      HTTPie prints outgoing request headers with --verbose/--print=H,
+      including the Authorization header with its full credential value,
+      which makes shared transcripts leak secrets. Add an opt-in flag
+      (suggested name --redact-auth) to the http/https command: when enabled,
+      any rendered request output replaces the value of the Authorization
+      header with a fixed placeholder (for example <redacted>); the request
+      actually sent on the wire must be unaffected and must carry the real
+      header; response output is untouched. Default behaviour without the
+      flag must be byte-for-byte unchanged. The redaction must apply wherever
+      request headers are rendered (pretty-printed or raw, terminal or
+      redirected), not just in one formatter.
+    touches:
+      - httpie/cli/definition.py
+      - httpie/models.py
+      - httpie/output/models.py
+      - httpie#arg-parser
+      - httpie#output-pipeline
+    scoring:
+      method: rubric
+      rubric:
+        - A new opt-in flag is declared in httpie/cli/definition.py (default
+          off) and reaches the output path via the parsed namespace (for
+          example through ProcessingOptions in httpie/output/models.py or an
+          equivalent explicit mechanism), not via a global variable.
+        - With the flag enabled, the rendered request-header text (produced
+          from HTTPRequest.headers in httpie/models.py) shows the placeholder
+          instead of the Authorization value in every output mode - pretty and
+          non-pretty, tty and redirected - and the real credential string
+          appears nowhere in the rendered output.
+        - The PreparedRequest that is dispatched still carries the genuine
+          Authorization header - redaction is display-only, verified by the
+          fact that the redaction is applied only on the rendering side and
+          never mutates the outgoing requests message.
+        - With the flag absent, output is unchanged, and response rendering is
+          unaffected in both modes.
+
+  - id: ht-change-session-auth-plugin-error
+    family: change
+    prompt: >-
+      A stored session file can carry an auth entry whose type refers to an
+      auth plugin that is no longer installed (for example a session recorded
+      with a third-party auth plugin that was later uninstalled). Today,
+      reusing such a session dies with a bare KeyError raised from the plugin
+      lookup, surfaced to the user as an unhelpful "KeyError: '<type>'"
+      message. Improve this: reusing a session whose auth type has no
+      registered plugin must produce a clear, actionable error that names the
+      unknown auth type, identifies the session (file path or session id),
+      and hints that the corresponding auth plugin needs to be installed. The
+      run must terminate through the normal error path with a non-zero exit
+      status and no traceback (unless --traceback is given). Behaviour for
+      sessions with valid or absent auth must be unchanged, as must the
+      existing --auth-type validation for command-line auth.
+    touches:
+      - httpie/sessions.py
+      - httpie/plugins/manager.py
+      - httpie#session-manager
+      - httpie#plugin-manager
+    scoring:
+      method: rubric
+      rubric:
+        - The unknown-auth-type lookup for session auth (Session.auth in
+          httpie/sessions.py calling plugin_manager.get_auth_plugin) no longer
+          escapes as a raw KeyError - it is caught or replaced by a dedicated,
+          intentional error path (custom exception or explicit membership
+          check in httpie/plugins/manager.py or httpie/sessions.py).
+        - The resulting message names the missing auth type, identifies the
+          session file (path or id), and suggests installing the missing auth
+          plugin - all three elements present.
+        - The failure exits through the existing error handling with a
+          non-zero status and without a traceback by default (traceback still
+          available with --traceback); no unrelated behaviour changes - valid
+          session auth, sessions without auth, and command-line --auth-type
+          validation behave exactly as before.
+
+  # ---------------------------------------------------------- model-maintenance
+  - id: ht-mm-manager-session-store
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace for this repository
+      (.yarramate/workspace.yaml, with the document under
+      .yarramate/architecture/, evidence under .yarramate/evidence/,
+      projections under .yarramate/projections/, and a LikeC4 adapter mapping
+      under .yarramate/integrations/likec4/) models the maintenance CLI
+      (httpie#manager-cli) as only influencing the plugin manager. The code
+      shows it also touches stored session files: httpie/manager/tasks/sessions.py
+      implements `httpie cli sessions upgrade` and `upgrade-all`, loading each
+      session via get_httpie_session, rewriting it in place with
+      session.save(bump_version=True), and walking the sessions/ directory
+      under the config directory. Update the workspace to capture this
+      responsibility: add the missing relationship(s) between the maintenance
+      CLI and the session-files data object (a read-write access is the
+      natural fit), record supporting evidence observations with repo:
+      locators in the evidence overlay, and update the LikeC4 subject mapping
+      for any new subjects so the adapter export stays complete. When you are
+      done, the native workspace check and the LikeC4 adapter check must both
+      pass, with no contradicted claims and no new open catalogue questions
+      left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-density-not-worse
+          - likec4-check-pass
+
+  - id: ht-mm-update-checker
+    family: model-maintenance
+    prompt: >-
+      HTTPie ships a self-update warning subsystem that this repository's
+      committed .yarramate workspace does not yet model:
+      httpie/internal/update_warnings.py is invoked as check_updates from
+      raw_main in httpie/core.py on every run, periodically fetches
+      https://packages.httpie.io/latest.json (spawning a background daemon via
+      httpie/internal/daemons.py and httpie/internal/daemon_runner.py), and
+      persists fetch/warn state to a version_info.json file resolved by
+      Config.version_info_file in httpie/config.py. Extend the workspace
+      (.yarramate/workspace.yaml and the documents it references) to reflect
+      this: declare an update-checker application component composed into the
+      http/https command concept, declare a version-info data object for the
+      persisted state file, and relate the new component to the command that
+      triggers it and to the data object it reads and writes (plus any further
+      relationship you can ground in the cited code, such as the outbound
+      fetch). Add evidence observations with repo: locators for each new
+      claim, and update the LikeC4 subject mapping so every new subject is
+      mapped. Afterwards the native workspace check and the LikeC4 adapter
+      check must both pass, with no contradicted claims and no new open
+      catalogue questions left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - catalogue-density-not-worse
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/v2/miniflux.yaml
+++ b/docs/research/context-benchmark/tasks/v2/miniflux.yaml
@@ -1,0 +1,274 @@
+# Frozen benchmark task suite for miniflux (context benchmark H1/H2/H3).
+# Ground truth verified against the source at the pinned commit; the gallery
+# model was used only to select targets, never as the authority.
+#
+# v2 errata against ../miniflux.yaml (frozen; swept 2026-07-29):
+# - mf-comp-integration-dispatch: SendEntry has four call sites, not two — the
+#   Google Reader and Fever compatibility handlers were missed.
+# - mf-change-per-feed-integration-optout: feed row scanning lives in
+#   internal/storage/feed_query_builder.go, so `touches` must list it.
+# - mf-mm-add-metrics-component: catalogue-density-not-worse, the additive form
+#   of the gate (see ../../runner/score.mjs).
+type: yarramate/benchmark-suite/v2
+suite: miniflux
+headline: true
+repository:
+  name: miniflux
+  source: https://github.com/miniflux/v2
+  commit: c4d54f87a81b30aa173fddf05d7ff83ae7da5796
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/miniflux
+
+tasks:
+  # ---------------------------------------------------------------- comprehension
+  - id: mf-comp-integration-dispatch
+    family: comprehension
+    prompt: >-
+      Miniflux can deliver entries to third-party services such as Wallabag,
+      Pinboard, and Telegram. Identify: (1) the Go package that implements this
+      fan-out delivery; (2) the two exported functions that are its only entry
+      points from the rest of the codebase; (3) for each of those functions,
+      every call site that invokes it — one path runs after a feed refresh has
+      persisted new entries, the other when a user saves a single entry from
+      the web UI or from the REST API. Give the package import path, the two
+      function names, and the file containing each call site.
+    groundTruth:
+      answer: >-
+        The package is internal/integration (miniflux.app/v2/internal/integration),
+        implemented in internal/integration/integration.go. Its two entry points
+        are SendEntry (integration.go:41) and PushEntries (integration.go:511).
+        PushEntries is invoked exactly once, as "go integration.PushEntries(...)"
+        from RefreshFeed in internal/reader/handler/handler.go:339, after
+        store.RefreshFeedEntries returns new entries and the user has integrations
+        configured. SendEntry is invoked from four call sites, each on its own
+        goroutine: the web UI save handler in internal/ui/entry_save.go:36 and
+        the REST API saveEntryHandler in internal/api/entry_handlers.go:273,
+        both as "go integration.SendEntry(...)"; and the two compatibility
+        APIs, editTagHandler in internal/googlereader/handler.go:314 (for each
+        entry newly starred through the Google Reader API) and
+        handleWriteItems in internal/fever/handler.go:459 (the Fever "saved"
+        mark), both as "go func() { integration.SendEntry(...) }()".
+      verifiedAgainst:
+        - internal/integration/integration.go:41
+        - internal/integration/integration.go:511
+        - internal/reader/handler/handler.go:339
+        - internal/ui/entry_save.go:36
+        - internal/api/entry_handlers.go:273
+        - internal/googlereader/handler.go:314
+        - internal/fever/handler.go:459
+    scoring:
+      method: ground-truth
+
+  - id: mf-comp-worker-pool-retirement
+    family: comprehension
+    prompt: >-
+      Suppose the background worker pool implemented in internal/worker were
+      deleted and nothing could enqueue refresh jobs any more, while everything
+      else stayed as-is. For each of the following operations, state whether it
+      would break or keep working, and cite the file that decides the answer:
+      (a) the periodic background refresh driven by the polling scheduler;
+      (b) "refresh all feeds" from the web UI;
+      (c) refreshing all feeds of one category from the web UI;
+      (d) PUT /v1/feeds/refresh (REST refresh-all);
+      (e) PUT /v1/categories/{categoryID}/refresh (REST category refresh);
+      (f) refreshing a single feed from the web UI;
+      (g) PUT /v1/feeds/{feedID}/refresh (REST single-feed refresh).
+    groundTruth:
+      answer: >-
+        (a)-(e) break: they all build a job batch and push it onto the pool.
+        (a) internal/cli/scheduler.go feedScheduler calls pool.Push(jobs);
+        (b) internal/ui/feed_refresh.go refreshAllFeeds calls go h.pool.Push(jobs);
+        (c) internal/ui/category_refresh.go refreshCategory calls go h.pool.Push(jobs);
+        (d) internal/api/feed_handlers.go refreshAllFeedsHandler calls go h.pool.Push(jobs) (line 97);
+        (e) internal/api/category_handlers.go calls go h.pool.Push(jobs) (line 191).
+        (f) and (g) keep working: single-feed refresh never touches the pool —
+        both call reader/handler RefreshFeed synchronously inside the HTTP
+        request: internal/ui/feed_refresh.go refreshFeed (line 21) and
+        internal/api/feed_handlers.go refreshFeedHandler (line 66).
+      verifiedAgainst:
+        - internal/cli/scheduler.go:36-49
+        - internal/worker/pool.go
+        - internal/ui/feed_refresh.go:21
+        - internal/ui/feed_refresh.go:61
+        - internal/ui/category_refresh.go:58
+        - internal/api/feed_handlers.go:66
+        - internal/api/feed_handlers.go:97
+        - internal/api/category_handlers.go:191
+    scoring:
+      method: ground-truth
+
+  - id: mf-comp-sql-ownership
+    family: comprehension
+    prompt: >-
+      For the Miniflux server: which Go package concentrates the application's
+      SQL data-access queries, which package owns schema migrations and
+      database connection setup, and which database engine or engines does the
+      server support? Name the database driver dependency from go.mod and the
+      file where the connection pool is opened.
+    groundTruth:
+      answer: >-
+        All SQL data-access queries live in internal/storage (feed.go, entry.go,
+        entry_query_builder.go, user.go, batch.go, integration.go, etc.).
+        Schema migrations and connection setup live in internal/database:
+        migrations.go holds the ordered migrations array (schemaVersion =
+        len(migrations)) applied by Migrate in database.go, and postgresql.go
+        opens the connection pool with sql.Open("postgres", dsn) in
+        NewConnectionPool. PostgreSQL is the only supported engine; the sole
+        driver dependency is github.com/lib/pq (go.mod).
+      verifiedAgainst:
+        - internal/storage/feed.go
+        - internal/storage/entry.go
+        - internal/storage/batch.go
+        - internal/database/database.go
+        - internal/database/migrations.go
+        - internal/database/postgresql.go
+        - go.mod:13
+    scoring:
+      method: ground-truth
+
+  # ---------------------------------------------------------------------- change
+  - id: mf-change-async-single-feed-refresh
+    family: change
+    prompt: >-
+      Single-feed refresh over HTTP currently runs the entire fetch/parse/store
+      cycle synchronously inside the request handler in two places: the web UI
+      (refreshFeed in internal/ui/feed_refresh.go) and the REST API
+      (refreshFeedHandler in internal/api/feed_handlers.go). Change both so the
+      refresh is enqueued onto the existing background worker queue instead of
+      running inline: the UI handler enqueues and redirects immediately as it
+      does today; the API handler validates that the feed exists (404 as today
+      when it does not), enqueues, and returns 204 No Content immediately.
+      The web UI's forceRefresh query parameter must keep working end to end,
+      which requires carrying a force-refresh flag on the queued job and
+      honoring it when the worker executes the job; jobs created by the
+      scheduler and by the existing refresh-all/category paths must keep
+      today's non-forced behavior. Reuse the existing job and pool types rather
+      than introducing a parallel mechanism.
+    touches:
+      - internal/ui/feed_refresh.go
+      - internal/api/feed_handlers.go
+      - internal/model/job.go
+      - internal/worker/worker.go
+      - miniflux#web-ui
+      - miniflux#rest-api
+      - miniflux#worker-pool
+    scoring:
+      method: rubric
+      rubric:
+        - Neither internal/ui/feed_refresh.go refreshFeed nor
+          internal/api/feed_handlers.go refreshFeedHandler calls
+          reader/handler.RefreshFeed inline any more; both enqueue a job for
+          the requested feed through the existing worker pool (Pool.Push).
+        - The force-refresh flag travels with the job (model.Job gains a field
+          or equivalent) and internal/worker/worker.go passes it through to
+          RefreshFeed, so a UI request with forceRefresh=true results in a
+          forced refresh when the worker runs the job.
+        - Scheduler, refresh-all, and category-refresh job producers are either
+          untouched or continue to produce non-forced jobs; no call path gains
+          forced refresh that did not have it.
+        - The API handler still returns 404 for a feed that does not belong to
+          the user, before anything is enqueued, and returns 204 immediately on
+          success; the UI handler still redirects to the feed entries page.
+        - No parallel queue, goroutine pool, or duplicate job type is
+          introduced; the change reuses the existing pool and job list types.
+
+  - id: mf-change-per-feed-integration-optout
+    family: change
+    prompt: >-
+      Add a per-feed setting that stops a feed's newly refreshed entries from
+      being pushed to the user's connected third-party services (Wallabag,
+      Telegram, webhooks, and the rest), while leaving manual "save this entry"
+      delivery untouched. Concretely: introduce a boolean feed option (for
+      example "disable_integrations", default false) that (1) is stored on the
+      feeds table via a new schema migration, (2) is part of the feed domain
+      type and of the feed creation and feed modification request payloads
+      accepted by the REST API, including partial updates, (3) is persisted and
+      loaded by the feed data-access code, and (4) is honored during feed
+      refresh: when set, new entries produced by a refresh of that feed must
+      not be dispatched to the user's third-party services. Saving an
+      individual entry by hand must still deliver it regardless of the new
+      option.
+    touches:
+      - internal/database/migrations.go
+      - internal/model/feed.go
+      - internal/storage/feed.go
+      - internal/storage/feed_query_builder.go
+      - internal/reader/handler/handler.go
+      - miniflux#storage
+      - miniflux#feed-pipeline
+      - miniflux#integration-hub
+      - miniflux#rest-api
+    scoring:
+      method: rubric
+      rubric:
+        - A new migration is appended to the migrations array in
+          internal/database/migrations.go adding the column with a false
+          default; no existing migration entry is edited.
+        - internal/model/feed.go carries the field on the Feed struct, on
+          FeedCreationRequest, and on FeedModificationRequest (nullable/pointer
+          so partial updates work), and the modification patch logic applies
+          it.
+        - The feed data-access code includes the new column in both the create
+          and update statements (internal/storage/feed.go) and in the feed row
+          scanning (internal/storage/feed_query_builder.go), so the value
+          round-trips.
+        - In internal/reader/handler/handler.go RefreshFeed, when the option is
+          set on the refreshed feed, integration.PushEntries is not invoked for
+          that feed's new entries; when unset, behavior is unchanged.
+        - The manual save paths (internal/ui/entry_save.go and the REST
+          save-entry handler) still call integration.SendEntry unconditionally;
+          the new option does not gate them.
+
+  # ---------------------------------------------------------- model-maintenance
+  - id: mf-mm-add-metrics-component
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace for this repository
+      (.yarramate/workspace.yaml, with documents under .yarramate/architecture/,
+      evidence under .yarramate/evidence/, projections under
+      .yarramate/projections/, and a LikeC4 adapter mapping under
+      .yarramate/integrations/likec4/) deliberately omitted the Prometheus
+      metrics subsystem. It is now in scope. In the code: internal/metric
+      defines the collectors, the /metrics endpoint is registered in
+      internal/http/server/routes.go behind config.Opts.HasMetricsCollector(),
+      the daemon starts a storage-metrics collector goroutine in
+      internal/cli/daemon.go, and the background workers record refresh
+      durations via internal/metric in internal/worker/worker.go. Update the
+      workspace to declare a metrics collector component: compose it into the
+      miniflux-server concept alongside the other runtime parts, and relate it
+      to at least the worker pool (whose refresh durations it measures) and the
+      storage layer (whose metrics the daemon collector gathers). Keep the
+      whole workspace consistent: extend or add projections as appropriate, and
+      update the LikeC4 subject mapping so both the native check and the LikeC4
+      adapter check pass, with no contradicted claims and no new open catalogue
+      questions left behind.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-density-not-worse
+
+  - id: mf-mm-remove-media-proxy
+    family: model-maintenance
+    prompt: >-
+      Miniflux maintainers have decided to drop the built-in media proxy:
+      internal/mediaproxy will be deleted, its rewriting will be removed from
+      the web UI, and browsers will load external media directly. Update this
+      repository's committed .yarramate workspace
+      (.yarramate/workspace.yaml and the documents it references) to reflect
+      that code-level change: remove the media proxy concept and every
+      relationship that references it, prune it from any projection that
+      renders it and from the evidence document's observations, and update the
+      LikeC4 subject mapping and project views under
+      .yarramate/integrations/likec4/ so that no orphaned mapping entries
+      remain. When you are done, the native workspace check and the LikeC4
+      adapter check must both pass.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass

--- a/docs/research/context-benchmark/tasks/v2/uptime-kuma.yaml
+++ b/docs/research/context-benchmark/tasks/v2/uptime-kuma.yaml
@@ -1,0 +1,342 @@
+# Frozen benchmark task suite — uptime-kuma (headline repository).
+# Authored against commit ca5323c2dd1ed85c8b36b5227d2da6f6c28eeebc; every
+# groundTruth.answer was verified by reading the cited source files in that
+# commit. Code is the authority; the gallery model was used only to select
+# declared components worth targeting.
+#
+# v2 errata against ../uptime-kuma.yaml (frozen; swept 2026-07-29):
+# - uk-mm-notification-worker-split: catalogue-density-not-worse, the additive
+#   form of the gate (see ../../runner/score.mjs). uk-mm-metrics-endpoint-removed
+#   keeps the absolute gate — it only removes concepts, so the count is the
+#   right comparison there.
+# - The four excluded weak-tier refusals came from this repository's upstream
+#   anti-AI CLAUDE.md; the runner now quarantines subject-repo agent config
+#   (runner/agent-config.mjs), so no task text changes for it.
+type: yarramate/benchmark-suite/v2
+suite: uptime-kuma
+headline: true
+repository:
+  name: uptime-kuma
+  source: https://github.com/louislam/uptime-kuma
+  commit: ca5323c2dd1ed85c8b36b5227d2da6f6c28eeebc
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/uptime-kuma
+
+tasks:
+  # ------------------------------------------------------------------
+  # Comprehension
+  # ------------------------------------------------------------------
+  - id: uk-comp-alert-decision-dispatch
+    family: comprehension
+    prompt: >-
+      In this repository, when an actively checked monitor transitions from UP
+      to DOWN, an alert is delivered to the operator's configured channels
+      (Telegram, Slack, email, and so on). Explain the code path with
+      repo-relative file paths: (a) which file and function decide that the
+      heartbeat warrants sending notifications, (b) which file and function
+      resolve the concrete provider implementation that formats and delivers
+      the message for a given channel type, and (c) where the individual
+      per-channel provider implementations live and what contract they
+      implement.
+    groundTruth:
+      answer: >-
+        (a) The per-monitor check loop in server/model/monitor.js decides:
+        after each beat, Monitor.isImportantBeat marks the transition and
+        Monitor.isImportantForNotification (server/model/monitor.js:1420,
+        called at line 968) determines that UP->DOWN warrants notifications;
+        Monitor.sendNotification (server/model/monitor.js:1452) then builds
+        the message and iterates the monitor's configured notification list
+        (re-sends while still DOWN are driven by resendInterval at lines
+        989-1002). (b) Notification.send in server/notification.js (line 238)
+        resolves the provider by looking up notification.type in the
+        providerList registry that Notification.init (line 112) builds at
+        startup. (c) Each channel is a module under
+        server/notification-providers/ (99 modules) whose class extends
+        NotificationProvider (server/notification-providers/notification-provider.js),
+        sets a unique name, and implements send(notification, msg,
+        monitorJSON, heartbeatJSON), returning a success message or throwing
+        on failure.
+      verifiedAgainst:
+        - server/model/monitor.js:961
+        - server/model/monitor.js:1420
+        - server/model/monitor.js:1452
+        - server/notification.js:112
+        - server/notification.js:238
+        - server/notification-providers/notification-provider.js
+    scoring:
+      method: ground-truth
+
+  - id: uk-comp-push-vs-active
+    family: comprehension
+    prompt: >-
+      Push monitors in this repository are passive: an external system calls
+      an HTTP endpoint to report its own liveness instead of being probed.
+      Identify, with repo-relative file paths: (a) the exact route and the
+      file that implements it, (b) how the handler decides whether the
+      resulting heartbeat is UP, PENDING, or DOWN when retries are configured,
+      and (c) whether the handler reuses the periodic check loop that active
+      monitors run through or implements its own path — and, in the latter
+      case, what state it updates before responding (persistence, live
+      dashboard updates, statistics, alerting).
+    groundTruth:
+      answer: >-
+        (a) router.all("/api/push/:pushToken") in server/routers/api-router.js
+        (line 47). (b) A local determineStatus() helper in the same file
+        (lines 576-619) applies upside-down flipping and the
+        maxretries/PENDING escalation against the previous heartbeat.
+        (c) It does not go through the active check loop in
+        server/model/monitor.js — the route handler itself dispenses a
+        heartbeat bean, checks maintenance via Monitor.isUnderMaintenance
+        (forcing MAINTENANCE status), updates the per-monitor UptimeCalculator
+        (line 92), calls Monitor.sendNotification on important transitions and
+        re-sends while DOWN per resendInterval (lines 102-123), stores the
+        heartbeat row (line 125), emits the "heartbeat" Socket.IO event to the
+        owning user's room and pushes aggregate stats via Monitor.sendStats
+        (lines 127-129), and updates Prometheus metrics (line 132) before
+        responding with { ok: true }.
+      verifiedAgainst:
+        - server/routers/api-router.js:47
+        - server/routers/api-router.js:576
+        - server/routers/api-router.js:92
+        - server/routers/api-router.js:125
+        - server/model/monitor.js:1596
+    scoring:
+      method: ground-truth
+
+  - id: uk-comp-uptime-calc-retired
+    family: comprehension
+    prompt: >-
+      Suppose the module server/uptime-calculator.js were retired from this
+      repository without a replacement. Based on what actually imports and
+      calls it, list the user-facing capabilities that would break, naming the
+      consuming file (repo-relative path) responsible for each.
+    groundTruth:
+      answer: >-
+        Breakages by consumer: (1) server/model/monitor.js — the check loop's
+        uptime/response aggregation (uptimeCalculator.update at line 1053) and
+        the live dashboard statistics Monitor.sendStats emits (avgPing and
+        uptime Socket.IO events, lines 1315-1340); (2)
+        server/routers/api-router.js — the public SVG uptime and ping badges
+        (getDataByDuration at lines 257 and 317) and the push endpoint's
+        heartbeat end-time/uptime update (line 92); (3)
+        server/routers/status-page-router.js — the public status page's 24h
+        uptime figures (get24Hour at line 99); (4)
+        server/socket-handlers/chart-socket-handler.js — dashboard chart data
+        (getUptimeCalculator at line 16); (5) server/server.js — the
+        clear-statistics operations (UptimeCalculator.clearStatistics /
+        clearAllStatistics at lines 1683 and 1711); (6) server/database.js —
+        the aggregate-stats migration during database setup (new
+        UptimeCalculator at line 932). server/prometheus.js only references
+        the module's typedef in a comment, so metric export itself does not
+        depend on it at runtime.
+      verifiedAgainst:
+        - server/uptime-calculator.js:72
+        - server/model/monitor.js:1053
+        - server/model/monitor.js:1315
+        - server/routers/api-router.js:257
+        - server/routers/api-router.js:317
+        - server/routers/status-page-router.js:99
+        - server/socket-handlers/chart-socket-handler.js:16
+        - server/server.js:1683
+        - server/database.js:932
+        - server/prometheus.js:147
+    scoring:
+      method: ground-truth
+
+  # ------------------------------------------------------------------
+  # Change
+  # ------------------------------------------------------------------
+  - id: uk-change-add-notification-provider
+    family: change
+    prompt: >-
+      Add a new notification channel named "SimplePost" to this repository.
+      Behaviour: it performs an HTTP POST of the JSON body {"title", "msg",
+      "status"} to a user-configured URL, with an optional user-configured
+      token sent as an Authorization bearer header. Requirements: (1)
+      implement the server-side provider following the existing provider
+      conventions so both alert (DOWN) and recovery (UP) messages are
+      delivered through it; (2) register it so the server can dispatch to it
+      by notification type; (3) add the settings form to the web UI so an
+      operator can create a SimplePost notification from the notification
+      dialog (URL required, token optional). Follow the existing patterns in
+      the codebase and do not modify unrelated providers.
+    touches:
+      - notification-hub
+      - web-app
+      - server/notification.js
+      - server/notification-providers/
+      - src/components/notifications/index.js
+      - src/components/notifications/
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new module under server/notification-providers/ exports a class
+          extending NotificationProvider, sets a unique name, and implements
+          send() performing the POST with the JSON body and the optional
+          Authorization header, following the existing okMsg-on-success /
+          throw-on-failure convention.
+        - >-
+          The provider is imported and instantiated in the provider list
+          inside Notification.init() in server/notification.js, so
+          Notification.send() resolves it by type.
+        - >-
+          A form component is added under src/components/notifications/ and
+          registered in NotificationFormList in
+          src/components/notifications/index.js under a key matching the
+          server-side provider name, making the type selectable in the
+          notification dialog with a required URL input and an optional token
+          input.
+        - >-
+          No unrelated notification providers or monitor code paths are
+          modified.
+
+  - id: uk-change-add-monitor-type
+    family: change
+    prompt: >-
+      Add a new active check type "tcp-banner" to this repository. Behaviour:
+      it opens a TCP connection to a configured hostname and port, reads the
+      first line the remote end sends (the banner), and reports the check as
+      up only if the banner contains a configured keyword; otherwise the check
+      fails with a descriptive error message. Requirements: (1) implement the
+      check following the repository's pluggable check-type conventions; (2)
+      register the type so per-monitor checks of this type are dispatched to
+      your implementation; (3) expose the new type in the monitor edit form,
+      reusing the existing hostname, port, and keyword inputs. Follow the
+      existing patterns and do not modify other check types.
+    touches:
+      - monitor-engine
+      - server-core
+      - web-app
+      - server/monitor-types/
+      - server/uptime-kuma-server.js
+      - src/pages/EditMonitor.vue
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new module under server/monitor-types/ exports a class extending
+          MonitorType with name "tcp-banner" and an async check(monitor,
+          heartbeat, server) that sets heartbeat.status to UP with a message
+          on success and throws a descriptive Error on failure, per the
+          contract in server/monitor-types/monitor-type.js.
+        - >-
+          The type is registered as
+          UptimeKumaServer.monitorTypeList["tcp-banner"] in initMonitorTypes()
+          in server/uptime-kuma-server.js — the dispatch table the check loop
+          consults (server/model/monitor.js line ~871).
+        - >-
+          src/pages/EditMonitor.vue offers "tcp-banner" as a selectable
+          monitor type and shows the hostname, port, and keyword inputs for
+          it; the forms of other types are unchanged.
+        - >-
+          No existing check-type modules are modified.
+
+  - id: uk-change-skip-recovery-notification
+    family: change
+    prompt: >-
+      Add a per-monitor setting "Skip recovery notifications" to this
+      repository. When enabled for a monitor, DOWN alerts are still sent, but
+      the recovery (DOWN to UP) notification is suppressed for that monitor —
+      for both actively checked monitors and passive push monitors.
+      Requirements: (1) persist the setting on the monitor record with a
+      schema migration following the repository's migration conventions,
+      defaulting to off; (2) enforce the suppression wherever up/down
+      notifications are dispatched, without affecting DOWN alerts or the
+      still-down re-send behaviour; (3) expose a checkbox for the setting in
+      the monitor edit form; (4) ensure the setting round-trips through
+      monitor create and edit.
+    touches:
+      - monitor-engine
+      - server-core
+      - web-app
+      - monitor-config
+      - db/knex_migrations/
+      - server/model/monitor.js
+      - server/server.js
+      - src/pages/EditMonitor.vue
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new migration file under db/knex_migrations/ adds a boolean column
+          (defaulting to false/0) to the monitor table, matching the naming
+          and up/down structure of the existing migrations (e.g.
+          2025-09-02-0000-add-domain-expiry.js).
+        - >-
+          The guard is enforced on the shared dispatch path (e.g. in
+          Monitor.sendNotification or at its call sites in
+          server/model/monitor.js) such that UP-recovery notifications are
+          skipped when the flag is set while UP->DOWN alerts and
+          resendInterval re-sends still fire; because the push route in
+          server/routers/api-router.js also calls Monitor.sendNotification,
+          push monitors honour the same behaviour.
+        - >-
+          The field is included in Monitor.toJSON in server/model/monitor.js
+          and copied from the client payload in both the "add" and
+          "editMonitor" socket handlers in server/server.js, so it round-trips
+          through create and edit.
+        - >-
+          src/pages/EditMonitor.vue renders the checkbox, defaulting to
+          unchecked, and no unrelated monitor settings change behaviour.
+
+  # ------------------------------------------------------------------
+  # Model maintenance
+  # ------------------------------------------------------------------
+  - id: uk-mm-metrics-endpoint-removed
+    family: model-maintenance
+    prompt: >-
+      Scenario — assume this change has landed in the repository: the
+      Prometheus integration has been removed entirely. The
+      app.get("/metrics", apiAuth, ...) route is gone from server/server.js,
+      server/prometheus.js is deleted, and the prometheus-api-metrics
+      dependency has been dropped; no metrics endpoint exists any more.
+      Update the repository's committed .yarramate workspace
+      (.yarramate/workspace.yaml and the documents it references: the
+      architecture document, the evidence document, and the LikeC4 integration
+      mapping under .yarramate/integrations/likec4/) so it accurately reflects
+      the repository after this change. In particular, the metrics-scraper
+      concept and the core-serves-scraper relationship no longer describe
+      anything real, and evidence observations citing the /metrics endpoint
+      must not survive unchanged. Deliver an updated workspace that passes
+      `yarramate check` with no contradicted evidence results, and keep the
+      LikeC4 mapping consistent with the model so `yarramate-likec4 check`
+      passes.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-not-worse
+
+  - id: uk-mm-notification-worker-split
+    family: model-maintenance
+    prompt: >-
+      Scenario — assume this change has landed in the repository: notification
+      dispatch has been extracted out of the main server process. A new
+      entrypoint server/notification-worker.js runs as a second Node.js
+      process inside the same container, started by the container command
+      alongside server/server.js. The monitor engine no longer calls
+      Notification.send in-process; instead it enqueues dispatch requests into
+      a new notification_queue table in the application database, which the
+      worker polls and delivers through the existing provider modules under
+      server/notification-providers/. Update the repository's committed
+      .yarramate workspace (.yarramate/workspace.yaml and the documents it
+      references) to reflect this: the notification hub's process/deployment
+      placement inside the Docker runtime, the engine-to-hub interaction
+      becoming queue-mediated through the application database, and the new
+      queued dispatch-request data. Adjust evidence observations that the
+      scenario invalidates and keep the LikeC4 mapping in sync with the
+      revised concepts and relationships. Deliver an updated workspace that
+      passes `yarramate check` with no contradicted evidence results and a
+      passing `yarramate-likec4 check`.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - no-contradicted
+          - likec4-check-pass
+          - catalogue-density-not-worse

--- a/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
+++ b/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
@@ -1,13 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://yarrasys.github.io/yarramate/research/yarramate-benchmark-suite.schema.json",
-  "title": "yarramate/benchmark-suite/v1 (research draft)",
+  "title": "yarramate/benchmark-suite v1-v2 (research draft)",
   "description": "Frozen task suite for one benchmark repository. Draft research artifact; not a normative contract.",
   "type": "object",
   "additionalProperties": false,
   "required": ["type", "suite", "headline", "repository", "tasks"],
   "properties": {
-    "type": { "const": "yarramate/benchmark-suite/v1" },
+    "type": {
+      "enum": ["yarramate/benchmark-suite/v1", "yarramate/benchmark-suite/v2"],
+      "description": "Suite version. Suites are frozen at merge: errata land as a new file at the next version, never as an edit to a version that has been swept."
+    },
     "suite": { "$ref": "#/$defs/slug" },
     "headline": {
       "type": "boolean",
@@ -88,7 +91,8 @@
                 "expect": {
                   "type": "array",
                   "minItems": 1,
-                  "items": { "enum": ["check-pass", "no-contradicted", "catalogue-not-worse", "likec4-check-pass"] }
+                  "items": { "enum": ["check-pass", "no-contradicted", "catalogue-not-worse", "catalogue-density-not-worse", "likec4-check-pass"] },
+                  "description": "catalogue-not-worse compares absolute open-question counts and only suits tasks that do not add concepts; catalogue-density-not-worse compares open questions per concept and is the additive-task form."
                 }
               }
             },


### PR DESCRIPTION
Harness defects and frozen-suite errata surfaced by the 2026-07-29 sweep (164 runs, [published results](https://github.com/yarrasys/yarramate-bench-results)). Everything is under `docs/research/context-benchmark/`; nothing in `src/`, `schema/`, or `.yarramate/` is touched.

## Harness fixes

- **Subject-repo agent config is quarantined.** Coding harnesses auto-load instruction files the subject repository ships, and tiers obey them unequally — uptime-kuma's upstream anti-AI `CLAUDE.md` cost the weak tier four one-turn refusals and the strong tier none. `runner/agent-config.mjs` moves `AGENTS.md`, `AGENT.md`, `CLAUDE.md`, `CLAUDE.local.md`, `.claude/` and `.mcp.json` — at any depth — to `<runDir>/.benchmark-quarantined/`, i.e. outside the workdir, so the agent cannot read them either. The run record carries `agentConfig: { policy, neutralized }`.
- **The override is explicit.** `--keep-subject-agent-config` keeps the subject's files as a documented realism choice; the record then reads `policy: "keep"`.
- **Ordering is pinned by test.** Conditions B and C deliberately place YarraMate's *own* pointer into `AGENTS.md` and `CLAUDE.md` (ADR 0045), the same names quarantine strips. Quarantine runs first, pointer placement second; `runner/agent-config.test.mjs` asserts both that the subject's files are gone and that the placed pointer is the whole content of those files afterwards. The runner also now replicates whatever delivery list the pinned toolchain's `init` produced, instead of hardcoding `AGENTS.md`.
- **Diff capture sees added and committed work.** The runner records `baselineCommit`; `score.mjs` runs `git add -A` and diffs the index against it, writing `<runDir>/diff.patch` for every run and feeding the same staged diff to the wrong-file metric. Previously `git diff --name-only HEAD` saw neither the new modules add-provider tasks create nor the two httpie runs that committed their work. Records from the published sweep, which predate `baselineCommit`, resolve the baseline by its commit message so they can be re-scored correctly.
- **Degenerate runs are flagged.** Change and model-maintenance runs finishing in fewer than three turns are marked `degenerate` in the run record, in `scores.jsonl`, in the adjudication queue, and on the scorer's console.

## Suite v2 errata

v1 files are **byte-untouched** (`git diff` over `tasks/*.yaml` is empty). Errata land in `tasks/v2/` at `type: yarramate/benchmark-suite/v2`; each file's header lists its own errata. `yarramate-self.yaml` has no v2 because no erratum applies to it.

- `mf-comp-integration-dispatch` — four `SendEntry` call sites, not two. ✅ Both new line numbers verified against the pinned commit `c4d54f8`: `internal/googlereader/handler.go:314` is in `editTagHandler`, `internal/fever/handler.go:459` is in `handleWriteItems`. Both wrap the call as `go func() { integration.SendEntry(...) }()`, unlike the two originally listed sites; the answer says so.
- `mf-change-per-feed-integration-optout` — `touches` gains `internal/storage/feed_query_builder.go` (the feed row `rows.Scan` is at line 224 there). Its rubric named `internal/storage/feed.go` for row scanning, the same erratum in a second place, so that item now names both files. Flagging this as slightly beyond the literal erratum: leaving it would have kept misdirecting the adjudicator.
- `ff-ctp-remove-unknown-error` — `touches` gains `test/internals/errors.test.js`, which pins `expectedErrors = 94` at the pinned commit.

### `catalogue-not-worse`: recalibrated, not dropped

The gate is miscalibrated, not wrong-headed. `evaluate-catalogue.mjs` counts subject-scoped questions **once per matching subject**, so declaring the concept an additive task asks for mechanically opens more of them — and at least one of those, `owner-missing`, is `authority: human` and cannot honestly be closed for a third-party OSS repository at all. The absolute gate therefore made "do what the task asks" strictly worse than "do nothing", on miniflux, fastify and httpie.

Dropping it loses a real signal (a bare, unenriched concept drop should still fail). So v2 additive tasks use a new expectation, **`catalogue-density-not-worse`**: open questions *per concept*, compared by integer cross-multiplication. Its properties are why it is the defensible choice:

- it degenerates to the absolute gate when concept count is unchanged, so it is a strict generalization;
- an addition passes only if it is enriched at least as well as the average concept already in the model — for a fully-enriched gallery model that still means zero new open questions;
- a bare unenriched drop still fails.

Subtractive tasks keep `catalogue-not-worse`: removing a well-enriched concept *raises* density, so the absolute count is the right comparison there. `uk-mm-metrics-endpoint-removed` is the only such task and keeps the old gate. Crucially, `catalogue-not-worse` semantics are unchanged, so the published v1 sweep stays re-scorable — that is why this is a new expectation name rather than a redefinition.

## Test plan

- [x] `node runner/validate-suite.mjs yarramate-benchmark-suite.schema.json tasks/*.yaml tasks/v2/*.yaml` — all 9 suites ok, run from the repo root as well as from the benchmark directory.
- [x] `node --test 'runner/*.test.mjs'` — 4/4 pass (quarantine coverage, quarantine-before-pointer ordering, ordering-is-load-bearing, empty-repo no-op).
- [x] End-to-end run of `run-benchmark.mjs` + `score.mjs` against a synthetic local subject repo with a fake harness that adds an untracked file, edits a tracked one, **and commits**: legacy `git diff --name-only HEAD` returns empty; the new capture lists all three files and writes a populated `diff.patch`. Quarantine moved all four planted config paths and preserved them outside the workdir; `degenerate` is `true` for the 2-turn change runs and `false` for comprehension.
- [x] `--keep-subject-agent-config` run: `policy: "keep"`, `neutralized: null`, subject `CLAUDE.md` still in the workdir, no quarantine directory.
- [x] `rm -rf dist && pnpm verify` — exit code **0** (267 tests, self-check, likec4 validate).
- [x] `git diff` over `tasks/*.yaml` is empty — v1 suites byte-untouched.

## Remaining on #56

The issue stays open. Not done here:

- **Harder comprehension tasks.** The comprehension family is saturated at both tiers on all four repositories, so H1 is not measurable from it. New multi-hop, cross-component tasks need authoring against the subject repos at their pinned commits — fresh task authoring, not errata, and out of scope for this PR. Noted in the README's "Suite versions" section.
- **Fifth repository for pooled N ≥ 5** — unchanged, still blocked on the gallery.
- **Re-run on v0.5.0** to measure whether harness-aware pointer delivery moves weak-tier workspace engagement.

Also worth a second opinion, not changed here: `mf-comp-integration-dispatch`'s prompt describes the `SendEntry` path as "when a user saves a single entry from the web UI or from the REST API", while the corrected ground truth includes the Google Reader and Fever compatibility handlers. It asks for *every* call site so the task is answerable as written, but the parenthetical under-describes the answer. Left byte-identical to v1 to keep the task comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
