### PR TITLE
Release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Minor release: git-derived review slices (ADR 0065, PR #127) — `ask --changed <git-range>` with inline projection-coverage reporting, and `export markdown|briefs --changed`. Authored review tags recorded as a deliberate deferral (#126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)