### PR TITLE
Organise the diagrams: five stories, a seven-verb view, and excludeStatuses

### DIFF
--- a/.yarramate/likec4-project.yaml
+++ b/.yarramate/likec4-project.yaml
@@ -4,17 +4,20 @@ version: "1.0"
 title: YarraMate architecture
 mapping: integrations/likec4/subject-mapping.yaml
 kindMapping: integrations/likec4/kind-mapping.yaml
+# Views are ordered as five stories, coarse to fine: orientation, the
+# agent contract, engine internals, the ArchiMate viewpoints, and
+# evolution. Retired subjects are excluded by the underlying projections
+# (excludeStatuses) - the diagrams show the living architecture; git and
+# the model keep the history.
 views:
+  # --- 1 · Orientation ------------------------------------------------
   - id: index
     projection: projections/starter-landscape.yaml
-  - projection: projections/starter-motivation.yaml
-  - projection: projections/starter-strategy.yaml
   - projection: projections/product-journeys.yaml
-  - projection: projections/starter-business-operation.yaml
-  - projection: projections/starter-application-cooperation.yaml
-  - projection: projections/starter-information-structure.yaml
-  - projection: projections/starter-technology-deployment.yaml
-  - projection: projections/starter-implementation-roadmap.yaml
+  - projection: projections/product-context.yaml
+  # --- 2 · The agent contract -----------------------------------------
+  - projection: projections/seven-verb-surface.yaml
+  # --- 3 · Engine internals -------------------------------------------
   - projection: projections/engine-components.yaml
   - id: compiler-pipeline
     projection: projections/current-engine.yaml
@@ -27,6 +30,19 @@ views:
         - relationship: yarramate-engine#semantic-validation-triggers-compilation
           title: compiles graph
   - projection: projections/likec4-export-path.yaml
+  - projection: projections/maintainer-tool-neutral-engine.yaml
+  - projection: projections/implementation-traceability.yaml
+  # --- 4 · ArchiMate viewpoints ---------------------------------------
+  - projection: projections/starter-motivation.yaml
+  - projection: projections/starter-strategy.yaml
+  - projection: projections/starter-business-operation.yaml
+  - projection: projections/starter-application-cooperation.yaml
+  - projection: projections/starter-information-structure.yaml
+  - projection: projections/starter-technology-deployment.yaml
+  - projection: projections/starter-implementation-roadmap.yaml
+  # --- 5 · Evolution ---------------------------------------------------
+  - projection: projections/state-foundation.yaml
+  - projection: projections/core-contract-foundation.yaml
   - projection: projections/state-engine-adapter.yaml
   - projection: projections/state-engine-target.yaml
   - projection: projections/state-engine-change.yaml

--- a/.yarramate/projections/implementation-traceability.yaml
+++ b/.yarramate/projections/implementation-traceability.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: implementation-traceability
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   documents: [yarramate-engine, yarramate-repository]
   kinds:
     - yarramate/development@1.0#compiler-module

--- a/.yarramate/projections/seven-verb-surface.yaml
+++ b/.yarramate/projections/seven-verb-surface.yaml
@@ -1,0 +1,21 @@
+format: yarramate/projection/v1
+id: seven-verb-surface
+version: "1.0"
+query:
+  subjects:
+    - yarramate-engine#cli
+    - yarramate-engine#init-command
+    - yarramate-engine#design-command
+    - yarramate-engine#apply-command
+    - yarramate-engine#ask-command
+    - yarramate-engine#check-command
+    - yarramate-engine#reconcile-command
+    - yarramate-engine#export-command
+    - yarramate-product#agent-harness
+  relationships: between
+presentation:
+  title: The seven-verb surface
+  description: >-
+    The agent-harness contract, one verb per lifecycle stage: init creates,
+    design fills, apply writes, ask reads, check gates, reconcile reports
+    drift, export derives artifacts (ADR 0059-0061).

--- a/.yarramate/projections/starter-application-cooperation.yaml
+++ b/.yarramate/projections/starter-application-cooperation.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: starter-application-cooperation
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   kinds:
     - yarramate/core@0.1#applicationComponent
     - yarramate/core@0.1#applicationCollaboration

--- a/.yarramate/projections/starter-business-operation.yaml
+++ b/.yarramate/projections/starter-business-operation.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: starter-business-operation
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   kinds:
     - yarramate/core@0.1#businessActor
     - yarramate/core@0.1#businessRole

--- a/.yarramate/projections/starter-landscape.yaml
+++ b/.yarramate/projections/starter-landscape.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: starter-landscape
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   kinds:
     - yarramate/core@0.1#goal
     - yarramate/core@0.1#capability

--- a/.yarramate/projections/state-engine-change.yaml
+++ b/.yarramate/projections/state-engine-change.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: state-engine-change
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   states:
     - yarramate-evolution#adapter-foundation
     - yarramate-evolution#state-foundation

--- a/.yarramate/projections/state-engine-target.yaml
+++ b/.yarramate/projections/state-engine-target.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: state-engine-target
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   states:
     - yarramate-evolution#state-foundation
   subjects:

--- a/.yarramate/projections/state-foundation.yaml
+++ b/.yarramate/projections/state-foundation.yaml
@@ -2,6 +2,7 @@ format: yarramate/projection/v1
 id: state-foundation
 version: "1.0"
 query:
+  excludeStatuses: [retired]
   states:
     - yarramate-evolution#state-foundation
   documents:

--- a/docs/PROJECTIONS.md
+++ b/docs/PROJECTIONS.md
@@ -37,6 +37,12 @@ Query fields combine with logical AND:
 - `relationshipKinds` filters relationships by globally qualified semantic
   kind identity without changing concept selection;
 - `statuses` filters controlled lifecycle status;
+- `excludeStatuses` drops concepts carrying one of the listed statuses while
+  keeping concepts that declare no status at all — the viewpoint form of
+  status filtering (`excludeStatuses: [retired]` shows the living
+  architecture without dropping unstatused actors and motivation elements);
+  it also vetoes `connected` expansion, so an excluded concept is never
+  pulled in as a neighbour and edges touching one are dropped;
 - `states` filters subject presence in globally qualified architecture states;
 - `relationships` is `between`, `connected`, or `none` and defaults to
   `between`.

--- a/schema/yarramate-projection.schema.json
+++ b/schema/yarramate-projection.schema.json
@@ -49,6 +49,14 @@
             "enum": ["planned", "current", "retired"]
           }
         },
+        "excludeStatuses": {
+          "description": "Drop concepts carrying one of these lifecycle statuses while keeping concepts that declare no status at all - 'everything except retired' for viewpoint projections, where a bare statuses filter would wrongly drop unstatused actors and motivation elements.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["planned", "current", "retired"]
+          }
+        },
         "states": {
           "type": "array",
           "minItems": 1,

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -27,6 +27,7 @@ export interface ProjectionDefinition {
     readonly documents?: readonly string[]
     readonly kinds?: readonly string[]
     readonly statuses?: readonly LifecycleStatus[]
+    readonly excludeStatuses?: readonly LifecycleStatus[]
     readonly states?: readonly string[]
     readonly owners?: readonly string[]
     readonly constraints?: readonly string[]
@@ -175,6 +176,11 @@ export function evaluateProjection(
           (projection.query.statuses === undefined ||
             (status !== undefined &&
               projection.query.statuses.includes(status as LifecycleStatus))) &&
+          (projection.query.excludeStatuses === undefined ||
+            status === undefined ||
+            !projection.query.excludeStatuses.includes(
+              status as LifecycleStatus,
+            )) &&
           (projection.query.owners === undefined ||
             (owner !== undefined &&
               projection.query.owners.includes(owner))) &&
@@ -196,9 +202,19 @@ export function evaluateProjection(
       const relationship = graph.claims.find(
         (claim) => claim.id === subject.id,
       )
+      const relationshipStatus = claimValue(
+        graph.claims,
+        subject.id,
+        'yarramate/lifecycle/status',
+      )
       if (
         relationship === undefined ||
         !('ref' in relationship.object) ||
+        (projection.query.excludeStatuses !== undefined &&
+          relationshipStatus !== undefined &&
+          projection.query.excludeStatuses.includes(
+            relationshipStatus as LifecycleStatus,
+          )) ||
         (projection.query.relationshipKinds !== undefined &&
           !projection.query.relationshipKinds.some(
             (selectedKind) =>
@@ -218,6 +234,29 @@ export function evaluateProjection(
       const targetSelected = initiallySelectedConceptIds.has(
         relationship.object.ref,
       )
+      // excludeStatuses also vetoes connected expansion: an excluded
+      // concept is never pulled in as a neighbour, and edges touching
+      // one are dropped rather than left dangling.
+      const endpointExcluded = (id: string): boolean => {
+        if (projection.query.excludeStatuses === undefined) return false
+        const endpointStatus = claimValue(
+          graph.claims,
+          id,
+          'yarramate/lifecycle/status',
+        )
+        return (
+          endpointStatus !== undefined &&
+          projection.query.excludeStatuses.includes(
+            endpointStatus as LifecycleStatus,
+          )
+        )
+      }
+      if (
+        endpointExcluded(relationship.subject) ||
+        endpointExcluded(relationship.object.ref)
+      ) {
+        continue
+      }
       if (
         (relationshipMode === 'between' &&
           sourceSelected &&

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1410,7 +1410,7 @@ views:
 
       expect(result.exitCode).toBe(0)
       const model = readFileSync(join(project, 'model.likec4'), 'utf8')
-      expect(model.match(/^  (?:dynamic )?view /gm)).toHaveLength(15)
+      expect(model.match(/^  (?:dynamic )?view /gm)).toHaveLength(21)
       expect(model).not.toMatch(/^    include \*$/gm)
       expect(model).toContain('view index')
       expect(model).not.toContain('view starter-landscape')
@@ -1423,6 +1423,9 @@ views:
       expect(model).toContain('view starter-technology-deployment')
       expect(model).toContain('view starter-implementation-roadmap')
       expect(model).toContain('view engine-components')
+      expect(model).toContain('view seven-verb-surface')
+      expect(model).toContain('view product-context')
+      expect(model).toContain('view state-foundation')
       expect(model).toContain('dynamic view compiler-pipeline')
       expect(model).toContain(
         "view starter-technology-deployment {\n" +
@@ -1436,7 +1439,7 @@ views:
           'utf8',
         ),
       )
-      expect(marker.views).toHaveLength(15)
+      expect(marker.views).toHaveLength(21)
       expect(marker.views[0]).toEqual({
         id: 'index',
         projection: 'starter-landscape@1.0',

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -665,3 +665,81 @@ query:
     })
   })
 })
+
+describe('excludeStatuses', () => {
+  const graphOf = (source: string) => {
+    const result = compileWorkspace([{ path: 'doc.yaml', source }])
+    if (!result.ok) throw new Error('fixture must compile')
+    return result.graph
+  }
+
+  it('drops excluded statuses while keeping unstatused concepts', () => {
+    const graph = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: actor
+    kind: businessActor
+    name: Actor
+  - id: live-service
+    kind: applicationService
+    name: Live service
+    status: current
+  - id: dead-service
+    kind: applicationService
+    name: Dead service
+    status: retired
+relationships:
+  - id: dead-serves-actor
+    kind: serving
+    from: dead-service
+    to: actor
+`)
+    const result = evaluateProjection(graph, {
+      format: 'yarramate/projection/v1',
+      id: 'living',
+      version: '1.0',
+      query: { excludeStatuses: ['retired'], relationships: 'between' },
+    })
+    expect(result.subjects.map(({ id }) => id)).toEqual([
+      'main#actor',
+      'main#live-service',
+    ])
+  })
+
+  it('vetoes connected expansion into excluded concepts', () => {
+    const graph = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: live-service
+    kind: applicationService
+    name: Live service
+    status: current
+  - id: dead-service
+    kind: applicationService
+    name: Dead service
+    status: retired
+relationships:
+  - id: live-serves-dead
+    kind: serving
+    from: live-service
+    to: dead-service
+`)
+    const result = evaluateProjection(graph, {
+      format: 'yarramate/projection/v1',
+      id: 'living',
+      version: '1.0',
+      query: {
+        subjects: ['main#live-service'],
+        excludeStatuses: ['retired'],
+        relationships: 'connected',
+      },
+    })
+    // The retired neighbour is not pulled in, and the edge to it is
+    // dropped rather than left dangling.
+    expect(result.subjects.map(({ id }) => id)).toEqual([
+      'main#live-service',
+    ])
+  })
+})

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -288,6 +288,7 @@ describe('workspace manifests', () => {
         '.yarramate/projections/maintainer-tool-neutral-engine.yaml',
         '.yarramate/projections/product-context.yaml',
         '.yarramate/projections/product-journeys.yaml',
+        '.yarramate/projections/seven-verb-surface.yaml',
         '.yarramate/projections/starter-application-cooperation.yaml',
         '.yarramate/projections/starter-business-operation.yaml',
         '.yarramate/projections/starter-implementation-roadmap.yaml',


### PR DESCRIPTION
Full re-curation of the LikeC4 view set, per the maintainer's pick. Verified starting problems: retired command services rendered in six views (26 references in the generated model), no view of the seven-verb surface existed, and 5 of 20 authored projections were absent from the project.

**The curated set — 21 views as five ordered stories** (the project file is the readable TOC):
1. **Orientation** — landscape (index), product journeys, product context
2. **The agent contract** — new `seven-verb-surface` view: `cli` + the seven verb services + the agent harness
3. **Engine internals** — components, compiler-pipeline (dynamic), export path, tool-neutrality, implementation traceability
4. **ArchiMate viewpoints** — motivation → strategy → business → application → information → technology → implementation
5. **Evolution** — state/contract foundations + the three state views

**One small projection-vocabulary addition, `excludeStatuses`** (additive, schema + evaluator + docs): drops concepts carrying a listed lifecycle status while *keeping unstatused concepts* — a bare `statuses:` allowlist would have wrongly dropped actors and motivation elements from the landscape. It also vetoes `connected` expansion (an excluded concept is never pulled in as a neighbour; edges touching one are dropped, never dangling). Applied as `excludeStatuses: [retired]` across seven projections: the diagrams show the living architecture, git and the model keep the history.

Verified exact-token: **zero retired references remain in any view include list**. `likec4 validate` green; 323 tests green; clean-slate `pnpm verify` green (pinned starter-pack expectations regenerated from actual output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)