### PR TITLE
Rotate lies across different sources: same-source swaps are set-invariant

### DIFF
--- a/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
+++ b/docs/research/context-benchmark/spec-build/runner/inject-lies.mjs
@@ -85,13 +85,24 @@ for (const key of [...byKind.keys()].sort()) {
   if (lies.length >= 3) break;
   const group = byKind.get(key).filter((entry) => entry.item.get('to') !== undefined);
   const kind = group[0]?.kind;
-  const targets = group.map((entry) => entry.item.get('to'));
-  if (new Set(targets).size < 2) continue;
-  // Rotate every target in the group one position: each relationship now
-  // points where its same-kind neighbour pointed. A rotation that changes
-  // nothing, or that would point a relationship at its own source (a
-  // self-loop no designer would write), stays truthful instead.
-  group.forEach((entry, index) => {
+  // Rotate across DIFFERENT sources only (one edge per source): rotating
+  // targets between edges that share a source permutes that source's own
+  // target set, and grouped brief sentences render sets — the lie comes
+  // out word-for-word identical to the truth (pilot injector artifact #2).
+  // One edge per distinct source guarantees every affected source's
+  // declared set visibly changes.
+  const seenSources = new Set();
+  const roots = group.filter((entry) => {
+    const from = entry.item.get('from');
+    if (seenSources.has(from)) return false;
+    seenSources.add(from);
+    return true;
+  });
+  const targets = roots.map((entry) => entry.item.get('to'));
+  if (roots.length < 2 || new Set(targets).size < 2) continue;
+  // A rotation that changes nothing, or that would point a relationship at
+  // its own source (a self-loop no designer would write), stays truthful.
+  roots.forEach((entry, index) => {
     const lyingTo = targets[(index + 1) % targets.length];
     if (lyingTo === targets[index] || lyingTo === entry.item.get('from')) return;
     entry.item.set('to', lyingTo);


### PR DESCRIPTION
The family-gating injector fix recorded as artifact #2 in the pilot note: same-source rotations render set-identical grouped sentences (two of Cc's five lies never existed on the page). One edge per distinct source now participates in each rotation ring, so every lie is set-visible by construction.

Dose note for the record: with the pre-registered family flags (`--kinds access,serving --consistent`), one document's access group forms a single ring — on the pilot's B workspace that rewires 8 of 11 declared ownership edges plus one serving edge (9 lies, 9 sources, all self-consistent, check green). That is a strong-dose H6 test: if implementers still build correct ownership under a spec, that genuinely bounds what structural lies can do when tests exist.

Smoked live; `rm -rf dist && pnpm verify` green from a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)