### PR TITLE
An apply diff is exactly the answer it landed: splice writes + retraction

### DIFF
--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -55,12 +55,14 @@ translates it into `apply` operations → re-invoke `design`.
 
 ### `yarramate apply` — write, validated
 
-[built — ADR 0057] All model writes: single operations and
-**atomic batches** (an operations document; any invalid op rejects the
-whole batch, preserving no-partial-graph). Structurally incapable of
-emitting YM404s — the weak tier's proven bridge, now cheap enough for
-the strong tier (one answer = one call). Swallows `add`, `connect`,
-and `new projection` scaffolding.
+[built — ADR 0057, write path ADR 0062] All model writes: single
+operations and **atomic batches** (an operations document; any invalid
+op rejects the whole batch, preserving no-partial-graph). Structurally
+incapable of emitting YM404s — the weak tier's proven bridge, now cheap
+enough for the strong tier (one answer = one call). Writes are spliced,
+never re-serialized: an apply diff is exactly the answer it landed.
+Updates enrich by default and retract explicitly (`remove`), so the
+assert → catch → retract loop closes through one audited surface.
 
 - Harness use: landing a design answer; discovery-journey authoring;
   maintenance edits.

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -326,11 +326,17 @@ The operations are `add-concept`, `add-relationship`, `update-concept`, and
 `update-relationship`. Concept and relationship records accept the same
 optional fields as the authoring format — for example `status`,
 `description`, `owner`, `constraints`, `references`, `presentIn`, and the
-controlled `mode` and `content` fields. `apply` preserves concise
-block-style YAML, compiles the entire candidate workspace in memory, and
-replaces the targets only when validation succeeds. A rejected batch leaves
-every source byte-for-byte unchanged. Update operations enrich only: scalar
-fields replace, list fields append, and removals stay ordinary Git edits.
+controlled `mode` and `content` fields. `apply` writes by splicing minimal
+text edits into the authored source, so bytes an operation never touched —
+including folded prose and comments — stay byte-identical (ADR 0062). It
+compiles the entire candidate workspace in memory and replaces the targets
+only when validation succeeds; a rejected batch leaves every source
+byte-for-byte unchanged. Update operations enrich by default — scalar
+fields replace, list fields append — and retract explicitly: an update may
+carry `remove: [<field> ...]` to delete optional fields it previously
+asserted. Identity fields (`id`, `kind`, `from`, `to`) are never removable,
+removing a field that is not set is an error, and one operation cannot both
+set and remove the same field.
 
 The workspace manifest supplies the extension profiles and documents needed
 for qualified references. This explicit input contract matches

--- a/docs/adr/0062-an-apply-diff-is-exactly-the-answer-it-landed.md
+++ b/docs/adr/0062-an-apply-diff-is-exactly-the-answer-it-landed.md
@@ -1,0 +1,36 @@
+# An apply diff is exactly the answer it landed
+
+Status: accepted
+
+Dogfooding 0.7.0 against a foreign model (yarradev-ai, #114) showed
+`apply` rewriting prose it never touched: the YAML AST round-trip
+re-emitted the whole document, reflowing every authored `>-` folded
+description — a 10-operation status batch produced a 350-line diff. On
+a git-reviewed model that buries the real change and claims authorship
+of untouched content.
+
+`apply` now writes by **splicing**: every operation becomes a minimal
+text edit against the document's current source, computed from the
+parsed nodes' source ranges — append an item after the last one,
+replace a scalar's value token, insert a new field line, delete a
+field's lines. Bytes the batch never touched stay byte-identical. The
+atomic compile gate is the safety net that makes this cheap to trust:
+the spliced text itself must compile as a whole workspace before a
+single byte is written, so a splice defect rejects the batch loudly
+instead of corrupting a document.
+
+The same dogfood run supplied the second half (#115): reconcile caught
+two unsupported `status: current` claims the moment they became
+checkable, and there was no verb to take them back — enrich-only
+`update` can overwrite a scalar but never unset it. Update operations
+now accept `remove: [<field>...]`: the field's lines are deleted,
+identity fields (`id`, `kind`, `from`, `to`) are not removable at the
+schema gate, removing a field that is not set is a located error, and
+setting and removing the same field in one operation is rejected. The
+loop is whole: apply asserts, reconcile catches, apply retracts — and
+retraction restores the exact prior bytes.
+
+This amends ADR 0057's "removals stay Git edits": *silent* shrinkage
+still does not exist, but explicit, reviewed retraction is part of the
+write surface, because a loop that can assert must be able to take an
+assertion back through the same audited door.

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -264,6 +264,22 @@
                   "type": "object"
                 }
               ]
+            },
+            "remove": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "enum": [
+                  "name",
+                  "description",
+                  "status",
+                  "owner",
+                  "constraints",
+                  "references",
+                  "presentIn",
+                  "attestations"
+                ]
+              }
             }
           }
         },
@@ -294,6 +310,21 @@
                   "type": "object"
                 }
               ]
+            },
+            "remove": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "enum": [
+                  "name",
+                  "description",
+                  "status",
+                  "mode",
+                  "content",
+                  "references",
+                  "presentIn"
+                ]
+              }
             }
           }
         }

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1,6 +1,15 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { isSeq, parseDocument, type Document } from 'yaml'
+import {
+  isMap,
+  isScalar,
+  isSeq,
+  parseDocument,
+  stringify,
+  type Pair,
+  type YAMLMap,
+  type YAMLSeq,
+} from 'yaml'
 import Ajv2020Module from 'ajv/dist/2020.js'
 import {
   diagnosticJson,
@@ -62,68 +71,289 @@ interface RelationshipFields {
 type Operation =
   | { readonly op: 'add-concept'; readonly document: string; readonly concept: ConceptFields }
   | { readonly op: 'add-relationship'; readonly document: string; readonly relationship: RelationshipFields }
-  | { readonly op: 'update-concept'; readonly document: string; readonly concept: ConceptFields }
-  | { readonly op: 'update-relationship'; readonly document: string; readonly relationship: RelationshipFields }
+  | {
+      readonly op: 'update-concept'
+      readonly document: string
+      readonly concept: ConceptFields
+      readonly remove?: readonly string[]
+    }
+  | {
+      readonly op: 'update-relationship'
+      readonly document: string
+      readonly relationship: RelationshipFields
+      readonly remove?: readonly string[]
+    }
 
 interface OperationsDocument {
   readonly format: 'yarramate/operations/v1'
   readonly operations: readonly Operation[]
 }
 
-// Scalar fields replace; list fields append. An answer enriches what is
-// there — it never silently shrinks it (removals stay Git edits).
+// Scalar fields replace; list fields append; `remove` retracts (ADR 0062).
+// An answer enriches what is there and may explicitly take back what it
+// asserted — it never silently shrinks anything.
 const SCALAR_CONCEPT_FIELDS = ['kind', 'name', 'description', 'status', 'owner'] as const
 const LIST_CONCEPT_FIELDS = ['constraints', 'references', 'presentIn', 'attestations'] as const
 const SCALAR_RELATIONSHIP_FIELDS = ['kind', 'from', 'to', 'name', 'description', 'status', 'mode', 'content'] as const
 const LIST_RELATIONSHIP_FIELDS = ['references', 'presentIn'] as const
 
-const appendBlockItem = (
-  document: Document,
+// ---------------------------------------------------------------------------
+// The splice layer. Every operation becomes a minimal text edit against the
+// document's current source, so bytes the batch never touched stay
+// byte-identical — an apply diff is exactly the answer it landed (#114).
+// The atomic compile gate below validates the spliced text itself, so any
+// splice defect rejects the batch loudly instead of corrupting a document.
+
+const lineStartOf = (source: string, offset: number): number =>
+  source.lastIndexOf('\n', offset - 1) + 1
+
+const indentAt = (source: string, offset: number): number =>
+  offset - lineStartOf(source, offset)
+
+// End of the last line a node occupies, extended through its newline.
+const lineEndAfter = (source: string, offset: number): number => {
+  const newline = source.indexOf('\n', Math.max(offset - 1, 0))
+  return newline === -1 ? source.length : newline + 1
+}
+
+const reindent = (text: string, indent: number): string =>
+  text.split('\n').join(`\n${' '.repeat(indent)}`)
+
+// A plain value as YAML source. lineWidth 0 keeps strings we author on one
+// line; genuinely multi-line strings become block scalars and are re-indented
+// by the caller.
+const valueText = (value: unknown): string =>
+  stringify(value, { lineWidth: 0 }).trimEnd()
+
+const pairFor = (
+  map: YAMLMap,
+  key: string,
+): Pair | undefined =>
+  map.items.find(
+    (pair) => isScalar(pair.key) && pair.key.value === key,
+  ) as Pair | undefined
+
+const nodeRange = (node: unknown): readonly [number, number, number] => {
+  const range = (node as { range?: readonly [number, number, number] }).range
+  if (range === undefined) {
+    throw new Error('YAML node has no source range')
+  }
+  return range
+}
+
+// Renders `items` as block sequence entries at the given marker indent.
+const sequenceEntries = (
+  items: readonly unknown[],
+  markerIndent: number,
+): string => {
+  const rendered = stringify(items, { lineWidth: 0 }).trimEnd()
+  return `${' '.repeat(markerIndent)}${reindent(rendered, markerIndent)}`
+}
+
+const splice = (
+  source: string,
+  start: number,
+  end: number,
+  text: string,
+): string => source.slice(0, start) + text + source.slice(end)
+
+// Insert a newline-terminated block at a line boundary, tolerating a
+// source that does not end in a newline.
+const insertBlock = (
+  source: string,
+  insertAt: number,
+  block: string,
+): string =>
+  splice(
+    source,
+    insertAt,
+    insertAt,
+    insertAt > 0 && source[insertAt - 1] !== '\n' ? `\n${block}` : block,
+  )
+
+// Node ranges may extend past their trailing newline to the start of the
+// next line; anchor insertions on the last CONTENT line instead.
+const afterContentLine = (source: string, offset: number): number => {
+  let anchor = offset
+  while (anchor > 0 && source[anchor - 1] === '\n') anchor -= 1
+  return lineEndAfter(source, anchor)
+}
+
+// Where a new field of an item lands: after the last line of the item's
+// final pair.
+const itemFieldInsertAt = (source: string, map: YAMLMap): number => {
+  const lastPair = map.items[map.items.length - 1]!
+  const anchor =
+    lastPair.value === null || lastPair.value === undefined
+      ? nodeRange(lastPair.key)[2]
+      : nodeRange(lastPair.value)[1]
+  return afterContentLine(source, anchor)
+}
+
+// Appends one item to a top-level block collection (`concepts:` or
+// `relationships:`), creating or converting the collection when needed.
+const appendCollectionItem = (
+  source: string,
   collection: 'concepts' | 'relationships',
   item: Readonly<Record<string, unknown>>,
-) => {
-  document.addIn([collection], item)
-  const sequence = document.getIn([collection], true)
-  if (isSeq(sequence)) {
-    sequence.flow = false
+): string => {
+  const document = parseDocument(source)
+  const root = document.contents
+  if (!isMap(root)) throw new Error('Document root is not a mapping')
+  const pair = pairFor(root, collection)
+  if (pair === undefined) {
+    const base = source.endsWith('\n') ? source : `${source}\n`
+    return `${base}${collection}:\n${sequenceEntries([item], 2)}\n`
   }
+  const sequence = pair.value
+  if (isSeq(sequence) && !sequence.flow && sequence.items.length > 0) {
+    const lastItem = sequence.items[sequence.items.length - 1]
+    const markerIndent = indentAt(source, nodeRange(lastItem)[0]) - 2
+    const insertAt = lineEndAfter(source, nodeRange(lastItem)[2])
+    return insertBlock(
+      source,
+      insertAt,
+      `${sequenceEntries([item], markerIndent)}\n`,
+    )
+  }
+  if (!isSeq(sequence)) {
+    // `concepts:` with no value at all: append the block under the key.
+    const insertAt = lineEndAfter(source, nodeRange(pair.key)[2])
+    return insertBlock(source, insertAt, `${sequenceEntries([item], 2)}\n`)
+  }
+  // Empty or flow collection: replace the whole value with a block
+  // sequence carrying any existing entries plus the new one, consuming
+  // the space that separated it from the key.
+  const existing =
+    sequence.items.length > 0
+      ? (sequence.toJSON() as readonly unknown[])
+      : []
+  let [start] = nodeRange(sequence)
+  const valueEnd = nodeRange(sequence)[1]
+  while (start > 0 && source[start - 1] === ' ') start -= 1
+  return splice(
+    source,
+    start,
+    valueEnd,
+    `\n${sequenceEntries([...existing, item], 2)}`,
+  )
 }
 
-const findItem = (document: Document, collection: string, id: string) => {
-  const sequence = document.get(collection, true)
-  if (!isSeq(sequence)) return undefined
-  return sequence.items.find(
-    (item) =>
-      typeof item === 'object' &&
-      item !== null &&
-      'get' in item &&
-      (item as { get(key: string): unknown }).get('id') === id,
-  ) as { get(key: string, keepScalar?: boolean): unknown; set(key: string, value: unknown): void } | undefined
+const itemMap = (
+  source: string,
+  collection: string,
+  id: string,
+): { readonly map: YAMLMap } | undefined => {
+  const document = parseDocument(source)
+  const root = document.contents
+  if (!isMap(root)) return undefined
+  const pair = pairFor(root, collection)
+  if (pair === undefined || !isSeq(pair.value)) return undefined
+  const found = (pair.value as YAMLSeq).items.find(
+    (candidate) =>
+      isMap(candidate) &&
+      (candidate as YAMLMap).items.some(
+        (field) =>
+          isScalar(field.key) &&
+          field.key.value === 'id' &&
+          isScalar(field.value) &&
+          field.value.value === id,
+      ),
+  )
+  return found === undefined ? undefined : { map: found as YAMLMap }
 }
 
-const applyFields = (
-  document: Document,
-  item: { get(key: string): unknown; set(key: string, value: unknown): void },
-  fields: Readonly<Record<string, unknown>>,
-  scalars: readonly string[],
-  lists: readonly string[],
-) => {
-  for (const key of scalars) {
-    if (fields[key] !== undefined) item.set(key, fields[key])
+// The indent item fields sit at, read off the item's own first field.
+const fieldIndentOf = (source: string, map: YAMLMap): number =>
+  indentAt(source, nodeRange(map.items[0]!.key)[0])
+
+const setScalarField = (
+  source: string,
+  map: YAMLMap,
+  key: string,
+  value: unknown,
+): string => {
+  const indent = fieldIndentOf(source, map)
+  const rendered = reindent(valueText(value), indent + 2)
+  const pair = pairFor(map, key)
+  if (pair === undefined) {
+    return insertBlock(
+      source,
+      itemFieldInsertAt(source, map),
+      `${' '.repeat(indent)}${key}: ${rendered}\n`,
+    )
   }
-  for (const key of lists) {
-    const additions = fields[key] as readonly unknown[] | undefined
-    if (additions === undefined || additions.length === 0) continue
-    const existing = item.get(key)
-    if (existing === undefined) {
-      item.set(key, additions)
-    } else if (isSeq(existing)) {
-      for (const entry of additions) {
-        existing.items.push(document.createNode(entry))
-      }
-    }
-  }
+  const [start, valueEnd] = nodeRange(pair.value)
+  return splice(source, start, valueEnd, rendered)
 }
+
+const appendListField = (
+  source: string,
+  map: YAMLMap,
+  key: string,
+  additions: readonly unknown[],
+): string => {
+  const indent = fieldIndentOf(source, map)
+  const pair = pairFor(map, key)
+  if (pair === undefined) {
+    return insertBlock(
+      source,
+      itemFieldInsertAt(source, map),
+      `${' '.repeat(indent)}${key}:\n${sequenceEntries(additions, indent + 2)}\n`,
+    )
+  }
+  const sequence = pair.value
+  if (isSeq(sequence) && !sequence.flow && sequence.items.length > 0) {
+    const lastItem = sequence.items[sequence.items.length - 1]
+    const markerIndent = indentAt(source, nodeRange(lastItem)[0]) - 2
+    const insertAt = lineEndAfter(source, nodeRange(lastItem)[2])
+    return insertBlock(
+      source,
+      insertAt,
+      `${sequenceEntries(additions, markerIndent)}\n`,
+    )
+  }
+  const existing =
+    isSeq(sequence) && sequence.items.length > 0
+      ? (sequence.toJSON() as readonly unknown[])
+      : []
+  const merged = [...existing, ...additions]
+  const [start, valueEnd] = isSeq(sequence)
+    ? nodeRange(sequence)
+    : nodeRange(pair.value)
+  if (isSeq(sequence) && sequence.flow) {
+    const flow = stringify(merged, {
+      collectionStyle: 'flow',
+      lineWidth: 0,
+    }).trimEnd()
+    return splice(source, start, valueEnd, flow)
+  }
+  return splice(
+    source,
+    start,
+    valueEnd,
+    `\n${sequenceEntries(merged, indent + 2)}`,
+  )
+}
+
+// Retraction (#115): delete the field's whole entry, from the start of its
+// key line through the end of its value's last line.
+const removeField = (
+  source: string,
+  map: YAMLMap,
+  key: string,
+): string | undefined => {
+  const pair = pairFor(map, key)
+  if (pair === undefined) return undefined
+  const start = lineStartOf(source, nodeRange(pair.key)[0])
+  const valueEnd =
+    pair.value === null || pair.value === undefined
+      ? nodeRange(pair.key)[2]
+      : nodeRange(pair.value)[2]
+  return splice(source, start, lineEndAfter(source, valueEnd), '')
+}
+
+// ---------------------------------------------------------------------------
 
 export function runApplyCommand(
   options: readonly string[],
@@ -181,7 +411,7 @@ export function runApplyCommand(
     const workspaceDocuments = new Map(
       workspace.documents.map((path) => [resolve(cwd, path), path]),
     )
-    const parsed = new Map<string, Document>()
+    const candidates = new Map<string, string>()
     const counts = {
       addedConcepts: 0,
       addedRelationships: 0,
@@ -210,21 +440,20 @@ export function runApplyCommand(
           ),
         ])
       }
-      let document = parsed.get(absolute)
-      if (document === undefined) {
-        document = parseDocument(readFileSync(absolute, 'utf8'))
-        parsed.set(absolute, document)
+      let source = candidates.get(absolute)
+      if (source === undefined) {
+        source = readFileSync(absolute, 'utf8')
       }
       if (operation.op === 'add-concept') {
-        appendBlockItem(
-          document,
+        source = appendCollectionItem(
+          source,
           'concepts',
           operation.concept as unknown as Readonly<Record<string, unknown>>,
         )
         counts.addedConcepts += 1
       } else if (operation.op === 'add-relationship') {
-        appendBlockItem(
-          document,
+        source = appendCollectionItem(
+          source,
           'relationships',
           operation.relationship as unknown as Readonly<Record<string, unknown>>,
         )
@@ -232,45 +461,84 @@ export function runApplyCommand(
       } else {
         const collection =
           operation.op === 'update-concept' ? 'concepts' : 'relationships'
-        const payload =
+        const payload = (
           operation.op === 'update-concept'
             ? operation.concept
             : operation.relationship
-        const item = findItem(document, collection, payload.id)
-        if (item === undefined) {
+        ) as unknown as Readonly<Record<string, unknown>>
+        const scalars: readonly string[] =
+          operation.op === 'update-concept'
+            ? SCALAR_CONCEPT_FIELDS
+            : SCALAR_RELATIONSHIP_FIELDS
+        const lists: readonly string[] =
+          operation.op === 'update-concept'
+            ? LIST_CONCEPT_FIELDS
+            : LIST_RELATIONSHIP_FIELDS
+        const id = payload.id as string
+        const removals = operation.remove ?? []
+        const contradiction = removals.find(
+          (key) => payload[key] !== undefined,
+        )
+        if (contradiction !== undefined) {
           return failed([
             locate(
-              `Operation ${index} updates "${payload.id}", which does not exist in ${operation.document}`,
+              `Operation ${index} both sets and removes "${contradiction}" on "${id}"`,
             ),
           ])
         }
-        applyFields(
-          document,
-          item,
-          payload as unknown as Readonly<Record<string, unknown>>,
-          operation.op === 'update-concept'
-            ? SCALAR_CONCEPT_FIELDS
-            : SCALAR_RELATIONSHIP_FIELDS,
-          operation.op === 'update-concept'
-            ? LIST_CONCEPT_FIELDS
-            : LIST_RELATIONSHIP_FIELDS,
-        )
+        const located = itemMap(source, collection, id)
+        if (located === undefined) {
+          return failed([
+            locate(
+              `Operation ${index} updates "${id}", which does not exist in ${operation.document}`,
+            ),
+          ])
+        }
+        for (const key of scalars) {
+          if (payload[key] === undefined) continue
+          source = setScalarField(
+            source,
+            itemMap(source, collection, id)!.map,
+            key,
+            payload[key],
+          )
+        }
+        for (const key of lists) {
+          const additions = payload[key] as readonly unknown[] | undefined
+          if (additions === undefined || additions.length === 0) continue
+          source = appendListField(
+            source,
+            itemMap(source, collection, id)!.map,
+            key,
+            additions,
+          )
+        }
+        for (const key of removals) {
+          const removed = removeField(
+            source,
+            itemMap(source, collection, id)!.map,
+            key,
+          )
+          if (removed === undefined) {
+            return failed([
+              locate(
+                `Operation ${index} removes "${key}", which is not set on "${id}"`,
+              ),
+            ])
+          }
+          source = removed
+        }
         if (operation.op === 'update-concept') {
           counts.updatedConcepts += 1
         } else {
           counts.updatedRelationships += 1
         }
       }
+      candidates.set(absolute, source)
     }
 
     // The atomic gate: the whole candidate workspace must compile before a
     // single byte is written; any diagnostic rejects the entire batch.
-    const candidates = new Map(
-      [...parsed.entries()].map(([absolute, document]) => [
-        absolute,
-        document.toString({ lineWidth: 0 }),
-      ]),
-    )
     const compilation = compileWorkspace(
       [...workspace.profiles, ...workspace.documents].map((path) => {
         const absolute = resolve(cwd, path)
@@ -285,7 +553,7 @@ export function runApplyCommand(
     for (const [absolute, source] of candidates) {
       writeFileSync(absolute, source, 'utf8')
     }
-    const touched = [...parsed.keys()]
+    const touched = [...candidates.keys()]
       .map((absolute) => workspaceDocuments.get(absolute)!)
       .sort()
     if (json) {

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -194,4 +194,208 @@ operations:
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('Usage:')
   })
+  it('leaves untouched bytes byte-identical: folded scalars and comments survive', () => {
+    // The #114 regression: a status update must not reflow prose the
+    // batch never touched.
+    const folded = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+# The commerce slice.
+concepts:
+  - id: catalogue
+    kind: applicationService
+    name: Catalogue
+    description: >-
+      Serves the product catalogue to every storefront;
+      the authoritative price source, deliberately wrapped
+      across three authored lines.
+  - id: checkout
+    kind: applicationService
+    name: Checkout
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), folded, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: checkout
+      status: planned
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const after = readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8')
+    expect(after).toBe(
+      folded.replace(
+        '    name: Checkout\n',
+        '    name: Checkout\n    status: planned\n',
+      ),
+    )
+  })
+
+  it('retracts a field with remove and restores the exact prior bytes', () => {
+    const before = readFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+      status: current
+`,
+      'utf8',
+    )
+    expect(
+      runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+        .exitCode,
+    ).toBe(0)
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(
+      before.replace('    name: User\n', '    name: User\n    status: current\n'),
+    )
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+    remove: [status]
+`,
+      'utf8',
+    )
+    const retracted = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(retracted.exitCode).toBe(0)
+    // Assert -> retract restores the exact prior bytes: the whole loop
+    // (apply sets, reconcile catches, apply removes) leaves no residue.
+    const after = readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8')
+    expect(after).toBe(before)
+  })
+
+  it('rejects removing a field that is not set, leaving files untouched', () => {
+    const before = readFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+    remove: [owner]
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('removes "owner", which is not set')
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(before)
+  })
+
+  it('rejects an operation that both sets and removes one field', () => {
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: todo-service
+      status: current
+    remove: [status]
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('both sets and removes "status"')
+  })
+
+  it('rejects removing identity fields at the schema gate', () => {
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: todo-service
+    remove: [kind]
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('YM201')
+  })
+
+  it('converts an empty flow collection when appending the first concept', () => {
+    const empty = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts: []
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), empty, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: add-concept
+    document: architecture/main.yaml
+    concept:
+      id: first
+      kind: goal
+      name: First goal
+`,
+      'utf8',
+    )
+    expect(
+      runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+        .exitCode,
+    ).toBe(0)
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: first
+    kind: goal
+    name: First goal
+relationships: []
+`)
+  })
 })


### PR DESCRIPTION
Fixes both defects the yarradev-ai dogfood surfaced, per ADR 0062.

**#114 — splice-based writes.** `apply` no longer re-serializes documents through the YAML AST. Every operation computes a minimal text edit against the current source using parsed node ranges:

- `add-*` → insert the rendered item after the collection's last entry (converting empty/flow collections in place)
- scalar set → replace the value token; new fields insert one line at the item's end
- list append → insert entries after the last one (flow lists merge in place)
- `remove` → delete the field's lines

Untouched bytes — folded prose, comments, authored wrapping — stay byte-identical. The existing atomic compile gate now validates the **spliced text** before any write, so a splice defect rejects the batch loudly rather than corrupting a document.

**Replay of the incident**: the exact 10-operation batch that produced a 350-line diff on yarradev-ai's model now produces exactly 10 inserted `status: current` lines.

**#115 — retraction.** Update operations accept `remove: [<field>...]`. The assert → catch → retract loop closes through one audited surface, and retraction restores the exact prior bytes (pinned by test). Guardrails: identity fields (`id`/`kind`/`from`/`to`) are unremovable at the schema gate; removing an unset field is a located YM912 error; one operation cannot both set and remove a field.

6 new tests (byte-preservation, retract-to-exact-bytes, unset-removal rejection, set+remove contradiction, schema gate, empty-flow conversion); 312 total green; clean-slate `pnpm verify` green.

Closes #114
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)