### PR TITLE
apply: atomic delete-concept / delete-relationship with reference validation

### DIFF
--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -63,6 +63,10 @@ enough for the strong tier (one answer = one call). Writes are spliced,
 never re-serialized: an apply diff is exactly the answer it landed.
 Updates enrich by default and retract explicitly (`remove`), so the
 assert → catch → retract loop closes through one audited surface.
+Whole-subject deletion (`delete-concept` / `delete-relationship`)
+walks through the same door: rejected while anything still references
+the target, judged against the post-batch state so a subject and its
+referring relationships leave in one batch (ADR 0069).
 
 - Harness use: landing a design answer; discovery-journey authoring;
   maintenance edits.

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -322,8 +322,9 @@ operations:
 yarramate apply operations.yaml .yarramate/workspace.yaml
 ```
 
-The operations are `add-concept`, `add-relationship`, `update-concept`, and
-`update-relationship`. Concept and relationship records accept the same
+The operations are `add-concept`, `add-relationship`, `update-concept`,
+`update-relationship`, `delete-concept`, and `delete-relationship`. Concept
+and relationship records accept the same
 optional fields as the authoring format — for example `status`,
 `description`, `owner`, `constraints`, `references`, `presentIn`, and the
 controlled `mode` and `content` fields. `apply` writes by splicing minimal
@@ -336,7 +337,13 @@ fields replace, list fields append — and retract explicitly: an update may
 carry `remove: [<field> ...]` to delete optional fields it previously
 asserted. Identity fields (`id`, `kind`, `from`, `to`) are never removable,
 removing a field that is not set is an error, and one operation cannot both
-set and remove the same field.
+set and remove the same field. Delete operations remove the whole authored
+item and are rejected while anything still references the target —
+relationship endpoints, `owner`, constraint refs, identified references.
+Integrity is evaluated against the post-batch state, so a concept and its
+referring relationships can leave in one batch (ADR 0069). Retirement
+(`status: retired`) remains the descoping path; delete only when the
+history itself is noise.
 
 The workspace manifest supplies the extension profiles and documents needed
 for qualified references. This explicit input contract matches

--- a/docs/adr/0069-deletion-completes-the-audited-write-surface.md
+++ b/docs/adr/0069-deletion-completes-the-audited-write-surface.md
@@ -1,0 +1,35 @@
+# Deletion completes the audited write surface
+
+Status: accepted
+
+ADR 0064 deferred whole-subject deletion: with field retraction
+(ADR 0062) and `status: retired` covering the honest cases, deleting
+a subject stayed a reviewed Git edit until real usage demanded
+otherwise. Issue #123 calls it due — the write surface that can
+assert, enrich, and retract could not remove, so retired noise that
+genuinely should leave the file had no audited exit.
+
+`apply` now accepts `delete-concept` and `delete-relationship`. A
+delete splices out the exact authored item range, marker line
+included, so bytes the batch never touched stay byte-identical
+(ADR 0062); deleting the last item leaves an explicit empty
+collection. Flow-style items are deleted whole through the same
+line-based path — unlike the 0.8.1 regression, where a line-based
+*field* removal silently destroyed the item, the whole item is
+precisely the intent here.
+
+A delete is rejected, located at its operation, while anything still
+references the target: relationship endpoints, `owner`, constraint
+refs, and identified references. Integrity is evaluated against the
+post-batch state — stage everything in memory, then look — so a batch
+that deletes a concept together with its referring relationships
+lands as one atomic motion, in any order. Projection selectors are
+deliberately not consulted: a selector that matches nothing is not a
+validation error by design. The compile gate stays the backstop: the
+staged workspace must compile whole or nothing is written.
+
+The write surface is now complete — assert, enrich, retract, delete —
+and every motion walks through the same audited door. The division of
+labour stands unchanged: retirement remains the descoping path,
+preserving the decision on record, and the catalogue's guidance still
+draws the line — "Delete only when the history itself is noise."

--- a/schema/yarramate-apply-result.schema.json
+++ b/schema/yarramate-apply-result.schema.json
@@ -15,13 +15,17 @@
         "addedConcepts",
         "addedRelationships",
         "updatedConcepts",
-        "updatedRelationships"
+        "updatedRelationships",
+        "deletedConcepts",
+        "deletedRelationships"
       ],
       "properties": {
         "addedConcepts": { "type": "integer", "minimum": 0 },
         "addedRelationships": { "type": "integer", "minimum": 0 },
         "updatedConcepts": { "type": "integer", "minimum": 0 },
-        "updatedRelationships": { "type": "integer", "minimum": 0 }
+        "updatedRelationships": { "type": "integer", "minimum": 0 },
+        "deletedConcepts": { "type": "integer", "minimum": 0 },
+        "deletedRelationships": { "type": "integer", "minimum": 0 }
       }
     },
     "documents": {

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -170,6 +170,18 @@
         }
       }
     },
+    "deleteTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyText"
+        }
+      }
+    },
     "operation": {
       "oneOf": [
         {
@@ -325,6 +337,46 @@
                   "presentIn"
                 ]
               }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "op",
+            "document",
+            "concept"
+          ],
+          "properties": {
+            "op": {
+              "const": "delete-concept"
+            },
+            "document": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "concept": {
+              "$ref": "#/$defs/deleteTarget"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "op",
+            "document",
+            "relationship"
+          ],
+          "properties": {
+            "op": {
+              "const": "delete-relationship"
+            },
+            "document": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "relationship": {
+              "$ref": "#/$defs/deleteTarget"
             }
           }
         }

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -168,8 +168,12 @@ yarramate apply operations.yaml workspace.yaml
 ```
 
 The whole candidate workspace must compile or nothing is written.
-Update operations enrich only — scalars replace, lists append; removals
-stay Git edits.
+Update operations enrich by default — scalars replace, lists append — and
+retract explicitly with `remove: [<field> ...]`. Whole subjects leave
+through `delete-concept` / `delete-relationship` (payload: the `id` only),
+rejected while anything still references the target; delete the referring
+relationships in the same batch. To descope, retire (`status: retired`)
+instead — delete only when the history itself is noise.
 
 ## Ownership and constraints
 

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -83,6 +83,16 @@ type Operation =
       readonly relationship: RelationshipFields
       readonly remove?: readonly string[]
     }
+  | {
+      readonly op: 'delete-concept'
+      readonly document: string
+      readonly concept: { readonly id: string }
+    }
+  | {
+      readonly op: 'delete-relationship'
+      readonly document: string
+      readonly relationship: { readonly id: string }
+    }
 
 interface OperationsDocument {
   readonly format: 'yarramate/operations/v1'
@@ -243,13 +253,14 @@ const itemMap = (
   source: string,
   collection: string,
   id: string,
-): { readonly map: YAMLMap } | undefined => {
+): { readonly map: YAMLMap; readonly sequence: YAMLSeq } | undefined => {
   const document = parseDocument(source)
   const root = document.contents
   if (!isMap(root)) return undefined
   const pair = pairFor(root, collection)
   if (pair === undefined || !isSeq(pair.value)) return undefined
-  const found = (pair.value as YAMLSeq).items.find(
+  const sequence = pair.value as YAMLSeq
+  const found = sequence.items.find(
     (candidate) =>
       isMap(candidate) &&
       (candidate as YAMLMap).items.some(
@@ -260,7 +271,9 @@ const itemMap = (
           field.value.value === id,
       ),
   )
-  return found === undefined ? undefined : { map: found as YAMLMap }
+  return found === undefined
+    ? undefined
+    : { map: found as YAMLMap, sequence }
 }
 
 // The indent item fields sit at, read off the item's own first field.
@@ -397,6 +410,54 @@ const removeField = (
   return splice(source, start, lineEndAfter(source, valueEnd), '')
 }
 
+// Whole-subject deletion (#123): remove the exact authored item range,
+// marker line included. Unlike field removal — where line deletion on a
+// flow item would silently take the whole item (the 0.8.1 regression) —
+// deleting the whole item is precisely the intent here, so flow-style
+// items in a block sequence share the line-based path. An item inside a
+// flow collection rewrites the collection value instead, and removing
+// the last item leaves an explicit empty collection: the document
+// schema requires the key.
+const removeCollectionItem = (
+  source: string,
+  collection: 'concepts' | 'relationships',
+  id: string,
+): string => {
+  const { map, sequence } = itemMap(source, collection, id)!
+  if (sequence.flow) {
+    const remaining = (
+      sequence.toJSON() as ReadonlyArray<Readonly<Record<string, unknown>>>
+    ).filter((item) => item.id !== id)
+    const [start, valueEnd] = nodeRange(sequence)
+    return splice(
+      source,
+      start,
+      valueEnd,
+      remaining.length === 0
+        ? '[]'
+        : stringify(remaining, {
+            collectionStyle: 'flow',
+            lineWidth: 0,
+          }).trimEnd(),
+    )
+  }
+  // Node ranges may extend past the trailing newline to the next line
+  // start; afterContentLine anchors the removal on the item's own last
+  // content line.
+  const end = afterContentLine(source, nodeRange(map)[2])
+  if (sequence.items.length === 1) {
+    let valueStart = nodeRange(sequence)[0]
+    while (
+      valueStart > 0 &&
+      (source[valueStart - 1] === ' ' || source[valueStart - 1] === '\n')
+    ) {
+      valueStart -= 1
+    }
+    return splice(source, valueStart, end, ' []\n')
+  }
+  return splice(source, lineStartOf(source, nodeRange(map)[0]), end, '')
+}
+
 // ---------------------------------------------------------------------------
 
 export function runApplyCommand(
@@ -461,22 +522,31 @@ export function runApplyCommand(
       addedRelationships: 0,
       updatedConcepts: 0,
       updatedRelationships: 0,
+      deletedConcepts: 0,
+      deletedRelationships: 0,
     }
+    const deletions: Array<{
+      readonly index: number
+      readonly absolute: string
+      readonly id: string
+    }> = []
+    const locateOperation = (index: number, message: string): Diagnostic => ({
+      severity: 'error',
+      code: 'YM912',
+      message,
+      ...locateSourcePath(
+        operationsPath,
+        yaml,
+        lineCounter,
+        ['operations', index, 'document'],
+        `/operations/${index}/document`,
+      ),
+    })
     for (const [index, operation] of operations.entries()) {
       const absolute = resolve(cwd, operation.document)
       const manifestPath = workspaceDocuments.get(absolute)
-      const locate = (message: string): Diagnostic => ({
-        severity: 'error',
-        code: 'YM912',
-        message,
-        ...locateSourcePath(
-          operationsPath,
-          yaml,
-          lineCounter,
-          ['operations', index, 'document'],
-          `/operations/${index}/document`,
-        ),
-      })
+      const locate = (message: string): Diagnostic =>
+        locateOperation(index, message)
       if (manifestPath === undefined) {
         return failed([
           locate(
@@ -502,6 +572,30 @@ export function runApplyCommand(
           operation.relationship as unknown as Readonly<Record<string, unknown>>,
         )
         counts.addedRelationships += 1
+      } else if (
+        operation.op === 'delete-concept' ||
+        operation.op === 'delete-relationship'
+      ) {
+        const collection =
+          operation.op === 'delete-concept' ? 'concepts' : 'relationships'
+        const id =
+          operation.op === 'delete-concept'
+            ? operation.concept.id
+            : operation.relationship.id
+        if (itemMap(source, collection, id) === undefined) {
+          return failed([
+            locate(
+              `Operation ${index} deletes "${id}", which does not exist in ${operation.document}`,
+            ),
+          ])
+        }
+        source = removeCollectionItem(source, collection, id)
+        deletions.push({ index, absolute, id })
+        if (operation.op === 'delete-concept') {
+          counts.deletedConcepts += 1
+        } else {
+          counts.deletedRelationships += 1
+        }
       } else {
         const collection =
           operation.op === 'update-concept' ? 'concepts' : 'relationships'
@@ -581,6 +675,106 @@ export function runApplyCommand(
       candidates.set(absolute, source)
     }
 
+    // Reference integrity for deletes (#123), evaluated against the
+    // post-batch state: stage everything first, then look, so a concept
+    // deleted together with its referring relationships in one batch
+    // succeeds while a target anything still points at rejects the
+    // whole batch. Referring sites are relationship endpoints, owner,
+    // constraint and identified references; projection selectors are
+    // deliberately unchecked — they tolerate no-match by design. The
+    // compile gate below stays the backstop.
+    if (deletions.length > 0) {
+      interface ReferringSite {
+        readonly ref: string
+        readonly subject: string
+        readonly field: string
+      }
+      const staged = workspace.documents.map((path) => {
+        const absolute = resolve(cwd, path)
+        return {
+          absolute,
+          value: parseDocument(
+            candidates.get(absolute) ?? readFileSync(absolute, 'utf8'),
+          ).toJSON() as {
+            readonly id?: string
+            readonly concepts?: readonly ConceptFields[]
+            readonly relationships?: readonly RelationshipFields[]
+          } | null,
+        }
+      })
+      const qualify = (documentId: string, reference: string): string =>
+        reference.includes('#') ? reference : `${documentId}#${reference}`
+      const referrers: ReferringSite[] = staged.flatMap(({ value }) => {
+        const documentId = value?.id
+        if (documentId === undefined) return []
+        const sites: ReferringSite[] = []
+        for (const concept of value?.concepts ?? []) {
+          const subject = `${documentId}#${concept.id}`
+          if (concept.owner !== undefined) {
+            sites.push({
+              ref: qualify(documentId, concept.owner),
+              subject,
+              field: 'owner',
+            })
+          }
+          for (const constraint of concept.constraints ?? []) {
+            sites.push({
+              ref: qualify(documentId, constraint.ref),
+              subject,
+              field: 'constraints',
+            })
+          }
+          for (const reference of concept.references ?? []) {
+            sites.push({
+              ref: qualify(documentId, reference.ref),
+              subject,
+              field: 'references',
+            })
+          }
+        }
+        for (const relationship of value?.relationships ?? []) {
+          const subject = `${documentId}#${relationship.id}`
+          for (const endpoint of ['from', 'to'] as const) {
+            const reference = relationship[endpoint]
+            if (reference !== undefined) {
+              sites.push({
+                ref: qualify(documentId, reference),
+                subject,
+                field: endpoint,
+              })
+            }
+          }
+          for (const reference of relationship.references ?? []) {
+            sites.push({
+              ref: qualify(documentId, reference.ref),
+              subject,
+              field: 'references',
+            })
+          }
+        }
+        return sites
+      })
+      const documentIds = new Map(
+        staged.map(({ absolute, value }) => [absolute, value?.id]),
+      )
+      const violations = deletions.flatMap((deletion) => {
+        const documentId = documentIds.get(deletion.absolute)
+        if (documentId === undefined) return []
+        const target = `${documentId}#${deletion.id}`
+        const referring = referrers.filter((site) => site.ref === target)
+        if (referring.length === 0) return []
+        return [
+          locateOperation(
+            deletion.index,
+            `Operation ${deletion.index} deletes "${deletion.id}", which is still referenced by ${referring
+              .map((site) => `"${site.subject}" (${site.field})`)
+              .join(', ')}`,
+          ),
+        ]
+      })
+      if (violations.length > 0) return failed(violations)
+    }
+
     // The atomic gate: the whole candidate workspace must compile before a
     // single byte is written; any diagnostic rejects the entire batch.
     const compilation = compileWorkspace(
@@ -620,7 +814,9 @@ export function runApplyCommand(
       counts.addedConcepts +
       counts.addedRelationships +
       counts.updatedConcepts +
-      counts.updatedRelationships
+      counts.updatedRelationships +
+      counts.deletedConcepts +
+      counts.deletedRelationships
     return {
       exitCode: 0,
       stdout: `Applied ${applied} operation${applied === 1 ? '' : 's'} to ${touched.join(', ')}\n`,

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -99,6 +99,8 @@ describe('apply command', () => {
       addedRelationships: 1,
       updatedConcepts: 1,
       updatedRelationships: 0,
+      deletedConcepts: 0,
+      deletedRelationships: 0,
     })
     const validate = new Ajv2020({ allErrors: true }).compile(resultSchema)
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
@@ -441,6 +443,304 @@ operations:
     // The neighbouring block item and everything else stay byte-identical.
     expect(after).toContain('  - id: neighbour\n    kind: businessActor\n    name: Neighbour\n')
     expect(after.split('flow-item').length).toBe(2)
+  })
+
+  it('deletes a concept and its referring relationship in one batch', () => {
+    const authored = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+  - id: legacy-portal
+    kind: applicationService
+    name: Legacy portal
+    status: retired
+relationships:
+  - id: portal-serves-user
+    kind: serving
+    from: legacy-portal
+    to: user
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), authored, 'utf8')
+    // The concept delete precedes the delete of the relationship that
+    // references it: integrity is evaluated against the post-batch
+    // state, so in-batch order does not matter.
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: legacy-portal
+  - op: delete-relationship
+    document: architecture/main.yaml
+    relationship:
+      id: portal-serves-user
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const payload = JSON.parse(result.stdout) as {
+      applied: Record<string, number>
+    }
+    expect(payload.applied).toEqual({
+      addedConcepts: 0,
+      addedRelationships: 0,
+      updatedConcepts: 0,
+      updatedRelationships: 0,
+      deletedConcepts: 1,
+      deletedRelationships: 1,
+    })
+    const validate = new Ajv2020({ allErrors: true }).compile(resultSchema)
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
+    // Untouched bytes stay byte-identical; deleting the last item of a
+    // collection leaves an explicit empty collection.
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+relationships: []
+`)
+  })
+
+  it('rejects deleting a concept that is still referenced, locating the operation', () => {
+    const authored = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+  - id: legacy-portal
+    kind: applicationService
+    name: Legacy portal
+relationships:
+  - id: portal-serves-user
+    kind: serving
+    from: legacy-portal
+    to: user
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), authored, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM912')
+    expect(result.stdout).toContain(
+      'deletes "user", which is still referenced by "main#portal-serves-user" (to)',
+    )
+    expect(result.stdout).toMatch(/^operations\.yaml:\d+:\d+ /)
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(authored)
+  })
+
+  it('rejects deletes referenced through owner, constraints, and identified references', () => {
+    const authored = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: platform-team
+    kind: businessActor
+    name: Platform team
+  - id: australia-only
+    kind: constraint
+    name: Australia only
+  - id: user
+    kind: businessActor
+    name: User
+  - id: checkout
+    kind: applicationService
+    name: Checkout
+    owner: platform-team
+    constraints:
+      - id: residency
+        ref: australia-only
+    references:
+      - id: served
+        ref: checkout-serves-user
+relationships:
+  - id: checkout-serves-user
+    kind: serving
+    from: checkout
+    to: user
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), authored, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: platform-team
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: australia-only
+  - op: delete-relationship
+    document: architecture/main.yaml
+    relationship:
+      id: checkout-serves-user
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      'deletes "platform-team", which is still referenced by "main#checkout" (owner)',
+    )
+    expect(result.stdout).toContain(
+      'deletes "australia-only", which is still referenced by "main#checkout" (constraints)',
+    )
+    expect(result.stdout).toContain(
+      'deletes "checkout-serves-user", which is still referenced by "main#checkout" (references)',
+    )
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(authored)
+  })
+
+  it('deletes a flow-style item wholly, leaving neighbours byte-identical', () => {
+    // Whole-item deletion is the intent here, unlike field removal
+    // where a line-based delete on a flow item destroyed the item.
+    const flow = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - { id: flow-item, kind: applicationService, name: Flow item }
+  - id: neighbour
+    kind: businessActor
+    name: Neighbour
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), flow, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: flow-item
+`,
+      'utf8',
+    )
+    expect(
+      runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+        .exitCode,
+    ).toBe(0)
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(
+      flow.replace(
+        '  - { id: flow-item, kind: applicationService, name: Flow item }\n',
+        '',
+      ),
+    )
+  })
+
+  it('rejects the whole batch when one delete violates integrity', () => {
+    const authored = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+  - id: portal
+    kind: applicationService
+    name: Portal
+relationships:
+  - id: portal-serves-user
+    kind: serving
+    from: portal
+    to: user
+  - id: portal-notifies-user
+    kind: serving
+    from: portal
+    to: user
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), authored, 'utf8')
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-relationship
+    document: architecture/main.yaml
+    relationship:
+      id: portal-serves-user
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    // The remaining referrer is reported; the one deleted in the same
+    // batch is not — integrity looks at the post-batch state even when
+    // it rejects.
+    expect(result.stdout).toContain(
+      'deletes "user", which is still referenced by "main#portal-notifies-user" (to)',
+    )
+    expect(result.stdout).not.toContain('by "main#portal-serves-user"')
+    // Atomicity: the valid relationship delete must not have landed.
+    expect(
+      readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+    ).toBe(authored)
+  })
+
+  it('locates a delete aimed at a subject that does not exist', () => {
+    writeFileSync(
+      join(workspace, 'operations.yaml'),
+      `format: yarramate/operations/v1
+operations:
+  - op: delete-concept
+    document: architecture/main.yaml
+    concept:
+      id: nobody
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['apply', 'operations.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM912')
+    expect(result.stdout).toContain('deletes "nobody", which does not exist')
   })
 
   it('removing a field from a flow-style item never deletes the item', () => {


### PR DESCRIPTION
Closes #123

Deletion completes the write surface deferred by ADR 0064: `apply` now takes `delete-concept` / `delete-relationship` operations, atomic with the batch. New ADR 0069 records the decision.

## Design decisions

- **Reference integrity is evaluated against the post-batch state.** All operations stage in memory first; only then are deletes checked. A concept deleted together with its referring relationships in one batch succeeds, in any order — matching the batch-atomicity philosophy. A target anything still references rejects the whole batch with a YM912 diagnostic located at the delete operation, naming every referring site (`"main#checkout" (owner)` style).
- **Checked referring sites**: relationship endpoints (`from`/`to`), `owner`, `constraints[].ref`, `references[].ref` — qualified exactly as the compiler qualifies them (`document#subject`). Projection selectors are deliberately not consulted: PROJECTIONS.md guarantees a selector that matches nothing is not a validation error.
- **The compile gate stays the backstop.** The integrity check exists to give an operation-located diagnostic; a dangling reference that slipped past it would still reject at the staged-workspace compile, and nothing is written on any rejection.
- **Splice-based removal (ADR 0062)**: the exact authored item range is removed, marker line included, anchored via `afterContentLine` to respect the yaml-lib block range[1]-past-newline behaviour; untouched bytes are asserted byte-identical in tests. Deleting the last item leaves an explicit `[]` (the document schema requires the collection keys). Flow-style items are deleted whole through the same line-based path — legitimate here, unlike the 0.8.1 field-removal bug; both PR #124 regression tests still pass. An item inside a flow *collection* rewrites the collection value instead.
- **Schema shape**: delete ops mirror the existing addressing convention (`concept:`/`relationship:` payload) but restricted to `id` only, so a delete carrying stray fields fails the schema gate instead of being silently ignored.
- **Result format**: `applied` gains required `deletedConcepts` / `deletedRelationships` counts (kept required for symmetry with the existing four; strictly this tightens `yarramate/apply-result/v1` — flagging in case you'd rather they be optional).

## Tests

7 new cases in `test/apply-command.test.ts` (house fixture style): cascade delete with byte-exact output and schema-valid JSON result, referenced-concept rejection with located YM912, owner/constraints/identified-reference rejections, whole flow-item deletion with byte-identical neighbours, atomicity on a mixed valid+violating batch (including proof the rejection message reflects the post-batch state), and nonexistent-target location.

`rm -rf dist && pnpm verify` passes clean: 335 tests / 33 files, self:check (self-model untouched), likec4 validate. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)