### PR TITLE
Release v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the 0.12.0 release.

Since v0.11.0:
- **LikeC4 sidebar folders** (#135, ADR 0067): `yarramate/likec4-project/v1` views take an optional `folder`, emitted as a LikeC4 title path (`title 'Folder / Title'`) — LikeC4 1.59 renders the segments as a native sidebar folder tree. Nesting via `/`, untitled views synthesize the leaf from the view id, sibling folders order by name. Zero new DSL constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)