### PR TITLE
Streamline the harness contract to seven verbs: the 0.7.0 clean break

### DIFF
--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -1,121 +1,208 @@
 # The agent-harness interface
 
-Status: target interface, decisions recorded 2026-07-31. This document
-is the map an agent harness builds against: every surface, whether it is
-built or planned, the use case it serves, and which observed problem it
-answers. Planned surfaces are direction, not contract, until they ship
-with their own ADRs.
+Status: target contract for **0.7.0, a clean break** (decided
+2026-07-31). The current fourteen commands accreted bottom-up and are
+individually justified but collectively incoherent; pre-release with
+near-zero adoption is the only cheap moment to fix that. This document
+is the top-down contract the break lands on: **seven verbs, one per
+lifecycle stage**. Planned surfaces are direction, not contract, until
+they ship with their own ADRs.
 
-The division of labour behind every surface (ADR 0054): the engine
+The division of labour behind every verb (ADR 0054): the engine
 derives, verifies, and renders deterministically; the LLM supplies
-judgment on top. No surface below asks the engine to read words or have
-taste.
+judgment on top. No verb asks the engine to read words or have taste.
 
-## 1. Discovery and entry — the agent arrives
+## The seven verbs
 
-| Surface | Status | Harness use case |
-| --- | --- | --- |
-| `init` + pointer delivery (ADR 0040/0045) | built | Repo adoption: the pointer in AGENTS.md/CLAUDE.md advertises the workspace |
-| Skill via plugin marketplace | built | Loads the methodology; currently the only carrier of loop discipline |
-| `yarramate-mcp` (ADR 0044, read-only) | built | Tool-calling harnesses |
-| Agent card / kinds roster (#89) | planned | Learn vocabulary, aspect rules, and commands in one ~2k read |
-| `yarramate design` entry | planned | Greenfield entry: an idea arrives as a prompt and the interview starts, instead of init-then-improvise |
+```text
+init → design → apply → ask → check → reconcile → export
+create  fill    write   read  gate    drift       derive
+```
 
-## 2. Conception — the interview loop (greenfield core)
+The rule separating `ask` from `export` is borrowed from graphify's
+query/wiki split: **does the output outlive the invocation?** An answer
+consumed now by the asking agent is `ask`; a persisted artifact
+consumed later by someone else is `export`. Same renderers underneath,
+two intents.
 
-The loop: ask the top question → the answer arrives as prose → the
-agent writes it into the model → recompute → next question. Stateless
-at every step (ADR 0053): the loop resumes from model + catalogue
-alone, across sessions and agents.
+### `yarramate init` — create
 
-| Surface | Status | Harness use case |
-| --- | --- | --- |
-| `interrogate <catalogue> <ws>` | built | All open questions, wave-ordered, with materiality |
-| `yarramate design <ws>` | planned — **stateless one-step command** | Emits exactly the top open question plus the model slice it concerns plus answering guidance; the harness loops it. No session state, headless-safe, resumable |
-| `apply` batch writes (#93) | planned | One prose answer becomes one atomic validated write; any invalid op rejects the batch (no-partial-graph) |
-| Deep catalogue: the ArchiMate path | planned — **motivation + business + application first** (~35–45 questions, in-wave ordering); technology/implementation follow | The "defined structured path": the interview no longer exhausts after ~10 answers |
-| Adequacy conditions | planned — **linkage-depth + attestation** | See below |
-| `add` / `connect` | built | Single validated writes; the weak tier's proven bridge |
-| `check` | built | Gate after every write |
+[built, unchanged] Scaffolds the workspace, delivers the pointer
+(ADR 0040/0045) so harnesses discover it.
 
-### Adequacy: how "filled" becomes "filled adequately"
+- Harness use: repo adoption; the greenfield entry hands off to
+  `design` immediately after.
 
-Two mechanisms, layered, both deterministic (decision 2026-07-31):
+### `yarramate design` — fill, guided
 
-1. **Linkage-depth conditions** — new catalogue trigger types that hold
-   a question open until the blank's *neighbourhood* exists: a goal
-   needs a realizing element, a stakeholder, and an influencing driver;
-   a requirement needs realization and an acceptance/constraint link.
-   Structural thinness caught mechanically.
+[new; machinery built] The conception loop's ask-half. Each invocation
+is stateless (ADR 0053) and emits exactly the **top open question** —
+materiality-ordered — plus the model slice it concerns plus answering
+guidance; the harness/LLM loops: answer arrives as prose → agent
+translates it into `apply` operations → re-invoke `design`.
+
+- **The catalogue is internal.** It ships inside the product, versioned
+  with it — the deep ArchiMate path (motivation + business +
+  application waves first, ~35–45 questions with in-wave ordering;
+  technology/implementation later) plus adequacy conditions (below).
+  `--catalogue <path>` exists only as an override for teams authoring
+  their own. Harnesses never pass or read catalogue files.
+- Today's `interrogate` demotes to internal machinery; the full
+  open-questions report remains reachable as a read (see `ask`).
+- Harness use: greenfield conception from a one-line idea; enrichment
+  of an existing model; resumable across sessions and agents because
+  nothing is stored but the model.
+
+### `yarramate apply` — write, validated
+
+[new; add/connect built] All model writes: single operations and
+**atomic batches** (an operations document; any invalid op rejects the
+whole batch, preserving no-partial-graph). Structurally incapable of
+emitting YM404s — the weak tier's proven bridge, now cheap enough for
+the strong tier (one answer = one call). Swallows `add`, `connect`,
+and `new projection` scaffolding.
+
+- Harness use: landing a design answer; discovery-journey authoring;
+  maintenance edits.
+
+### `yarramate ask` — read, interactive
+
+[new verb; renderers built] One entry point for every consumed-now
+read; graphify analogues: `query` / `explain` / `path`.
+
+- `ask` (bare) — orientation: the status verdict, drift summary,
+  inventory (today's `status`; the known backlog-orientation gap
+  belongs here).
+- `ask <subject|projection>` — the slice as a brief (ADR 0055) or
+  digest/JSON (`--budget`, `--json`).
+- `ask --advise <topic>` — the expert composition: slice + open
+  questions + drift state assembled deterministically into one context
+  block the LLM answers *as* the architect. The engine composes ground
+  truth; it never advises.
+- `ask --next` — dependency-ordered planned work (ADR 0048).
+- `ask --open` — the full open-questions report (today's interrogate
+  output as a read).
+- `ask --compare <from> <to>` — state delta (today's `compare`).
+- Harness use: mid-task orientation, bounded context retrieval,
+  design-review advice, build ordering.
+
+### `yarramate check` — gate
+
+[built, scope unchanged] The pass/fail verdict CI and loops key on:
+structural validity always; `--strict` adds evidence contradictions.
+Exit code is the contract.
+
+- Harness use: gate after every `apply`; CI on every PR.
+
+### `yarramate reconcile` — drift report
+
+[built, kept separate — decision 2026-07-31] The full intent-vs-
+evidence report: supported, contradicted, unknown, unobserved. A
+report, never a gate; `check --strict` is the gate form of its
+contradiction signal.
+
+- Harness use: trust assessment before relying on a model; the CI
+  drift Action's substance.
+
+### `yarramate export` — derive artifacts
+
+[new verb; renderers built] Persisted outputs consumed later or by
+others; graphify analogues: `--wiki` / `--svg` / `--neo4j`.
+
+- `export graph` — canonical graph v2 JSON (today's `compile`).
+- `export briefs <projection>` — the handoff bundle: one brief per
+  slice for N implementers (the spec-build family's `handoff/`).
+- `export markdown <projection>` — human-readable document (today's
+  `view`).
+- `export likec4` — visualization project (today's adapter surface;
+  the adapter binary remains the implementation).
+- Harness use: handoff preparation, CI artifact generation,
+  visualization refresh.
+
+## Adequacy: how "filled" becomes "filled adequately"
+
+Two mechanisms, layered, both deterministic (decision 2026-07-31),
+living inside `design`'s internal catalogue:
+
+1. **Linkage-depth conditions** — a question stays open until the
+   blank's *neighbourhood* exists: a goal needs a realizing element, a
+   stakeholder, and an influencing driver; a requirement needs
+   realization and an acceptance/constraint link. Structural thinness
+   caught mechanically.
 2. **Attestation claims** — a question stays open until an authority
    (human, or an LLM acting as named reviewer) records an attestation
    claim in the model. The judgment lives outside the engine; its
-   *record* is structural, stateless, git-reviewed, and revocable.
-   Content thinness caught by explicit, auditable sign-off — the
-   engine still never reads words.
+   record is structural, stateless, git-reviewed, and revocable.
+   Content thinness caught by explicit, auditable sign-off — the engine
+   still never reads words.
 
 Text heuristics (length, name-mention) were considered and rejected:
 they erode the wiring-not-words boundary for little gain.
 
-## 3. Advisory — query the model as an expert
+## Migration map (0.7.0 clean break)
 
-| Surface | Status | Harness use case |
+| Today | Becomes |
+| --- | --- |
+| `init` | `init` (unchanged) |
+| `add`, `connect`, `new projection` | `apply` |
+| `interrogate <catalogue> <ws>` | `design` machinery; report via `ask --open` |
+| `status` | `ask` (bare) |
+| `context <projection>` / `--subject` / `--budget` / `--brief` | `ask <slice>` |
+| `next` | `ask --next` |
+| `compare` | `ask --compare` |
+| `view` | `export markdown` (interactive form: `ask <slice>`) |
+| `compile` | `export graph` |
+| `check` / `--strict` | `check` (unchanged) |
+| `evidence` | machinery under `check`/`reconcile` (open question below) |
+| `reconcile` | `reconcile` (unchanged) |
+| adapter binaries (`yarramate-likec4`, `yarramate-graphify`) | implementation behind `export` / `reconcile`; direct binaries remain for advanced use |
+| MCP adapter | re-exposed as the seven verbs |
+
+Core contract, skill, MCP, README, and the marketplace listing rewrite
+to the seven verbs in the same release. No aliases: old names are
+removed, and the release notes carry the map above.
+
+## Problem map — observed problem → owning verb
+
+| Observed problem (evidence) | Owner | Status |
 | --- | --- | --- |
-| `context <projection|--subject> --brief` (ADR 0055) | built | Deterministic prose of a slice |
-| `next` (ADR 0048) | built | Build order with evidence coverage |
-| `status` (ADR 0038) | built (known gap: not backlog-oriented) | One-call orientation |
-| `context --advise` composition | planned — **CLI composition command** | Deterministically composes the relevant slice + open questions + drift state into one context block; the LLM answers *as* the architect reading it. Engine supplies ground truth, never advice |
-
-## 4. Handoff — N implementers, one model
-
-| Surface | Status | Harness use case |
-| --- | --- | --- |
-| `context --brief` per slice | built | Bounded per-implementer briefs (exercised 11 times in the 2026-07-31 family) |
-| `context --budget` / JSON | built | Machine consumers |
-| `view`, LikeC4 export | built | Human review |
-
-## 5. Verification and drift — is the model still true
-
-| Surface | Status | Harness use case |
-| --- | --- | --- |
-| `check --strict`, `evidence`, `reconcile` | built | CI gates; contradiction detection once code exists |
-| `compare` | built | State deltas |
-| Drift GitHub Action | built | PR-time signal |
-| One-call verdict (#92) | planned | check + open questions in one turn |
-
-## Problem map — observed problem → owning surface
-
-| Observed problem (evidence) | Owning surface | Status |
-| --- | --- | --- |
-| Weak tier never opens the workspace unprompted (sweep 0/5) | init pointer, skill, `design` entry | pointer fixed (ADR 0045); entry gap open |
-| ~67k tokens per interview question (loop cost) | #89 card, #92 verdict, #93 batch | skill fix shipped; rest planned |
-| A five-word goal closes `outcome-missing` forever | adequacy conditions | planned |
-| Same spec modeled at 47 vs 27 concepts (sank H5) | deep catalogue granularity guidance | planned |
-| Interview exhausts after ~10 answers | deep catalogue | planned |
-| Agents batch the whole model; no incremental discipline | `yarramate design` | planned |
-| Engine blind to requirement words (privacy-leak text passes) | permanent boundary; mitigated by `--advise` + attestations | by design |
-| Lies absorbed silently pre-code (family run 1 C) | reconcile once code exists; adequacy raises the witness count before | partial by design |
+| Weak tier never opens the workspace unprompted (sweep 0/5; AGENTS.md read in 0 of 28 runs) | `init` pointer + skill + `design` entry | pointer shipped; entry gap open |
+| ~67k tokens per interview question (loop cost) | `design` (one-step), `apply` (batch), agent card #89 | planned |
+| A five-word goal closes `outcome-missing` forever | `design` adequacy conditions | planned |
+| Same spec modeled at 47 vs 27 concepts (sank H5) | `design` catalogue granularity guidance | planned |
+| Interview exhausts after ~10 answers | `design` deep catalogue | planned |
+| Agents batch the whole model; no incremental discipline | `design` | planned |
+| Harness must know catalogue file paths | `design` (catalogue internal) | fixed by this contract |
+| Fourteen sibling commands, four of them just to read | `ask` / `export` consolidation | fixed by this contract |
+| Engine blind to requirement words (privacy-leak text passes) | permanent boundary; mitigated by `ask --advise` + attestations | by design |
+| Lies absorbed silently pre-code (family run 1 C) | `reconcile` once code exists; adequacy raises the witness count before | partial by design |
 | Strong tiers never use add/connect | `apply` batch | planned |
-| Agents read src/profile.ts to learn kinds | #89 agent card | planned |
-| `status` not backlog-oriented | status/next | open |
-| Brief reads "is assigned to" both directions | brief phrase table | small fix open |
+| Agents read src/profile.ts to learn kinds | agent card #89 (entry) | planned |
+| `status` not backlog-oriented | `ask` (bare) | open |
+| Brief reads "is assigned to" both directions | brief renderer phrase table (`ask`/`export`) | small fix open |
 
-## Build order
+## Build order (the 0.7.0 arc)
 
-1. Deep catalogue + adequacy condition types (extends `interrogate`;
-   pure data + trigger code; the interview becomes real)
-2. `apply` batch writes (#93) — the loop's write half
-3. `yarramate design` — the loop's ask half, composing 1 and 2
-4. `context --advise` — the advisory composition
-5. #89 agent card and #92 one-call verdict as they slot in
+1. Deep catalogue + adequacy condition types (engine side of `design`)
+2. `apply` (#93 shape) — the loop's write half
+3. `design` (#103) — the loop's ask half, catalogue internal
+4. `ask` — consolidation of status/context/next/compare + `--advise`
+   (#105) + `--open`
+5. `export` — consolidation of compile/view/likec4/briefs
+6. Contract/skill/MCP/docs rewrite; release 0.7.0
+7. Agent card (#89) folds into the skill/entry surfaces along the way
 
-## Open questions (second order, to settle at build time)
+## Open questions (settle at build time, not by assumption)
 
-- Attestation claim shape: predicate namespace, who-may-attest rules,
-  and whether revocation is deletion or a counter-claim.
-- `design` argument surface: how a harness scopes the interview
-  (whole workspace vs a wave vs a subject).
-- `--advise` topic addressing: subject id, projection, or free question
-  routed to a slice.
+- Attestation claim shape: predicate namespace, who-may-attest, and
+  whether revocation is deletion or a counter-claim.
+- `design` argument surface: scoping the interview (workspace vs wave
+  vs subject).
+- `ask --advise` topic addressing: subject id, projection, or free
+  question routed to a slice.
+- Where the standalone `evidence` evaluation lands: `check` machinery,
+  `reconcile` mode, or gone as a public surface.
+- Whether `ask` bare output grows the backlog-oriented section the
+  status gap calls for, and its shape.
 - Catalogue versioning as the path deepens (the pinned-baseline lesson
   from the benchmark applies).


### PR DESCRIPTION
Docs-only rewrite of `docs/AGENT-INTERFACE.md` around the seven-verb contract settled in tonight's design session: `init / design / apply / ask / check / reconcile / export` — one verb per lifecycle stage, clean break at 0.7.0, no aliases.

Key calls recorded: the catalogue is **internal to `design`** (harnesses never see catalogue paths; `interrogate` demotes to machinery, its report becomes `ask --open`); the `ask`/`export` boundary is graphify's query/wiki rule — *does the output outlive the invocation?* — with briefs living on both sides accordingly; `reconcile` stays a separate verb (gate vs report distinction preserved). Includes the full migration map for all fourteen current commands, the problem map re-owned by verb, the 0.7.0 build order, and six open questions explicitly deferred to build time rather than assumed.

`rm -rf dist && pnpm verify` green from a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)