### PR TITLE
Tell agents not to read the catalogue: the interrogation report is self-contained

### DIFF
--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -116,7 +116,10 @@ yarramate interrogate catalogues/core-enrichment.yaml .yarramate/workspace.yaml
 ```
 
    (Resolve the shipped catalogue from the installed package when the
-   consuming repository has no catalogue of its own.) Work the open questions
+   consuming repository has no catalogue of its own.) Do not open the
+   catalogue file itself: the interrogation report is self-contained —
+   question text, materiality, and authority all appear in the output, so
+   reading the catalogue only spends context. Work the open questions
    wave by wave — motivation before business before hygiene. Answer questions
    the evidence can answer; ask the human the ones marked `human`, quoting the
    question and its materiality. Re-run after every batch of answers: a


### PR DESCRIPTION
One-sentence skill fix from the combined-arm token accounting (ELICITATION-PILOT-2026-07-31.md addendum): agents read the shipped catalogue (~2.5k tokens) that `interrogate` reads for them, and everything an agent acts on — question text, materiality, authority — is already in the report. Docs read early in an agent loop are re-billed on every subsequent turn, so this is the cheapest available cut to the loop cost.

Part of the loop-cost cluster: #92 (one-call verdict), #93 (batch validated writes), #89 (agent card / kinds roster).

`rm -rf dist && pnpm verify` green from clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)