### PR TITLE
Release v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the 0.13.0 release.

Since v0.12.0:
- **`ask --where`** (#139, ADR 0068, closes #137): evidence-backed pointing — the verified code locations of matched subjects, contradicted locations included and marked, with an explicit coverage boundary handing unmodeled code to the agent's own search tools.
- **Cross-harness case study shipped** (#138): docs/CASE-STUDY-CROSS-HARNESS.md + a 'Proven across harnesses' README section — the README ships in the npm tarball, so the package page now leads with the story.
- CI: codeql-action bumped 4 → 4.37.3 (#119).

🤖 Generated with [Claude Code](https://claude.com/claude-code)