### PR TITLE
Offer the canonical skill through a self-hosted plugin marketplace (ADR 0052)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "yarramate",
+  "description": "The canonical YarraMate architecture skill, distributed from the repository that owns it.",
+  "owner": {
+    "name": "YarraMate contributors",
+    "url": "https://github.com/yarrasys/yarramate"
+  },
+  "plugins": [
+    {
+      "name": "yarramate-architecture",
+      "source": "./skills/yarramate-architecture",
+      "description": "Discover, design, or maintain repository architecture using native YarraMate documents and the stable CLI.",
+      "homepage": "https://github.com/yarrasys/yarramate",
+      "repository": "https://github.com/yarrasys/yarramate",
+      "license": "MIT"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ src/                 compiler, CLI, graph, and adapter sources
 schema/              normative JSON Schemas
 test/                tests and acceptance fixtures
 skills/              portable architecture workflow for agent harnesses
+.claude-plugin/      plugin marketplace manifest offering that skill
 docs/                contracts, guides, and decisions
 .yarramate/          canonical dogfooded architecture
 .yarramate-out/      reproducible generated output (ignored)
@@ -139,6 +140,13 @@ yarramate --help
 
 See [Consuming YarraMate](docs/CONSUMING-YARRAMATE.md) for the packaged CLI,
 schemas, agent skill, and optional adapters.
+
+In Claude Code, this repository is its own plugin marketplace:
+
+```sh
+/plugin marketplace add yarrasys/yarramate
+/plugin install yarramate-architecture@yarramate
+```
 
 ## Library API
 

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -63,7 +63,19 @@ self-model, source, tests, and fixtures.
 
 ## Install the agent skill
 
-After the repository is public, use the agent-skills installer:
+For Claude Code, the repository is its own plugin marketplace:
+
+```sh
+/plugin marketplace add yarrasys/yarramate
+/plugin install yarramate-architecture@yarramate
+```
+
+The marketplace entry points at `skills/yarramate-architecture` in this
+repository, so the installed plugin is the canonical skill rather than a
+copy. It declares no version, taking its version from the commit it was
+installed from.
+
+For other harnesses, use the agent-skills installer:
 
 ```sh
 npx skills add yarrasys/yarramate --skill yarramate-architecture

--- a/docs/adr/0052-the-repository-is-its-own-plugin-marketplace.md
+++ b/docs/adr/0052-the-repository-is-its-own-plugin-marketplace.md
@@ -1,0 +1,25 @@
+# The repository is its own plugin marketplace
+
+Status: accepted
+
+Distributing the canonical agent skill to Claude Code was tracked as work
+blocked on creating a separate organisation registry repository. That premise
+was wrong: a marketplace manifest may live in the repository that owns the
+plugin, so no second repository, account, or publication step is required.
+
+`.claude-plugin/marketplace.json` therefore ships here, and its single plugin
+entry points at `skills/yarramate-architecture` — the same directory the npm
+package ships and the same one the repository edits. A consumer installs the
+canonical skill, never a fork or a copy, and the existing `npx skills add`
+path for other harnesses is unchanged.
+
+The marketplace is named `yarramate` rather than something organisation-wide.
+A user may register only one marketplace per name, so claiming a broader name
+from inside one product's repository would collide with any future registry
+that legitimately wanted it.
+
+The entry declares no `version`, so the marketplace versions it by commit.
+A hand-maintained version here would be a second source of truth for
+something `package.json` already states, and this repository has already
+shipped one stale duplicated version constant. Consumers who need a fixed
+version install from a tag.

--- a/test/plugin-marketplace.test.ts
+++ b/test/plugin-marketplace.test.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+interface MarketplaceManifest {
+  readonly name: string
+  readonly description?: string
+  readonly owner: { readonly name: string; readonly url?: string }
+  readonly plugins: readonly {
+    readonly name: string
+    readonly source: string
+    readonly description?: string
+    readonly version?: string
+  }[]
+}
+
+const manifest = JSON.parse(
+  readFileSync(
+    join(repositoryRoot, '.claude-plugin/marketplace.json'),
+    'utf8',
+  ),
+) as MarketplaceManifest
+
+const frontmatter = (source: string): Record<string, string> => {
+  const match = /^---\n([\s\S]*?)\n---/.exec(source)
+  if (match === null) return {}
+  const entries = match[1]!.split('\n').flatMap((line) => {
+    const separator = line.indexOf(':')
+    return separator <= 0
+      ? []
+      : [
+          [
+            line.slice(0, separator).trim(),
+            line.slice(separator + 1).trim(),
+          ] as const,
+        ]
+  })
+  return Object.fromEntries(entries)
+}
+
+describe('plugin marketplace manifest', () => {
+  it('declares a collision-safe marketplace identity', () => {
+    expect(manifest.name).toBe('yarramate')
+    expect(manifest.name).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+    expect(manifest.description).toBeTruthy()
+    expect(manifest.owner.name).toBeTruthy()
+  })
+
+  it('offers the canonical skill as its only plugin', () => {
+    expect(manifest.plugins).toHaveLength(1)
+    const plugin = manifest.plugins[0]!
+    expect(plugin.name).toBe('yarramate-architecture')
+    expect(plugin.source).toBe('./skills/yarramate-architecture')
+  })
+
+  it('resolves every plugin source to a directory holding a skill', () => {
+    for (const plugin of manifest.plugins) {
+      const directory = resolve(repositoryRoot, plugin.source)
+      expect(existsSync(directory), `${plugin.source} exists`).toBe(true)
+      expect(
+        existsSync(join(directory, 'SKILL.md')),
+        `${plugin.source}/SKILL.md exists`,
+      ).toBe(true)
+    }
+  })
+
+  it('keeps the plugin entry consistent with the skill it points at', () => {
+    const plugin = manifest.plugins[0]!
+    const skill = frontmatter(
+      readFileSync(
+        resolve(repositoryRoot, plugin.source, 'SKILL.md'),
+        'utf8',
+      ),
+    )
+    expect(skill.name).toBe(plugin.name)
+    // The listing is browse copy for a human; the skill description is the
+    // trigger text a model matches against, so the listing may be shorter.
+    // Requiring it to open the skill description keeps it a faithful
+    // summary that cannot contradict what gets installed.
+    expect(plugin.description).toBeTruthy()
+    expect(skill.description).toMatch(
+      new RegExp(
+        `^${plugin.description!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+      ),
+    )
+  })
+
+  it('ships the plugin source inside the published package', () => {
+    const packageManifest = JSON.parse(
+      readFileSync(join(repositoryRoot, 'package.json'), 'utf8'),
+    ) as { readonly files: readonly string[] }
+    for (const plugin of manifest.plugins) {
+      const packaged = plugin.source.replace(/^\.\//, '')
+      expect(packageManifest.files).toContain(packaged)
+    }
+  })
+
+  it('carries no hand-maintained version to drift from the release', () => {
+    // Omitting version lets the marketplace auto-version by commit, so the
+    // manifest cannot go stale the way a duplicated constant would.
+    for (const plugin of manifest.plugins) {
+      expect(plugin.version).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Delivers backlog task #8 (skill marketplace distribution). 🔑 **The blocker was a false premise, not a missing account.** This was tracked as needing a separate `yarrasys` registry repository; it does not. A plugin marketplace manifest can live in the repository that owns the plugin, so no second repo, org account, or publication step is required — #8 was never actually blocked on anything external.

- `.claude-plugin/marketplace.json` declares one plugin whose `source` is `./skills/yarramate-architecture` — the same directory the npm package ships and the repository edits. Consumers install the **canonical** skill, not a fork or copy.
- The existing `npx skills add` path for other harnesses is unchanged; this is additive.

```sh
/plugin marketplace add yarrasys/yarramate
/plugin install yarramate-architecture@yarramate
```

## Two decisions worth reviewing (ADR 0052)

- **Marketplace named `yarramate`, not something org-wide.** A user may register only one marketplace per name, so claiming a broad name from inside one product's repo would collide with any future registry that legitimately wants it.
- **No `version` declared**, so the marketplace versions by commit. A hand-maintained version here would be a second source of truth for what `package.json` already states — and this repo has already shipped one stale duplicated version constant (the MCP `serverInfo.version` fixed in #59). Consumers needing a fixed version install from a tag.

## Verification
Not just validated — **installed end to end**, then the local marketplace was removed so no environment state leaks:

```
claude plugin validate . --strict     -> exit 0
claude plugin marketplace add <repo>  -> Successfully added marketplace: yarramate
claude plugin install ...@yarramate   -> Successfully installed
claude plugin details ...             -> Skills (1) yarramate-architecture
                                         always-on ~158 tok, on-invoke ~3.9k
```

## Test plan
- [x] New `test/plugin-marketplace.test.ts` (6 tests) pins what would otherwise rot: source path resolves to a directory containing `SKILL.md`; plugin name matches the skill's frontmatter `name`; the listing description opens the skill description so it cannot contradict what installs; the source is present in `package.json` `files`; no hand-maintained `version`.
- [x] `rm -rf dist && pnpm verify` exit 0 — 279 tests / 28 files.
- [x] `claude plugin validate . --strict` exit 0 (warnings-as-errors clean).

One note: the test initially asserted the listing description equal the skill description and failed. That was the *test's* invariant being wrong, not the manifest — the skill description is 450-char model-facing trigger text, which is poor browse copy. The assertion is now "listing must be a faithful prefix," which forbids contradiction without forcing duplication.

Also fixes a stale line in `CONSUMING-YARRAMATE.md` that still said "After the repository is public" — it is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)