### PR TITLE
One answer, many subjects: design steps carry the open-subject roster

### DIFF
--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -139,6 +139,14 @@
             "remainingSubjects": {
               "type": "integer",
               "minimum": 1
+            },
+            "openSubjects": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -129,7 +129,11 @@ yarramate design .yarramate/workspace.yaml
    .yarramate/workspace.yaml`), then re-run `design` — the next question is
    recomputed from the model, so the loop is resumable across sessions and
    agents with no handover. Use `--subject <id>` to focus the interview on
-   one element. The interview is complete when `design` says so.
+   one element. When a step reports many `openSubjects` sharing one
+   question (ownership is the classic case), do not interview N times:
+   collect the policy answer once — "who owns what, by area" — and land it
+   across every listed subject as one apply batch. The interview is
+   complete when `design` says so.
 5. Create:
    - an alternatives projection for the decision;
    - a bounded target projection for implementation agents.

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -42,6 +42,7 @@ interface DesignStep {
   readonly resolution: string
   readonly subject?: { readonly id: string; readonly name?: string }
   readonly remainingSubjects?: number
+  readonly openSubjects?: readonly string[]
 }
 
 interface DesignStepResult {
@@ -102,6 +103,10 @@ const selectStep = (
         ...(subjects.length > 1
           ? { remainingSubjects: subjects.length - 1 }
           : {}),
+        // The full roster sharing this question (#116): when one policy
+        // answer covers many subjects, the harness can collect it once
+        // and land one apply batch instead of interviewing N times.
+        openSubjects: subjects.map(({ id }) => id),
       }
     }
   }

--- a/test/design-command.test.ts
+++ b/test/design-command.test.ts
@@ -162,6 +162,58 @@ questions:
     expect(result.stdout).toContain('states-question')
   })
 
+  it('carries the full open-subject roster for shared questions', () => {
+    writeFileSync(
+      join(workspace, 'owners.yaml'),
+      `format: yarramate/question-catalogue/v1
+id: owners
+version: "1.0"
+profile: yarramate/core@0.1
+waves:
+  - id: business
+    name: Business
+questions:
+  - id: owner-missing
+    wave: business
+    scope: subject
+    subjects:
+      kinds:
+        - "yarramate/core@0.1#businessActor"
+        - "yarramate/core@0.1#applicationService"
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/ownership/owner
+    question: Who is accountable for {subject.name}?
+    materiality: Ownership decides who accepts changes.
+    authority: either
+    resolution: Add an owner reference.
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['design', 'workspace.yaml', '--catalogue', 'owners.yaml', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const payload = JSON.parse(result.stdout) as {
+      step: {
+        subject: { id: string }
+        remainingSubjects?: number
+        openSubjects?: readonly string[]
+      }
+    }
+    // One policy answer covers both: the roster lets the harness land it
+    // as one apply batch instead of interviewing twice.
+    expect(payload.step.subject.id).toBe('main#todo-service')
+    expect(payload.step.remainingSubjects).toBe(1)
+    expect(payload.step.openSubjects).toEqual([
+      'main#todo-service',
+      'main#user',
+    ])
+    const validate = new Ajv2020({ allErrors: true }).compile(stepSchema)
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
+  })
+
   it('requires an explicit workspace manifest', () => {
     const result = runCli(
       ['design', 'architecture/main.yaml'],


### PR DESCRIPTION
Fixes #116, from the yarradev-ai dogfood: 84 of that model's 160 open questions were one question repeated (ownership), and `design` serves subject-scoped questions one at a time. The one-step discipline stays — but the harness needs enough context to recognize the one-answer-many-subjects case and land it as a single batch.

- Subject-scoped steps now include **`openSubjects`**: the full id roster of subjects sharing the served question (served subject included). `remainingSubjects` stays for display; the roster is what batch authoring needs.
- `yarramate/design-step/v1` schema extended accordingly (additive).
- SKILL.md design journey names the pattern: *"when a step reports many openSubjects sharing one question, collect the policy answer once and land it across every listed subject as one apply batch."*

New test pins a two-subject shared question: served subject, `remainingSubjects: 1`, and the sorted two-id roster, schema-valid. Full suite green, clean-slate verify green.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)