### PR TITLE
Release v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Minor release: the `excludeStatuses` projection filter (PR #130) — drop listed lifecycle statuses while keeping unstatused concepts, with connected-expansion veto — plus the curated 21-view diagram set organised as five stories including the new seven-verb-surface view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)