### PR TITLE
Record the spec-build pilot: all arms green, lies discriminate by self-consistency

### DIFF
--- a/docs/research/context-benchmark/spec-build/PILOT-2026-07-31.md
+++ b/docs/research/context-benchmark/spec-build/PILOT-2026-07-31.md
@@ -1,0 +1,112 @@
+# Spec-build pilot (2026-07-31)
+
+Status: pilot record, n = 1 per arm plus one variant. Nothing here is a
+publishable number; this documents the first live execution of the
+pre-registered family (DESIGN-HANDOFF-FAMILY.md), what it produced, and
+the one mechanism finding worth designing the full family around. Total
+agent spend ≈ $20.
+
+## Setup
+
+- Tier: **Sonnet** for every agent, pre-registered before launch.
+- Toolchain: yarramate 0.6.0 packed from main `381e82a` (`context
+  --brief` ADR 0055, skill catalogue fix #94).
+- Spec: RealWorld/Conduit pinned at `98f29fb3` plus the frozen delta
+  (SPEC-DELTA.md: rate limiting, audit log, revision history).
+- Hermetic scratchpad workdirs; artifacts copied to
+  `yarramate-bench-results/spec-build-pilot-2026-07-31/`.
+- Two operational runner patches landed mid-pilot, recorded in the
+  results provenance and merged as #96 (rotation stays within one
+  document — cross-document targets dangle as YM302 rather than lie)
+  and #97 (`--kinds` lie targeting, arm labels).
+
+## Scoreboard
+
+| Arm | Handoff | Design | Build | Gate (upstream + delta) | Promises | Deviations declared |
+| --- | --- | --- | --- | --- | --- | --- |
+| A | 2,943-word design document | $0.51 | $3.63 | ✅ | 15/15 | 1 |
+| B | 48 briefs from the checked model | $3.41 | $3.97 | ✅ | 47/47 | 11 |
+| C | briefs from model with **requirement-realization lies** (4) | derived | $4.57 | ✅ | 44/47 | **0 — "followed as given"** |
+| Cs | briefs from model with **serving-edge lies** (5) | derived | $3.72 | ✅ | 44/47 | lies **detected and overridden** |
+
+Gate = RealWorld's own Hurl suite AND the frozen delta suite against
+each implementation's `run.sh`. All four builds passed; at this tier,
+with the spec in hand, the gate is a floor, exactly as designed — the
+information is in the process and the record, not in pass/fail.
+
+## Findings
+
+1. **The delta is implementable from its text alone.** Arm A's
+   implementer passed all three delta suites with no model and no
+   contact with us. Whatever happens in later runs, "the tests were
+   impossible" is off the table.
+
+2. **Both handoff forms held, at very different resolution.** A's
+   document declared 15 components, all honoured. B's model declared 47
+   planned concepts — every service, store, middleware, and behavior
+   named — and all 47 appear in the implementation, with 11 deviations
+   honestly recorded. Same compliance rate; roughly three times more
+   intent under explicit control in B. (Not evidence B is *better* at
+   n = 1; evidence a much finer contract survived contact with a
+   builder.)
+
+3. **Self-consistent lies were swallowed silently.** Arm C's lies
+   rotated which requirement each service *realizes* — bookkeeping the
+   implementer never needs to consume. Result: a functionally correct
+   build whose DEVIATIONS.md certifies "None. The implementation
+   follows the component names, boundaries, and data-ownership rules
+   in `handoff/` as given." A corrupted traceability layer now carries
+   an implementer's endorsement. Nobody noticed anything; nothing
+   fired.
+
+4. **Self-contradictory lies were caught by the reader.** The Cs
+   variant rotated five serving edges — the cross-service dependency
+   web. The rotation moved each edge's endpoint but dragged its
+   original description along, so the brief read e.g. *"Articles
+   Service serves 'Tags Service' (Confirms the target article exists
+   before it is favorited or unfavorited.)"* — endpoint and
+   parenthetical disagreeing in one sentence. The implementer flagged
+   exactly these edges ("look like a graph-generation artifact"),
+   implemented the evident intent instead, and documented the override
+   in DEVIATIONS.md. The build passed.
+
+5. **The danger axis is lie self-consistency, not lie kind.** C vs Cs
+   is not motivation-vs-structure: it is that C's lies contradicted
+   nothing visible while Cs's lies contradicted their own attached
+   descriptions. `check` was green in both (wiring valid either way).
+   The product-relevant corollary: **the more a model says, the harder
+   it is to lie in it consistently** — every description is one more
+   sentence a lie must agree with, and `--brief` puts that sentence
+   next to the edge where a reader trips over the mismatch.
+
+6. **Cost is flat across arms.** Builds ran $3.6–4.6 and 10–13 minutes
+   regardless of handoff; the design phase is where B spends more
+   ($3.41 vs $0.51) buying the finer contract and the interrogate
+   closure (2 of 13 catalogue questions left open, both
+   spec-unanswerable).
+
+## What this does not show
+
+- **No convergence data.** The headline metric needs runs 2 and 3.
+- **No B-beats-A claim.** Both arms performed; n = 1 cannot rank them.
+- **The Cs detection is partly an artifact of the injector.** Lies were
+  caught *because* rotation leaves descriptions behind. An adversary —
+  or ordinary drift — that keeps the model self-consistent would look
+  like arm C, not Cs. A serious H6 test needs consistent lies
+  (rotate the description with the edge), which is a pre-registerable
+  injector change for the full family.
+- **The mechanical promise floor is name-presence only.** B's 11
+  deviations and both C-variants' three missing behavior names (Browse
+  Articles, Manage Current User, Publish Articles — dropped in both,
+  kept in B) await the human adjudication pass.
+
+## Relationship to the family
+
+The full family (3 runs per arm, convergence scoring, extension phase)
+runs on this harness unchanged except: stratified and self-consistent
+lie injection per finding 5, and the runbook's pilot-first rule is now
+discharged. Finding 3 is the reframed H6 stake: a lying model's cost is
+not a failed build but a false record that survives the build with an
+implementer's signature on it — which is precisely the failure mode the
+evidence/reconcile half of the product exists to catch once code
+exists to reconcile against.

--- a/docs/research/context-benchmark/spec-build/README.md
+++ b/docs/research/context-benchmark/spec-build/README.md
@@ -12,6 +12,7 @@ spec-build/
   delta-hurl/          # FROZEN: their acceptance tests (upstream Hurl conventions)
   prompts/             # FROZEN: designer-A/B, implementer, extension prompts
   RUNBOOK.md           # how to execute a run matrix
+  PILOT-2026-07-31.md  # first live run: all arms green, lie self-consistency finding
   runner/
     lib.mjs            # shared plumbing (spec cache, harness, records)
     run-design.mjs     # design phase, arms A and B


### PR DESCRIPTION
Pilot record for the first live execution of the spec-build family (docs-only): setup and provenance, the four-arm scoreboard, six findings, stated limits, and what the full family changes (stratified + self-consistent lie injection). Companion runner patches already merged as #96/#97; artifacts in the private results repo pending a publish decision.

The finding worth the read: arm C's self-consistent lies were swallowed silently (implementer certified a corrupted design as followed-as-given) while arm Cs's self-contradictory lies were caught and overridden in writing — the danger axis is lie self-consistency, not lie kind, and richer descriptions make consistent lying harder.

`rm -rf dist && pnpm verify` green from a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)