### PR TITLE
Deepen the catalogue to the design path: linkage, attestation, and an application wave

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -276,11 +276,13 @@ concepts:
       - yarramate-evolution#core-contract-foundation
   - id: likec4-check-result
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 adapter check result
     description: Versioned machine-readable verdict of the bundled adapter path check.
     status: current
   - id: likec4-diagnostic-result
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 adapter diagnostic result
     description: Machine-readable failure payload shared by LikeC4 adapter commands.
     status: current
@@ -316,136 +318,163 @@ concepts:
     status: current
   - id: native-document
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Native YAML document
     description: Canonical authored YAML declaring concepts, relationships, and states under one selected profile.
     status: current
   - id: document-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Native document JSON Schema
     description: Normative structure for native yarramate/v1 documents; vocabulary validity belongs to the selected profile.
     status: current
   - id: kind-catalogue
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Concept kind catalogue
     description: Resolved concept kinds with aspects and lineage available to a compilation.
     status: current
   - id: relationship-policy-catalogue
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Relationship policy catalogue
     description: Resolved relationship kinds with endpoint aspect constraints available to a compilation.
     status: current
   - id: semantic-graph
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Tool-neutral semantic graph
     description: Claim-centred tool-neutral compilation output; every fact is a sourced claim.
     status: current
   - id: diagnostics
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Source-located diagnostics
     description: Deterministic source-located errors pointing at authored input; never advice or taste.
     status: current
   - id: check-result
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Machine-readable check result
     description: Versioned machine-readable verdict of a check run, consumed by CI and agent harnesses.
     status: current
   - id: check-result-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Check result JSON Schema
     description: Normative structure for the yarramate/check-result/v1 contract.
     status: current
   - id: diagnostic-result
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Semantic command diagnostic result
     description: Shared machine-readable failure payload emitted by semantic commands that cannot produce their primary output.
     status: current
   - id: diagnostic-result-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Diagnostic result JSON Schema
     description: Normative structure for the yarramate/diagnostic-result/v1 contract.
     status: current
   - id: likec4-diagnostic-result-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 diagnostic result JSON Schema
     description: Normative structure for LikeC4 adapter failure payloads.
     status: current
   - id: likec4-generated-project-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Generated LikeC4 project marker JSON Schema
     description: Normative marker structure guarding single-view generated LikeC4 projects.
     status: current
   - id: likec4-project-definition
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 project definition
     description: Adapter-owned composition of semantic projections into one derived multi-view project, with optional renderer view identities that preserve native projection identity.
     status: current
   - id: likec4-project-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 project definition JSON Schema
     description: Normative structure for LikeC4 project definitions composing projections as views.
     status: current
   - id: likec4-generated-project-v2-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Multi-view generated LikeC4 project marker JSON Schema
     description: Normative marker structure guarding multi-view generated LikeC4 projects.
     status: current
   - id: likec4-kind-mapping
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 kind compatibility mapping
     description: Versioned adapter-owned mapping from qualified semantic kinds to LikeC4 declaration kinds.
     status: current
   - id: likec4-kind-mapping-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 kind mapping JSON Schema
     description: Normative structure for explicit LikeC4 kind compatibility declarations.
     status: current
   - id: likec4-check-result-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: LikeC4 check result JSON Schema
     description: Normative structure for the LikeC4 adapter check verdict.
     status: current
   - id: adapter-mapping
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Optional adapter mapping
     description: Versioned correspondence between globally qualified native subjects and external identities.
     status: current
   - id: adapter-mapping-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Adapter mapping JSON Schema
     description: Normative structure for optional adapter subject mappings; it does not admit adapter fields into native documents.
     status: current
   - id: semantic-graph-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Semantic graph v2 JSON Schema
     description: Normative structure for the yarramate/graph/v2 interchange contract.
     status: current
   - id: projection-definition
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Semantic projection definition
     description: Portable selector describing one bounded semantic slice; presentation only, never new semantics.
     status: current
   - id: projection-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Projection definition JSON Schema
     description: Normative structure for projection definitions.
     status: current
   - id: projection-result
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Deterministic projection result
     description: Deterministic bounded context produced by evaluating a projection against the compiled graph.
     status: current
   - id: projection-result-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Projection result JSON Schema
     description: Normative structure for the yarramate/projection-result/v1 contract.
     status: current
   - id: starter-view-pack
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Native starter view pack
     description: Eight optional projection templates for landscape, motivation, strategy, business, application, information, technology, and implementation concerns, with selective isolated-concept suppression for broad views.
     status: current
   - id: state-comparison
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Architecture-state comparison
     description: Versioned deterministic added, removed, and retained subject classification.
     status: current
@@ -454,6 +483,7 @@ concepts:
       - yarramate-evolution#core-contract-foundation
   - id: state-comparison-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Architecture-state comparison JSON Schema
     description: Normative structure for architecture-state comparison results.
     status: current
@@ -462,6 +492,7 @@ concepts:
       - yarramate-evolution#core-contract-foundation
   - id: core-contract-manifest
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Core contract manifest
     description: Versioned declaration of one tool-neutral Core release boundary.
     status: current
@@ -469,6 +500,7 @@ concepts:
       - yarramate-evolution#core-contract-foundation
   - id: core-contract-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Core contract JSON Schema
     description: Normative structure for Core release contract manifests.
     status: current
@@ -476,41 +508,49 @@ concepts:
       - yarramate-evolution#core-contract-foundation
   - id: workspace-manifest
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Workspace manifest
     description: Explicit versioned declaration of every workspace input; nothing is discovered implicitly.
     status: current
   - id: workspace-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Workspace manifest JSON Schema
     description: Normative structure for workspace manifests.
     status: current
   - id: evidence-document
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Evidence overlay document
     description: Provider observations about existing subjects and claims; evidence supports or challenges intent and never authors it.
     status: current
   - id: evidence-report
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Deterministic evidence report
     description: Deterministic evaluation of one evidence document against the compiled graph.
     status: current
   - id: evidence-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Evidence overlay JSON Schema
     description: Normative structure for evidence overlay documents.
     status: current
   - id: evidence-report-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Evidence report JSON Schema
     description: Normative structure for the yarramate/evidence-report/v1 contract.
     status: current
   - id: reconciliation-report
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Reconciliation report
     description: Deterministic unresolved evidence findings with provider provenance.
     status: current
   - id: reconciliation-report-schema
     kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
     name: Reconciliation report JSON Schema
     description: Normative structure for workspace reconciliation reports.
     status: current
@@ -1039,3 +1079,45 @@ relationships:
     kind: serving
     from: cli
     to: mcp-adapter
+  - id: cli-provides-status
+    kind: implements
+    from: cli
+    to: status-command
+  - id: cli-provides-next
+    kind: implements
+    from: cli
+    to: next-command
+  - id: cli-provides-compare
+    kind: implements
+    from: cli
+    to: compare-command
+  - id: cli-provides-context
+    kind: implements
+    from: cli
+    to: context-command
+  - id: cli-provides-new
+    kind: implements
+    from: cli
+    to: new-command
+  - id: cli-provides-interrogate
+    kind: implements
+    from: cli
+    to: interrogate-command
+  - id: likec4-adapter-provides-export
+    kind: implements
+    from: likec4-export-adapter
+    to: likec4-export-command
+  - id: likec4-adapter-provides-check
+    kind: implements
+    from: likec4-export-adapter
+    to: likec4-check-command
+  - id: mcp-adapter-implements-machine-context
+    kind: implements
+    from: mcp-adapter
+    to: yarramate-product#provide-machine-context
+    description: The MCP affordance re-exposes the stable read surface as tools, per ADR 0044.
+  - id: profile-catalogue-implements-tool-neutrality
+    kind: implements
+    from: profile-catalogue
+    to: yarramate-product#tool-neutral-core
+    description: Core-owned kind semantics are what keep meaning independent of adapters.

--- a/.yarramate/architecture/product.yaml
+++ b/.yarramate/architecture/product.yaml
@@ -28,30 +28,58 @@ concepts:
     description: Review, merge, and ADR governance for the YarraMate repository as described in GOVERNANCE.md.
   - id: shared-architecture-context
     kind: goal
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Shared architecture context
     description: People and agents work from the same structured architectural meaning.
   - id: repository-native-operation
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Repository-native operation
     description: Git supplies authorship, review, history, and approval.
   - id: tool-neutral-core
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Tool-neutral core
     description: Core remains independent of authoring, visualization, evidence, and compatibility adapters.
   - id: native-documents-are-canonical
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Native documents are canonical
     description: Versioned YarraMate documents are the committed semantic source of truth.
   - id: deterministic-correctness
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Deterministic correctness
     description: Core validation checks reproducible correctness rather than taste or completeness.
   - id: stable-cli
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Stable CLI
     description: Humans, CI, skills, and agent harnesses share one command interface.
   - id: evidence-intent-separation
     kind: requirement
+    attestations:
+      - topic: adequacy
+        by: claude-fable-5
+        on: "2026-08-01"
     name: Evidence and intent remain distinct
     description: Observations may support or challenge architecture proposals but cannot silently author declared intent.
     references:
@@ -188,3 +216,31 @@ relationships:
     kind: realization
     from: provide-machine-context
     to: shared-architecture-context
+  - id: validation-realizes-correctness
+    kind: realization
+    from: validate-native-architecture
+    to: deterministic-correctness
+  - id: evidence-evaluation-realizes-separation
+    kind: realization
+    from: evaluate-architecture-evidence
+    to: evidence-intent-separation
+  - id: reconciliation-realizes-separation
+    kind: realization
+    from: reconcile-intent-and-evidence
+    to: evidence-intent-separation
+  - id: compilation-realizes-canonical-documents
+    kind: realization
+    from: compile-native-architecture
+    to: native-documents-are-canonical
+  - id: discovery-realizes-shared-context
+    kind: realization
+    from: discover-project-architecture
+    to: shared-architecture-context
+  - id: design-realizes-shared-context
+    kind: realization
+    from: design-solution-before-build
+    to: shared-architecture-context
+  - id: stewardship-realizes-repository-operation
+    kind: realization
+    from: repository-stewardship
+    to: repository-native-operation

--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -31,9 +31,9 @@ concepts:
   - id: likec4-adapter-prototype
     kind: applicationComponent
     name: LikeC4 adapter prototype
-    description: Optional validated vocabulary and visualization prototype.
+    description: Optional validated vocabulary and visualization prototype, superseded by the shipped LikeC4 adapter.
     owner: yarramate-product#yarramate-maintainers
-    status: current
+    status: retired
   - id: compiler-source
     kind: repository-file
     name: src/compiler.ts

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1239,3 +1239,54 @@ mappings:
   - native: yarramate-repository#interrogate-command-source-realizes-command
     external: interrogateCommandSourceRealizesCommand
     type: relationship
+  - native: yarramate-engine#cli-provides-compare
+    external: cliProvidesCompare
+    type: relationship
+  - native: yarramate-engine#cli-provides-context
+    external: cliProvidesContext
+    type: relationship
+  - native: yarramate-engine#cli-provides-interrogate
+    external: cliProvidesInterrogate
+    type: relationship
+  - native: yarramate-engine#cli-provides-new
+    external: cliProvidesNew
+    type: relationship
+  - native: yarramate-engine#cli-provides-next
+    external: cliProvidesNext
+    type: relationship
+  - native: yarramate-engine#cli-provides-status
+    external: cliProvidesStatus
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-provides-check
+    external: likec4AdapterProvidesCheck
+    type: relationship
+  - native: yarramate-engine#likec4-adapter-provides-export
+    external: likec4AdapterProvidesExport
+    type: relationship
+  - native: yarramate-engine#mcp-adapter-implements-machine-context
+    external: mcpAdapterImplementsMachineContext
+    type: relationship
+  - native: yarramate-engine#profile-catalogue-implements-tool-neutrality
+    external: profileCatalogueImplementsToolNeutrality
+    type: relationship
+  - native: yarramate-product#compilation-realizes-canonical-documents
+    external: compilationRealizesCanonicalDocuments
+    type: relationship
+  - native: yarramate-product#design-realizes-shared-context
+    external: designRealizesSharedContext
+    type: relationship
+  - native: yarramate-product#discovery-realizes-shared-context
+    external: discoveryRealizesSharedContext
+    type: relationship
+  - native: yarramate-product#evidence-evaluation-realizes-separation
+    external: evidenceEvaluationRealizesSeparation
+    type: relationship
+  - native: yarramate-product#reconciliation-realizes-separation
+    external: reconciliationRealizesSeparation
+    type: relationship
+  - native: yarramate-product#stewardship-realizes-repository-operation
+    external: stewardshipRealizesRepositoryOperation
+    type: relationship
+  - native: yarramate-product#validation-realizes-correctness
+    external: validationRealizesCorrectness
+    type: relationship

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,13 +1,15 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.2"
+version: "0.3"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
   description: >-
-    Seed questions for the enrichment journey. Motivation and business waves,
-    plus cross-cutting hygiene. Each question states the decision its answer
-    changes; a question that cannot is deleted, not softened.
+    The guided design path: motivation, business, and application waves plus
+    cross-cutting hygiene (technology and implementation follow in a later
+    version). Each question states the decision its answer changes; a
+    question that cannot is deleted, not softened. Adequacy is enforced by
+    linkage depth and attestation, never by reading words.
 
 waves:
   - id: motivation
@@ -16,6 +18,11 @@ waves:
   - id: business
     name: Business
     description: Who acts, what is served, and what information matters.
+  - id: application
+    name: Application
+    description: >-
+      How declared services are realized, performed, and fed with
+      information.
   - id: hygiene
     name: Model hygiene
     description: Cross-cutting completeness that keeps every wave honest.
@@ -99,6 +106,164 @@ questions:
     resolution: >-
       Add realization relationships from the fulfilling capability or
       service, or record the aspirational status in the goal's description.
+
+
+  - id: goal-no-driver
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#goal
+        - yarramate/core@0.1#outcome
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#influence
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#driver
+          - yarramate/core@0.1#assessment
+          - yarramate/core@0.1#stakeholder
+    question: >-
+      What pressure produces {subject.name}?
+    materiality: >-
+      A goal with no driver behind it cannot be reprioritized when the
+      environment changes; it floats free of the forces that would retire
+      or sharpen it.
+    authority: human
+    resolution: >-
+      Add the driver, assessment, or stakeholder that motivates the goal
+      and connect it with an influence relationship.
+
+  - id: driver-influences-nothing
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#driver
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#influence
+        direction: outgoing
+    question: >-
+      What does {subject.name} actually push on?
+    materiality: >-
+      A driver that influences nothing cannot participate in any trade-off;
+      it is context theatre until it points at a goal or principle.
+    authority: either
+    resolution: >-
+      Add influence relationships toward the goals, principles, or
+      assessments the driver shapes, or remove it.
+
+  - id: stakeholder-unconcerned
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#stakeholder
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#influence
+          - yarramate/core@0.1#association
+        direction: any
+    question: >-
+      What does {subject.name} care about here?
+    materiality: >-
+      A stakeholder with no stated concern cannot veto or endorse anything;
+      their objections will arrive as surprises at review time.
+    authority: human
+    resolution: >-
+      Relate the stakeholder to the goals or drivers they care about, or
+      remove them from the model.
+
+  - id: requirement-unrealized
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#requirement
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+    question: >-
+      Nothing realizes {subject.name}. What will fulfil it — or is it
+      out of scope?
+    materiality: >-
+      An unrealized requirement is either unplanned work hiding in plain
+      sight or scope that should be explicitly declined; both change the
+      roadmap.
+    authority: either
+    resolution: >-
+      Add realization from the fulfilling service, component, or behavior,
+      or record the descoping decision and remove the requirement.
+
+  - id: principle-unapplied
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#principle
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#influence
+          - yarramate/core@0.1#realization
+        direction: any
+    question: >-
+      Where does {subject.name} bite?
+    materiality: >-
+      A principle applied nowhere constrains nothing; naming what it
+      influences is what makes it enforceable in review.
+    authority: either
+    resolution: >-
+      Add influence relationships to the decisions the principle governs,
+      or realization from the elements that embody it.
+
+  - id: assessment-unlinked
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#assessment
+    trigger:
+      - condition: isolated
+    question: >-
+      What does the finding {subject.name} bear on?
+    materiality: >-
+      An assessment that touches nothing changes no decision; link it to
+      the driver or goal it evaluates or drop it.
+    authority: either
+    resolution: >-
+      Relate the assessment to its driver or goal with influence or
+      association.
+
+  - id: motivation-unattested
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#goal
+        - yarramate/core@0.1#outcome
+        - yarramate/core@0.1#requirement
+    trigger:
+      - condition: missing-attestation
+        topic: adequacy
+    question: >-
+      Has an accountable reviewer accepted {subject.name} as adequately
+      stated?
+    materiality: >-
+      Linkage proves the wiring exists; only a recorded judgment says the
+      words are right. Without an attestation, adequacy is nobody's
+      decision on record.
+    authority: human
+    resolution: >-
+      Review the subject's description and linkage, then record an
+      attestation with topic "adequacy" (revoke by deleting it; Git
+      reviews both).
 
   # ---- business ------------------------------------------------------------
   - id: service-consumer-unknown
@@ -209,6 +374,243 @@ questions:
     resolution: >-
       Add the externally meaningful services and serve them to their
       consumers.
+
+
+  - id: service-realizes-no-motivation
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#capability
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#requirement
+          - yarramate/core@0.1#goal
+          - yarramate/core@0.1#outcome
+    question: >-
+      Which requirement or goal does {subject.name} exist to satisfy?
+    materiality: >-
+      A service with no motivation link cannot be traded off against
+      anything; when budgets tighten nobody can say what breaks if it
+      goes.
+    authority: either
+    resolution: >-
+      Add realization from the service or capability to the requirement,
+      goal, or outcome it satisfies.
+
+  - id: process-untriggered
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessProcess
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#triggering
+          - yarramate/core@0.1#assignment
+        direction: incoming
+    question: >-
+      What starts {subject.name}?
+    materiality: >-
+      A process nothing triggers or performs either runs on an undeclared
+      schedule or does not actually happen; both are design facts worth
+      stating.
+    authority: either
+    resolution: >-
+      Add the triggering event or the assignment from its performer.
+
+  - id: business-service-unrealized
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#businessProcess
+          - yarramate/core@0.1#businessFunction
+          - yarramate/core@0.1#applicationService
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#capability
+    question: >-
+      What actually delivers {subject.name}?
+    materiality: >-
+      A business service with no realizing behavior or application is a
+      promise with no mechanism; the gap is where delivery estimates go
+      wrong.
+    authority: either
+    resolution: >-
+      Add realization from the process, function, or application element
+      that delivers it.
+
+
+  # ---- application ---------------------------------------------------------
+  - id: app-service-unrealized
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationService
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationCollaboration
+    question: >-
+      Which component or behavior realizes {subject.name}?
+    materiality: >-
+      An application service with no realizer is interface without
+      implementation; implementers cannot be handed a slice that names no
+      mechanism.
+    authority: either
+    resolution: >-
+      Add realization from the component, function, or process that
+      implements the service.
+
+  - id: component-realizes-nothing
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationComponent
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+          - yarramate/core@0.1#assignment
+        direction: outgoing
+    question: >-
+      What does {subject.name} contribute?
+    materiality: >-
+      A component that realizes and performs nothing is either missing its
+      purpose links or is inventory the build does not need.
+    authority: either
+    resolution: >-
+      Add realization to the services it implements or assignment to the
+      behavior it performs, or remove it.
+
+  - id: behavior-unassigned
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationProcess
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#assignment
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationCollaboration
+          - yarramate/core@0.1#businessActor
+          - yarramate/core@0.1#businessRole
+    question: >-
+      Who or what performs {subject.name}?
+    materiality: >-
+      Behavior with no performer cannot be placed in any component
+      boundary; it will be implemented wherever the first builder happens
+      to put it.
+    authority: either
+    resolution: >-
+      Add assignment from the component, collaboration, or actor that
+      performs the behavior.
+
+  - id: event-triggers-nothing
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#businessEvent
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#triggering
+        direction: outgoing
+    question: >-
+      What responds to {subject.name}?
+    materiality: >-
+      An event that triggers nothing is either an unhandled condition —
+      a real design gap — or noise; deciding which changes the build.
+    authority: either
+    resolution: >-
+      Add triggering to the responding process or function, or remove the
+      event.
+
+  - id: information-unowned
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#dataObject
+        - yarramate/core@0.1#businessObject
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/ownership/owner
+    question: >-
+      Who is accountable for {subject.name} — its meaning, retention, and
+      access?
+    materiality: >-
+      Unowned information has no one to adjudicate schema changes,
+      retention, or access disputes; ownership is where data governance
+      starts.
+    authority: human
+    resolution: >-
+      Add an owner reference to the accountable actor.
+
+  - id: planned-design-unattested
+    wave: application
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+      statuses:
+        - planned
+    trigger:
+      - condition: missing-attestation
+        topic: design-review
+    question: >-
+      Has the design of {subject.name} been reviewed before it is built?
+    materiality: >-
+      A planned element carries every unbuilt decision; a recorded
+      design-review attestation is the difference between a reviewed
+      intention and a hopeful one.
+    authority: human
+    resolution: >-
+      Review the planned element's slice, then record an attestation with
+      topic "design-review" (revoke by deleting it when the design
+      changes).
 
   # ---- hygiene -------------------------------------------------------------
   - id: concept-isolated

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -27,7 +27,14 @@ questions. Each question binds:
 
 - a **trigger** — one or more deterministic conditions over the compiled
   graph (all must hold): `missing-claim`, `missing-relationship`,
-  `isolated`, `no-subject-of-kind`, or `no-state-defined`;
+  `isolated`, `no-subject-of-kind`, `no-state-defined`,
+  `missing-linkage` (no relationship of given kinds, in a given
+  direction, whose counterpart is of a given kind — the linkage-depth
+  primitive), `missing-reference` (no reference-bearing claim such as a
+  constraint binding, by direction), or `missing-attestation` (no
+  recorded `yarramate/attestation/<topic>` claim; see ADR 0056).
+  Relationship kinds in conditions resolve through profile lineage by
+  default, the same rule as subject selectors;
 - a **scope** — `workspace` (asked once) or `subject` (asked per matching
   subject, selected by kinds, statuses, and documents, with `descendants`
   kind matching by default so profile-derived kinds satisfy a catalogue

--- a/docs/adr/0056-adequacy-is-linkage-and-attestation-never-text.md
+++ b/docs/adr/0056-adequacy-is-linkage-and-attestation-never-text.md
@@ -1,0 +1,38 @@
+# Adequacy is linkage and attestation, never text
+
+Status: accepted
+
+The interrogation engine could see absence but not thinness: a
+five-word goal with one relationship closed every question that would
+ever ask about it, and two designers modeling the same specification
+produced 47- and 27-concept models with nothing to interrogate the
+difference. "Filled" needed to become "filled adequately" without the
+engine reading words — the wiring-not-words boundary is permanent.
+
+Two mechanisms, layered, both deterministic. **Linkage depth**: new
+trigger conditions hold a question open until a blank's neighbourhood
+exists — `missing-linkage` requires a relationship of given kinds, in a
+given direction, whose counterpart is of a given kind, and
+`missing-reference` requires a reference-bearing claim such as a
+constraint binding. **Attestation**: a question stays open until an
+authority records a judgment in the model. Concepts may declare
+`attestations: [{topic, by, on}]`, compiling to a
+`yarramate/attestation/<topic>` claim; the `missing-attestation`
+condition sees only the claim's existence. The judgment lives outside
+the engine; its record is structural, stateless, and revocable by
+deletion, with both the signing and the revoking reviewed at the Git
+boundary. Text heuristics were rejected: length thresholds and
+name-mention checks erode the boundary for little gain.
+
+All relationship-kind matching in conditions now resolves through
+profile lineage by default, the same rule as subject selectors — a
+catalogue written against core kinds must see a profile-derived kind
+such as `implements`. Exact matching remains available per condition.
+
+The shipped catalogue grows to 0.3: motivation, business, and a new
+application wave (29 questions; technology and implementation follow),
+with contribution questions scoped to planned and current elements —
+retired ones owe nothing. Enriching the self-model until the deep
+catalogue closed rediscovered real drift (eight CLI commands never
+linked to their component) and forced forty ownership decisions, which
+is the catalogue doing exactly what it ships to do.

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -4,7 +4,13 @@
   "title": "YarraMate native document",
   "type": "object",
   "additionalProperties": false,
-  "required": ["format", "id", "profile", "concepts", "relationships"],
+  "required": [
+    "format",
+    "id",
+    "profile",
+    "concepts",
+    "relationships"
+  ],
   "properties": {
     "format": {
       "const": "yarramate/v1"
@@ -51,13 +57,21 @@
     "architectureState": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "kind", "name"],
+      "required": [
+        "id",
+        "kind",
+        "name"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/id"
         },
         "kind": {
-          "enum": ["baseline", "transition", "target"]
+          "enum": [
+            "baseline",
+            "transition",
+            "target"
+          ]
         },
         "name": {
           "$ref": "#/$defs/nonEmptyText"
@@ -73,7 +87,11 @@
     "concept": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "kind", "name"],
+      "required": [
+        "id",
+        "kind",
+        "name"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/id"
@@ -105,13 +123,23 @@
         },
         "presentIn": {
           "$ref": "#/$defs/stateReferences"
+        },
+        "attestations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/attestation"
+          }
         }
       }
     },
     "constraint": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "ref"],
+      "required": [
+        "id",
+        "ref"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/id"
@@ -124,7 +152,10 @@
     "identifiedReference": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "ref"],
+      "required": [
+        "id",
+        "ref"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/id"
@@ -144,7 +175,12 @@
     "relationship": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "kind", "from", "to"],
+      "required": [
+        "id",
+        "kind",
+        "from",
+        "to"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/id"
@@ -166,7 +202,12 @@
           "$ref": "#/$defs/nonEmptyText"
         },
         "mode": {
-          "enum": ["read", "write", "read-write", "unspecified"]
+          "enum": [
+            "read",
+            "write",
+            "read-write",
+            "unspecified"
+          ]
         },
         "content": {
           "$ref": "#/$defs/nonEmptyText"
@@ -191,7 +232,33 @@
       }
     },
     "lifecycleStatus": {
-      "enum": ["planned", "current", "retired"]
+      "enum": [
+        "planned",
+        "current",
+        "retired"
+      ]
+    },
+    "attestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "topic",
+        "by",
+        "on"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "by": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "on": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        }
+      }
     }
   }
 }

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -195,8 +195,7 @@
               "enum": [
                 "exact",
                 "descendants"
-              ],
-              "default": "descendants"
+              ]
             }
           }
         },
@@ -249,6 +248,89 @@
           "properties": {
             "condition": {
               "const": "no-state-defined"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "predicate",
+            "direction"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-reference"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "topic"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-attestation"
+            },
+            "topic": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$"
             }
           }
         }

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -147,6 +147,25 @@ information.
 Ownership is one accountable reference, not approval workflow. Constraints are
 identified references, not a policy engine or free-form metadata bag.
 
+## Attestations
+
+```yaml
+- id: shared-context
+  kind: goal
+  name: Shared architecture context
+  attestations:
+    - topic: adequacy
+      by: reviewer-name
+      on: "2026-08-01"
+```
+
+An attestation records that an authority accepted the subject as adequate
+for a topic (the interrogation catalogue asks for `adequacy` on motivation
+subjects and `design-review` on planned elements). The judgment stays
+outside the engine — only the claim's existence is checked. Revoke by
+deleting the entry; both signing and revoking are reviewed at the Git
+boundary (ADR 0056).
+
 ## Rationale and citations
 
 Use `description` on either a concept or relationship for decided narrative

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -48,6 +48,11 @@ interface NativeConcept {
   }>
   readonly references?: readonly NativeIdentifiedReference[]
   readonly presentIn?: readonly string[]
+  readonly attestations?: ReadonlyArray<{
+    readonly topic: string
+    readonly by: string
+    readonly on: string
+  }>
 }
 
 interface NativeIdentifiedReference {
@@ -1321,6 +1326,24 @@ function compileWorkspaceResolved(
           source: location(
             ['concepts', index, 'references', referenceIndex, 'ref'],
             `/concepts/${index}/references/${referenceIndex}/ref`,
+          ),
+        })
+      }
+      // An attestation is a recorded judgment, not content the engine
+      // evaluates: the claim's existence is what triggers can see, and
+      // revocation is deletion, reviewed at the Git boundary.
+      for (const [attestationIndex, attestation] of (
+        concept.attestations ?? []
+      ).entries()) {
+        claims.push({
+          id: `${subject}~attestation-${attestation.topic}`,
+          subject,
+          predicate: `yarramate/attestation/${attestation.topic}`,
+          object: { value: `${attestation.by} ${attestation.on}` },
+          origin: 'declared',
+          source: location(
+            ['concepts', index, 'attestations', attestationIndex, 'topic'],
+            `/concepts/${index}/attestations/${attestationIndex}/topic`,
           ),
         })
       }

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -43,6 +43,7 @@ type CatalogueCondition =
       readonly condition: 'missing-relationship'
       readonly kinds: readonly string[]
       readonly direction: 'incoming' | 'outgoing' | 'any'
+      readonly kindMatching?: 'exact' | 'descendants'
     }
   | { readonly condition: 'isolated' }
   | {
@@ -50,6 +51,19 @@ type CatalogueCondition =
       readonly kinds: readonly string[]
     }
   | { readonly condition: 'no-state-defined' }
+  | {
+      readonly condition: 'missing-linkage'
+      readonly kinds: readonly string[]
+      readonly direction: 'incoming' | 'outgoing'
+      readonly counterpartKinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
+  | {
+      readonly condition: 'missing-reference'
+      readonly predicate: string
+      readonly direction: 'incoming' | 'outgoing'
+    }
+  | { readonly condition: 'missing-attestation'; readonly topic: string }
 
 interface CatalogueQuestion {
   readonly id: string
@@ -227,10 +241,26 @@ const selectSubjects = (
   return ids.sort((left, right) => left.localeCompare(right))
 }
 
+const relationshipKindMatches = (
+  predicate: string,
+  selectedKinds: readonly string[],
+  matching: 'exact' | 'descendants',
+  profileContext: ResolvedProfileContext | undefined,
+): boolean =>
+  selectedKinds.some(
+    (selected) =>
+      selected === predicate ||
+      (matching === 'descendants' &&
+        profileContext?.relationshipKindLineages
+          .get(predicate)
+          ?.includes(selected) === true),
+  )
+
 const conditionHolds = (
   index: GraphIndex,
   condition: CatalogueCondition,
   subjectId: string | undefined,
+  profileContext: ResolvedProfileContext | undefined,
 ): boolean => {
   switch (condition.condition) {
     case 'missing-claim':
@@ -238,9 +268,17 @@ const conditionHolds = (
         ({ predicate }) => predicate === condition.predicate,
       )
     case 'missing-relationship': {
-      const kinds = new Set(condition.kinds)
+      // Relationship kinds resolve through profile lineage by default, the
+      // same rule as selectors: a catalogue written against core kinds must
+      // see a profile-derived kind such as implements (realization child).
+      const matching = condition.kindMatching ?? 'descendants'
       const touching = index.relationshipClaims.filter(({ predicate }) =>
-        kinds.has(predicate),
+        relationshipKindMatches(
+          predicate,
+          condition.kinds,
+          matching,
+          profileContext,
+        ),
       )
       const outgoing = touching.some(({ subject }) => subject === subjectId)
       const incoming = touching.some(
@@ -269,6 +307,57 @@ const conditionHolds = (
       )
     case 'no-state-defined':
       return !index.hasStates
+    case 'missing-linkage': {
+      // The linkage-depth primitive: the subject lacks a relationship of
+      // these kinds, in this direction, whose counterpart is of one of
+      // these kinds. Both relationship and counterpart kinds resolve
+      // through profile lineage by default, matching the selector rule.
+      const matching = condition.kindMatching ?? 'descendants'
+      return !index.relationshipClaims.some((claim) => {
+        if (!('ref' in claim.object)) return false
+        if (
+          !relationshipKindMatches(
+            claim.predicate,
+            condition.kinds,
+            matching,
+            profileContext,
+          )
+        ) {
+          return false
+        }
+        const counterpart =
+          condition.direction === 'outgoing'
+            ? claim.subject === subjectId
+              ? claim.object.ref
+              : undefined
+            : claim.object.ref === subjectId
+              ? claim.subject
+              : undefined
+        return (
+          counterpart !== undefined &&
+          kindMatches(
+            index.kindOf.get(counterpart),
+            condition.counterpartKinds,
+            matching,
+            profileContext,
+          )
+        )
+      })
+    }
+    case 'missing-reference':
+      return !index.referenceClaims.some(
+        (claim) =>
+          claim.predicate === condition.predicate &&
+          'ref' in claim.object &&
+          (condition.direction === 'outgoing'
+            ? claim.subject === subjectId
+            : claim.object.ref === subjectId),
+      )
+    case 'missing-attestation':
+      return !(index.claimsBySubject.get(subjectId!) ?? []).some(
+        ({ predicate }) =>
+          predicate === `yarramate/attestation/${condition.topic}`,
+      )
   }
 }
 
@@ -306,7 +395,7 @@ export function evaluateCatalogue(
         }
         if (question.scope === 'workspace') {
           const isOpen = question.trigger.every((condition) =>
-            conditionHolds(index, condition, undefined),
+            conditionHolds(index, condition, undefined, profileContext),
           )
           if (isOpen) {
             open += 1
@@ -320,7 +409,7 @@ export function evaluateCatalogue(
           profileContext,
         ).filter((id) =>
           question.trigger.every((condition) =>
-            conditionHolds(index, condition, id),
+            conditionHolds(index, condition, id, profileContext),
           ),
         )
         if (matches.length === 0) {

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -262,6 +262,130 @@ describe('interrogate command', () => {
     expect(result.stderr).toContain('Usage:')
   })
 
+  it('evaluates linkage, reference, and attestation conditions with lineage', () => {
+    const adequacy =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: adequacy-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: depth\n' +
+      '    name: Depth\n' +
+      'questions:\n' +
+      '  - id: goal-no-driver\n' +
+      '    wave: depth\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#goal"]\n' +
+      '    trigger:\n' +
+      '      - condition: missing-linkage\n' +
+      '        kinds: ["yarramate/core@0.1#influence"]\n' +
+      '        direction: incoming\n' +
+      '        counterpartKinds: ["yarramate/core@0.1#businessActor"]\n' +
+      '    question: What pressure produces {subject.name}?\n' +
+      '    materiality: Goals with no driver cannot be reprioritized.\n' +
+      '    authority: human\n' +
+      '    resolution: Link the driver.\n' +
+      '  - id: constraint-unenforced\n' +
+      '    wave: depth\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#constraint"]\n' +
+      '    trigger:\n' +
+      '      - condition: missing-reference\n' +
+      '        predicate: yarramate/constraint/requires\n' +
+      '        direction: incoming\n' +
+      '    question: Nothing binds itself to {subject.name}. Enforced where?\n' +
+      '    materiality: A constraint nothing cites constrains nothing.\n' +
+      '    authority: either\n' +
+      '    resolution: Attach constraint references from bound subjects.\n' +
+      '  - id: goal-unattested\n' +
+      '    wave: depth\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#goal"]\n' +
+      '    trigger:\n' +
+      '      - condition: missing-attestation\n' +
+      '        topic: adequacy\n' +
+      '    question: Has {subject.name} been accepted as adequately stated?\n' +
+      '    materiality: Without attestation adequacy is nobody\'s decision.\n' +
+      '    authority: human\n' +
+      '    resolution: Record an adequacy attestation.\n'
+    const enriched =
+      'format: yarramate/v1\n' +
+      'id: main\n' +
+      'profile: example/platform@1.0\n' +
+      'concepts:\n' +
+      '  - id: engagement\n' +
+      '    kind: goal\n' +
+      '    name: Engagement\n' +
+      '  - id: platform\n' +
+      '    kind: platform-team\n' +
+      '    name: Platform team\n' +
+      '  - id: budget-cap\n' +
+      '    kind: constraint\n' +
+      '    name: Budget cap\n' +
+      'relationships: []\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), adequacy, 'utf8')
+    writeFileSync(join(workspace, 'architecture/main.yaml'), enriched, 'utf8')
+
+    const before = runCli(
+      ['interrogate', 'catalogue.yaml', 'workspace.yaml', '--json'],
+      workspace,
+    )
+    expect(before.exitCode).toBe(0)
+    expect(JSON.parse(before.stdout).summary).toEqual({
+      questions: 3,
+      openQuestions: 3,
+      open: 3,
+    })
+
+    // Close all three: an influence from a profile-derived actor (lineage
+    // reaches businessActor), a constraint reference, and an attestation.
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: example/platform@1.0\n' +
+        'concepts:\n' +
+        '  - id: engagement\n' +
+        '    kind: goal\n' +
+        '    name: Engagement\n' +
+        '    attestations:\n' +
+        '      - topic: adequacy\n' +
+        '        by: reviewer\n' +
+        '        on: "2026-08-01"\n' +
+        '  - id: platform\n' +
+        '    kind: platform-team\n' +
+        '    name: Platform team\n' +
+        '  - id: budget-cap\n' +
+        '    kind: constraint\n' +
+        '    name: Budget cap\n' +
+        '  - id: rollout\n' +
+        '    kind: businessProcess\n' +
+        '    name: Rollout\n' +
+        '    constraints:\n' +
+        '      - id: cap\n' +
+        '        ref: budget-cap\n' +
+        'relationships:\n' +
+        '  - id: platform-drives-engagement\n' +
+        '    kind: influence\n' +
+        '    from: platform\n' +
+        '    to: engagement\n',
+      'utf8',
+    )
+    const after = runCli(
+      ['interrogate', 'catalogue.yaml', 'workspace.yaml', '--json'],
+      workspace,
+    )
+    expect(after.exitCode).toBe(0)
+    expect(JSON.parse(after.stdout).summary).toEqual({
+      questions: 3,
+      openQuestions: 0,
+      open: 0,
+    })
+  })
+
   it('keeps the shipped catalogue fully closed on the repository self-model', () => {
     const result = runCli(
       [

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2402,7 +2402,29 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+              'Semantic relationship kind \"yarramate/development@1.0#implements\" resolves to unsupported bundled LikeC4 kind \"implements\"',
+            subject: 'yarramate-engine#likec4-adapter-provides-export',
+            path: '.yarramate/architecture/engine.yaml',
+            pointer: '/relationships/124',
+            line: 1106,
+            column: 5,
+          },
+          {
+            severity: 'error',
+            code: 'YMLC104',
+            message:
+              'Semantic relationship kind \"yarramate/development@1.0#implements\" resolves to unsupported bundled LikeC4 kind \"implements\"',
+            subject: 'yarramate-engine#likec4-adapter-provides-check',
+            path: '.yarramate/architecture/engine.yaml',
+            pointer: '/relationships/125',
+            line: 1110,
+            column: 5,
+          },
+          {
+            severity: 'error',
+            code: 'YMLC104',
+            message:
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
             subject: 'yarramate-repository#likec4-export-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/21/kind',
@@ -2413,7 +2435,7 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
             subject: 'yarramate-repository#likec4-prepare-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/24/kind',
@@ -2424,7 +2446,7 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
             subject: 'yarramate-repository#likec4-project-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/25/kind',
@@ -2435,9 +2457,8 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject:
-              'yarramate-repository#likec4-project-definition-source',
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
+            subject: 'yarramate-repository#likec4-project-definition-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/26/kind',
             line: 115,
@@ -2447,9 +2468,8 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject:
-              'yarramate-repository#likec4-project-schema-source',
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
+            subject: 'yarramate-repository#likec4-project-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/53/kind',
             line: 228,
@@ -2459,9 +2479,8 @@ mappings:
             severity: 'error',
             code: 'YMLC104',
             message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject:
-              'yarramate-repository#likec4-generated-project-v2-schema-source',
+              'Semantic concept kind \"yarramate/development@1.0#repository-file\" resolves to unsupported bundled LikeC4 kind \"repository-file\"',
+            subject: 'yarramate-repository#likec4-generated-project-v2-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/54/kind',
             line: 232,


### PR DESCRIPTION
The engine side of `yarramate design` — first build of the 0.7.0 arc (#104, ADR 0056, per the seven-verb contract in docs/AGENT-INTERFACE.md).

## Adequacy: linkage + attestation, never text
- Concepts may declare `attestations: [{topic, by, on}]`, compiling to `yarramate/attestation/<topic>` claims. The judgment stays outside the engine; the record is structural, revocation is deletion, both reviewed at the Git boundary.
- Three new trigger conditions: `missing-linkage` (relationship of given kinds, direction, **counterpart kind** — the linkage-depth primitive), `missing-reference` (reference-bearing claims by direction), `missing-attestation` (topic).
- Consistency fix found while dogfooding: `missing-relationship` matched kinds exactly while everything else resolves lineage — all relationship-kind matching in conditions is now descendants-by-default (a catalogue written against `realization` sees the profile's `implements`), with `kindMatching: exact` opt-out.

## Catalogue 0.2 → 0.3
Sixteen new questions (29 total): deepened motivation (driver/stakeholder/principle/assessment linkage, requirement realization, adequacy attestation), business traceability (service → motivation, process triggering, business-service realization), and a new **application wave** (service realization, component contribution, behavior assignment, event handling, information ownership, planned-design attestation). Contribution questions scoped to planned+current — retired elements owe nothing. Technology/implementation waves follow per the settled scope.

## Self-model enrichment (the dogfood forcing function — 67 open → 0)
The deep catalogue immediately rediscovered **real recorded drift** (eight CLI commands — status, next, compare, context, new, interrogate, likec4-export, likec4-check — never linked to their providing component) and forced honest decisions: 17 realization edges (via `connect`), 40 information-ownership references, one honest retirement (the LikeC4 prototype, superseded), and **7 adequacy attestations on the motivation layer, signed `claude-fable-5` — merging this PR is the human endorsement of those attestations; reject any by commenting and I'll revoke.**

Verification: clean-slate `rm -rf dist && pnpm verify` green (295 tests; new lineage/reference/attestation closure test; YMLC104 pinned fixture regenerated from the actual run; `map --sync` applied; self-model 0-open test still enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)