### PR TITLE
Promote the spec-build family results from draft to adjudicated

### DIFF
--- a/docs/research/context-benchmark/spec-build/RESULTS-2026-07-31.md
+++ b/docs/research/context-benchmark/spec-build/RESULTS-2026-07-31.md
@@ -1,9 +1,9 @@
 # Spec-build family results (runs 1–3, 2026-07-31)
 
-Status: complete family record, n = 3 per arm, Sonnet throughout,
-deterministic scoring floor only — the human adjudication pass has not
-happened, and per the no-LLM-judging rule these numbers are draft until
-it does. Total spend across pilot + probes + runs 2–3 ≈ $56.
+Status: complete family record, n = 3 per arm, Sonnet throughout.
+**ADJUDICATED** by nabsha on 2026-08-01 (see Adjudication below): every
+draft verdict passed as drafted, so the numbers here are final per the
+no-LLM-judging rule. Total spend across pilot + probes + runs 2–3 ≈ $56.
 
 **The headline, stated honestly: on this well-specified task, the
 pre-registered convergence hypotheses were NOT supported. The
@@ -111,11 +111,34 @@ spec, tests, or redundant claims bear witness.
    wave or profile guidance about modeling depth would attack the
    variance that sank H5.
 
+## Adjudication (2026-08-01, nabsha)
+
+All fourteen packet items **passed as drafted** (ADJUDICATION-PACKET.md
+in the published artifacts carries the marked verdicts):
+
+- Eleven per-build verdicts confirmed, including all five C-family lie
+  outcomes (silent absorption, drowned-out, and three catches — two via
+  cross-brief redundancy).
+- The one genuine judgment call — run 2 arm A's shared `userRepo`
+  between Auth and User services — was classified **consolidation**,
+  not boundary violation: the lookup boundary the design's rationale
+  cares about was respected as written; the shared low-level repo is
+  infrastructure, not another component's public interface.
+- Packet erratum accepted: run 1 arm B's "11 deviations" was a
+  compliance map under a DEVIATIONS.md that literally declares none.
+- X1: the A > B convergence reversal is real (granularity variance,
+  47/44/27 planned concepts, plus layout-taste file paths) — not a
+  token-extraction artifact.
+- X2: the three recurring missing names in C builds (Browse Articles,
+  Manage Current User, Publish Articles) are genuine non-carryover of
+  behavior-level function names folded into services, not scorer noise.
+- X3: the full run artifacts are **published** in
+  [yarramate-bench-results](https://github.com/yarrasys/yarramate-bench-results)
+  (`spec-build-pilot-2026-07-31/`), transcripts included.
+
 ## Boundaries
 
-One spec, one tier, one model family, three runs, deterministic floor
-only, layout-agnostic briefs vs layout-bearing documents (a format
-asymmetry we did not control), and run 1's C-family used earlier
-injector variants (recorded per-run in `PROVENANCE.txt`). Human
-adjudication of the eleven DEVIATIONS files and five lie records is the
-step that converts any of this into publishable numbers.
+One spec, one tier, one model family, three runs, layout-agnostic
+briefs vs layout-bearing documents (a format asymmetry we did not
+control), and run 1's C-family used earlier injector variants (recorded
+per-run in `PROVENANCE.txt`).


### PR DESCRIPTION
nabsha's adjudication pass (2026-08-01): all fourteen packet items **passed as drafted** — the eleven per-build verdicts (including all five lie outcomes), the run-2-arm-A judgment call (**consolidation**), X1 (the A>B reversal is real), X2 (genuine non-carryover), and X3 (**published**: full artifacts including transcripts and the marked packet now live in [yarramate-bench-results@a35b7df](https://github.com/yarrasys/yarramate-bench-results)).

RESULTS-2026-07-31.md carries the adjudication section and drops its draft caveats. Per the no-LLM-judging rule, these numbers are final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)