### PR TITLE
Retired is a closed question, and flow items survive enrichment

### DIFF
--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.4"
+version: "0.5"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -122,7 +122,9 @@ questions:
     authority: either
     resolution: >-
       Add realization relationships from the fulfilling capability or
-      service, or record the aspirational status in the goal's description.
+      service, record the aspirational status in the goal's description,
+      or retire the goal (status: retired) to record that it no longer
+      steers design.
 
 
   - id: goal-no-driver
@@ -219,8 +221,11 @@ questions:
       roadmap.
     authority: either
     resolution: >-
-      Add realization from the fulfilling service, component, or behavior,
-      or record the descoping decision and remove the requirement.
+      Add realization from the fulfilling service, component, or
+      behavior; to descope instead, retire the requirement (status:
+      retired) — retirement preserves the decision on record and closes
+      the question (ADR 0064). Delete only when the history itself is
+      noise.
 
   - id: principle-unapplied
     wave: motivation

--- a/docs/adr/0064-retired-is-a-closed-question.md
+++ b/docs/adr/0064-retired-is-a-closed-question.md
@@ -1,0 +1,29 @@
+# Retired is a closed question
+
+Status: accepted
+
+Found by a cross-harness dogfood (a Codex session resuming the design
+loop, 2026-08-01): a human explicitly descoped two requirements by
+retiring them, and `requirement-unrealized` stayed open. The agent was
+left with three bad options — a permanently open question, a false
+realization, or bypassing `apply` to hand-edit YAML.
+
+The evaluator now excludes `status: retired` subjects from the
+enrichment target set entirely, alongside architecture states:
+retirement is the recorded decision that a subject left the design
+conversation, so no subject-scoped question stays open against it.
+This is engine semantics, not per-question selector configuration —
+a catalogue author cannot reintroduce interrogation of the past by
+forgetting a status filter. Retired concepts still participate as
+counterparts (a service realizing a retired requirement keeps its
+linkage answered) and still appear in reads; they are simply no longer
+asked to improve.
+
+The catalogue (0.5) names the motion: the prescribed resolution for
+unrealized requirements and goals now says to retire for descoping —
+preserving the decision on record — and to delete only when the
+history itself is noise. Deletion through `apply` (atomic
+`delete-concept`/`delete-relationship` with reference validation)
+remains unbuilt: with field retraction (ADR 0062) and status
+retirement covering the honest cases, deletion stays a reviewed Git
+edit until real usage demands otherwise.

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -267,12 +267,39 @@ const itemMap = (
 const fieldIndentOf = (source: string, map: YAMLMap): number =>
   indentAt(source, nodeRange(map.items[0]!.key)[0])
 
+// A flow-style item (`- { id: x, ... }`) cannot take block field lines;
+// splicing them after it corrupts the sequence (Codex dogfood finding,
+// 2026-08-01). The whole item is rewritten as a block mapping with the
+// mutation applied — churn confined to the item being edited.
+const rewriteFlowItem = (
+  source: string,
+  map: YAMLMap,
+  mutate: (
+    fields: Record<string, unknown>,
+  ) => Record<string, unknown>,
+): string => {
+  const mutated = mutate(map.toJSON() as Record<string, unknown>)
+  const [start, valueEnd] = nodeRange(map)
+  const fieldIndent = indentAt(source, start)
+  const rendered = reindent(
+    stringify(mutated, { lineWidth: 0 }).trimEnd(),
+    fieldIndent,
+  )
+  return splice(source, start, valueEnd, rendered)
+}
+
 const setScalarField = (
   source: string,
   map: YAMLMap,
   key: string,
   value: unknown,
 ): string => {
+  if (map.flow) {
+    return rewriteFlowItem(source, map, (fields) => ({
+      ...fields,
+      [key]: value,
+    }))
+  }
   const indent = fieldIndentOf(source, map)
   const rendered = reindent(valueText(value), indent + 2)
   const pair = pairFor(map, key)
@@ -293,6 +320,15 @@ const appendListField = (
   key: string,
   additions: readonly unknown[],
 ): string => {
+  if (map.flow) {
+    return rewriteFlowItem(source, map, (fields) => ({
+      ...fields,
+      [key]: [
+        ...((fields[key] as readonly unknown[] | undefined) ?? []),
+        ...additions,
+      ],
+    }))
+  }
   const indent = fieldIndentOf(source, map)
   const pair = pairFor(map, key)
   if (pair === undefined) {
@@ -337,7 +373,9 @@ const appendListField = (
 }
 
 // Retraction (#115): delete the field's whole entry, from the start of its
-// key line through the end of its value's last line.
+// key line through the end of its value's last line. A flow item is
+// rewritten instead — line-based deletion there would take the whole item
+// with it.
 const removeField = (
   source: string,
   map: YAMLMap,
@@ -345,6 +383,12 @@ const removeField = (
 ): string | undefined => {
   const pair = pairFor(map, key)
   if (pair === undefined) return undefined
+  if (map.flow) {
+    return rewriteFlowItem(source, map, (fields) => {
+      const { [key]: _removed, ...rest } = fields
+      return rest
+    })
+  }
   const start = lineStartOf(source, nodeRange(pair.key)[0])
   const valueEnd =
     pair.value === null || pair.value === undefined

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -140,16 +140,6 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
       .filter(({ predicate }) => predicate === 'yarramate/state/type')
       .map(({ subject }) => subject),
   )
-  // Architecture states carry concept subjects in the graph but are not
-  // enrichment targets; the catalogue interrogates the model, not the
-  // planning overlay.
-  const concepts = new Set(
-    graph.subjects
-      .filter(
-        ({ id, type }) => type === 'concept' && !stateSubjects.has(id),
-      )
-      .map(({ id }) => id),
-  )
   const claimsBySubject = new Map<string, GraphClaim[]>()
   const kindOf = new Map<string, string>()
   const nameOf = new Map<string, string>()
@@ -178,6 +168,21 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
       }
     }
   }
+  // Architecture states carry concept subjects in the graph but are not
+  // enrichment targets; the catalogue interrogates the model, not the
+  // planning overlay. Retired concepts are excluded for the same reason
+  // (ADR 0064): retirement is the recorded decision that a subject left
+  // the design conversation, so no question stays open against it.
+  const concepts = new Set(
+    graph.subjects
+      .filter(
+        ({ id, type }) =>
+          type === 'concept' &&
+          !stateSubjects.has(id) &&
+          statusOf.get(id) !== 'retired',
+      )
+      .map(({ id }) => id),
+  )
   return {
     concepts,
     claimsBySubject,

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -398,4 +398,80 @@ concepts:
 relationships: []
 `)
   })
+  it('rewrites a flow-style item as block when adding fields', () => {
+    // Codex dogfood finding: block field lines spliced after a
+    // `- { ... }` item corrupt the sequence.
+    const flow = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - { id: flow-item, kind: applicationService, name: Flow item }
+  - id: neighbour
+    kind: businessActor
+    name: Neighbour
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), flow, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: flow-item
+      status: planned
+      description: "Handles ingestion: parsing and storage."
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const after = readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8')
+    expect(after).toContain(
+      '  - id: flow-item\n' +
+        '    kind: applicationService\n' +
+        '    name: Flow item\n' +
+        '    description: "Handles ingestion: parsing and storage."\n' +
+        '    status: planned\n',
+    )
+    // The neighbouring block item and everything else stay byte-identical.
+    expect(after).toContain('  - id: neighbour\n    kind: businessActor\n    name: Neighbour\n')
+    expect(after.split('flow-item').length).toBe(2)
+  })
+
+  it('removing a field from a flow-style item never deletes the item', () => {
+    const flow = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - { id: flow-item, kind: applicationService, name: Flow item, status: planned }
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), flow, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: flow-item
+    remove: [status]
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const after = readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8')
+    expect(after).toContain('id: flow-item')
+    expect(after).toContain('name: Flow item')
+    expect(after).not.toContain('status: planned')
+  })
 })

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -223,6 +223,31 @@ describe('ask --open interrogation', () => {
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
   })
 
+  it('never interrogates retired subjects (ADR 0064)', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      document.replace(
+        '  - id: customer\n' +
+          '    kind: businessActor\n' +
+          '    name: Customer\n',
+        '  - id: customer\n' +
+          '    kind: businessActor\n' +
+          '    name: Customer\n' +
+          '    status: retired\n',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    // Retirement is the recorded descoping decision: the retired actor
+    // leaves the interview entirely; the live one is still asked.
+    expect(result.stdout).not.toContain('Customer?')
+    expect(result.stdout).toContain('Platform team?')
+  })
+
   it('locates a question referencing an undeclared wave', () => {
     writeFileSync(
       join(workspace, 'catalogue.yaml'),


### PR DESCRIPTION
The first cross-harness dogfood: a Codex session resumed the design loop in yarradev-ai from nothing but the AGENTS.md pointer and the published CLI — and exercised it hard enough to surface two real defects. Both fixed, per ADR 0064. Answers to the investigation's three questions:

**1. Should `requirement-unrealized` ignore `status: retired`?** Yes — and one level deeper: the **evaluator** now excludes retired subjects from the enrichment target set entirely (like architecture states). Retirement is the recorded descoping decision; no subject-scoped question stays open against it, and no catalogue author can reintroduce interrogation of the past by forgetting a status filter. Retired concepts still count as counterparts (existing linkage stays answered) and still appear in reads. Corollary that fell out correctly: if a workspace's *only* requirement is retired, workspace-level `constraints-missing` reopens — descoped away means genuinely absent.

**2. Should `apply` support atomic `delete-concept`/`delete-relationship`?** Deferred, filed as #123. With field retraction (ADR 0062) and retirement now honoured by the evaluator, the honest cases are covered; deleting history is a reviewed Git edit until real usage shows retired noise that should truly leave the file.

**3. Should the resolution recommend retirement?** Yes — catalogue 0.5: `requirement-unrealized` and `goal-unrealized` now prescribe `status: retired` for descoping ("retirement preserves the decision on record"), deletion "only when the history itself is noise."

**The second report — YM101 on multi-field updates — was a genuine splice-writer defect on flow-style items** (`- { id: x, ... }`): block field lines spliced after a flow map corrupt the sequence (the compile gate refused, as designed), and worse, `remove` on a flow item deleted the *entire item line* — a silent-loss path that could pass the gate. All three mutation paths now rewrite a flow item as a block mapping with the change applied; churn confined to the edited item. Reproduced against published 0.8.0 and replayed green against this branch, including the reporter's exact expected behavior.

3 new tests; 316 green; clean-slate `pnpm verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)