### PR TITLE
Release v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch release carrying the yarradev-ai dogfood fixes:

- **#114** (PR #117): `apply` writes by splicing — untouched bytes stay byte-identical; the 350-line-diff reflow is gone (replayed: 10 ops → exactly 10 inserted lines).
- **#115** (PR #117): update operations accept `remove: [<field>...]` — explicit retraction restoring exact prior bytes; ADR 0062.
- **#116** (PR #118): subject-scoped design steps carry the full `openSubjects` roster; skill names the one-answer-many-subjects batch pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)