### PR TITLE
The catalogue deepens honestly: versioning discipline and the 0.4 waves

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -618,6 +618,24 @@ concepts:
     description: Derives every persisted artifact - the canonical graph, projection markdown, the per-concept briefs handoff bundle, and the LikeC4 visualization project delegated to the sibling adapter binary in a separate process.
     owner: yarramate-product#yarramate-maintainers
     status: current
+  - id: consumer-host
+    kind: node
+    name: Consumer host
+    description: The machine a consuming repository runs YarraMate on - a developer workstation or CI runner. YarraMate ships no server; every binary executes here.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: nodejs-runtime
+    kind: systemSoftware
+    name: Node.js runtime
+    description: The Node.js 22+ runtime that executes every shipped binary on the consumer host.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: npm-package
+    kind: artifact
+    name: npm package
+    description: The published yarramate package - compiled binaries, normative schemas, the internal catalogue, and the agent skill.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
 relationships:
   - id: core-contract-checker-loads-contract
     kind: assignment
@@ -1299,3 +1317,32 @@ relationships:
     to: projection-definition
     mode: read
     description: markdown and briefs exports scope their artifacts by a projection.
+  - id: consumer-host-composes-runtime
+    kind: composition
+    from: consumer-host
+    to: nodejs-runtime
+  - id: consumer-host-deploys-package
+    kind: assignment
+    from: consumer-host
+    to: npm-package
+    description: The package is installed and executed on the consumer host; no other deployment target exists.
+  - id: npm-package-realizes-cli
+    kind: realization
+    from: npm-package
+    to: cli
+  - id: runtime-serves-cli
+    kind: serving
+    from: nodejs-runtime
+    to: cli
+  - id: runtime-serves-graphify-adapter
+    kind: serving
+    from: nodejs-runtime
+    to: graphify-evidence-adapter
+  - id: runtime-serves-likec4-adapter
+    kind: serving
+    from: nodejs-runtime
+    to: likec4-export-adapter
+  - id: runtime-serves-mcp-adapter
+    kind: serving
+    from: nodejs-runtime
+    to: mcp-adapter

--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -9,10 +9,11 @@ concepts:
     kind: deliverable
     name: Architecture decision records
   - id: roadmap
-    kind: deliverable
+    kind: representation
     name: Product roadmap
+    description: The staged product plan as a reviewable document. A representation, not a deliverable - it describes the evolution; the merged work realizes it.
   - id: backlog-disposition
-    kind: deliverable
+    kind: representation
     name: Backlog disposition
     description: Distinguishes completed local scope from decision-gated, externally blocked, and demand-gated future work.
   - id: product-journeys-guide

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1386,3 +1386,33 @@ mappings:
   - native: yarramate-engine#export-command-writes-semantic-graph
     external: exportCommandWritesSemanticGraph
     type: relationship
+  - native: yarramate-engine#consumer-host
+    external: consumerHost
+    type: concept
+  - native: yarramate-engine#consumer-host-composes-runtime
+    external: consumerHostComposesRuntime
+    type: relationship
+  - native: yarramate-engine#consumer-host-deploys-package
+    external: consumerHostDeploysPackage
+    type: relationship
+  - native: yarramate-engine#nodejs-runtime
+    external: nodejsRuntime
+    type: concept
+  - native: yarramate-engine#npm-package
+    external: npmPackage
+    type: concept
+  - native: yarramate-engine#npm-package-realizes-cli
+    external: npmPackageRealizesCli
+    type: relationship
+  - native: yarramate-engine#runtime-serves-cli
+    external: runtimeServesCli
+    type: relationship
+  - native: yarramate-engine#runtime-serves-graphify-adapter
+    external: runtimeServesGraphifyAdapter
+    type: relationship
+  - native: yarramate-engine#runtime-serves-likec4-adapter
+    external: runtimeServesLikec4Adapter
+    type: relationship
+  - native: yarramate-engine#runtime-serves-mcp-adapter
+    external: runtimeServesMcpAdapter
+    type: relationship

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,15 +1,18 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.3"
+version: "0.4"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
   description: >-
-    The guided design path: motivation, business, and application waves plus
-    cross-cutting hygiene (technology and implementation follow in a later
-    version). Each question states the decision its answer changes; a
-    question that cannot is deleted, not softened. Adequacy is enforced by
-    linkage depth and attestation, never by reading words.
+    The guided design path: motivation, business, application, technology,
+    and implementation waves plus cross-cutting hygiene. Each question
+    states the decision its answer changes; a question that cannot is
+    deleted, not softened. Adequacy is enforced by linkage depth and
+    attestation, never by reading words. Versioning is additive within a
+    major version: every question records the catalogue version it arrived
+    in (ADR 0063), and a completed interview honestly reopens when the
+    path deepens.
 
 waves:
   - id: motivation
@@ -23,6 +26,16 @@ waves:
     description: >-
       How declared services are realized, performed, and fed with
       information.
+  - id: technology
+    name: Technology
+    description: >-
+      Where the declared applications actually run and what materializes
+      them.
+  - id: implementation
+    name: Implementation
+    description: >-
+      How the planned architecture becomes real: work, deliverables, and
+      the plateaus between here and there.
   - id: hygiene
     name: Model hygiene
     description: Cross-cutting completeness that keeps every wave honest.
@@ -31,6 +44,7 @@ questions:
   # ---- motivation ----------------------------------------------------------
   - id: outcome-missing
     wave: motivation
+    since: "0.1"
     scope: workspace
     trigger:
       - condition: no-subject-of-kind
@@ -50,6 +64,7 @@ questions:
 
   - id: stakeholders-missing
     wave: motivation
+    since: "0.1"
     scope: workspace
     trigger:
       - condition: no-subject-of-kind
@@ -68,6 +83,7 @@ questions:
 
   - id: constraints-missing
     wave: motivation
+    since: "0.1"
     scope: workspace
     trigger:
       - condition: no-subject-of-kind
@@ -86,6 +102,7 @@ questions:
 
   - id: goal-unrealized
     wave: motivation
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -110,6 +127,7 @@ questions:
 
   - id: goal-no-driver
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -137,6 +155,7 @@ questions:
 
   - id: driver-influences-nothing
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -158,6 +177,7 @@ questions:
 
   - id: stakeholder-unconcerned
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -180,6 +200,7 @@ questions:
 
   - id: requirement-unrealized
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -203,6 +224,7 @@ questions:
 
   - id: principle-unapplied
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -225,6 +247,7 @@ questions:
 
   - id: assessment-unlinked
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -243,6 +266,7 @@ questions:
 
   - id: motivation-unattested
     wave: motivation
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -268,6 +292,7 @@ questions:
   # ---- business ------------------------------------------------------------
   - id: service-consumer-unknown
     wave: business
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -291,6 +316,7 @@ questions:
 
   - id: owner-missing
     wave: business
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -313,6 +339,7 @@ questions:
 
   - id: actor-unassigned
     wave: business
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -335,6 +362,7 @@ questions:
 
   - id: information-unaccessed
     wave: business
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -358,6 +386,7 @@ questions:
 
   - id: no-service-declared
     wave: business
+    since: "0.1"
     scope: workspace
     trigger:
       - condition: no-subject-of-kind
@@ -378,6 +407,7 @@ questions:
 
   - id: service-realizes-no-motivation
     wave: business
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -405,6 +435,7 @@ questions:
 
   - id: process-untriggered
     wave: business
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -427,6 +458,7 @@ questions:
 
   - id: business-service-unrealized
     wave: business
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -460,6 +492,7 @@ questions:
   # ---- application ---------------------------------------------------------
   - id: app-service-unrealized
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -490,6 +523,7 @@ questions:
 
   - id: component-realizes-nothing
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -515,6 +549,7 @@ questions:
 
   - id: behavior-unassigned
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -546,6 +581,7 @@ questions:
 
   - id: event-triggers-nothing
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -568,6 +604,7 @@ questions:
 
   - id: information-unowned
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -589,6 +626,7 @@ questions:
 
   - id: planned-design-unattested
     wave: application
+    since: "0.3"
     scope: subject
     subjects:
       kinds:
@@ -612,9 +650,246 @@ questions:
       topic "design-review" (revoke by deleting it when the design
       changes).
 
+  # ---- technology ----------------------------------------------------------
+  - id: component-unhosted
+    wave: technology
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationComponent
+      kindMatching: exact
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#assignment
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#node
+          - yarramate/core@0.1#device
+          - yarramate/core@0.1#systemSoftware
+          - yarramate/core@0.1#technologyService
+    question: >-
+      Where does {subject.name} run?
+    materiality: >-
+      The hosting boundary decides latency, failure domain, scaling
+      model, and data residency; a component with no declared runtime is
+      deployed by whoever gets there first. Matching is exact by intent:
+      profile-derived module kinds inherit their deployable parent's
+      hosting rather than answering separately.
+    authority: either
+    resolution: >-
+      Add the node, device, or system software that hosts it with a
+      serving or assignment relationship into the component.
+
+  - id: node-serves-nothing
+    wave: technology
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#node
+        - yarramate/core@0.1#device
+        - yarramate/core@0.1#systemSoftware
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#assignment
+        direction: outgoing
+    question: >-
+      What does {subject.name} host or serve?
+    materiality: >-
+      Declared infrastructure that serves nothing is either cost without
+      purpose or missing the links that justify it; both change the
+      deployment budget.
+    authority: either
+    resolution: >-
+      Add serving or assignment relationships to the applications and
+      behavior it hosts, or remove it.
+
+  - id: technology-service-unrealized
+    wave: technology
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#technologyService
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#node
+          - yarramate/core@0.1#systemSoftware
+          - yarramate/core@0.1#technologyFunction
+          - yarramate/core@0.1#technologyProcess
+    question: >-
+      What provides {subject.name}?
+    materiality: >-
+      A technology service with no realizing node or behavior is a
+      dependency assumed rather than provided; outages and upgrades have
+      no owner in the model.
+    authority: either
+    resolution: >-
+      Add realization from the node, system software, or technology
+      behavior that provides the service.
+
+  - id: artifact-unassigned
+    wave: technology
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#artifact
+      kindMatching: exact
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#assignment
+          - yarramate/core@0.1#realization
+        direction: any
+    question: >-
+      What deploys {subject.name}, and what does it materialize?
+    materiality: >-
+      An artifact with no deployment target and nothing it realizes is a
+      build output the architecture cannot place; release engineering
+      starts from exactly these links.
+    authority: either
+    resolution: >-
+      Assign the artifact to the node that deploys it and add realization
+      to the component or data it materializes.
+
+  # ---- implementation ------------------------------------------------------
+  - id: workpackage-delivers-nothing
+    wave: implementation
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#workPackage
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+          - yarramate/core@0.1#aggregation
+        direction: outgoing
+    question: >-
+      What does {subject.name} produce?
+    materiality: >-
+      Work with no deliverable cannot be accepted or declared done; the
+      deliverable link is what makes progress reviewable rather than
+      reported.
+    authority: either
+    resolution: >-
+      Add realization from the work package to its deliverables.
+
+  - id: workpackage-unassigned
+    wave: implementation
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#workPackage
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#assignment
+        direction: incoming
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+          - yarramate/core@0.1#businessRole
+    question: >-
+      Who is committed to {subject.name}?
+    materiality: >-
+      An unassigned work package is a plan without capacity; commitment
+      is the difference between a roadmap and a wish list.
+    authority: human
+    resolution: >-
+      Add assignment from the actor or role that owns the work.
+
+  - id: deliverable-realizes-nothing
+    wave: implementation
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#deliverable
+      kindMatching: exact
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: outgoing
+    question: >-
+      What does {subject.name} make real?
+    materiality: >-
+      A deliverable that realizes no architecture element is effort
+      disconnected from the design; its acceptance criteria cannot be
+      stated architecturally.
+    authority: either
+    resolution: >-
+      Add realization from the deliverable to the plateau, requirement,
+      or element it brings into being.
+
+  - id: plateau-aggregates-nothing
+    wave: implementation
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#plateau
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#aggregation
+          - yarramate/core@0.1#composition
+        direction: outgoing
+    question: >-
+      Which architecture does {subject.name} stabilize?
+    materiality: >-
+      A plateau that aggregates nothing describes no state anyone can
+      stand on; migration planning needs to know what is stable when.
+    authority: either
+    resolution: >-
+      Aggregate the elements that are current during this plateau, or use
+      architecture states instead and remove it.
+
+  - id: gap-unaddressed
+    wave: implementation
+    since: "0.4"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#gap
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#association
+          - yarramate/core@0.1#realization
+        direction: any
+    question: >-
+      What closes {subject.name}?
+    materiality: >-
+      A named gap nothing addresses is a known risk with no plan; either
+      work closes it or the acceptance of it should be on record.
+    authority: human
+    resolution: >-
+      Associate the gap with the plateaus it separates and the
+      deliverable that closes it, or record the decision to accept it.
+
   # ---- hygiene -------------------------------------------------------------
   - id: concept-isolated
     wave: hygiene
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -640,6 +915,7 @@ questions:
 
   - id: concept-undescribed
     wave: hygiene
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -663,6 +939,7 @@ questions:
 
   - id: status-missing
     wave: hygiene
+    since: "0.1"
     scope: subject
     subjects:
       kinds:
@@ -685,6 +962,7 @@ questions:
 
   - id: states-undefined
     wave: hygiene
+    since: "0.1"
     scope: workspace
     trigger:
       - condition: no-state-defined

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -215,6 +215,6 @@ vocabulary as a read.
 - Where the standalone `evidence` evaluation lands: SETTLED (ADR 0061) —
   gone as a public surface; `reconcile` reports, `check --strict` gates,
   `yarramate/evidence-report/v1` remains a library-level format.
-- Catalogue versioning as the path deepens (the pinned-baseline lesson
-  from the benchmark applies) — still open; revisit when the
-  technology/implementation waves land.
+- Catalogue versioning: SETTLED (ADR 0063, with the 0.4 waves) —
+  honest reopen, `since` delta annotations, semver discipline (minor
+  is additive), no pinning.

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -77,3 +77,23 @@ by wave — answering what evidence can answer and escalating questions marked
 decision their answer changes. Answers are captured back into the model
 through the normal authoring surface and Git review; closure is then
 automatic on the next run.
+
+## Catalogue versioning
+
+The shipped catalogue is versioned with the product and deepens over time
+(ADR 0063). The discipline:
+
+- **Minor versions are additive**: new questions and loosened triggers
+  only. A model whose interview was complete honestly reopens when the
+  path deepens — the model did not regress; the standard of adequacy grew.
+- **Every question records `since`**, the catalogue version it first
+  appeared in. Reports, design steps, and `ask --open` carry the marker
+  (`[since 0.4]`), so consumers can attribute a reopened interview to the
+  catalogue delta without diffing catalogue files.
+- **There is no pinning.** The interview is stateless (ADR 0053/0058);
+  storing "the version this model was interviewed against" would let
+  models silently age against the path. Teams that need a frozen path can
+  copy the shipped catalogue and pass `--catalogue` explicitly.
+- **Major versions may change or remove triggers** — the only change
+  class that can silently alter what an existing "complete" means, which
+  is why it demands the major signal.

--- a/docs/adr/0063-the-catalogue-deepens-honestly.md
+++ b/docs/adr/0063-the-catalogue-deepens-honestly.md
@@ -1,0 +1,41 @@
+# The catalogue deepens honestly
+
+Status: accepted
+
+The internal design catalogue is versioned with the product, and it
+grows: 0.4 completes the deep ArchiMate path with technology and
+implementation waves. That raises the question the pinned-baseline
+lesson from the benchmark predicted: what happens to a model whose
+interview was "complete" when the catalogue deepens under it?
+
+Decision (with Nabeel, 2026-08-01): **it honestly reopens, with a
+delta annotation and no pinning.**
+
+- Reopening is correct behavior, not breakage. The model did not
+  regress; our shared standard of adequacy deepened. A pinned
+  catalogue version would let models silently age against the path
+  and would add stored state the stateless loop (ADR 0053/0058)
+  deliberately refuses.
+- Every question records `since: <version>` — the catalogue version
+  it first appeared in. The report, the design step, and the
+  `ask --open` rendering carry it (`[since 0.4]`), so a harness or a
+  human can distinguish "twenty new questions arrived with 0.4" from
+  "the model lost ground" without diffing catalogues.
+- Semver discipline: a **minor** bump only adds questions or loosens
+  triggers; a **major** bump may change or remove triggers, because
+  that silently flips the meaning of an existing "complete". The 0.x
+  series follows the minor rule from 0.4 onward.
+- A question that fires on subjects its author never meant is a
+  catalogue defect, not model debt: 0.4's `artifact-unassigned` and
+  `deliverable-realizes-nothing` select with `kindMatching: exact`
+  after descendant matching pulled in profile-derived documentation
+  kinds. Selector precision is part of the additive contract.
+
+0.4 itself: six waves; `component-unhosted` (exact-matched — derived
+module kinds inherit their deployable parent's hosting),
+`node-serves-nothing`, `technology-service-unrealized`,
+`artifact-unassigned`, and four implementation-wave questions over
+work packages, deliverables, plateaus, and gaps. A considered
+rejection: "every data object needs a materializing artifact" fails
+the catalogue's own bar — for result and message data objects the
+question changes no decision, so it was not added.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -147,6 +147,9 @@
                 "type": "string",
                 "minLength": 1
               }
+            },
+            "since": {
+              "type": "string"
             }
           }
         }

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -68,6 +68,7 @@
         "question": { "type": "string", "minLength": 1 },
         "materiality": { "type": "string", "minLength": 1 },
         "resolution": { "type": "string", "minLength": 1 },
+        "since": { "type": "string" },
         "subjects": {
           "type": "array",
           "minItems": 1,

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -392,6 +392,11 @@
         "resolution": {
           "description": "Guidance for how an accepted answer should land as native authoring (which claim, relationship, or state to add).",
           "$ref": "#/$defs/nonEmptyText"
+        },
+        "since": {
+          "description": "The catalogue version this question first appeared in. Lets consumers distinguish 'the catalogue deepened' from 'the model regressed' when a completed interview reopens (ADR 0063).",
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+$"
         }
       },
       "allOf": [

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -43,6 +43,7 @@ interface DesignStep {
   readonly subject?: { readonly id: string; readonly name?: string }
   readonly remainingSubjects?: number
   readonly openSubjects?: readonly string[]
+  readonly since?: string
 }
 
 interface DesignStepResult {
@@ -80,6 +81,7 @@ const selectStep = (
           question: question.question,
           materiality: question.materiality,
           resolution: question.resolution,
+          ...(question.since === undefined ? {} : { since: question.since }),
         }
       }
       const subjects =
@@ -96,6 +98,7 @@ const selectStep = (
         question: first.question,
         materiality: question.materiality,
         resolution: question.resolution,
+        ...(question.since === undefined ? {} : { since: question.since }),
         subject: {
           id: first.id,
           ...(first.name === undefined ? {} : { name: first.name }),

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -64,6 +64,7 @@ export interface CatalogueQuestion {
   readonly materiality: string
   readonly resolution: string
   readonly authority: 'human' | 'agent' | 'either'
+  readonly since?: string
 }
 
 export interface QuestionCatalogue {
@@ -97,6 +98,7 @@ interface ReportQuestion {
   readonly question: string
   readonly materiality: string
   readonly resolution: string
+  readonly since?: string
   readonly subjects?: readonly OpenSubject[]
 }
 
@@ -381,6 +383,7 @@ export function evaluateCatalogue(
           question: question.question.trim(),
           materiality: question.materiality.trim(),
           resolution: question.resolution.trim(),
+          ...(question.since === undefined ? {} : { since: question.since }),
         }
         if (question.scope === 'workspace') {
           const isOpen = question.trigger.every((condition) =>
@@ -492,13 +495,17 @@ export function renderInterrogationReport(
         lines.push(`  closed ${question.id}`)
         continue
       }
+      const sinceMarker =
+        question.since === undefined ? '' : ` [since ${question.since}]`
       if (question.subjects === undefined) {
-        lines.push(`  OPEN   ${question.id} — ${question.question}`)
+        lines.push(
+          `  OPEN   ${question.id}${sinceMarker} — ${question.question}`,
+        )
         lines.push(`         why: ${question.materiality}`)
         continue
       }
       lines.push(
-        `  OPEN   ${question.id} (${question.subjects.length} ${question.subjects.length === 1 ? 'subject' : 'subjects'})`,
+        `  OPEN   ${question.id}${sinceMarker} (${question.subjects.length} ${question.subjects.length === 1 ? 'subject' : 'subjects'})`,
       )
       for (const subject of question.subjects) {
         lines.push(

--- a/test/design-command.test.ts
+++ b/test/design-command.test.ts
@@ -110,6 +110,8 @@ describe('design command', () => {
       'motivation',
       'business',
       'application',
+      'technology',
+      'implementation',
       'hygiene',
     ])
     const validate = new Ajv2020({ allErrors: true }).compile(stepSchema)

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -43,6 +43,7 @@ const catalogue =
   '    resolution: Add a goal concept.\n' +
   '  - id: actor-owner-missing\n' +
   '    wave: hygiene\n' +
+  '    since: "1.1"\n' +
   '    scope: subject\n' +
   '    subjects:\n' +
   '      kinds: ["yarramate/core@0.1#businessActor"]\n' +
@@ -139,7 +140,9 @@ describe('ask --open interrogation', () => {
       workspace,
     )
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('actor-owner-missing (2 subjects)')
+    expect(result.stdout).toContain(
+      'actor-owner-missing [since 1.1] (2 subjects)',
+    )
     expect(result.stdout).toContain(
       'ask: "Who is accountable for Customer?" [authority: either]',
     )
@@ -163,7 +166,9 @@ describe('ask --open interrogation', () => {
       workspace,
     )
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('actor-owner-missing (1 subject)')
+    expect(result.stdout).toContain(
+      'actor-owner-missing [since 1.1] (1 subject)',
+    )
     expect(result.stdout).not.toContain('Platform team?')
   })
 
@@ -211,6 +216,9 @@ describe('ask --open interrogation', () => {
       'main#customer',
       'main#platform',
     ])
+    // The delta annotation (ADR 0063) rides the report so consumers can
+    // tell 'the catalogue deepened' from 'the model regressed'.
+    expect((owners as { since?: string }).since).toBe('1.1')
     const validate = new Ajv2020({ allErrors: true }).compile(reportSchema)
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
   })

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1428,7 +1428,7 @@ views:
         "view starter-technology-deployment {\n" +
           "    title 'Technology and deployment'\n" +
           "    description 'Technology structure, behavior, services, networks, and deployed artifacts.'\n" +
-          '    include consumerPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli',
+          '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, likec4ExportAdapter, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli',
       )
       const marker = JSON.parse(
         readFileSync(
@@ -2406,7 +2406,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1190,
+            line: 1208,
             column: 5,
           },
           {
@@ -2417,7 +2417,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1194,
+            line: 1212,
             column: 5,
           },
           {
@@ -2428,7 +2428,7 @@ mappings:
             subject: 'yarramate-repository#likec4-export-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/21/kind',
-            line: 95,
+            line: 96,
             column: 11,
           },
           {
@@ -2439,7 +2439,7 @@ mappings:
             subject: 'yarramate-repository#likec4-prepare-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/24/kind',
-            line: 107,
+            line: 108,
             column: 11,
           },
           {
@@ -2450,7 +2450,7 @@ mappings:
             subject: 'yarramate-repository#likec4-project-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/25/kind',
-            line: 111,
+            line: 112,
             column: 11,
           },
           {
@@ -2461,7 +2461,7 @@ mappings:
             subject: 'yarramate-repository#likec4-project-definition-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/26/kind',
-            line: 115,
+            line: 116,
             column: 11,
           },
           {
@@ -2472,7 +2472,7 @@ mappings:
             subject: 'yarramate-repository#likec4-project-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/53/kind',
-            line: 228,
+            line: 229,
             column: 11,
           },
           {
@@ -2483,7 +2483,7 @@ mappings:
             subject: 'yarramate-repository#likec4-generated-project-v2-schema-source',
             path: '.yarramate/architecture/repository.yaml',
             pointer: '/concepts/54/kind',
-            line: 232,
+            line: 233,
             column: 11,
           },
         ],


### PR DESCRIPTION
The arc Nabeel greenlit before leaving: catalogue versioning + the 0.4 waves, per the two decisions recorded at kickoff (honest reopen + delta annotation; both waves in one bump). Settles the **last open question** in docs/AGENT-INTERFACE.md (ADR 0063).

**Versioning discipline:**
- Completed interviews honestly reopen when the catalogue deepens — the model didn't regress; the adequacy standard grew. No pinning, no stored state (stateless per ADR 0053/0058; teams needing a frozen path copy the catalogue and pass `--catalogue`).
- Every question records `since: <version>`; the interrogation report, design steps, and `ask --open` (`[since 0.4]`) carry it, so harnesses can attribute reopening to the catalogue delta.
- Semver: minor = additive only; major = trigger changes/removals.

**Catalogue 0.4** — the deep path is complete: 6 waves, 38 questions (+9 across technology and implementation). `component-unhosted` matches exactly by intent: profile-derived module kinds inherit their deployable parent's hosting. One considered rejection documented in the ADR (data-materialization fails the decision-changing bar).

**The dogfood was the QA**: 0.4 opened 20 on the self-model — 17 turned out to be *catalogue* defects (descendant matching pulling dev-profile test-file/doc kinds into `artifact-unassigned`/`deliverable-realizes-nothing`; fixed with exact selectors before shipping — selector precision is part of the additive contract) and 3 were genuine (the three adapter binaries had no declared runtime). Answered with one batch: consumer host, Node.js runtime, npm package artifact, deployment/serving edges — plus an honest re-kinding of `roadmap`/`backlog-disposition` from `deliverable` to `representation`. Interview complete at 0.4; the starter technology-deployment view now renders a real deployment picture (host → runtime → package → binaries) instead of 5 stray elements.

313 tests green; clean-slate `pnpm verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)