### PR TITLE
Organise LikeC4 views into sidebar folders via title paths

### DIFF
--- a/.yarramate/likec4-project.yaml
+++ b/.yarramate/likec4-project.yaml
@@ -6,21 +6,30 @@ mapping: integrations/likec4/subject-mapping.yaml
 kindMapping: integrations/likec4/kind-mapping.yaml
 # Views are ordered as five stories, coarse to fine: orientation, the
 # agent contract, engine internals, the ArchiMate viewpoints, and
-# evolution. Retired subjects are excluded by the underlying projections
-# (excludeStatuses) - the diagrams show the living architecture; git and
-# the model keep the history.
+# evolution. Each story is a sidebar folder (view titles become LikeC4
+# title paths, ADR 0067). LikeC4 orders folders by name, so the story
+# number is part of the folder name; views inside a folder keep this
+# list's order. Retired subjects are excluded by the underlying
+# projections (excludeStatuses) - the diagrams show the living
+# architecture; git and the model keep the history.
 views:
   # --- 1 · Orientation ------------------------------------------------
   - id: index
     projection: projections/starter-landscape.yaml
+    folder: "1 · Orientation"
   - projection: projections/product-journeys.yaml
+    folder: "1 · Orientation"
   - projection: projections/product-context.yaml
+    folder: "1 · Orientation"
   # --- 2 · The agent contract -----------------------------------------
   - projection: projections/seven-verb-surface.yaml
+    folder: "2 · Agent contract"
   # --- 3 · Engine internals -------------------------------------------
   - projection: projections/engine-components.yaml
+    folder: "3 · Engine internals"
   - id: compiler-pipeline
     projection: projections/current-engine.yaml
+    folder: "3 · Engine internals"
     dynamic:
       steps:
         - relationship: yarramate-engine#parse-triggers-structure-validation
@@ -30,22 +39,37 @@ views:
         - relationship: yarramate-engine#semantic-validation-triggers-compilation
           title: compiles graph
   - projection: projections/likec4-export-path.yaml
+    folder: "3 · Engine internals"
   - projection: projections/maintainer-tool-neutral-engine.yaml
+    folder: "3 · Engine internals"
   - projection: projections/implementation-traceability.yaml
+    folder: "3 · Engine internals"
   # --- 4 · ArchiMate viewpoints ---------------------------------------
   - projection: projections/starter-motivation.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-strategy.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-business-operation.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-application-cooperation.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-information-structure.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-technology-deployment.yaml
+    folder: "4 · ArchiMate viewpoints"
   - projection: projections/starter-implementation-roadmap.yaml
+    folder: "4 · ArchiMate viewpoints"
   # --- 5 · Evolution ---------------------------------------------------
   - projection: projections/state-foundation.yaml
+    folder: "5 · Evolution"
   - projection: projections/core-contract-foundation.yaml
+    folder: "5 · Evolution"
   - projection: projections/state-engine-adapter.yaml
+    folder: "5 · Evolution"
   - projection: projections/state-engine-target.yaml
+    folder: "5 · Evolution"
   - projection: projections/state-engine-change.yaml
+    folder: "5 · Evolution"
     compare:
       from: yarramate-evolution#adapter-foundation
       to: yarramate-evolution#state-foundation

--- a/docs/ADAPTER-MAPPINGS.md
+++ b/docs/ADAPTER-MAPPINGS.md
@@ -228,8 +228,11 @@ kindMapping: integrations/likec4/kind-mapping.yaml
 views:
   - id: index
     projection: projections/starter-landscape.yaml
+    folder: "1 · Orientation"
   - projection: projections/likec4-export-path.yaml
+    folder: "3 · Engine internals"
   - projection: projections/state-engine-change.yaml
+    folder: "5 · Evolution"
     compare:
       from: yarramate-evolution#adapter-foundation
       to: yarramate-evolution#state-foundation
@@ -256,6 +259,16 @@ entries may supply an adapter-owned `id` override without changing the native
 projection identity. Using `id: index` on a curated landscape prevents LikeC4
 from synthesizing a landing view over the entire unioned model. The generated
 ownership marker records both the override and projection identity.
+
+An optional `folder` per view files it in LikeC4's sidebar tree: the folder
+is emitted as a title path (`title 'Folder / Title'`), which LikeC4 renders
+natively — every segment but the last becomes a folder, and `/` inside the
+folder value nests further (ADR 0067). A view whose projection declares no
+presentation title still gets a title line, with the view id as the leaf.
+LikeC4 orders sibling folders by name, so encode a deliberate reading order
+in the folder names themselves (`"1 · Orientation"`); views inside one
+folder keep the views-list order. No new LikeC4 constructs are involved,
+and the folder never touches the native projection.
 Project definition and generated marker v2 schemas are
 `schema/yarramate-likec4-project.schema.json` and
 `schema/yarramate-likec4-generated-project-v2.schema.json`. The lower-level

--- a/docs/adr/0067-diagram-folders-are-title-paths.md
+++ b/docs/adr/0067-diagram-folders-are-title-paths.md
@@ -1,0 +1,37 @@
+# Diagram folders are title paths
+
+Status: accepted
+
+Organizing the repository's 21 views into five ordered stories (PR
+#130) fixed the table of contents in the project document — but only
+there. The generated LikeC4 project still presented every view in one
+flat root list, because the story structure lived in YAML comments the
+exporter cannot see.
+
+LikeC4 1.59 groups views without any dedicated grammar: a view title
+containing `/` separators is a path, every segment but the last is a
+sidebar folder, and the last segment is the displayed title. So the
+grouping construct we need already exists, and it is a plain string.
+
+Decided:
+
+- The project definition gains an optional `folder` per view. It is
+  presentation data of the *diagram project*, not of the projection —
+  the same projection may sit in different folders in different
+  projects, and markdown or graph exports of it are untouched.
+- The exporter emits the folder as a title path: `title 'Folder /
+  Title'`. Nesting is `/` inside the folder value. A view whose
+  projection declares no presentation title still gets a title line,
+  with the view id as the leaf — a folder assignment must never be
+  silently dropped.
+- Folder names carry their own order. LikeC4 sorts sibling folders by
+  name (natural compare on the path), so a deliberate reading order is
+  encoded where it belongs, in the name: `"1 · Orientation"`, `"2 ·
+  Agent contract"`. Views inside a folder keep the views-list order,
+  so the project document remains the table of contents.
+- The synthetic `review-changes` view (ADR 0066) stays at the root: it
+  is the view a reviewer opens first, not part of any story.
+
+Zero new LikeC4 constructs, continuing ADR 0066's discipline: the
+generated model validates against the same grammar as before, and a
+consumer on an older LikeC4 simply sees the path as a longer title.

--- a/schema/yarramate-likec4-project.schema.json
+++ b/schema/yarramate-likec4-project.schema.json
@@ -72,6 +72,11 @@
         "projection": {
           "$ref": "#/$defs/path"
         },
+        "folder": {
+          "type": "string",
+          "description": "Sidebar folder for the rendered view, emitted as a LikeC4 title path ('Folder / Title'). Nest with '/' separators; folders appear in the order their first view appears in the views list.",
+          "pattern": "^[^/]+(?:/[^/]+)*$"
+        },
         "compare": {
           "$ref": "#/$defs/comparison"
         },

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -926,6 +926,9 @@ export function runLikeC4Cli(
             ? [
                 {
                   ...(view.id === undefined ? {} : { id: view.id }),
+                  ...(view.folder === undefined
+                    ? {}
+                    : { folder: view.folder }),
                   prepared,
                   ...(view.compare === undefined
                     ? {}

--- a/src/adapters/likec4-project.ts
+++ b/src/adapters/likec4-project.ts
@@ -27,6 +27,7 @@ export interface LikeC4ProjectDefinition {
   readonly views: ReadonlyArray<{
     readonly id?: string
     readonly projection: string
+    readonly folder?: string
     readonly compare?: {
       readonly from: string
       readonly to: string
@@ -64,6 +65,7 @@ export const loadLikeC4ProjectDefinition = (source: WorkspaceSource) =>
 
 export interface PreparedLikeC4ProjectView {
   readonly id?: string
+  readonly folder?: string
   readonly prepared: Extract<LikeC4PreparationResult, { readonly ok: true }>
   readonly comparison?: {
     readonly from: string
@@ -80,6 +82,21 @@ export interface PreparedLikeC4ProjectView {
 
 const quote = (value: string): string =>
   `'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'").replaceAll('\n', '\\n')}'`
+
+// A folder files the view in LikeC4's sidebar tree: the title becomes a
+// path ('Folder / Title') whose last segment is the displayed title (ADR
+// 0067). A view without a declared title still needs a title line to
+// carry the path, so the view id stands in as the leaf.
+const titleLines = (
+  folder: string | undefined,
+  title: string | undefined,
+  viewId: string,
+): readonly string[] =>
+  folder === undefined
+    ? title === undefined
+      ? []
+      : [`    title ${quote(title)}`]
+    : [`    title ${quote(`${folder} / ${title ?? viewId}`)}`]
 
 const unionProjection = (
   project: LikeC4ProjectDefinition,
@@ -120,6 +137,7 @@ const unionProjection = (
 const viewBody = (
   {
     id,
+    folder,
     prepared,
     dynamic,
     deployment,
@@ -159,12 +177,14 @@ const viewBody = (
       .map(({ id }) => `${id}.**`)
       .sort()
     const viewId =
-      id ?? prepared.projection.projection.split('@')[0]
+      id ?? prepared.projection.projection.split('@')[0]!
     return [
       `  deployment view ${viewId} {`,
-      ...(prepared.projection.presentation?.title === undefined
-        ? []
-        : [`    title ${quote(prepared.projection.presentation.title)}`]),
+      ...titleLines(
+        folder,
+        prepared.projection.presentation?.title,
+        viewId,
+      ),
       ...(prepared.projection.presentation?.description === undefined
         ? []
         : [
@@ -220,12 +240,14 @@ const viewBody = (
           ]
     })
     const viewId =
-      id ?? prepared.projection.projection.split('@')[0]
+      id ?? prepared.projection.projection.split('@')[0]!
     return [
       `  dynamic view ${viewId} {`,
-      ...(prepared.projection.presentation?.title === undefined
-        ? []
-        : [`    title ${quote(prepared.projection.presentation.title)}`]),
+      ...titleLines(
+        folder,
+        prepared.projection.presentation?.title,
+        viewId,
+      ),
       ...(prepared.projection.presentation?.description === undefined
         ? []
         : [
@@ -260,13 +282,25 @@ const viewBody = (
     ...relationshipRules,
     ...overlayRules,
   ].join('\n')
-  return source
+  const viewId = id ?? prepared.projection.projection.split('@')[0]!
+  const body = source
     .slice(start + startToken.length, end)
     .replace(
       /^  view [A-Za-z_][A-Za-z0-9_-]* \{/,
-      `  view ${id ?? prepared.projection.projection.split('@')[0]} {`,
+      `  view ${viewId} {`,
     )
     .replace('    include *', membershipRules)
+  if (folder === undefined) return body
+  const title = prepared.projection.presentation?.title
+  return title === undefined
+    ? body.replace(
+        `  view ${viewId} {`,
+        `  view ${viewId} {\n${titleLines(folder, undefined, viewId).join('\n')}`,
+      )
+    : body.replace(
+        `    title ${quote(title)}`,
+        titleLines(folder, title, viewId).join('\n'),
+      )
 }
 
 const deploymentBody = ({

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1276,6 +1276,167 @@ views:
     }
   })
 
+  it('files project views into sidebar folders via title paths', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-likec4-folders-'))
+    const project = join(parent, 'generated')
+    try {
+      writeFileSync(
+        join(parent, 'architecture.yaml'),
+        `format: yarramate/v1
+id: system
+profile: yarramate/core@0.1
+concepts:
+  - id: service
+    kind: applicationComponent
+    name: Service
+  - id: store
+    kind: dataObject
+    name: Store
+relationships:
+  - id: service-uses-store
+    kind: access
+    from: service
+    to: store
+`,
+      )
+      writeFileSync(
+        join(parent, 'overview.projection.yaml'),
+        `format: yarramate/projection/v1
+id: overview
+version: "1.0"
+query:
+  documents: [system]
+presentation:
+  title: Overview
+`,
+      )
+      writeFileSync(
+        join(parent, 'bare.projection.yaml'),
+        `format: yarramate/projection/v1
+id: bare
+version: "1.0"
+query:
+  documents: [system]
+`,
+      )
+      writeFileSync(
+        join(parent, 'likec4.mapping.yaml'),
+        `format: yarramate/adapter-mapping/v1
+id: system-likec4
+version: "1.0"
+adapter: likec4
+mappings:
+  - native: system#service
+    external: service
+    type: concept
+  - native: system#store
+    external: store
+    type: concept
+  - native: system#service-uses-store
+    external: serviceUsesStore
+    type: relationship
+`,
+      )
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.0"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: overview.projection.yaml
+    folder: Platform
+  - id: edge
+    projection: bare.projection.yaml
+    folder: Platform / Edge
+  - id: deployed
+    projection: bare.projection.yaml
+    folder: Runtime
+    deployment:
+      nodes:
+        - id: prod
+          kind: environment
+          name: Production
+      instances:
+        - id: prod-service
+          subject: system#service
+          node: prod
+`,
+      )
+
+      const result = runLikeC4Cli(
+        [
+          'export-project',
+          'yarramate.likec4.yaml',
+          project,
+          'architecture.yaml',
+        ],
+        parent,
+      )
+      expect(result).toEqual({
+        exitCode: 0,
+        stdout: `Wrote LikeC4 project to ${project}\n`,
+        stderr: '',
+      })
+      const model = readFileSync(join(project, 'model.likec4'), 'utf8')
+      // A declared presentation title becomes the path's leaf.
+      expect(model).toContain(
+        "  view index {\n    title 'Platform / Overview'\n",
+      )
+      // A view without a presentation title still carries the folder,
+      // with the view id standing in as the leaf.
+      expect(model).toContain(
+        "  view edge {\n    title 'Platform / Edge / edge'\n",
+      )
+      // The deployment branch files the same way.
+      expect(model).toContain(
+        "  deployment view deployed {\n    title 'Runtime / deployed'\n",
+      )
+
+      const validation = spawnSync(
+        join(repositoryRoot, 'node_modules/.bin/likec4'),
+        [
+          'validate',
+          '--json',
+          '--no-layout',
+          '--file',
+          'model.likec4',
+          '.',
+        ],
+        { cwd: project, encoding: 'utf8' },
+      )
+      expect(
+        validation.status,
+        `${validation.stderr}\n${validation.stdout}`,
+      ).toBe(0)
+
+      writeFileSync(
+        join(parent, 'yarramate.likec4.yaml'),
+        `format: yarramate/likec4-project/v1
+id: system
+version: "1.0"
+title: System architecture
+mapping: likec4.mapping.yaml
+views:
+  - id: index
+    projection: overview.projection.yaml
+    folder: "Platform /"
+`,
+      )
+      const rejected = runLikeC4Cli(
+        ['check', 'yarramate.likec4.yaml', 'architecture.yaml'],
+        parent,
+      )
+      expect(rejected.exitCode).toBe(1)
+      expect(rejected.stdout).toContain('YM201')
+      expect(rejected.stdout).toContain('/views/0/folder')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('resolves project references from the project document, not the CWD', () => {
     const parent = mkdtempSync(
       join(tmpdir(), 'yarramate-likec4-portable-'),
@@ -1431,8 +1592,14 @@ views:
       expect(model).toContain('view state-foundation')
       expect(model).toContain('dynamic view compiler-pipeline')
       expect(model).toContain(
+        "  view index {\n    title '1 · Orientation / Architecture landscape'\n",
+      )
+      expect(model).toContain(
+        "  dynamic view compiler-pipeline {\n    title '3 · Engine internals / Current engine'\n",
+      )
+      expect(model).toContain(
         "view starter-technology-deployment {\n" +
-          "    title 'Technology and deployment'\n" +
+          "    title '4 · ArchiMate viewpoints / Technology and deployment'\n" +
           "    description 'Technology structure, behavior, services, networks, and deployed artifacts.'\n" +
           '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, likec4ExportAdapter, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli',
       )


### PR DESCRIPTION
The five-story organisation of the repository's 21 views (PR #130) lived only in YAML comments, so the generated LikeC4 project still rendered every view in one flat root list.

LikeC4 1.59 groups views natively by **title path**: every `/`-separated segment but the last becomes a sidebar folder. This PR uses exactly that — no new DSL constructs, continuing ADR 0066's discipline.

- `yarramate/likec4-project/v1` views gain an optional `folder` (nesting via `/`; empty segments schema-rejected).
- The exporter emits it as `title 'Folder / Title'` across all three view branches (ordinary, dynamic, deployment). A view whose projection has no presentation title synthesizes `title 'Folder / <viewId>'` so a folder assignment is never silently dropped.
- LikeC4 sorts sibling folders by name, so the reading order lives in the names: the repository project now files its 21 views under `1 · Orientation` → `5 · Evolution`, with in-folder order following the views list. Verified against LikeC4's own computed model (`rootViewFolder` walk) and `likec4 validate`.
- The synthetic `review-changes` view stays at the root — it is the open-first view, not part of a story.

ADR 0067 records the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)