### PR TITLE
Record the Cc probe: consistent structural lies drown in redundant truth

### DIFF
--- a/docs/research/context-benchmark/spec-build/PILOT-2026-07-31.md
+++ b/docs/research/context-benchmark/spec-build/PILOT-2026-07-31.md
@@ -100,6 +100,43 @@ information is in the process and the record, not in pass/fail.
   Articles, Manage Current User, Publish Articles — dropped in both,
   kept in B) await the human adjudication pass.
 
+## Addendum: the Cc probe (consistent structural lies)
+
+One further build ran after the note above was drafted: arm Cc, briefs
+from the same five serving-edge rotations but injected with
+`--consistent` (free text stripped, so nothing contradicts the lie).
+Gate passed, 44/47 promises, $4.12 — and **88 turns against B's 58**,
+the longest build of the day.
+
+The lies were **neither followed nor flagged**. The implementation's
+dependency graph matches the truth (Comments requires Articles, Tags
+derives from Articles, Articles reads Favorites; the net-false
+"Favorites serves Comments" appears nowhere), and neither DEVIATIONS.md
+nor the final message mentions anything odd. Two mechanisms, both
+recorded for the family:
+
+- **Rotation artifact #2: within-source rotations can be
+  set-invariant.** Two of the five lies swapped targets between edges
+  sharing one source, and the brief renders grouped sentences — so
+  "Profiles serves X and Y" came out identical to the truth. The family
+  injector should rotate across *different* sources.
+- **Redundancy defends the build.** The three net-false claims were
+  outnumbered by surviving truthful claims (described edges, access and
+  triggering relations, per-service briefs) and by the spec's own
+  implied topology; the implementer triangulated the true wiring and
+  the bare lying sentences simply carried no weight. The extra thirty
+  turns are weak evidence that reconciling the noise cost effort
+  rather than nothing.
+
+Three C variants, three behaviors at n = 1: self-contradictory lies get
+**caught**; self-consistent bookkeeping lies get **absorbed into the
+record**; self-consistent structural lies in a rich truthful model get
+**drowned out, at some effort cost**. The case none of these probes can
+reach — and the honest boundary of this design — is a model whose lies
+sit on the critical path with *no spec or conformance suite to
+contradict them*, which is precisely the ordinary condition of
+greenfield work before tests exist.
+
 ## Relationship to the family
 
 The full family (3 runs per arm, convergence scoring, extension phase)

--- a/docs/research/context-benchmark/spec-build/runner/run-build.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/run-build.mjs
@@ -27,8 +27,8 @@ const toolchain = opt(args, 'toolchain');
 const harness = opt(args, 'harness', 'claude -p --output-format json');
 const port = opt(args, 'port', '3199');
 const dryRun = flag(args, 'dry-run');
-if (!['A', 'B', 'C', 'Cs'].includes(arm) || !runN || !outDir) {
-  console.error('usage: run-build.mjs --arm A|B|C|Cs --run <n> --out <dir> [--design-run <n>] [--harness <cmd>] [--toolchain <bins>] [--port <p>] [--no-gate] [--dry-run]');
+if (!/^(A|B|C[a-z]*)$/.test(arm ?? '') || !runN || !outDir) {
+  console.error('usage: run-build.mjs --arm A|B|C[<variant>] --run <n> --out <dir> [--design-run <n>] [--harness <cmd>] [--toolchain <bins>] [--port <p>] [--no-gate] [--dry-run]');
   process.exit(2);
 }
 


### PR DESCRIPTION
Addendum to the pilot note plus the small runner patch it used (`run-build` accepts `C<variant>` labels).

The probe answers the question the Cs variant left open: with nothing contradicting them, do consistent structural lies flow into the code? At n=1: no — but not by detection. Two of five rotations were set-invariant (within-source swaps render the same grouped sentence — injector artifact #2, recorded), and the remaining false claims were drowned out by the model's redundant truthful majority plus the spec's implied topology. Cost signal: 88 turns vs B's 58. The recorded boundary: none of the three C variants reaches the case where lies sit on the critical path with no spec to contradict them — greenfield before tests exist.

`rm -rf dist && pnpm verify` green from a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)