### PR TITLE
Release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Minor release: the catalogue deepens (honestly).

- Catalogue 0.4 completes the deep ArchiMate path — technology + implementation waves, 38 questions across 6 waves (ADR 0063, PR #121).
- Versioning discipline: completed interviews honestly reopen when the catalogue deepens; every question carries `since`, surfaced in reports, design steps, and `ask --open`; minor bumps are additive-only. **Consumers on 0.7.x will see new open questions on models whose interviews were complete — that is the feature, not a regression.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)