### PR TITLE
Target lie kinds explicitly: --kinds on inject-lies, arm labels on derive

### DIFF
--- a/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
@@ -15,13 +15,15 @@ const args = process.argv.slice(2);
 const runN = opt(args, 'run');
 const outDir = opt(args, 'out');
 const toolchain = opt(args, 'toolchain');
+const armLabel = opt(args, 'arm', 'C');
+const kinds = opt(args, 'kinds');
 if (!runN || !outDir || !toolchain) {
   console.error('usage: derive-arm-c.mjs --run <n> --out <dir> --toolchain <bins>');
   process.exit(2);
 }
 
 const sourceWork = join(outDir, 'design', 'B', `run-${runN}`, 'work');
-const runDir = join(outDir, 'design', 'C', `run-${runN}`);
+const runDir = join(outDir, 'design', armLabel, `run-${runN}`);
 const workdir = join(runDir, 'work');
 rmSync(runDir, { recursive: true, force: true });
 mkdirSync(runDir, { recursive: true });
@@ -31,6 +33,7 @@ const lieRecord = execFileSync('node', [
   join(here, 'inject-lies.mjs'),
   '--workdir', workdir,
   '--toolchain', toolchain,
+  ...(kinds ? ['--kinds', kinds] : []),
 ], { encoding: 'utf8' });
 writeFileSync(join(runDir, 'lies.json'), lieRecord);
 
@@ -42,9 +45,9 @@ const briefs = JSON.parse(execFileSync('node', [
 ], { encoding: 'utf8' })).rendered;
 
 record(outDir, {
-  phase: 'design', arm: 'C', run: Number(runN), derivedFrom: `B/run-${runN}`,
+  phase: 'design', arm: armLabel, run: Number(runN), derivedFrom: `B/run-${runN}`,
   exitCode: 0, durationMs: 0, metrics: null,
   deliverable: { kind: 'workspace', ok: briefs.length > 0, lies: JSON.parse(lieRecord).lies.length, briefs },
   runDir,
 });
-console.log(JSON.stringify({ arm: 'C', run: Number(runN), lies: JSON.parse(lieRecord).lies, briefs }, null, 2));
+console.log(JSON.stringify({ arm: armLabel, run: Number(runN), lies: JSON.parse(lieRecord).lies, briefs }, null, 2));

--- a/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
@@ -8,8 +8,11 @@
 // gate is not the failure mode under test.
 //
 // Usage:
-//   node inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins>
-// Prints the lie record (JSON) to stdout; the caller persists it.
+//   node inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> [--kinds access,serving]
+// --kinds restricts which relationship kinds may be rotated (default: any),
+// so a variant can target structural wiring (access/serving) rather than
+// whatever group sorts first. Prints the lie record (JSON) to stdout; the
+// caller persists it.
 
 import { execFileSync } from 'node:child_process';
 import { globSync, readFileSync, writeFileSync } from 'node:fs';
@@ -23,8 +26,9 @@ const YAML = require('yaml');
 const args = process.argv.slice(2);
 const workdir = opt(args, 'workdir');
 const toolchain = opt(args, 'toolchain');
+const allowedKinds = opt(args, 'kinds') ? new Set(opt(args, 'kinds').split(',')) : null;
 if (!workdir || !toolchain) {
-  console.error('usage: inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins>');
+  console.error('usage: inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> [--kinds a,b]');
   process.exit(2);
 }
 
@@ -58,8 +62,10 @@ for (const { path, doc } of documents) {
   const relationships = doc.get('relationships');
   if (!relationships || !relationships.items) continue;
   for (const item of relationships.items) {
-    const key = `${path}::${item.get('kind')}`;
-    const entry = { path, doc, item, kind: item.get('kind') };
+    const kind = item.get('kind');
+    if (allowedKinds !== null && !allowedKinds.has(kind)) continue;
+    const key = `${path}::${kind}`;
+    const entry = { path, doc, item, kind };
     byKind.set(key, [...(byKind.get(key) ?? []), entry]);
   }
 }

--- a/docs/research/context-benchmark/spec-build/runner/run-build.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/run-build.mjs
@@ -27,8 +27,8 @@ const toolchain = opt(args, 'toolchain');
 const harness = opt(args, 'harness', 'claude -p --output-format json');
 const port = opt(args, 'port', '3199');
 const dryRun = flag(args, 'dry-run');
-if (!['A', 'B', 'C'].includes(arm) || !runN || !outDir) {
-  console.error('usage: run-build.mjs --arm A|B|C --run <n> --out <dir> [--design-run <n>] [--harness <cmd>] [--toolchain <bins>] [--port <p>] [--no-gate] [--dry-run]');
+if (!['A', 'B', 'C', 'Cs'].includes(arm) || !runN || !outDir) {
+  console.error('usage: run-build.mjs --arm A|B|C|Cs --run <n> --out <dir> [--design-run <n>] [--harness <cmd>] [--toolchain <bins>] [--port <p>] [--no-gate] [--dry-run]');
   process.exit(2);
 }
 


### PR DESCRIPTION
Operational runner extension from the 2026-07-31 pilot (provenance-recorded): the first C derivation rotated the alphabetically-first group — requirement-realization edges, bookkeeping the implementer never consumes — so the lies were absorbed without any behavioral effect. The structural-lies variant (arm Cs) needs the rotation aimed: `inject-lies --kinds access,serving`, `derive-arm-c --arm Cs`, and `run-build` accepting the label. Used live for the Cs run; results in the pilot artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)