### PR TITLE
Link yarramate.dev: homepage fields, README, release-coupled taglines

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,6 @@ authors:
   - name: YarraMate contributors
 version: 0.6.0
 date-released: 2026-07-30
-url: "https://github.com/yarrasys/yarramate"
+url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"
 license: MIT

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![CodeQL](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml/badge.svg)](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml)
 [![license: MIT](https://img.shields.io/github/license/yarrasys/yarramate)](LICENSE)
 
+Product site: **[yarramate.dev](https://yarramate.dev)**
+
 YarraMate keeps your coding agents' architecture context correct. Declare
 the design once, as a checked model in git; agents receive prose rendered
 from it — bounded briefs and open design questions — and the CLI

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,0 +1,10 @@
+# yarramate.dev rotating hero taglines.
+# Line 1 (first non-comment line) is the released version; every later
+# non-empty line is one tagline. Update with each release — docs/RELEASING.md.
+v0.13.0
+a design interview any agent can resume.
+the map your coding agents share.
+architecture your CI can check.
+a model that knows what's missing.
+intent your code can contradict.
+the handover between your agents.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,7 +14,11 @@ either action.
 
 ## Release preparation
 
-1. Select the version and update `package.json`.
+1. Select the version and update `package.json`. Set the first non-comment
+   line of `assets/taglines.txt` to the same version (`vX.Y.Z`); the lines
+   after it are the rotating hero taglines on [yarramate.dev](https://yarramate.dev),
+   fetched from `main` at page load — refresh them when the release changes
+   the story.
 2. Update public documentation for any stable-interface change.
 3. Run:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/yarrasys/yarramate.git"
   },
-  "homepage": "https://github.com/yarrasys/yarramate#readme",
+  "homepage": "https://yarramate.dev",
   "bugs": {
     "url": "https://github.com/yarrasys/yarramate/issues"
   },


### PR DESCRIPTION
yarramate.dev is live. This PR points the repo's surfaces at it and ships the site's tagline contract:

- `package.json` homepage + `CITATION.cff` url → https://yarramate.dev (npm page picks it up at next publish)
- README: product-site line under the badges
- `assets/taglines.txt` (NEW): line 1 = released version, later non-`#` lines = the six hero taglines the site types out. Fetched from `main` at page load with a baked-in fallback; deliberately not in the npm tarball.
- RELEASING.md: step to keep the version line + taglines current each release

No auto-merge — the taglines are brand voice; merge is the acceptance step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)