### PR TITLE
Release v0.14.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.6.0
-date-released: 2026-07-30
+version: 0.14.0
+date-released: 2026-08-03
 url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"
 license: MIT

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,7 +1,7 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.13.0
+v0.14.0
 a design interview any agent can resume.
 the map your coding agents share.
 architecture your CI can check.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to 0.14.0 (additive minor):

- **apply delete ops** — atomic `delete-concept`/`delete-relationship` with post-batch reference integrity (#144, ADR 0069, closes #123)
- **ask neighbour cap** — seeded slices keep 12 materiality-ordered neighbours/seed with honest omission; `--neighbours` override (#145, ADR 0070, closes #132)
- **evidence coverage complete** — 47 → 160 observations, every status-current subject observed (#142)
- **yarramate.dev linked** — homepage fields, README, release-coupled `assets/taglines.txt` (#143)

Also stamps CITATION.cff (was stale at 0.6.0) and bumps the taglines version line — first release exercising that RELEASING.md step. Verify green: 345 tests / 34 files, tarball 102 files, taglines excluded from the package as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)