### PR TITLE
Make lies self-consistent on request: --consistent strips lied edges' free text

### DIFF
--- a/docs/research/context-benchmark/spec-build/RUNBOOK.md
+++ b/docs/research/context-benchmark/spec-build/RUNBOOK.md
@@ -38,7 +38,8 @@ OUT=<results-dir>; TC=<toolchain-bins>; TIER='claude -p --model <model> --output
 # 1. Design phase (A and B are agent runs; C is derived, no agent)
 node run-design.mjs --arm A --run N --out $OUT --harness "$TIER"
 node run-design.mjs --arm B --run N --out $OUT --toolchain $TC --harness "$TIER"
-node derive-arm-c.mjs   --run N --out $OUT --toolchain $TC
+node derive-arm-c.mjs   --run N --out $OUT --toolchain $TC \
+  --kinds access,serving --consistent
 
 # 2. Build phase (fresh implementer agents; C's run N builds from B's
 #    lie-injected run N — the pre-registered mapping)
@@ -83,6 +84,12 @@ prints the plan without materializing or spending anything.
   prompts never mention YarraMate, arms, or the experiment.
 - Arm C derives from arm B **after** B's design run completes and before
   any build run of either; `lies.json` records the injected rotations.
+- **Lie injection for the full family is structural AND self-consistent**
+  (`--kinds access,serving --consistent`), pre-registered from the
+  pilot's finding 5: self-contradictory lies get caught by the reader
+  (an injector artifact, not a fair H6 test), while self-consistent
+  ones are the danger case. `--consistent` strips the lied edge's free
+  text and records the originals in `lies.json`.
 - Pilot before the full family: run N=1 across all three arms
   (~$20–30) and inspect every artifact before committing to N=2,3.
 

--- a/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/derive-arm-c.mjs
@@ -17,6 +17,7 @@ const outDir = opt(args, 'out');
 const toolchain = opt(args, 'toolchain');
 const armLabel = opt(args, 'arm', 'C');
 const kinds = opt(args, 'kinds');
+const consistent = args.includes('--consistent');
 if (!runN || !outDir || !toolchain) {
   console.error('usage: derive-arm-c.mjs --run <n> --out <dir> --toolchain <bins>');
   process.exit(2);
@@ -34,6 +35,7 @@ const lieRecord = execFileSync('node', [
   '--workdir', workdir,
   '--toolchain', toolchain,
   ...(kinds ? ['--kinds', kinds] : []),
+  ...(consistent ? ['--consistent'] : []),
 ], { encoding: 'utf8' });
 writeFileSync(join(runDir, 'lies.json'), lieRecord);
 

--- a/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
@@ -8,11 +8,20 @@
 // gate is not the failure mode under test.
 //
 // Usage:
-//   node inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> [--kinds access,serving]
+//   node inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> \
+//     [--kinds access,serving] [--consistent]
 // --kinds restricts which relationship kinds may be rotated (default: any),
 // so a variant can target structural wiring (access/serving) rather than
-// whatever group sorts first. Prints the lie record (JSON) to stdout; the
-// caller persists it.
+// whatever group sorts first.
+// --consistent makes every lie self-consistent: the pilot showed a rotated
+// edge dragging its original description along contradicts itself in one
+// brief sentence and gets caught by the reader, while a lie that asserts
+// nothing extra is absorbed silently. A deterministic injector cannot
+// rewrite prose for the new endpoint (that would take generation), so
+// consistency here means stripping the lied edge's free text — description,
+// name, flow content — and recording the originals in the lie record for
+// the adjudicator. The lie becomes a confident bare structural claim.
+// Prints the lie record (JSON) to stdout; the caller persists it.
 
 import { execFileSync } from 'node:child_process';
 import { globSync, readFileSync, writeFileSync } from 'node:fs';
@@ -27,8 +36,9 @@ const args = process.argv.slice(2);
 const workdir = opt(args, 'workdir');
 const toolchain = opt(args, 'toolchain');
 const allowedKinds = opt(args, 'kinds') ? new Set(opt(args, 'kinds').split(',')) : null;
+const consistent = args.includes('--consistent');
 if (!workdir || !toolchain) {
-  console.error('usage: inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> [--kinds a,b]');
+  console.error('usage: inject-lies.mjs --workdir <arm-C-workdir> --toolchain <bins> [--kinds a,b] [--consistent]');
   process.exit(2);
 }
 
@@ -85,12 +95,23 @@ for (const key of [...byKind.keys()].sort()) {
     const lyingTo = targets[(index + 1) % targets.length];
     if (lyingTo === targets[index] || lyingTo === entry.item.get('from')) return;
     entry.item.set('to', lyingTo);
+    const stripped = {};
+    if (consistent) {
+      for (const field of ['description', 'name', 'content']) {
+        const value = entry.item.get(field);
+        if (value !== undefined) {
+          stripped[field] = value;
+          entry.item.delete(field);
+        }
+      }
+    }
     lies.push({
       relationship: entry.item.get('id'),
       kind,
       from: entry.item.get('from'),
       originalTo: targets[index],
       lyingTo,
+      ...(Object.keys(stripped).length > 0 ? { stripped } : {}),
     });
   });
 }


### PR DESCRIPTION
The fair-H6 injector pre-registered by the pilot note's finding 5. `inject-lies --consistent` strips each lied edge's free text (description, name, flow content) and records the originals in `lies.json`, so the lie asserts nothing that contradicts — reproducing exactly the mechanism that made arm C's lies slip through, now applicable to structural edges. The stronger variant (rewriting prose to describe the new endpoint) requires generation and stays out of deterministic scope, documented in the header.

Smoked live on the pilot's arm-B workspace (as variant `Cc`): 5 serving-edge lies, all stripped and recorded, model stayed check-green, and the lying brief sentences are now bare confident claims (`It serves "Favorites Service" and "Tags Service".`) while truthful edges keep their parentheticals. RUNBOOK now pre-registers the full family's injection as `--kinds access,serving --consistent`.

`rm -rf dist && pnpm verify` green from a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)