### PR TITLE
README: human audience first, then AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,73 +5,203 @@
 [![CodeQL](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml/badge.svg)](https://github.com/yarrasys/yarramate/actions/workflows/codeql.yml)
 [![license: MIT](https://img.shields.io/github/license/yarrasys/yarramate)](LICENSE)
 
-Product site: **[yarramate.dev](https://yarramate.dev)**
+**[yarramate.dev](https://yarramate.dev)** ·
+[Case study](docs/CASE-STUDY-CROSS-HARNESS.md) ·
+[Documentation](docs/README.md)
 
-YarraMate keeps your coding agents' architecture context correct. Declare
-the design once, as a checked model in git; agents receive prose rendered
-from it — bounded briefs and open design questions — and the CLI
+Your coding agents re-derive your system's design every session — and each
+one derives it a little differently. The design document that could stop
+them says whatever it said the day someone last edited it.
+
+YarraMate keeps the design as a small, checked model in git instead. Agents
+and people read prose rendered from it — bounded briefs and open design
+questions — write decisions back through validated batches, and the CLI
 mechanically proves the model still matches the code as changes land.
 
-Prose is the interface; structure is the guarantee: every sentence an agent
-reads stands on a graph whose names resolve, whose drift is detected, and
-whose gaps are found deterministically.
+There is no LLM inside and no service behind it: the engine is a
+deterministic CLI, nothing leaves your repository, and git remains the only
+governance — a proposed change becomes architecture when a human merges it.
 
 > YarraMate is pre-release software. Interfaces may evolve before the first
 > stable release.
 
+## Two minutes to a model
+
+```sh
+npm install -g yarramate
+
+yarramate init .                                 # scaffold .yarramate/, write the agent pointer
+yarramate design .yarramate/workspace.yaml       # the interview: the top open design question
+yarramate apply answers.yaml .yarramate/workspace.yaml   # answers land as one atomic batch
+yarramate check .yarramate/workspace.yaml        # names resolve and rules hold — or it says where not
+```
+
+The whole surface is seven verbs, one per lifecycle stage:
+
+```text
+init → design → apply → ask → check → reconcile → export
+create  fill    write   read  gate    drift       derive
+```
+
+`design` recomputes the next open question from the model itself — there is
+no session state anywhere. That is the design bet: the model, not the
+session, is the state, so any agent in any harness resumes the interview
+cold, and a crashed session or a vendor switch costs nothing.
+
+## Every fact is a claim
+
+What you author — plain YAML in git:
+
+```yaml
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    status: current
+```
+
+What the engine checks — a claim in the compiled graph, with provenance:
+
+```json
+{
+  "subject": "orders#order-gateway",
+  "predicate": "yarramate/concept/kind",
+  "value": "yarramate/core@0.1#applicationComponent",
+  "origin": "declared",
+  "source": { "document": "orders", "line": 3, "column": 5 }
+}
+```
+
+What an agent reads — deterministic prose rendered from the graph:
+
+> "Order Gateway is an application component; it already exists in this
+> system."
+
+Every sentence stands on claims, and every claim cites the file and line it
+came from. The same YAML compiles to a byte-identical graph and the same
+sentence, every time. There is no other structure to learn: concepts,
+relationships, statuses, owners, and evidence are all claims.
+
+## What structure buys
+
+Three things prose alone can't do — and deliberately the whole list:
+
+- **Identity** — a stable name every agent agrees on. References resolve or
+  the model doesn't compile; two sessions can't invent two names for the
+  same component.
+- **Verifiability** — internal consistency and drift against the code,
+  checked mechanically. A claim of "current" without supporting evidence is
+  flagged the moment it becomes checkable, and `reconcile` reports both
+  sides of every disagreement without auto-fixing either.
+- **Sliceability** — each implementer receives exactly its neighbourhood: a
+  bounded, deterministic brief rendered from the model, so parallel agents
+  share one map.
+
+Anything a good document does as well, we leave to your documents. The model
+holds only what nothing can derive from code: what's planned, what was
+deliberately retired, who owns what, and why.
+
 ## Proven across harnesses
 
-The design bet is that the model — not the session — is the state, so any
-agent in any harness can resume the work cold. We tested that adversarially
-on a real product: a Claude Code session worked the design interview all
-day, then an OpenAI Codex session — no shared context, the tool never
-named — resumed it from a ten-line pointer file and the published CLI. It
-answered 63 open design questions, filed two genuine defect reports, and in
-a later session reported that the model "was not merely documentation" — it
-caught an approval-path regression before the release shipped.
+We tested the handover bet adversarially on a real product: a Claude Code
+session worked the design interview all day, then an OpenAI Codex session —
+no shared context, the tool never named in the prompt — resumed it from a
+ten-line pointer file and the published CLI. It answered 63 open design
+questions, filed two genuine defect reports, and in a later session reported
+that the model "was not merely documentation" — it caught an approval-path
+regression before the release shipped.
 
 The full story, with every commit, PR, and release attached:
 [The model is the handover](docs/CASE-STUDY-CROSS-HARNESS.md).
 
-## Why YarraMate?
+## Research, honestly
 
-Architecture documents often drift away from implementation or become tied to
-one notation and tool. YarraMate keeps concise, native YAML documents
-canonical and compiles them into an explicit semantic graph.
+We benchmark our own claims and publish the misses alongside the wins:
 
-The same model supports two workflows:
+- **Held** — cross-harness handover; elicitation (tool-equipped agents
+  across three model tiers reached a green check first try, 5/5, and
+  converged on a design question zero freehand frontier runs ever asked);
+  lie resistance (five builds from deliberately corrupted models — zero
+  lies reached code).
+- **Not held** — under a strong external spec, a checked model did not
+  measurably beat a good design document on build convergence. We ran that
+  experiment and published it.
 
-- discover an existing project's architecture from repository evidence;
-- design a solution before implementation and later reconcile intent with
-  evidence.
+Results with full transcripts, diffs, and the adjudication trail:
+[docs/research/context-benchmark](docs/research/context-benchmark) and
+[yarramate-bench-results](https://github.com/yarrasys/yarramate-bench-results).
 
-Git provides authorship, review, history, and acceptance. YarraMate does not
-introduce a parallel governance workflow.
+And honestly: maintaining a model is rent. Two things make it payable —
+agents do most of the authoring through the interview loop, and the engine
+tells you exactly what's missing instead of leaving completeness to
+discipline. It pays when more than one agent, session, or human has to
+share the same map.
+
+## For AI agents
+
+If you are an agent working in a repository with a `.yarramate/` workspace,
+orientation is one call and the loop is three:
+
+```sh
+yarramate ask .yarramate/workspace.yaml      # verdict, drift summary, backlog — one round-trip
+yarramate design .yarramate/workspace.yaml   # the top open design question + its model slice
+# answer with an operations batch, then:
+yarramate apply operations.yaml .yarramate/workspace.yaml
+```
+
+Re-run `design` for the next question. Stop with an uncommitted, reviewable
+diff — merging is the human acceptance step, not yours.
+
+- Every command takes `--json` and returns a versioned, schema-backed
+  envelope; writes are atomic batches that compile as a whole workspace or
+  are rejected outright, so you cannot half-corrupt a document.
+- `ask` accepts free text (`yarramate ask <ws> "billing"`), `--subjects`
+  for the full roster, `--where` for evidence-backed pointing, and
+  `--changed <git-range>` for review slices.
+- `init` writes the discovery pointer into both `AGENTS.md` and
+  `CLAUDE.md`, so this section finds you rather than the reverse.
+- `yarramate-mcp` exposes four read-only tools (ask/design/check/reconcile)
+  over MCP stdio.
+- In Claude Code, this repository is its own plugin marketplace:
+
+  ```sh
+  /plugin marketplace add yarrasys/yarramate
+  /plugin install yarramate-architecture@yarramate
+  ```
+
+The full agent contract is [docs/AGENT-INTERFACE.md](docs/AGENT-INTERFACE.md).
 
 ## Product boundaries
 
-YarraMate Core:
+YarraMate Core owns native, versioned architecture documents; compiles a
+claim-centred, tool-neutral semantic graph; checks deterministic correctness
+rather than architectural taste; supports explicit workspaces, profiles,
+projections, evidence, and architecture states; and exposes a stable CLI for
+people, CI, skills, and agent harnesses.
 
-- owns native, versioned architecture documents;
-- compiles a claim-centred, tool-neutral semantic graph;
-- checks deterministic correctness rather than architectural taste;
-- supports explicit workspaces, profiles, projections, evidence, and
-  architecture states;
-- exposes a stable CLI for people, CI, skills, and agent harnesses.
+Optional adapters provide LikeC4 visualization from semantic projections,
+Graphify observations as evidence overlays, and separately governed
+compatibility profiles for external languages. Core depends on none of them.
 
-Optional adapters provide:
+YarraMate is not affiliated with or certified by The Open Group. ArchiMate®
+is a registered trademark of The Open Group. LikeC4 and Graphify are
+independent projects; their mention does not imply affiliation or
+endorsement.
 
-- LikeC4 visualization from semantic projections;
-- Graphify observations as evidence overlays;
-- separately governed compatibility profiles for external languages.
+## Development
 
-Core does not depend on LikeC4, Graphify, or ArchiMate.
+Requirements: Node.js 22 or newer, Corepack.
 
-YarraMate is not affiliated with or certified by The Open Group. ArchiMate® is
-a registered trademark of The Open Group. LikeC4 and Graphify are independent
-projects; their mention does not imply affiliation or endorsement.
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm run verify
+```
 
-## Repository layout
+The full CI command runs typechecking, tests, native self-validation, LikeC4
+generation, and LikeC4 validation. Useful focused commands: `pnpm build`,
+`pnpm test`, `pnpm typecheck`, `pnpm self:check`, `pnpm self:reconcile`,
+`pnpm self:check:likec4`, `pnpm docs:dev`.
 
 ```text
 src/                 compiler, CLI, graph, and adapter sources
@@ -84,89 +214,9 @@ docs/                contracts, guides, and decisions
 .yarramate-out/      reproducible generated output (ignored)
 ```
 
-The [documentation index](docs/README.md) links the public guides and
-maintainer material. Start semantic work with the
-[product contract](docs/PRODUCT-CONTRACT.md) and
-[glossary](docs/GLOSSARY.md).
-
-## Development
-
-Requirements:
-
-- Node.js 22 or newer
-- Corepack
-
-```sh
-corepack enable
-pnpm install --frozen-lockfile
-pnpm run verify
-```
-
-The full CI command runs typechecking, tests, native self-validation, LikeC4
-generation, and LikeC4 validation.
-
-Useful focused commands:
-
-```sh
-pnpm build
-pnpm test
-pnpm typecheck
-pnpm self:check
-pnpm self:evidence
-pnpm self:reconcile
-pnpm self:check:likec4
-pnpm self:export:likec4
-pnpm docs:dev
-```
-
-## CLI
-
-Install the published executable or invoke it directly with `npx`:
-
-```sh
-npm install --global yarramate
-yarramate --help
-
-npx yarramate check .yarramate/workspace.yaml
-npx yarramate ask .yarramate/workspace.yaml
-```
-
-The CLI is seven verbs, one per lifecycle stage:
-
-```text
-init → design → apply → ask → check → reconcile → export
-create  fill    write   read  gate    drift       derive
-```
-
-When developing the repository, build and invoke the same executable surface:
-
-```sh
-pnpm build
-
-node dist/cli.js init .
-node dist/cli.js design .yarramate/workspace.yaml
-node dist/cli.js apply operations.yaml .yarramate/workspace.yaml
-node dist/cli.js ask .yarramate/workspace.yaml
-node dist/cli.js ask .yarramate/workspace.yaml "free text about the model"
-node dist/cli.js ask .yarramate/workspace.yaml --subjects
-node dist/cli.js ask .yarramate/workspace.yaml --advise "a design question"
-node dist/cli.js ask .yarramate/workspace.yaml --where "compiler"
-node dist/cli.js check .yarramate/workspace.yaml --json
-node dist/cli.js reconcile .yarramate/workspace.yaml
-node dist/cli.js export graph .yarramate/workspace.yaml
-node dist/cli.js export briefs .yarramate/projections/context.yaml .yarramate/workspace.yaml --out handoff
-```
-
-`init` creates `.yarramate/architecture/main.yaml` and
-`.yarramate/workspace.yaml` and delivers the agent pointer. `design`
-serves the top open design question; `apply` lands answers as one
-validated atomic batch; `ask` is every consumed-now read; `export`
-derives persisted artifacts. `check --strict` additionally fails when
-any evidence observation contradicts the model, for gates that want one
-knob. The full contract is
-[docs/AGENT-INTERFACE.md](docs/AGENT-INTERFACE.md).
-
-For a local consumer test, create a package artifact:
+When developing the repository, build and invoke the same executable
+surface: `pnpm build`, then `node dist/cli.js <verb> …` mirrors every
+command above. For a local consumer test:
 
 ```sh
 pnpm pack --pack-destination /tmp/yarramate-package
@@ -174,15 +224,12 @@ npm install --global /tmp/yarramate-package/yarramate-*.tgz
 yarramate --help
 ```
 
-See [Consuming YarraMate](docs/CONSUMING-YARRAMATE.md) for the packaged CLI,
+The [documentation index](docs/README.md) links the public guides and
+maintainer material. Start semantic work with the
+[product contract](docs/PRODUCT-CONTRACT.md) and
+[glossary](docs/GLOSSARY.md). See
+[Consuming YarraMate](docs/CONSUMING-YARRAMATE.md) for the packaged CLI,
 schemas, agent skill, and optional adapters.
-
-In Claude Code, this repository is its own plugin marketplace:
-
-```sh
-/plugin marketplace add yarrasys/yarramate
-/plugin install yarramate-architecture@yarramate
-```
 
 ## Library API
 
@@ -197,27 +244,15 @@ const result = compileWorkspace([
 ```
 
 `compileWorkspaceWithProfileContext` additionally returns resolved profile
-lineage for operations that explicitly require kind ancestry. Graph v2 remains
-the stable, graph-only interchange result.
+lineage for operations that explicitly require kind ancestry. Graph v2
+remains the stable, graph-only interchange result.
 
-Normative schemas are available through package exports such as:
-
-```text
-yarramate/schema/document
-yarramate/schema/profile
-yarramate/schema/workspace
-yarramate/schema/graph-v2
-yarramate/schema/projection
-yarramate/schema/evidence
-yarramate/schema/core-contract
-```
-
-Optional adapter entry points are exported from:
-
-```text
-yarramate/adapter/likec4
-yarramate/adapter/graphify
-```
+Normative schemas are available through package exports such as
+`yarramate/schema/document`, `yarramate/schema/workspace`,
+`yarramate/schema/graph-v2`, `yarramate/schema/projection`,
+`yarramate/schema/evidence`, and `yarramate/schema/core-contract`. Optional
+adapter entry points are exported from `yarramate/adapter/likec4` and
+`yarramate/adapter/graphify`.
 
 ## Contributing and security
 


### PR DESCRIPTION
Reapproaches the README front door per today's direction: humans first, agents second.

**New order**: problem → mechanism (no LLM, git-only governance) → two-minute quickstart + seven verbs → **Every fact is a claim** (the YAML → claim → prose triad, mirroring the site's hero) → **What structure buys** (Identity/Verifiability/Sliceability, with the 'whole list, deliberately' discipline) → case study → **Research, honestly** (negative result stated in the README for the first time, plus the 'rent' admission) → **For AI agents** (loop, envelopes, free-text/--where/--changed ask modes, pointer delivery, MCP, marketplace) → boundaries/development/library/contributing unchanged in substance.

Notes for review:
- The claim JSON example is abridged (no `id` field) for readability — happy to add it if you'd rather the excerpt be schema-complete.
- 'Why YarraMate?' and the old CLI section folded into the new intro/quickstart/agents sections; no command or contract claims were altered.
- Verify green (345 tests).

No auto-merge — front-door voice, your pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)