### PR TITLE
Build the spec-build family: frozen delta, arm prompts, and runner

### DIFF
--- a/docs/research/context-benchmark/DESIGN-HANDOFF-FAMILY.md
+++ b/docs/research/context-benchmark/DESIGN-HANDOFF-FAMILY.md
@@ -1,7 +1,9 @@
 # Testing YarraMate on building something new (draft)
 
-Status: **settled design (decisions recorded 2026-07-31). Nothing built
-yet — the harness is the next step.**
+Status: **settled design (decisions recorded 2026-07-31), harness
+built.** The frozen spec delta, its acceptance tests, the arm prompts,
+and the runner live in [`spec-build/`](spec-build/); execution starts
+from [`spec-build/RUNBOOK.md`](spec-build/RUNBOOK.md).
 
 ## Two deliverables, deliberately kept apart
 

--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -9,6 +9,7 @@ context-benchmark/
   DESIGN.md                              # frozen protocol: hypotheses, conditions, metrics
   DESIGN-HANDOFF-FAMILY.md               # settled design: building from a published spec (H4-H6)
   ELICITATION-PILOT-2026-07-31.md        # pilot: freehand vs interrogate across 3 tiers (8 runs)
+  spec-build/                            # H4-H6 executable family: frozen delta + prompts + runner
   yarramate-benchmark-suite.schema.json  # draft schema for yarramate/benchmark-suite v1-v2
   tasks/                                 # frozen task suites, one per repository
     v2/                                  # errata-corrected suites (see "Suite versions")

--- a/docs/research/context-benchmark/spec-build/README.md
+++ b/docs/research/context-benchmark/spec-build/README.md
@@ -1,0 +1,29 @@
+# Spec-build experiment family
+
+The executable half of `../DESIGN-HANDOFF-FAMILY.md` (pre-registered
+2026-07-31): build RealWorld/Conduit from its published spec plus a
+frozen novel delta, comparing a design-document handoff (arm A), briefs
+rendered from a checked YarraMate model (arm B), and briefs from the
+same model with injected lies (arm C).
+
+```text
+spec-build/
+  SPEC-DELTA.md        # FROZEN: the three novel requirements + pinned base spec
+  delta-hurl/          # FROZEN: their acceptance tests (upstream Hurl conventions)
+  prompts/             # FROZEN: designer-A/B, implementer, extension prompts
+  RUNBOOK.md           # how to execute a run matrix
+  runner/
+    lib.mjs            # shared plumbing (spec cache, harness, records)
+    run-design.mjs     # design phase, arms A and B
+    derive-arm-c.mjs   # arm C = B's workspace + inject-lies + re-render
+    render-briefs.mjs  # mechanical handoff: context --brief per slice
+    inject-lies.mjs    # same-kind endpoint rotation, check must stay green
+    run-build.mjs      # build phase + gate + promise scoring
+    conformance.mjs    # run.sh lifecycle + upstream & delta Hurl suites
+    score-promises.mjs # declared-name floor + DEVIATIONS.md
+    convergence.mjs    # pairwise Jaccard across repeat runs
+    reference-stub.mjs # test-the-tests fixture (never an arm artifact)
+```
+
+Frozen files must not change once runs begin; the runner is operational
+and patchable with patches recorded alongside results.

--- a/docs/research/context-benchmark/spec-build/RUNBOOK.md
+++ b/docs/research/context-benchmark/spec-build/RUNBOOK.md
@@ -1,0 +1,94 @@
+# Spec-build family: runbook
+
+Executes the experiment pre-registered in `../DESIGN-HANDOFF-FAMILY.md`.
+The spec delta and its acceptance tests (`SPEC-DELTA.md`, `delta-hurl/`)
+are frozen; this runbook and the runner are operational and may be
+patched, with patches recorded in the results directory.
+
+## Prerequisites
+
+- `hurl` ≥ 6 (`brew install hurl`) — conformance runner
+- `claude` CLI (or any harness command that reads the prompt on stdin,
+  runs in the workdir, and prints `claude -p --output-format json`-shaped
+  JSON to stdout)
+- a **pinned toolchain**: `npm install` the exact yarramate build under
+  test into a scratch prefix; pass its `node_modules/.bin` as
+  `--toolchain`. The brief renderer (`context --brief`, ADR 0055) must be
+  present. Record the package version/commit in the results directory.
+- network on first run (the runner clones the pinned RealWorld commit
+  into `<out>/cache`)
+
+Self-test without spending tokens (the reference stub is a
+test-the-tests fixture only — never an arm artifact):
+
+```sh
+cd docs/research/context-benchmark/spec-build
+PORT=3971 node runner/reference-stub.mjs &
+hurl --test --jobs 1 --variable host=http://localhost:3971 \
+  --variable uid=smoke$$ delta-hurl/*.hurl
+kill %1
+```
+
+## Phases (per run number N ∈ {1,2,3})
+
+```sh
+cd docs/research/context-benchmark/spec-build/runner
+OUT=<results-dir>; TC=<toolchain-bins>; TIER='claude -p --model <model> --output-format json'
+
+# 1. Design phase (A and B are agent runs; C is derived, no agent)
+node run-design.mjs --arm A --run N --out $OUT --harness "$TIER"
+node run-design.mjs --arm B --run N --out $OUT --toolchain $TC --harness "$TIER"
+node derive-arm-c.mjs   --run N --out $OUT --toolchain $TC
+
+# 2. Build phase (fresh implementer agents; C's run N builds from B's
+#    lie-injected run N — the pre-registered mapping)
+node run-build.mjs --arm A --run N --out $OUT --harness "$TIER"
+node run-build.mjs --arm B --run N --out $OUT --toolchain $TC --harness "$TIER"
+node run-build.mjs --arm C --run N --out $OUT --toolchain $TC --harness "$TIER"
+
+# 3. Scoring (deterministic floor; human adjudication on top, per the
+#    no-LLM-judging rule)
+node convergence.mjs --mode names --runs $OUT/design/A/run-1 $OUT/design/A/run-2 $OUT/design/A/run-3
+node convergence.mjs --mode names --runs $OUT/design/B/run-1 $OUT/design/B/run-2 $OUT/design/B/run-3
+node convergence.mjs --mode files --runs $OUT/build/A/run-1 $OUT/build/A/run-2 $OUT/build/A/run-3
+node convergence.mjs --mode files --runs $OUT/build/B/run-1 $OUT/build/B/run-2 $OUT/build/B/run-3
+```
+
+Every run appends one record to `$OUT/runs.jsonl` (phase, arm, run,
+metrics, gate, promise scores). `--dry-run` on the two agent runners
+prints the plan without materializing or spending anything.
+
+## The gate and the scores
+
+- **Gate**: `conformance.mjs` — upstream Hurl suite AND delta suite must
+  pass against the implementation's `run.sh`. Failing runs are excluded,
+  never ranked. Applied automatically by `run-build.mjs`; re-run
+  manually with `--suites upstream,delta` to reproduce.
+- **Promise-keeping floor**: `score-promises.mjs` — declared component
+  names (A: `## Components` bullets; B/C: planned concepts) found or
+  missing in the implementation, plus `DEVIATIONS.md` count. Boundary
+  violations beyond naming need human adjudication; the scorer never
+  claims more than name presence.
+- **Convergence**: pairwise Jaccard across an arm's repeat runs. The
+  pre-registered guard: if arm A converges as strongly as B, the spec is
+  forcing the structure and the metric is uninformative for this task.
+- **Cost**: turns/tokens/USD per run from the harness JSON, in
+  `runs.jsonl`.
+
+## Order of operations and blinding
+
+- Design runs before any build run; a build run only ever sees
+  `spec/` + `handoff/`.
+- Implementers and designers are separate agent sessions; implementer
+  prompts never mention YarraMate, arms, or the experiment.
+- Arm C derives from arm B **after** B's design run completes and before
+  any build run of either; `lies.json` records the injected rotations.
+- Pilot before the full family: run N=1 across all three arms
+  (~$20–30) and inspect every artifact before committing to N=2,3.
+
+## Extension phase (optional, after the main family)
+
+`prompts/extension.md` (tag subscription) extends a finished build with
+a fresh agent. Its acceptance tests are **not yet frozen** — freeze them
+in `extension-hurl/` before running that phase, same discipline as the
+delta.

--- a/docs/research/context-benchmark/spec-build/SPEC-DELTA.md
+++ b/docs/research/context-benchmark/spec-build/SPEC-DELTA.md
@@ -1,0 +1,134 @@
+# Spec delta (pre-registered 2026-07-31)
+
+Status: **frozen before any run.** This file, and the Hurl acceptance
+tests beside it, must be on `main` before the first design-phase agent
+starts. Editing either after runs begin invalidates the affected runs.
+
+## Why a delta exists
+
+The base spec is RealWorld/Conduit, pinned:
+
+- repository: `https://github.com/gothinkster/realworld`
+- commit: `98f29fb3f8bcb1dd614b91f2851371bf22c34775`
+- spec: `specs/api/openapi.yml`
+- conformance suite: `specs/api/hurl/*.hurl` (Hurl files are upstream's
+  source of truth)
+
+Hundreds of public Conduit implementations exist, so an agent may recall
+one wholesale. Recall bites hardest on the standard surface and cannot
+reach requirements that did not exist when those implementations were
+written. The three requirements below are therefore where
+promise-keeping is scored with extra weight (DESIGN-HANDOFF-FAMILY.md,
+decision 1): they force real architectural choices — a cross-cutting
+middleware concern, an append-only store fed by every mutation, and
+versioned data on the update path — that no recalled codebase provides.
+
+Every arm receives this delta together with the base spec. The delta is
+part of the spec, not an extension task.
+
+## D1 — Per-user rate limiting on mutations
+
+A signed-in user may perform at most **60 mutating requests (POST, PUT,
+DELETE) within any rolling 60-second window**. The request that exceeds
+the limit receives **HTTP 429** with the standard error envelope:
+
+```json
+{ "errors": { "rate-limit": ["too many mutating requests"] } }
+```
+
+Rules:
+
+- The window is per authenticated user, not per connection or IP.
+- GET requests never count toward or against the limit.
+- Unauthenticated mutating requests (register, login) are exempt — they
+  have no user to attribute.
+- After the window slides past, mutations succeed again. (The acceptance
+  test does not wait out the window; it only asserts the 429 boundary.)
+
+The limit of 60 is chosen so the upstream conformance suite — well under
+60 mutations per test user — passes untouched; only a deliberate burst
+trips it.
+
+## D2 — Audit log
+
+Every **successful** mutating request must append one audit record:
+actor (the authenticated user), action, resource type, resource id, and
+timestamp. Failed and unauthenticated requests are not recorded.
+
+Exposed at **`GET /api/audit`** (authentication required):
+
+```json
+{
+  "audit": [
+    { "action": "favorite", "resourceType": "article",
+      "resourceId": "<slug>", "createdAt": "<ISO 8601>" }
+  ],
+  "auditCount": 1
+}
+```
+
+Rules:
+
+- A caller sees **only their own** audit records, newest first.
+- `limit`/`offset` query parameters paginate, defaults 20/0.
+- Action names are fixed by this table (scored literally):
+
+| Endpoint | action | resourceType | resourceId |
+| --- | --- | --- | --- |
+| POST /api/articles | `create` | `article` | slug |
+| PUT /api/articles/:slug | `update` | `article` | slug |
+| DELETE /api/articles/:slug | `delete` | `article` | slug |
+| POST /api/articles/:slug/favorite | `favorite` | `article` | slug |
+| DELETE /api/articles/:slug/favorite | `unfavorite` | `article` | slug |
+| POST /api/articles/:slug/comments | `create` | `comment` | comment id |
+| DELETE /api/articles/:slug/comments/:id | `delete` | `comment` | comment id |
+| POST /api/profiles/:username/follow | `follow` | `profile` | username |
+| DELETE /api/profiles/:username/follow | `unfollow` | `profile` | username |
+| PUT /api/user | `update` | `user` | username |
+
+## D3 — Article revision history
+
+**`PUT /api/articles/:slug` must preserve the replaced version** as a
+revision. Revisions are exposed at **`GET /api/articles/:slug/revisions`**
+(authentication required, **author only** — anyone else receives 403):
+
+```json
+{
+  "revisions": [
+    { "title": "...", "description": "...", "body": "...",
+      "revisedAt": "<ISO 8601>" }
+  ],
+  "revisionCount": 1
+}
+```
+
+Rules:
+
+- Each revision is the article state that an update **replaced**; an
+  article updated twice has two revisions.
+- Newest first: `revisions[0]` is the most recently replaced state.
+- An article never updated has `revisionCount: 0` and an empty list.
+- Deleting the article deletes its revisions.
+
+## Acceptance tests
+
+`delta-hurl/*.hurl`, written in the upstream suite's conventions and run
+by the same command:
+
+```sh
+hurl --test --jobs 1 \
+  --variable host=$HOST --variable uid=$UID_VAL \
+  docs/research/context-benchmark/spec-build/delta-hurl/*.hurl
+```
+
+The conformance gate for every build run is: **upstream suite passes AND
+delta suite passes**. A gate, never a ranking (DESIGN-HANDOFF-FAMILY.md).
+
+## What the delta deliberately avoids
+
+- Nothing here contradicts the base spec; every base test passes on a
+  delta-compliant implementation.
+- No requirement dictates architecture (no "use middleware", no storage
+  choice) — the architecture is the experiment's free variable.
+- Numbers (60/60s, pagination defaults) are exact so conformance is
+  mechanical, not judged.

--- a/docs/research/context-benchmark/spec-build/delta-hurl/audit-log.hurl
+++ b/docs/research/context-benchmark/spec-build/delta-hurl/audit-log.hurl
@@ -1,0 +1,98 @@
+# D2 — audit log: successful mutations recorded, caller sees only their own.
+# Unauthenticated access is rejected
+GET {{host}}/api/audit
+HTTP 401
+
+# First user
+POST {{host}}/api/users
+{
+  "user": {
+    "username": "audit1_{{uid}}",
+    "email": "audit1_{{uid}}@test.com",
+    "password": "password123"
+  }
+}
+HTTP 201
+[Captures]
+token1: jsonpath "$.user.token"
+
+# Three audited mutations: create, update, favorite
+POST {{host}}/api/articles
+Authorization: Token {{token1}}
+{
+  "article": {
+    "title": "Audit probe {{uid}}",
+    "description": "probe",
+    "body": "v0",
+    "tagList": []
+  }
+}
+HTTP 201
+[Captures]
+slug: jsonpath "$.article.slug"
+
+PUT {{host}}/api/articles/{{slug}}
+Authorization: Token {{token1}}
+{
+  "article": {
+    "body": "v1"
+  }
+}
+HTTP 200
+
+POST {{host}}/api/articles/{{slug}}/favorite
+Authorization: Token {{token1}}
+HTTP 200
+
+# Newest first, actions and resources literal per the delta table
+GET {{host}}/api/audit
+Authorization: Token {{token1}}
+HTTP 200
+[Asserts]
+jsonpath "$.auditCount" == 3
+jsonpath "$.audit" count == 3
+jsonpath "$.audit[0].action" == "favorite"
+jsonpath "$.audit[0].resourceType" == "article"
+jsonpath "$.audit[0].resourceId" == "{{slug}}"
+jsonpath "$.audit[1].action" == "update"
+jsonpath "$.audit[2].action" == "create"
+jsonpath "$.audit[0].createdAt" isString
+
+# Pagination: limit narrows the page, not the count
+GET {{host}}/api/audit?limit=1
+Authorization: Token {{token1}}
+HTTP 200
+[Asserts]
+jsonpath "$.audit" count == 1
+jsonpath "$.auditCount" == 3
+jsonpath "$.audit[0].action" == "favorite"
+
+# Second user's action lands in their log, not the first user's
+POST {{host}}/api/users
+{
+  "user": {
+    "username": "audit2_{{uid}}",
+    "email": "audit2_{{uid}}@test.com",
+    "password": "password123"
+  }
+}
+HTTP 201
+[Captures]
+token2: jsonpath "$.user.token"
+
+POST {{host}}/api/articles/{{slug}}/favorite
+Authorization: Token {{token2}}
+HTTP 200
+
+GET {{host}}/api/audit
+Authorization: Token {{token2}}
+HTTP 200
+[Asserts]
+jsonpath "$.auditCount" == 1
+jsonpath "$.audit[0].action" == "favorite"
+
+GET {{host}}/api/audit
+Authorization: Token {{token1}}
+HTTP 200
+[Asserts]
+jsonpath "$.auditCount" == 3

--- a/docs/research/context-benchmark/spec-build/delta-hurl/rate-limit.hurl
+++ b/docs/research/context-benchmark/spec-build/delta-hurl/rate-limit.hurl
@@ -1,0 +1,50 @@
+# D1 — per-user rate limit on mutations: 60 per rolling 60s, then 429.
+# Register (unauthenticated: exempt from the limit)
+POST {{host}}/api/users
+{
+  "user": {
+    "username": "rl_{{uid}}",
+    "email": "rl_{{uid}}@test.com",
+    "password": "password123"
+  }
+}
+HTTP 201
+[Captures]
+token: jsonpath "$.user.token"
+
+# Mutation 1 of 60: create an article to favorite
+POST {{host}}/api/articles
+Authorization: Token {{token}}
+{
+  "article": {
+    "title": "Rate limit probe {{uid}}",
+    "description": "probe",
+    "body": "probe",
+    "tagList": []
+  }
+}
+HTTP 201
+[Captures]
+slug: jsonpath "$.article.slug"
+
+# Mutations 2..60: 59 favorites, all inside the limit, all succeed
+POST {{host}}/api/articles/{{slug}}/favorite
+Authorization: Token {{token}}
+[Options]
+repeat: 59
+HTTP 200
+
+# Mutation 61 inside the window: rejected with the standard envelope
+DELETE {{host}}/api/articles/{{slug}}/favorite
+Authorization: Token {{token}}
+HTTP 429
+[Asserts]
+jsonpath "$.errors['rate-limit']" count == 1
+jsonpath "$.errors['rate-limit'][0]" == "too many mutating requests"
+
+# GET requests are never limited
+GET {{host}}/api/articles/{{slug}}
+Authorization: Token {{token}}
+HTTP 200
+[Asserts]
+jsonpath "$.article.slug" == "{{slug}}"

--- a/docs/research/context-benchmark/spec-build/delta-hurl/revisions.hurl
+++ b/docs/research/context-benchmark/spec-build/delta-hurl/revisions.hurl
@@ -1,0 +1,89 @@
+# D3 — revision history: updates preserve the replaced state, author-only.
+# Author
+POST {{host}}/api/users
+{
+  "user": {
+    "username": "rev1_{{uid}}",
+    "email": "rev1_{{uid}}@test.com",
+    "password": "password123"
+  }
+}
+HTTP 201
+[Captures]
+author: jsonpath "$.user.token"
+
+POST {{host}}/api/articles
+Authorization: Token {{author}}
+{
+  "article": {
+    "title": "Revisions probe {{uid}}",
+    "description": "d0",
+    "body": "b0",
+    "tagList": []
+  }
+}
+HTTP 201
+[Captures]
+slug: jsonpath "$.article.slug"
+
+# Never updated: zero revisions
+GET {{host}}/api/articles/{{slug}}/revisions
+Authorization: Token {{author}}
+HTTP 200
+[Asserts]
+jsonpath "$.revisionCount" == 0
+jsonpath "$.revisions" count == 0
+
+# Two updates (title constant so the slug is stable)
+PUT {{host}}/api/articles/{{slug}}
+Authorization: Token {{author}}
+{
+  "article": {
+    "description": "d1",
+    "body": "b1"
+  }
+}
+HTTP 200
+
+PUT {{host}}/api/articles/{{slug}}
+Authorization: Token {{author}}
+{
+  "article": {
+    "body": "b2"
+  }
+}
+HTTP 200
+
+# Each revision is the replaced state, newest first: [v1, v0]
+GET {{host}}/api/articles/{{slug}}/revisions
+Authorization: Token {{author}}
+HTTP 200
+[Asserts]
+jsonpath "$.revisionCount" == 2
+jsonpath "$.revisions" count == 2
+jsonpath "$.revisions[0].body" == "b1"
+jsonpath "$.revisions[0].description" == "d1"
+jsonpath "$.revisions[1].body" == "b0"
+jsonpath "$.revisions[1].description" == "d0"
+jsonpath "$.revisions[0].revisedAt" isString
+
+# Authentication required
+GET {{host}}/api/articles/{{slug}}/revisions
+HTTP 401
+
+# Author only
+POST {{host}}/api/users
+{
+  "user": {
+    "username": "rev2_{{uid}}",
+    "email": "rev2_{{uid}}@test.com",
+    "password": "password123"
+  }
+}
+HTTP 201
+[Captures]
+other: jsonpath "$.user.token"
+
+GET {{host}}/api/articles/{{slug}}/revisions
+Authorization: Token {{other}}
+HTTP 403

--- a/docs/research/context-benchmark/spec-build/prompts/designer-A.md
+++ b/docs/research/context-benchmark/spec-build/prompts/designer-A.md
@@ -1,0 +1,35 @@
+You are the designer for a new backend implementation of the Conduit
+specification. The implementation will be built later by other engineers
+who have never spoken to you; your design document is the only channel
+between you and them.
+
+In your working directory:
+
+- `spec/openapi.yml` — the pinned RealWorld/Conduit API specification
+- `spec/SPEC-DELTA.md` — three additional requirements that are part of
+  the spec (rate limiting, audit log, revision history)
+- `spec/hurl/` and `spec/delta-hurl/` — the conformance tests the final
+  implementation must pass
+
+Produce **`DESIGN.md`** in the working directory root: the design a
+competent team would want before writing code. Design the architecture;
+do not write implementation code.
+
+`DESIGN.md` must contain at least these sections:
+
+- `## Components` — a bulleted list, one component per line, formatted
+  exactly `- **Component Name** — one-line responsibility`. Name every
+  part you expect to exist as a distinct unit in the implementation.
+  This list is a contract: implementers are asked to honour these names
+  and boundaries, and the experiment measures whether they did.
+- `## Boundaries and data ownership` — which component owns which data,
+  who may read or write what, and through which interfaces.
+- `## Data model` — the entities, their fields, and their relationships.
+- `## Cross-cutting concerns` — how rate limiting, the audit log, and
+  revision history are handled and where they attach.
+- `## Build order` — the order in which the components should be built
+  and why.
+
+Be specific enough that two independent teams following the document
+would produce recognizably the same system. Aim for roughly 2,000–4,000
+words; depth beats breadth where you must choose.

--- a/docs/research/context-benchmark/spec-build/prompts/designer-B.md
+++ b/docs/research/context-benchmark/spec-build/prompts/designer-B.md
@@ -1,0 +1,41 @@
+You are the designer for a new backend implementation of the Conduit
+specification. The implementation will be built later by other engineers
+who have never spoken to you; the architecture model you produce is the
+only channel between you and them — they will receive prose briefs
+rendered from it.
+
+In your working directory:
+
+- `spec/openapi.yml` — the pinned RealWorld/Conduit API specification
+- `spec/SPEC-DELTA.md` — three additional requirements that are part of
+  the spec (rate limiting, audit log, revision history)
+- `spec/hurl/` and `spec/delta-hurl/` — the conformance tests the final
+  implementation must pass
+
+The `yarramate` CLI is on your PATH. Read the skill guide first:
+`SKILL.md` in the working directory root. Then:
+
+1. Run `yarramate init .` and author the architecture as a YarraMate
+   model: the components you expect to exist as distinct units, the
+   services and behaviors they provide, the data they own and access,
+   the actors, and the motivation layer (goals, requirements,
+   constraints) that justifies them. Everything unbuilt is
+   `status: planned`. Model the delta requirements (rate limiting,
+   audit log, revision history) explicitly — they are where independent
+   implementers most need your intent.
+2. Get `yarramate check .yarramate/workspace.yaml` passing.
+3. Run `yarramate interrogate <catalogue> .yarramate/workspace.yaml`
+   with the catalogue at `catalogue/core-enrichment.yaml`. Answer every
+   open question the specification can answer by enriching the model;
+   re-run until the only open items are ones the spec genuinely cannot
+   decide, and list those explicitly in your final message. Do not open
+   the catalogue file itself; the report is self-contained.
+4. Create a projection at `.yarramate/projections/target.yaml` covering
+   the planned system (the implementers' slice), and confirm
+   `yarramate context .yarramate/projections/target.yaml
+   .yarramate/workspace.yaml --brief` renders it.
+
+Your deliverable is the checked workspace; the briefs handed to
+implementers are rendered from it mechanically. Name components the way
+you want them to exist in code — the experiment measures whether
+implementers honour your declared names and boundaries.

--- a/docs/research/context-benchmark/spec-build/prompts/extension.md
+++ b/docs/research/context-benchmark/spec-build/prompts/extension.md
@@ -1,0 +1,33 @@
+You are extending an existing Conduit backend implementation that you
+did not write. The team that built it is gone; you have their design
+handoff and their code.
+
+In your working directory:
+
+- `spec/` — the API specification, delta requirements, and conformance
+  tests the implementation already passes (do not break them)
+- `handoff/` — the design the original implementers received
+- the implementation itself, started with `run.sh` (listens on `$PORT`,
+  default 3000)
+
+New requirement — **tag subscription**:
+
+- `POST /api/tags/:tag/subscribe` (auth required) subscribes the caller
+  to a tag; `DELETE /api/tags/:tag/subscribe` unsubscribes. Both return
+  `{ "tag": "<tag>", "subscribed": true|false }` with HTTP 200.
+- `GET /api/tags/subscriptions` (auth required) returns
+  `{ "tags": [ ... ] }` — the caller's subscribed tags, alphabetical.
+- `GET /api/articles/feed` additionally includes articles carrying any
+  tag the caller subscribes to, merged with the existing followed-author
+  articles, still newest first, still deduplicated and paginated.
+- Tag subscriptions are per user. Subscribing twice is idempotent.
+- These mutations count toward the D1 rate limit and are audited (D2)
+  with action `subscribe`/`unsubscribe`, resourceType `tag`,
+  resourceId the tag name.
+
+Extend the implementation to satisfy this. Follow the existing design's
+boundaries and the handoff's intent; record any deviation in
+`DEVIATIONS.md` (append, do not rewrite). All existing conformance tests
+must still pass. Your final message: what you changed, where, and why
+there — and whether the original design made this extension easy or
+hard, concretely.

--- a/docs/research/context-benchmark/spec-build/prompts/implementer.md
+++ b/docs/research/context-benchmark/spec-build/prompts/implementer.md
@@ -1,0 +1,33 @@
+You are implementing a backend for the Conduit specification from a
+design handed to you by a designer you have never met.
+
+In your working directory:
+
+- `spec/openapi.yml` — the pinned RealWorld/Conduit API specification
+- `spec/SPEC-DELTA.md` — three additional requirements that are part of
+  the spec (rate limiting, audit log, revision history)
+- `spec/hurl/` and `spec/delta-hurl/` — the conformance tests your
+  implementation must pass
+- `handoff/` — the design you received. Read it before writing any code.
+
+Build the backend in this directory. Requirements:
+
+1. **Pass the conformance tests.** Your server must pass both
+   `spec/hurl/` and `spec/delta-hurl/` run with
+   `hurl --test --jobs 1 --variable host=http://localhost:$PORT
+   --variable uid=<any>`.
+2. **Provide `run.sh`** in the working directory root: a script that
+   starts your server listening on `$PORT` (default 3000), with no
+   prior manual steps. In-memory or file-backed storage is fine;
+   persistence across restarts is not required.
+3. **Honour the design you received.** Use its component names and
+   respect its boundaries and data-ownership rules in your code
+   structure. Where you must deviate, record each deviation in
+   `DEVIATIONS.md` (component, what you did instead, why). An empty or
+   absent `DEVIATIONS.md` asserts you followed the design as given.
+4. Keep the implementation self-contained: standard toolchains are
+   available, but the server must not depend on external services or
+   network resources at runtime.
+
+Verify against the conformance tests yourself before finishing. Your
+final message: what you built, which tests pass, and any deviations.

--- a/docs/research/context-benchmark/spec-build/runner/conformance.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/conformance.mjs
@@ -1,0 +1,72 @@
+// The conformance gate: start the implementation's run.sh, wait for it to
+// answer, run the upstream Hurl suite and the delta suite, stop the server.
+// A gate, never a ranking (DESIGN-HANDOFF-FAMILY.md): output is pass/fail
+// per suite plus the failing files.
+//
+// Usage:
+//   node conformance.mjs --workdir <impl-workdir> [--port 3199] [--suites upstream,delta]
+// Prints a JSON summary to stdout; exit 0 iff every requested suite passed.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { opt } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const workdir = opt(args, 'workdir');
+const port = opt(args, 'port', '3199');
+const suites = opt(args, 'suites', 'upstream,delta').split(',');
+if (!workdir) {
+  console.error('usage: conformance.mjs --workdir <impl-workdir> [--port <p>] [--suites upstream,delta]');
+  process.exit(2);
+}
+
+const host = `http://localhost:${port}`;
+const server = spawn('bash', ['run.sh'], {
+  cwd: workdir,
+  env: { ...process.env, PORT: port },
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: true,
+});
+let serverLog = '';
+server.stdout.on('data', (chunk) => { serverLog += chunk; });
+server.stderr.on('data', (chunk) => { serverLog += chunk; });
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+let up = false;
+for (let attempt = 0; attempt < 120; attempt += 1) {
+  try {
+    await fetch(`${host}/api/tags`);
+    up = true;
+    break;
+  } catch {
+    await wait(500);
+  }
+}
+
+const results = {};
+if (up) {
+  const uid = `${Date.now()}`;
+  for (const suite of suites) {
+    const dir = suite === 'upstream' ? join(workdir, 'spec', 'hurl') : join(workdir, 'spec', 'delta-hurl');
+    const run = spawnSync('bash', ['-c', `hurl --test --jobs 1 --variable host=${host} --variable uid=${uid}_${suite} "${dir}"/*.hurl`], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    results[suite] = {
+      ok: run.status === 0,
+      report: (run.stderr ?? '').split('\n').filter((line) => line.includes('hurl') || line.includes('Success') || line.includes('Fail')).slice(-20),
+    };
+  }
+} else {
+  for (const suite of suites) results[suite] = { ok: false, report: ['server never answered'] };
+}
+
+try {
+  process.kill(-server.pid, 'SIGTERM');
+} catch {
+  try { server.kill('SIGTERM'); } catch { /* already gone */ }
+}
+
+const ok = up && suites.every((suite) => results[suite].ok);
+console.log(JSON.stringify({ ok, up, results, serverLogTail: serverLog.split('\n').slice(-15) }, null, 2));
+process.exit(ok ? 0 : 1);

--- a/docs/research/context-benchmark/spec-build/runner/convergence.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/convergence.mjs
@@ -1,0 +1,94 @@
+// Convergence across the repeat runs of one arm: do independent sessions
+// produce the same structure? Two pre-registered measures, both needing no
+// right answer (DESIGN-HANDOFF-FAMILY.md):
+//   names  — Jaccard similarity of the declared component-name token sets
+//            across design runs;
+//   files  — Jaccard similarity of implementation source paths (top two
+//            levels) across build runs.
+// Guard (pre-registered): compute arm A's convergence too — if A's runs
+// converge as strongly as B's, the spec is forcing the structure and the
+// metric is uninformative for this task.
+//
+// Usage:
+//   node convergence.mjs --mode names --runs <dir> <dir> [<dir> ...]
+//     names: pass design run dirs (uses promises-visible declared names via
+//            score output is not required; reads DESIGN.md / workspace directly
+//            is the build runner's job — here we read the recorded runs.jsonl
+//            entries' promise scores when present, else the raw artifacts)
+//   node convergence.mjs --mode files --runs <dir> <dir> [<dir> ...]
+//     files: pass build run dirs (reads work/ trees)
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { opt } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const mode = opt(args, 'mode');
+const runsIndex = args.indexOf('--runs');
+const runs = runsIndex >= 0 ? args.slice(runsIndex + 1) : [];
+if (!['names', 'files'].includes(mode) || runs.length < 2) {
+  console.error('usage: convergence.mjs --mode names|files --runs <dir> <dir> [...]');
+  process.exit(2);
+}
+
+const SKIP = new Set(['node_modules', '.git', 'spec', 'handoff', '.yarramate', 'vendor', 'target', 'dist', '__pycache__']);
+
+const nameTokens = (runDir) => {
+  // Design run: declared names from promises.json when a build recorded
+  // them, else directly from the artifact.
+  const promisesPath = join(runDir, 'promises.json');
+  if (existsSync(promisesPath)) {
+    const { names } = JSON.parse(readFileSync(promisesPath, 'utf8'));
+    return new Set(names.flatMap(({ name }) => name.toLowerCase().split(/[^a-z0-9]+/)).filter((token) => token.length >= 3));
+  }
+  const designDoc = join(runDir, 'work', 'DESIGN.md');
+  if (existsSync(designDoc)) {
+    const section = readFileSync(designDoc, 'utf8').split(/^## Components$/m)[1]?.split(/^## /m)[0] ?? '';
+    const names = [...section.matchAll(/^\s*[-*]\s+\*\*([^*]+)\*\*/gm)].map((match) => match[1]);
+    return new Set(names.flatMap((name) => name.toLowerCase().split(/[^a-z0-9]+/)).filter((token) => token.length >= 3));
+  }
+  const briefsDir = join(runDir, 'briefs');
+  if (existsSync(briefsDir)) {
+    return new Set(readdirSync(briefsDir)
+      .flatMap((file) => file.replace(/^brief-|\.md$/g, '').split(/[^a-z0-9]+/))
+      .filter((token) => token.length >= 3));
+  }
+  return new Set();
+};
+
+const filePaths = (runDir) => {
+  const found = new Set();
+  const walk = (dir, relative, depth) => {
+    if (depth > 2) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (SKIP.has(entry.name)) continue;
+      const rel = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(join(dir, entry.name), rel, depth + 1);
+      else found.add(rel);
+    }
+  };
+  walk(join(runDir, 'work'), '', 0);
+  return found;
+};
+
+const sets = runs.map((runDir) => (mode === 'names' ? nameTokens(runDir) : filePaths(runDir)));
+const jaccard = (a, b) => {
+  const union = new Set([...a, ...b]);
+  if (union.size === 0) return null;
+  const intersection = [...a].filter((item) => b.has(item)).length;
+  return Number((intersection / union.size).toFixed(3));
+};
+
+const pairs = [];
+for (let i = 0; i < runs.length; i += 1) {
+  for (let j = i + 1; j < runs.length; j += 1) {
+    pairs.push({ a: runs[i], b: runs[j], jaccard: jaccard(sets[i], sets[j]) });
+  }
+}
+const values = pairs.map(({ jaccard: value }) => value).filter((value) => value !== null);
+console.log(JSON.stringify({
+  mode,
+  pairs,
+  mean: values.length === 0 ? null : Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(3)),
+  setSizes: sets.map((set) => set.size),
+}, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
@@ -1,0 +1,50 @@
+// Derives arm C's handoff from a completed arm B design run: copy the
+// designer workspace, inject lies (same-kind endpoint rotation), and
+// re-render the briefs from the lying model. The C run number mirrors the
+// B run it derives from — pre-registered mapping, no choice at run time.
+//
+// Usage:
+//   node derive-arm-c.mjs --run <n> --out <results-dir> --toolchain <bins>
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { here, opt, record } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const runN = opt(args, 'run');
+const outDir = opt(args, 'out');
+const toolchain = opt(args, 'toolchain');
+if (!runN || !outDir || !toolchain) {
+  console.error('usage: derive-arm-c.mjs --run <n> --out <dir> --toolchain <bins>');
+  process.exit(2);
+}
+
+const sourceWork = join(outDir, 'design', 'B', `run-${runN}`, 'work');
+const runDir = join(outDir, 'design', 'C', `run-${runN}`);
+const workdir = join(runDir, 'work');
+rmSync(runDir, { recursive: true, force: true });
+mkdirSync(runDir, { recursive: true });
+cpSync(sourceWork, workdir, { recursive: true });
+
+const lieRecord = execFileSync('node', [
+  join(here, 'inject-lies.mjs'),
+  '--workdir', workdir,
+  '--toolchain', toolchain,
+], { encoding: 'utf8' });
+writeFileSync(join(runDir, 'lies.json'), lieRecord);
+
+const briefs = JSON.parse(execFileSync('node', [
+  join(here, 'render-briefs.mjs'),
+  '--workdir', workdir,
+  '--toolchain', toolchain,
+  '--out', join(runDir, 'briefs'),
+], { encoding: 'utf8' })).rendered;
+
+record(outDir, {
+  phase: 'design', arm: 'C', run: Number(runN), derivedFrom: `B/run-${runN}`,
+  exitCode: 0, durationMs: 0, metrics: null,
+  deliverable: { kind: 'workspace', ok: briefs.length > 0, lies: JSON.parse(lieRecord).lies.length, briefs },
+  runDir,
+});
+console.log(JSON.stringify({ arm: 'C', run: Number(runN), lies: JSON.parse(lieRecord).lies, briefs }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
@@ -1,0 +1,103 @@
+// Turns arm B's designer workspace into arm C's: a model that still passes
+// check but lies about the wiring. Greenfield variant of the sweep's
+// inject-stale.mjs — there is no evidence to flip, so the lie is pure
+// rotation: for up to three relationship kinds with at least two instances,
+// rotate the `to` endpoints among the instances. Deterministic (sorted
+// order, no randomness) so a C run is reproducible from its B workspace.
+// Refuses to proceed if the lying model fails check: a lie that breaks the
+// gate is not the failure mode under test.
+//
+// Usage:
+//   node inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins>
+// Prints the lie record (JSON) to stdout; the caller persists it.
+
+import { execFileSync } from 'node:child_process';
+import { globSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { opt, repoRoot } from './lib.mjs';
+
+const require = createRequire(join(repoRoot, 'package.json'));
+const YAML = require('yaml');
+
+const args = process.argv.slice(2);
+const workdir = opt(args, 'workdir');
+const toolchain = opt(args, 'toolchain');
+if (!workdir || !toolchain) {
+  console.error('usage: inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins>');
+  process.exit(2);
+}
+
+const cli = join(toolchain, 'yarramate');
+const manifestPath = join(workdir, '.yarramate', 'workspace.yaml');
+const manifest = YAML.parse(readFileSync(manifestPath, 'utf8'));
+
+const check = (allowFail) => {
+  try {
+    execFileSync(cli, ['check', '.yarramate/workspace.yaml'], { cwd: workdir, stdio: 'pipe' });
+    return true;
+  } catch (error) {
+    if (allowFail) return false;
+    throw error;
+  }
+};
+check(false);
+
+// Collect relationships across the manifest's documents, grouped by kind.
+// Manifest entries may be globs (the CLI expands them; so must we).
+const documents = manifest.documents
+  .flatMap((path) => globSync(path, { cwd: join(workdir, '.yarramate') }).sort())
+  .map((path) => {
+    const absolute = join(workdir, '.yarramate', path);
+    return { path: absolute, doc: YAML.parseDocument(readFileSync(absolute, 'utf8')) };
+  });
+const byKind = new Map();
+for (const { path, doc } of documents) {
+  const relationships = doc.get('relationships');
+  if (!relationships || !relationships.items) continue;
+  for (const item of relationships.items) {
+    const kind = item.get('kind');
+    const entry = { path, doc, item };
+    byKind.set(kind, [...(byKind.get(kind) ?? []), entry]);
+  }
+}
+
+const lies = [];
+for (const kind of [...byKind.keys()].sort()) {
+  if (lies.length >= 3) break;
+  const group = byKind.get(kind).filter((entry) => entry.item.get('to') !== undefined);
+  const targets = group.map((entry) => entry.item.get('to'));
+  if (new Set(targets).size < 2) continue;
+  // Rotate every target in the group one position: each relationship now
+  // points where its same-kind neighbour pointed. A rotation that changes
+  // nothing, or that would point a relationship at its own source (a
+  // self-loop no designer would write), stays truthful instead.
+  group.forEach((entry, index) => {
+    const lyingTo = targets[(index + 1) % targets.length];
+    if (lyingTo === targets[index] || lyingTo === entry.item.get('from')) return;
+    entry.item.set('to', lyingTo);
+    lies.push({
+      relationship: entry.item.get('id'),
+      kind,
+      from: entry.item.get('from'),
+      originalTo: targets[index],
+      lyingTo,
+    });
+  });
+}
+
+if (lies.length === 0) {
+  console.error('inject-lies: no rotatable relationship group found; arm C cannot be derived from this workspace');
+  process.exit(1);
+}
+
+for (const { path, doc } of documents) {
+  writeFileSync(path, doc.toString());
+}
+
+if (!check(true)) {
+  console.error('inject-lies: the lying model fails check; rotation produced an invalid model (aspect rules?). Inspect and re-derive.');
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ lies }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/lib.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/lib.mjs
@@ -1,0 +1,111 @@
+// Shared plumbing for the spec-build family runners. Mirrors the sweep
+// runner's conventions (../../runner/run-benchmark.mjs): explicit options,
+// nothing runs without a harness command, one jsonl record per run.
+
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import { appendFileSync, cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const here = dirname(fileURLToPath(import.meta.url));
+export const familyRoot = join(here, '..');
+export const repoRoot = join(here, '..', '..', '..', '..', '..');
+
+// The pinned base spec (SPEC-DELTA.md is the authority; keep in sync).
+export const SPEC_REPO = 'https://github.com/gothinkster/realworld';
+export const SPEC_COMMIT = '98f29fb3f8bcb1dd614b91f2851371bf22c34775';
+
+export const opt = (args, name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+export const flag = (args, name) => args.includes(`--${name}`);
+
+// One pinned clone per results directory; every workdir copies from it.
+export const ensureSpecCache = (outDir) => {
+  const cacheDir = join(outDir, 'cache', 'realworld');
+  if (!existsSync(join(cacheDir, 'specs'))) {
+    mkdirSync(cacheDir, { recursive: true });
+    execSync('git init -q', { cwd: cacheDir });
+    execFileSync('git', ['fetch', '-q', '--depth', '1', SPEC_REPO, SPEC_COMMIT], { cwd: cacheDir });
+    execSync('git checkout -q FETCH_HEAD', { cwd: cacheDir });
+  }
+  return cacheDir;
+};
+
+// Every phase's workdir carries the same spec materials: the OpenAPI spec,
+// the upstream conformance suite, the frozen delta, and its acceptance
+// tests. Constant across arms by construction.
+export const placeSpecMaterials = (workdir, cacheDir) => {
+  const spec = join(workdir, 'spec');
+  mkdirSync(spec, { recursive: true });
+  cpSync(join(cacheDir, 'specs', 'api', 'openapi.yml'), join(spec, 'openapi.yml'));
+  cpSync(join(cacheDir, 'specs', 'api', 'hurl'), join(spec, 'hurl'), { recursive: true });
+  cpSync(join(familyRoot, 'SPEC-DELTA.md'), join(spec, 'SPEC-DELTA.md'));
+  cpSync(join(familyRoot, 'delta-hurl'), join(spec, 'delta-hurl'), { recursive: true });
+};
+
+export const runHarness = (harness, workdir, prompt, extraPath) => {
+  const started = Date.now();
+  const result = spawnSync('bash', ['-lc', harness], {
+    cwd: workdir,
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, PATH: extraPath ? `${extraPath}:${process.env.PATH}` : process.env.PATH },
+  });
+  const durationMs = Date.now() - started;
+  let metrics = null;
+  try {
+    const parsed = JSON.parse(result.stdout);
+    metrics = {
+      numTurns: parsed.num_turns ?? null,
+      inputTokens: parsed.usage?.input_tokens ?? null,
+      outputTokens: parsed.usage?.output_tokens ?? null,
+      costUsd: parsed.total_cost_usd ?? null,
+    };
+  } catch {
+    metrics = null;
+  }
+  return { result, durationMs, metrics };
+};
+
+export const record = (outDir, entry) => {
+  mkdirSync(outDir, { recursive: true });
+  appendFileSync(join(outDir, 'runs.jsonl'), `${JSON.stringify({ ...entry, finishedAt: new Date().toISOString() })}\n`);
+};
+
+export const saveTranscript = (runDir, result) => {
+  writeFileSync(join(runDir, 'transcript.json'), result.stdout ?? '');
+  writeFileSync(join(runDir, 'stderr.log'), result.stderr ?? '');
+};
+
+// Planned concepts (id + name) from a compiled workspace — the declared
+// component list arms B and C are scored against.
+export const plannedConcepts = (toolchain, workspaceDir) => {
+  const graph = JSON.parse(execFileSync(
+    join(toolchain, 'yarramate'),
+    ['compile', join(workspaceDir, 'workspace.yaml')],
+    { encoding: 'utf8', cwd: dirname(workspaceDir) },
+  ));
+  const planned = new Set(
+    graph.claims
+      .filter((claim) => claim.predicate === 'yarramate/lifecycle/status' && claim.object.value === 'planned')
+      .map((claim) => claim.subject),
+  );
+  const names = new Map();
+  for (const claim of graph.claims) {
+    if (claim.predicate === 'yarramate/concept/name' && planned.has(claim.subject)) {
+      names.set(claim.subject, claim.object.value);
+    }
+  }
+  return [...planned].sort().map((id) => ({ id, name: names.get(id) ?? id.split('#').pop() }));
+};
+
+export const readPrompt = (name, substitutions = {}) => {
+  let text = readFileSync(join(familyRoot, 'prompts', `${name}.md`), 'utf8');
+  for (const [key, value] of Object.entries(substitutions)) {
+    text = text.replaceAll(`{{${key}}}`, value);
+  }
+  return text;
+};

--- a/docs/research/context-benchmark/spec-build/runner/reference-stub.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/reference-stub.mjs
@@ -1,0 +1,134 @@
+// Test-the-tests fixture, NOT an arm artifact and never handed to any
+// agent: a minimal in-memory server implementing just enough of Conduit
+// plus the full spec delta to prove the delta-hurl suites are runnable and
+// the conformance runner works. Pre-registered acceptance tests that are
+// themselves broken would burn a paid run; this stub is how we know they
+// are not. It deliberately does NOT implement the full upstream suite.
+//
+//   PORT=3199 node reference-stub.mjs
+
+import { createServer } from 'node:http';
+
+const users = new Map();          // token -> { username, email }
+const articles = new Map();       // slug -> { title, description, body, author, favoritedBy:Set, revisions: [] }
+const audits = new Map();         // username -> [{ action, resourceType, resourceId, createdAt }]
+const mutationTimes = new Map();  // username -> [epoch-ms]
+
+const json = (res, status, payload) => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(payload));
+};
+const unauthorized = (res) => json(res, 401, { errors: { body: ['unauthorized'] } });
+const slugify = (title) => title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+const audit = (username, action, resourceType, resourceId) => {
+  const list = audits.get(username) ?? [];
+  list.unshift({ action, resourceType, resourceId, createdAt: new Date().toISOString() });
+  audits.set(username, list);
+};
+
+const rateLimited = (username) => {
+  const now = Date.now();
+  const recent = (mutationTimes.get(username) ?? []).filter((time) => now - time < 60_000);
+  if (recent.length >= 60) {
+    mutationTimes.set(username, recent);
+    return true;
+  }
+  recent.push(now);
+  mutationTimes.set(username, recent);
+  return false;
+};
+
+const articleView = (slug) => {
+  const article = articles.get(slug);
+  return {
+    slug, title: article.title, description: article.description, body: article.body,
+    tagList: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    favorited: false, favoritesCount: article.favoritedBy.size,
+    author: { username: article.author, bio: null, image: null, following: false },
+  };
+};
+
+const server = createServer((req, res) => {
+  let raw = '';
+  req.on('data', (chunk) => { raw += chunk; });
+  req.on('end', () => {
+    const body = raw ? JSON.parse(raw) : {};
+    const url = new URL(req.url, 'http://localhost');
+    const path = url.pathname;
+    const token = (req.headers.authorization ?? '').replace(/^Token /, '');
+    const user = users.get(token);
+
+    if (req.method === 'POST' && path === '/api/users') {
+      const { username, email } = body.user;
+      users.set(username, { username, email });
+      return json(res, 201, { user: { username, email, token: username, bio: null, image: null } });
+    }
+    if (req.method === 'GET' && path === '/api/tags') return json(res, 200, { tags: [] });
+
+    const mutating = req.method !== 'GET';
+    if (mutating) {
+      if (!user) return unauthorized(res);
+      if (rateLimited(user.username)) {
+        return json(res, 429, { errors: { 'rate-limit': ['too many mutating requests'] } });
+      }
+    }
+
+    if (req.method === 'POST' && path === '/api/articles') {
+      const { title, description, body: articleBody } = body.article;
+      const slug = slugify(title);
+      articles.set(slug, { title, description, body: articleBody, author: user.username, favoritedBy: new Set(), revisions: [] });
+      audit(user.username, 'create', 'article', slug);
+      return json(res, 201, { article: articleView(slug) });
+    }
+
+    const articleMatch = path.match(/^\/api\/articles\/([^/]+)(\/.*)?$/);
+    if (articleMatch && articles.has(articleMatch[1])) {
+      const slug = articleMatch[1];
+      const article = articles.get(slug);
+      const rest = articleMatch[2] ?? '';
+      if (req.method === 'PUT' && rest === '') {
+        article.revisions.unshift({
+          title: article.title, description: article.description, body: article.body,
+          revisedAt: new Date().toISOString(),
+        });
+        const update = body.article;
+        if (update.title !== undefined) article.title = update.title;
+        if (update.description !== undefined) article.description = update.description;
+        if (update.body !== undefined) article.body = update.body;
+        audit(user.username, 'update', 'article', slug);
+        return json(res, 200, { article: articleView(slug) });
+      }
+      if (req.method === 'POST' && rest === '/favorite') {
+        article.favoritedBy.add(user.username);
+        audit(user.username, 'favorite', 'article', slug);
+        return json(res, 200, { article: articleView(slug) });
+      }
+      if (req.method === 'DELETE' && rest === '/favorite') {
+        article.favoritedBy.delete(user.username);
+        audit(user.username, 'unfavorite', 'article', slug);
+        return json(res, 200, { article: articleView(slug) });
+      }
+      if (req.method === 'GET' && rest === '/revisions') {
+        if (!user) return unauthorized(res);
+        if (user.username !== article.author) return json(res, 403, { errors: { body: ['author only'] } });
+        return json(res, 200, { revisions: article.revisions, revisionCount: article.revisions.length });
+      }
+      if (req.method === 'GET' && rest === '') return json(res, 200, { article: articleView(slug) });
+    }
+
+    if (req.method === 'GET' && path === '/api/audit') {
+      if (!user) return unauthorized(res);
+      const list = audits.get(user.username) ?? [];
+      const limit = Number(url.searchParams.get('limit') ?? 20);
+      const offset = Number(url.searchParams.get('offset') ?? 0);
+      return json(res, 200, { audit: list.slice(offset, offset + limit), auditCount: list.length });
+    }
+
+    return json(res, 404, { errors: { body: ['not found'] } });
+  });
+});
+
+server.listen(Number(process.env.PORT ?? 3000), () => {
+  console.log(`reference stub on :${process.env.PORT ?? 3000}`);
+});

--- a/docs/research/context-benchmark/spec-build/runner/render-briefs.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/render-briefs.mjs
@@ -1,0 +1,48 @@
+// Renders the implementer handoff for arms B and C: prose briefs composed
+// mechanically from a designer workspace (context --brief, ADR 0055). One
+// brief for the target projection when the designer authored one, plus one
+// ad-hoc neighbourhood brief per planned concept. Deterministic: rendering
+// twice from the same workspace is byte-identical, so the handoff carries
+// no hand of ours.
+//
+// Usage:
+//   node render-briefs.mjs --workdir <designer-workdir> --toolchain <bins> --out <briefs-dir>
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { opt, plannedConcepts } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const workdir = opt(args, 'workdir');
+const toolchain = opt(args, 'toolchain');
+const out = opt(args, 'out');
+if (!workdir || !toolchain || !out) {
+  console.error('usage: render-briefs.mjs --workdir <designer-workdir> --toolchain <bins> --out <briefs-dir>');
+  process.exit(2);
+}
+
+const cli = join(toolchain, 'yarramate');
+const manifest = '.yarramate/workspace.yaml';
+mkdirSync(out, { recursive: true });
+
+const rendered = [];
+const targetProjection = '.yarramate/projections/target.yaml';
+if (existsSync(join(workdir, targetProjection))) {
+  const brief = execFileSync(cli, ['context', targetProjection, manifest, '--brief'], { cwd: workdir, encoding: 'utf8' });
+  writeFileSync(join(out, 'brief-target.md'), brief);
+  rendered.push('brief-target.md');
+}
+
+for (const concept of plannedConcepts(toolchain, join(workdir, '.yarramate'))) {
+  const local = concept.id.split('#').pop();
+  const brief = execFileSync(
+    cli,
+    ['context', '--subject', concept.id, manifest, '--brief'],
+    { cwd: workdir, encoding: 'utf8' },
+  );
+  writeFileSync(join(out, `brief-${local}.md`), brief);
+  rendered.push(`brief-${local}.md`);
+}
+
+console.log(JSON.stringify({ rendered }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/run-build.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/run-build.mjs
@@ -1,0 +1,98 @@
+// Build phase, one run of one arm: a fresh implementer receives the spec
+// materials plus the arm's handoff artifact, builds the backend, and is
+// gated by the conformance suites. Promise-keeping is scored mechanically
+// afterwards; both scores land in the run record.
+//
+// Usage:
+//   node run-build.mjs --arm A|B|C --run <n> --out <results-dir> \
+//     [--design-run <n>]     (defaults to --run; which design run feeds this build) \
+//     [--harness 'claude -p --output-format json'] \
+//     [--toolchain <bins>]   (required for B/C promise scoring) \
+//     [--port 3199] [--no-gate] [--dry-run]
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ensureSpecCache, flag, here, opt, placeSpecMaterials, readPrompt,
+  record, runHarness, saveTranscript,
+} from './lib.mjs';
+
+const args = process.argv.slice(2);
+const arm = opt(args, 'arm');
+const runN = opt(args, 'run');
+const outDir = opt(args, 'out');
+const designRun = opt(args, 'design-run', runN);
+const toolchain = opt(args, 'toolchain');
+const harness = opt(args, 'harness', 'claude -p --output-format json');
+const port = opt(args, 'port', '3199');
+const dryRun = flag(args, 'dry-run');
+if (!['A', 'B', 'C'].includes(arm) || !runN || !outDir) {
+  console.error('usage: run-build.mjs --arm A|B|C --run <n> --out <dir> [--design-run <n>] [--harness <cmd>] [--toolchain <bins>] [--port <p>] [--no-gate] [--dry-run]');
+  process.exit(2);
+}
+
+const designDir = join(outDir, 'design', arm, `run-${designRun}`);
+const runDir = join(outDir, 'build', arm, `run-${runN}`);
+const workdir = join(runDir, 'work');
+
+if (dryRun) {
+  console.log(`build arm=${arm} run=${runN} design=${designDir} harness=${JSON.stringify(harness)}`);
+  process.exit(0);
+}
+
+rmSync(runDir, { recursive: true, force: true });
+mkdirSync(workdir, { recursive: true });
+placeSpecMaterials(workdir, ensureSpecCache(outDir));
+
+// The handoff: exactly what the arm's design phase produced, nothing else.
+// Implementers never see the model or the CLI — briefs are the interface
+// (ADR 0054); arm A's document plays the same role.
+const handoff = join(workdir, 'handoff');
+mkdirSync(handoff);
+if (arm === 'A') {
+  cpSync(join(designDir, 'work', 'DESIGN.md'), join(handoff, 'DESIGN.md'));
+} else {
+  cpSync(join(designDir, 'briefs'), handoff, { recursive: true });
+}
+
+const prompt = readPrompt('implementer');
+writeFileSync(join(runDir, 'prompt.txt'), prompt);
+const { result, durationMs, metrics } = runHarness(harness, workdir, prompt);
+saveTranscript(runDir, result);
+
+let gate = null;
+if (!flag(args, 'no-gate') && existsSync(join(workdir, 'run.sh'))) {
+  try {
+    gate = JSON.parse(execFileSync('node', [
+      join(here, 'conformance.mjs'),
+      '--workdir', workdir,
+      '--port', port,
+    ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }));
+  } catch (error) {
+    gate = { ok: false, error: String(error.stdout ?? error).slice(0, 4000) };
+  }
+} else if (!existsSync(join(workdir, 'run.sh'))) {
+  gate = { ok: false, error: 'run.sh missing' };
+}
+writeFileSync(join(runDir, 'gate.json'), JSON.stringify(gate, null, 2));
+
+let promises = null;
+try {
+  promises = JSON.parse(execFileSync('node', [
+    join(here, 'score-promises.mjs'),
+    '--arm', arm,
+    '--design', designDir,
+    '--impl', workdir,
+    ...(toolchain ? ['--toolchain', toolchain] : []),
+  ], { encoding: 'utf8' }));
+} catch (error) {
+  promises = { error: String(error).slice(0, 2000) };
+}
+writeFileSync(join(runDir, 'promises.json'), JSON.stringify(promises, null, 2));
+
+record(outDir, {
+  phase: 'build', arm, run: Number(runN), designRun: Number(designRun),
+  exitCode: result.status, durationMs, metrics, gate, promises, runDir,
+});
+console.log(JSON.stringify({ arm, run: Number(runN), gate, promises, metrics }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/run-design.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/run-design.mjs
@@ -1,0 +1,102 @@
+// Design phase, one run of one arm. Arm A's designer writes DESIGN.md;
+// arm B's designer authors a YarraMate workspace, which is then verified
+// (check green) and rendered to briefs mechanically. Arm C has no design
+// phase of its own: derive it from a B run with derive-arm-c.mjs.
+//
+// Runs cost real agent tokens; nothing executes without --harness, and
+// --dry-run prints what would run.
+//
+// Usage:
+//   node run-design.mjs --arm A|B --run <n> --out <results-dir> \
+//     [--toolchain <dir with yarramate bins>]   (required for arm B) \
+//     [--harness 'claude -p --output-format json'] [--dry-run]
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ensureSpecCache, flag, opt, placeSpecMaterials, readPrompt,
+  record, runHarness, saveTranscript,
+} from './lib.mjs';
+
+const args = process.argv.slice(2);
+const arm = opt(args, 'arm');
+const runN = opt(args, 'run');
+const outDir = opt(args, 'out');
+const toolchain = opt(args, 'toolchain');
+const harness = opt(args, 'harness', 'claude -p --output-format json');
+const dryRun = flag(args, 'dry-run');
+if (!['A', 'B'].includes(arm) || !runN || !outDir) {
+  console.error('usage: run-design.mjs --arm A|B --run <n> --out <dir> [--toolchain <bins>] [--harness <cmd>] [--dry-run]');
+  process.exit(2);
+}
+if (arm === 'B' && !toolchain && !dryRun) {
+  console.error('run-design: arm B needs --toolchain (pinned yarramate bins)');
+  process.exit(2);
+}
+
+const runDir = join(outDir, 'design', arm, `run-${runN}`);
+const workdir = join(runDir, 'work');
+const prompt = readPrompt(arm === 'A' ? 'designer-A' : 'designer-B');
+
+if (dryRun) {
+  console.log(`design arm=${arm} run=${runN} harness=${JSON.stringify(harness)} workdir=${workdir}`);
+  process.exit(0);
+}
+
+rmSync(runDir, { recursive: true, force: true });
+mkdirSync(workdir, { recursive: true });
+placeSpecMaterials(workdir, ensureSpecCache(outDir));
+
+if (arm === 'B') {
+  // The designer gets the pinned toolchain's own skill and catalogue, so
+  // the run exercises exactly what the package ships.
+  const packageRoot = join(toolchain, '..', 'yarramate');
+  cpSync(join(packageRoot, 'skills', 'yarramate-architecture', 'SKILL.md'), join(workdir, 'SKILL.md'));
+  cpSync(join(packageRoot, 'skills', 'yarramate-architecture', 'references'), join(workdir, 'references'), { recursive: true });
+  mkdirSync(join(workdir, 'catalogue'), { recursive: true });
+  cpSync(join(packageRoot, 'catalogues', 'core-enrichment.yaml'), join(workdir, 'catalogue', 'core-enrichment.yaml'));
+}
+
+writeFileSync(join(runDir, 'prompt.txt'), prompt);
+const { result, durationMs, metrics } = runHarness(harness, workdir, prompt, arm === 'B' ? toolchain : undefined);
+saveTranscript(runDir, result);
+
+// Deliverable gates: a design run that produced no scoreable artifact is
+// recorded as failed rather than silently passed downstream.
+let deliverable = null;
+if (arm === 'A') {
+  const ok = existsSync(join(workdir, 'DESIGN.md'))
+    && readFileSync(join(workdir, 'DESIGN.md'), 'utf8').includes('## Components');
+  deliverable = { kind: 'design-doc', ok };
+} else {
+  let checkOk = false;
+  let interrogate = null;
+  try {
+    execFileSync(join(toolchain, 'yarramate'), ['check', '.yarramate/workspace.yaml'], { cwd: workdir, stdio: 'pipe' });
+    checkOk = true;
+    interrogate = JSON.parse(execFileSync(
+      join(toolchain, 'yarramate'),
+      ['interrogate', 'catalogue/core-enrichment.yaml', '.yarramate/workspace.yaml', '--json'],
+      { cwd: workdir, encoding: 'utf8' },
+    )).summary;
+  } catch {
+    checkOk = false;
+  }
+  let briefs = null;
+  if (checkOk) {
+    briefs = JSON.parse(execFileSync('node', [
+      join(import.meta.dirname, 'render-briefs.mjs'),
+      '--workdir', workdir,
+      '--toolchain', toolchain,
+      '--out', join(runDir, 'briefs'),
+    ], { encoding: 'utf8' })).rendered;
+  }
+  deliverable = { kind: 'workspace', ok: checkOk && (briefs?.length ?? 0) > 0, interrogate, briefs };
+}
+
+record(outDir, {
+  phase: 'design', arm, run: Number(runN),
+  exitCode: result.status, durationMs, metrics, deliverable, runDir,
+});
+console.log(JSON.stringify({ arm, run: Number(runN), deliverable, metrics }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/score-promises.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/score-promises.mjs
@@ -1,0 +1,79 @@
+// Mechanical promise-keeping floor. The declared component names are the
+// promises: arm A's come from DESIGN.md's mandated `## Components` bullets,
+// arms B/C's from the designer workspace's planned concepts. A name is
+// honoured when its tokens appear in the implementation (file names or
+// source text), missing otherwise; DEVIATIONS.md entries are surfaced but
+// not judged. This is deliberately the floor — boundary violations need
+// human adjudication on top (no-LLM-judging), and the scorer never claims
+// more than name presence.
+//
+// Usage:
+//   node score-promises.mjs --arm A|B|C --design <design-run-dir> --impl <workdir> [--toolchain <bins>]
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { opt, plannedConcepts } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const arm = opt(args, 'arm');
+const designDir = opt(args, 'design');
+const impl = opt(args, 'impl');
+const toolchain = opt(args, 'toolchain');
+if (!arm || !designDir || !impl) {
+  console.error('usage: score-promises.mjs --arm A|B|C --design <design-run-dir> --impl <workdir> [--toolchain <bins>]');
+  process.exit(2);
+}
+
+const declaredNames = () => {
+  if (arm === 'A') {
+    const text = readFileSync(join(designDir, 'work', 'DESIGN.md'), 'utf8');
+    const section = text.split(/^## Components$/m)[1]?.split(/^## /m)[0] ?? '';
+    return [...section.matchAll(/^\s*[-*]\s+\*\*([^*]+)\*\*/gm)].map((match) => match[1].trim());
+  }
+  if (!toolchain) {
+    console.error('score-promises: arms B/C need --toolchain to compile the designer workspace');
+    process.exit(2);
+  }
+  return plannedConcepts(toolchain, join(designDir, 'work', '.yarramate')).map(({ name }) => name);
+};
+
+// Implementation corpus: file paths plus source text, excluding dependency
+// trees and the materials the harness placed.
+const SKIP = new Set(['node_modules', '.git', 'spec', 'handoff', '.yarramate', 'vendor', 'target', 'dist', '__pycache__']);
+const corpus = [];
+const walk = (dir, relative) => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    const path = join(dir, entry.name);
+    const rel = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      walk(path, rel);
+    } else if (statSync(path).size < 512 * 1024) {
+      corpus.push({ path: rel, text: readFileSync(path, 'utf8').toLowerCase() });
+    }
+  }
+};
+walk(impl, '');
+const allText = corpus.map(({ path, text }) => `${path.toLowerCase()}\n${text}`).join('\n');
+
+// A name is honoured when every informative token appears; single-token
+// names match as-is. Tokens under three characters carry no signal.
+const tokens = (name) => name.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3);
+const names = declaredNames();
+const scored = names.map((name) => {
+  const parts = tokens(name);
+  const honoured = parts.length > 0 && parts.every((token) => allText.includes(token));
+  return { name, honoured };
+});
+
+const deviationsPath = join(impl, 'DEVIATIONS.md');
+const deviations = existsSync(deviationsPath) ? readFileSync(deviationsPath, 'utf8').trim() : '';
+
+console.log(JSON.stringify({
+  arm,
+  declared: names.length,
+  honoured: scored.filter(({ honoured }) => honoured).length,
+  missing: scored.filter(({ honoured }) => !honoured).map(({ name }) => name),
+  names: scored,
+  deviations: deviations === '' ? null : deviations.split('\n').filter((line) => line.trim().startsWith('-')).length || 'present',
+}, null, 2));


### PR DESCRIPTION
The executable half of the pre-registered experiment (#85, merged as b4fcb84). Once this merges, the frozen surface is on main **before any run**, per decision 1's rule.

## Frozen (must not change once runs begin)
- **SPEC-DELTA.md** — Conduit pinned at `gothinkster/realworld@98f29fb3` + three requirements no public implementation has: per-user rate limiting on mutations (60/rolling 60s, chosen so the upstream suite passes untouched), an audit log (`GET /api/audit`, literal action table), and article revision history (author-only `GET .../revisions`).
- **delta-hurl/** — their acceptance tests, written in the upstream Hurl suite's own conventions and runnable by the same command. Validated: all three pass against the reference stub (83 requests, 100%).
- **prompts/** — designer-A (mandated `## Components` contract for mechanical scoring), designer-B (checked + interrogated workspace, briefs rendered mechanically), implementer (spec + handoff only, `run.sh` contract, DEVIATIONS.md), extension (tag subscription; its tests to be frozen before that optional phase).

## Runner (operational, patchable with patches recorded)
- `run-design.mjs` / `derive-arm-c.mjs` — arm C is B's workspace + `inject-lies.mjs` (deterministic same-kind endpoint rotation, self-loops excluded, **check must stay green**) + re-rendered briefs. Smoke-tested on a real agent-authored workspace: 2 clean lies, briefs differ, model still green.
- `run-build.mjs` + `conformance.mjs` — gate = upstream AND delta suites against the implementation's `run.sh`; full server lifecycle verified against the stub (exit codes, teardown, JSON summary).
- `score-promises.mjs` — the deterministic promise-keeping floor (declared names honoured/missing + deviations); human adjudication on top per the no-LLM-judging rule.
- `convergence.mjs` — pairwise Jaccard (names / file trees) with the pre-registered A-converges-too guard. Verified on synthetic fixtures with exact expected values.
- `reference-stub.mjs` — test-the-tests fixture only, never an arm artifact.

`RUNBOOK.md` gives the full matrix (pilot N=1 ≈ $20–30 before committing to 3 runs/arm). Nothing spends tokens without an explicit `--harness`; `--dry-run` everywhere.

`rm -rf dist && pnpm verify` green from a clean slate (research dir is outside the package test tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)