### PR TITLE
Adopt the product thesis: prose is the interface, structure is the guarantee (ADR 0054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 [![CodeQL](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml/badge.svg)](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml)
 [![license: MIT](https://img.shields.io/github/license/yarrasys/yarramate)](LICENSE)
 
-YarraMate is a tool-neutral semantic architecture engine and guided
-methodology. It turns architectural intent into deterministic, testable
-context shared by people and agents.
+YarraMate keeps your coding agents' architecture context correct. Declare
+the design once, as a checked model in git; agents receive prose rendered
+from it — bounded briefs and open design questions — and the CLI
+mechanically proves the model still matches the code as changes land.
+
+Prose is the interface; structure is the guarantee: every sentence an agent
+reads stands on a graph whose names resolve, whose drift is detected, and
+whose gaps are found deterministically.
 
 > YarraMate is pre-release software. Interfaces may evolve before the first
 > stable release.

--- a/docs/adr/0054-prose-is-the-interface-structure-is-the-guarantee.md
+++ b/docs/adr/0054-prose-is-the-interface-structure-is-the-guarantee.md
@@ -1,0 +1,38 @@
+# Prose is the interface, structure is the guarantee
+
+Status: accepted
+
+Two observations forced a decision about what the model is for. First, the
+engine verifies wiring, never words: a requirement whose description asserts
+the opposite of the truth still passes `check`, while a single dangling
+reference fails with a file and line. The guarantees stop exactly where prose
+meaning begins. Second, real usage showed agents neither authored nor read
+the model willingly — bulk YAML beat the validated writes, rendered context
+went unused during implementation, and when the vocabulary resisted, agents
+smuggled meaning through free-text descriptions. Structured YAML is the form
+language models handle worst; prose is the form they handle best.
+
+The decision: the model is the substrate, not the surface. People and agents
+interact in prose — design conversations in, interview questions and
+implementation briefs out — and every rendered sentence stands on a checked
+graph, so names are real, references resolve, drift is detected, and the
+same truth reaches every consumer. What structure alone can hold — identity,
+referential integrity, reconciliation against code, bounded slicing,
+deterministic gap detection — is the guarantee. What prose alone can hold —
+meaning, nuance, rules, taste — is the interface. Neither is asked to do
+the other's job.
+
+Both directions of the interface follow. Inbound, `interrogate` (ADR 0053)
+drives the design conversation: deterministic detection of what the model
+has not answered, rendered as prose questions with their materiality, with
+answers structured back through validated writes and Git review. Outbound,
+projections must render as genuine briefs — prose a task agent reads as a
+colleague's handover, not an id digest. The budgeted context rendering is
+the seam; its quality is now core product surface rather than an
+afterthought, precisely because it was the half nobody used.
+
+This retires the implication that agents should live inside the YAML. The
+authoring surface remains for the structuring step and for humans at the Git
+boundary, but the product is judged by the prose it emits and the guarantees
+behind it — and its experiments must therefore hold format constant and vary
+only whether a verified structure stands behind the words.


### PR DESCRIPTION
## Summary
Records the thesis as ADR 0054 and applies it to the README opening.

- **The decision**: the model is the substrate, not the surface. Agents and people interact in prose — interview questions and design conversations inbound, implementation briefs outbound — and every rendered sentence stands on a checked graph. Structure holds what only structure can (identity, referential integrity, reconciliation, slicing, gap detection); prose holds what only prose can (meaning, nuance, rules).
- **Grounded in two findings**: the wiring-vs-words demonstration (content corruption passes `check`; a typo'd reference fails with file:line), and real usage where agents neither authored nor read the model willingly.
- **Consequences named in the ADR**: `interrogate` is the shipped inbound half (ADR 0053); the outbound brief renderer becomes core product surface (filed as a follow-up issue); experiments hold format constant.
- README now opens with the agent framing rather than "semantic architecture engine" — applying the positioning decision from 2026-07-29 that was never executed.

## Test plan
- [x] `rm -rf dist && pnpm verify` exit 0 — docs/README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)