### PR TITLE
First-class non-goals: a declared home for what the system will never do

### DIFF
--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.5"
+version: "0.6"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -124,7 +124,10 @@ questions:
       Add realization relationships from the fulfilling capability or
       service, record the aspirational status in the goal's description,
       or retire the goal (status: retired) to record that it no longer
-      steers design.
+      steers design. A goal may also be authored retired from the start:
+      status retired with the rationale in its description is the
+      declared non-goal record, and exports render it under a Non-goals
+      heading (ADR 0073).
 
 
   - id: goal-no-driver
@@ -224,8 +227,11 @@ questions:
       Add realization from the fulfilling service, component, or
       behavior; to descope instead, retire the requirement (status:
       retired) — retirement preserves the decision on record and closes
-      the question (ADR 0064). Delete only when the history itself is
-      noise.
+      the question (ADR 0064). Descoping at inception is the same
+      motion: a requirement authored with status retired, rationale in
+      its description, is the standing non-goal record and exports
+      render it under a Non-goals heading (ADR 0073). Delete only when
+      the history itself is noise.
 
   - id: principle-unapplied
     wave: motivation

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -136,7 +136,8 @@ others; graphify analogues: `--wiki` / `--svg` / `--neo4j`.
 - `export briefs <projection>` — the handoff bundle: one brief per
   slice for N implementers (the spec-build family's `handoff/`).
 - `export markdown <projection>` — human-readable document (today's
-  `view`).
+  `view`). Retired goals, outcomes, and requirements in the result
+  render under a Non-goals heading (ADR 0073), as they do in briefs.
 - `export likec4` — visualization project (today's adapter surface;
   the adapter binary remains the implementation).
 - Harness use: handoff preparation, CI artifact generation,

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -124,6 +124,15 @@ Concepts and relationships may also declare an operational `status` of
 `yarramate/lifecycle/status` claim. Status describes architecture lifecycle,
 not review or approval; Git remains authoritative for governance.
 
+Retirement also records scope that was considered and declined. A goal,
+outcome, or requirement may be authored with `status: retired` from the
+start, with the rationale in its `description`: that entry is the model's
+non-goal record, and no dedicated status value exists for it (ADR 0073).
+`export markdown` and `export briefs` render such subjects under a
+Non-goals heading so declined scope stays visible to stakeholders. A
+projection that lists `retired` in `excludeStatuses` keeps them out of
+its exports entirely; exclusion always wins over rendering.
+
 Documents may optionally declare baseline, transition, and target architecture
 states. Concepts and relationships use concise `presentIn` references to
 compile explicit presence claims:

--- a/docs/adr/0073-a-non-goal-is-a-subject-retired-at-birth.md
+++ b/docs/adr/0073-a-non-goal-is-a-subject-retired-at-birth.md
@@ -1,0 +1,56 @@
+# A non-goal is a subject retired at birth
+
+Status: accepted
+
+Good PRDs carry a Non-Goals section; the model had no honest home for
+"we considered X and will not do it" (#153). Retiring a requirement at
+inception already works mechanically: ADR 0064 closes every question
+against it, and catalogue 0.5 prescribes retirement for descoping. But
+it read as history rather than as a standing decision, and no export
+rendered it as the section stakeholders actually look for. The markdown
+export listed a retired requirement as one inventory bullet with a
+status suffix and no rationale; the brief rendered it inside "Why this
+exists" indistinguishable from a live requirement.
+
+Decided: the convention suffices, no new status value. A goal, outcome,
+or requirement authored with `status: retired`, rationale in its
+description, IS the non-goal record. A distinct lifecycle value (a
+`declined` marker) was considered and rejected: it is contract surface
+across the schema, the projection vocabulary, the evaluator, and every
+adapter, bought only to distinguish "retired at birth" from "retired
+later", a distinction the description already carries in prose. The
+issue leaned convention until rendering proves ambiguous; rendering did
+not prove ambiguous.
+
+The rendering decision belongs to the renderers, not the projection
+evaluator. Membership stays the projection's job: a projection whose
+`excludeStatuses` lists `retired` drops those subjects from the result,
+nothing reaches any renderer, and exclusion wins (PR #130 semantics are
+untouched). Where retired subjects ARE in the result, the two
+stakeholder renderers share one predicate (`isDeclaredNonGoal`):
+`export markdown` appends a "Non-goals" section restating each declared
+non-goal with its rationale while keeping it in the Concepts inventory,
+so relationship endpoints still resolve; the brief closes with a
+"Non-goals" section ("Requirement "X" is declined: ...") and keeps
+those subjects out of "Why this exists". Because the brief renderer
+also backs `ask` slices and the design verb, those surfaces inherit the
+section, which is consistent: bounded implementation context should say
+what not to build. Under a budget the non-goal paragraphs are the first
+omitted; they inform, they are not the work.
+
+The set is goal, outcome, and requirement only. Constraint and
+principle are motivation-layer kinds, but retiring one lifts a rule
+that used to bind; presenting that as declined scope would misread it,
+so they render as they always did. Retired subjects in every other
+layer are history, not non-goals, and stay out of the section.
+
+Consequences: catalogue 0.6 names descoping-at-inception in the
+requirement-unrealized and goal-unrealized resolutions. The bump
+follows the 0.5 precedent, where a resolution-prose-only diff took a
+minor version; no question or trigger changes, so no completed
+interview reopens and every `since` annotation stands. Relationship
+counterpart semantics need no change: the enrichment evaluator's
+trigger checks scan the unfiltered relationship claims, so a
+counterpart being retired, at birth or later, still satisfies
+missing-relationship and missing-linkage conditions, exactly as ADR
+0064 promised.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -54,7 +54,11 @@ relationships:
 
 IDs are document-local and compile to `document-id#subject-id`. Cross-document
 references must be globally qualified. Use `planned`, `current`, or `retired`
-only for operational lifecycle—not approval or alternative selection.
+only for operational lifecycle—not approval or alternative selection. A goal,
+outcome, or requirement authored with `status: retired` at inception, with
+the rationale in its description, records a declared non-goal; `export
+markdown` and `export briefs` render these under a Non-goals heading
+(ADR 0073).
 
 Supported relationship kinds are:
 
@@ -173,7 +177,9 @@ retract explicitly with `remove: [<field> ...]`. Whole subjects leave
 through `delete-concept` / `delete-relationship` (payload: the `id` only),
 rejected while anything still references the target; delete the referring
 relationships in the same batch. To descope, retire (`status: retired`)
-instead — delete only when the history itself is noise.
+instead — delete only when the history itself is noise. Descoping at
+inception is the same motion: author the subject retired with its
+rationale in the description and it becomes the non-goal record.
 
 ## Ownership and constraints
 

--- a/src/brief.ts
+++ b/src/brief.ts
@@ -55,6 +55,27 @@ export const coreLocalKind = (
   return undefined
 }
 
+// First-class non-goals (ADR 0073): the convention is a goal, outcome,
+// or requirement carrying `status: retired` with its rationale in the
+// description. That record is the declared non-goal; no dedicated status
+// value exists. Principles and constraints are deliberately outside the
+// set: retiring one lifts a rule rather than declining scope. Both
+// stakeholder renderers (projection markdown and the brief) share this
+// predicate. Projection membership is not consulted here: a projection
+// whose excludeStatuses drops retired subjects has already kept them out
+// of the result, so nothing reaches the renderers to present.
+const nonGoalKindIds = new Set(['goal', 'outcome', 'requirement'])
+
+export const isDeclaredNonGoal = (
+  kind: string | undefined,
+  status: string | undefined,
+  lineages: ReadonlyMap<string, readonly string[]> | undefined,
+): boolean => {
+  if (status !== 'retired' || kind === undefined) return false
+  const core = coreLocalKind(kind, lineages)
+  return core !== undefined && nonGoalKindIds.has(core)
+}
+
 const humanizeKind = (kind: string): string => {
   const local = kind.slice(kind.indexOf('#') + 1)
   return local
@@ -258,6 +279,22 @@ export function renderBrief(
     )
   }
 
+  const nonGoalParagraph = (id: string): string => {
+    const kind = kindOf(id) ?? ''
+    const reading = kindReading(kind)
+    const label = reading.charAt(0).toUpperCase() + reading.slice(1)
+    const description = descriptionOf(id)
+    const opening =
+      description === undefined
+        ? `${label} "${nameOf(id)}" is declined.`
+        : `${label} "${nameOf(id)}" is declined: "${description}"`
+    return [
+      sentenceEnd(opening),
+      ...relationshipSentences(id),
+      ...supportSentences(id),
+    ].join(' ')
+  }
+
   const workParagraph = (id: string): string => {
     const kind = kindOf(id) ?? ''
     const reading = kindReading(kind)
@@ -283,11 +320,23 @@ export function renderBrief(
   // Motivation opens the brief (the interview's waves lead with why), the
   // planned work follows (it is what the reader came to do), and existing
   // context comes after; the same order ranks paragraphs under a budget.
+  // Declared non-goals close the brief (ADR 0073): they tell the reader
+  // what not to build, they are not the work itself, so under a budget
+  // their paragraphs are the first to be omitted.
   const statusRank = (id: string): number => {
     const status = statusOf(id)
     return status === 'planned' ? 1 : status === 'retired' ? 3 : 2
   }
-  const motivation = concepts.filter(({ id }) => isMotivation(id))
+  const isNonGoal = (id: string): boolean =>
+    isDeclaredNonGoal(
+      kindOf(id),
+      statusOf(id),
+      profileContext?.conceptKindLineages,
+    )
+  const motivation = concepts.filter(
+    ({ id }) => isMotivation(id) && !isNonGoal(id),
+  )
+  const nonGoals = concepts.filter(({ id }) => isNonGoal(id))
   const work = concepts.filter(({ id }) => !isMotivation(id))
   const paragraphs: {
     readonly heading: string
@@ -305,6 +354,13 @@ export function renderBrief(
       entries: work
         .map(({ id }) => ({ text: workParagraph(id), rank: statusRank(id) }))
         .sort((a, b) => a.rank - b.rank),
+    },
+    {
+      heading: '## Non-goals',
+      entries: nonGoals.map(({ id }) => ({
+        text: nonGoalParagraph(id),
+        rank: 0,
+      })),
     },
   ]
 

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -290,7 +290,10 @@ export function runExportCommand(
     }
 
     if (kind === 'markdown') {
-      const rendered = renderProjectionMarkdown(result)
+      const rendered = renderProjectionMarkdown(
+        result,
+        compilation.profileContext,
+      )
       if (parsed.out === undefined) {
         return { exitCode: 0, stdout: rendered, stderr: '' }
       }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,4 +1,5 @@
 import Ajv2020Module from 'ajv/dist/2020.js'
+import { isDeclaredNonGoal } from './brief.js'
 import type {
   Diagnostic,
   GraphClaim,
@@ -335,7 +336,10 @@ export function evaluateProjection(
 const markdownText = (value: string) =>
   value.replaceAll('\n', ' ').replaceAll('`', '\\`')
 
-export function renderProjectionMarkdown(result: ProjectionResult): string {
+export function renderProjectionMarkdown(
+  result: ProjectionResult,
+  profileContext?: ResolvedProfileContext,
+): string {
   const title = result.presentation?.title ?? result.projection
   const concepts = result.subjects.filter(({ type }) => type === 'concept')
   const relationships = result.subjects.filter(
@@ -373,6 +377,36 @@ export function renderProjectionMarkdown(result: ProjectionResult): string {
     if (claim !== undefined && 'ref' in claim.object) {
       lines.push(
         `- \`${claim.subject}\` — \`${claim.predicate}\` → \`${claim.object.ref}\` (\`${relationship.id}\`)`,
+      )
+    }
+  }
+
+  // First-class non-goals (ADR 0073): retired goals, outcomes, and
+  // requirements in the result are declared decisions, not history to
+  // bury. They stay in the Concepts inventory above (relationship
+  // endpoints must resolve there) and are restated here with their
+  // rationale. Subjects a projection's excludeStatuses dropped never
+  // reach this renderer, so exclusion still wins.
+  const nonGoals = concepts.filter(({ id }) =>
+    isDeclaredNonGoal(
+      claimValue(result.claims, id, 'yarramate/concept/kind'),
+      claimValue(result.claims, id, 'yarramate/lifecycle/status'),
+      profileContext?.conceptKindLineages,
+    ),
+  )
+  if (nonGoals.length > 0) {
+    lines.push('', '## Non-goals', '')
+    for (const concept of nonGoals) {
+      const name =
+        claimValue(result.claims, concept.id, 'yarramate/concept/name') ??
+        concept.id
+      const description = claimValue(
+        result.claims,
+        concept.id,
+        'yarramate/concept/description',
+      )
+      lines.push(
+        `- ${markdownText(name)} (\`${concept.id}\`)${description === undefined ? '' : ` — ${markdownText(description)}`}`,
       )
     }
   }

--- a/test/export-command.test.ts
+++ b/test/export-command.test.ts
@@ -199,4 +199,184 @@ describe('export command', () => {
       expect(result.stderr, args.join(' ')).toContain('Usage:')
     }
   })
+
+  it('renders no Non-goals section when nothing is retired', () => {
+    const result = runCli(
+      ['export', 'markdown', 'everything.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).not.toContain('## Non-goals')
+  })
+})
+
+// First-class non-goals (ADR 0073): a goal, outcome, or requirement
+// authored `status: retired` with its rationale in the description is
+// the declared non-goal, and both stakeholder exports render it under
+// an explicit Non-goals heading instead of burying it.
+const nonGoalDocument = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: capture-todos
+    kind: requirement
+    name: Capture todos
+    description: A user records a todo in one step.
+  - id: offline-sync
+    kind: requirement
+    name: Offline sync
+    status: retired
+    description: Declined for launch; conflict resolution outweighs the value.
+  - id: team-boards
+    kind: goal
+    name: Team boards
+    status: retired
+    description: Single-user scope holds; collaboration is out.
+  - id: files-portable
+    kind: principle
+    name: Files stay portable
+    status: retired
+    description: A retired principle is a lifted rule, not declined scope.
+  - id: legacy-api
+    kind: applicationService
+    name: Legacy API
+    status: retired
+    description: Replaced by the todo service; kept for history.
+  - id: todo-service
+    kind: applicationService
+    name: Todo service
+    status: planned
+    description: Stores and serves todo items.
+relationships:
+  - id: service-realizes-capture
+    kind: realization
+    from: todo-service
+    to: capture-todos
+`
+
+const livingProjection = `format: yarramate/projection/v1
+id: living
+version: "1.0"
+query:
+  excludeStatuses: [retired]
+presentation:
+  title: Living architecture
+`
+
+describe('non-goals in exports (ADR 0073)', () => {
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-nongoals-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      nonGoalDocument,
+      'utf8',
+    )
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest, 'utf8')
+    writeFileSync(join(workspace, 'everything.yaml'), projection, 'utf8')
+    writeFileSync(join(workspace, 'living.yaml'), livingProjection, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('markdown renders retired motivation subjects under Non-goals, deterministically', () => {
+    const first = runCli(
+      ['export', 'markdown', 'everything.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(first.exitCode).toBe(0)
+    const [inventory, nonGoals] = first.stdout.split('## Non-goals')
+    expect(nonGoals).toBeDefined()
+    expect(nonGoals).toContain(
+      'Offline sync (`main#offline-sync`) — Declined for launch; ' +
+        'conflict resolution outweighs the value.',
+    )
+    expect(nonGoals).toContain(
+      'Team boards (`main#team-boards`) — Single-user scope holds; ' +
+        'collaboration is out.',
+    )
+    // The Concepts inventory keeps the declared non-goals: relationship
+    // endpoints must still resolve against the concept list.
+    expect(inventory).toContain('Offline sync')
+    // Non-motivation retired subjects and retired principles are
+    // history or lifted rules, never non-goals.
+    expect(nonGoals).not.toContain('Legacy API')
+    expect(nonGoals).not.toContain('Files stay portable')
+    const second = runCli(
+      ['export', 'markdown', 'everything.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(second.stdout).toBe(first.stdout)
+  })
+
+  it('excludeStatuses still suppresses retired subjects entirely', () => {
+    const result = runCli(
+      ['export', 'markdown', 'living.yaml', 'workspace.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).not.toContain('## Non-goals')
+    expect(result.stdout).not.toContain('Offline sync')
+    expect(result.stdout).not.toContain('Team boards')
+  })
+
+  it('briefs close with a Non-goals section for declared non-goals', () => {
+    const result = runCli(
+      [
+        'export',
+        'briefs',
+        'everything.yaml',
+        'workspace.yaml',
+        '--out',
+        'handoff',
+      ],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const declined = readFileSync(
+      join(workspace, 'handoff/main--offline-sync.md'),
+      'utf8',
+    )
+    expect(declined).toContain('## Non-goals')
+    expect(declined).toContain(
+      'Requirement "Offline sync" is declined: "Declined for launch; ' +
+        'conflict resolution outweighs the value."',
+    )
+    expect(declined).not.toContain('## Why this exists')
+    // Live motivation still opens the brief; no Non-goals section
+    // appears where nothing in the slice is a declared non-goal.
+    const building = readFileSync(
+      join(workspace, 'handoff/main--todo-service.md'),
+      'utf8',
+    )
+    expect(building).toContain('## Why this exists')
+    expect(building).toContain('Requirement "Capture todos"')
+    expect(building).not.toContain('## Non-goals')
+    // A retired principle keeps its motivation reading.
+    const principle = readFileSync(
+      join(workspace, 'handoff/main--files-portable.md'),
+      'utf8',
+    )
+    expect(principle).toContain('## Why this exists')
+    expect(principle).not.toContain('## Non-goals')
+    const again = runCli(
+      [
+        'export',
+        'briefs',
+        'everything.yaml',
+        'workspace.yaml',
+        '--out',
+        'handoff',
+      ],
+      workspace,
+    )
+    expect(again.stdout).toBe(result.stdout)
+    expect(
+      readFileSync(join(workspace, 'handoff/main--offline-sync.md'), 'utf8'),
+    ).toBe(declined)
+  })
 })


### PR DESCRIPTION
Closes #153

A non-goal is a goal, outcome, or requirement authored with `status: retired` and its rationale in the description. The issue's central call stands: **convention, not a new lifecycle status.** Nothing in the schema, the projection vocabulary, or the evaluator gained a value.

## Verified starting behavior (before changing anything)

- `export markdown` did not omit retired subjects, it **buried** them: one inventory bullet with a `— retired` suffix and no description, indistinguishable from any other concept.
- `export briefs` was worse than burying: a retired requirement rendered inside `## Why this exists`, reading as live motivation.
- `excludeStatuses` (PR #130) already drops retired subjects from the projection result outright, including vetoing `connected` expansion.

## What changed

**Rendering is the renderers' decision, not the evaluator's.** Membership stays the projection's job. A projection listing `retired` in `excludeStatuses` keeps those subjects out of the result, so nothing reaches a renderer and exclusion still wins; PR #130 semantics are untouched. Where retired subjects **are** in the result, both stakeholder renderers share one predicate, `isDeclaredNonGoal`:

- `export markdown` appends a `## Non-goals` section restating each declared non-goal with its rationale. They stay in the Concepts inventory too, because relationship endpoints must resolve there.
- `export briefs` closes with a `## Non-goals` section ("Requirement "X" is declined: ...") and lifts those subjects out of `## Why this exists`. Under a `--budget` those paragraphs are the first omitted: they inform, they are not the work.

Catalogue 0.6 names descoping-at-inception in the `requirement-unrealized` and `goal-unrealized` resolutions, plus `docs/NATIVE-DOCUMENT.md`, `docs/AGENT-INTERFACE.md`, and the skill's `native-authoring.md` reference.

## Relationship counterparts: verified, not assumed

The issue expected no change here. Confirmed empirically rather than by reading the code. A probe workspace where a live requirement's **only** realizer is a `status: retired` service, alongside a genuinely unrealized requirement:

```
OPEN   requirement-unrealized [since 0.3] (1 subject)
       ask: "Nothing realizes Orphan requirement. What will fulfil it — or is it out of scope?"
```

It fires on exactly one subject, the genuinely orphaned one. The requirement realized only by the retired service stays closed, so a retired subject still satisfies a counterpart condition, exactly as ADR 0064 promised. The enrichment evaluator's trigger checks scan the unfiltered relationship claims; only the **target set** excludes retired subjects. No change was needed and none was made.

## Design decisions, honestly

- **Convention over a new status value.** A `declined` marker is contract surface across the schema, projection vocabulary, evaluator, and every adapter, bought only to distinguish "retired at birth" from "retired later", a distinction the description already carries in prose. The issue leaned convention until rendering proves ambiguous; rendering did not prove ambiguous.
- **Which kinds count: goal, outcome, requirement only.** Constraint and principle are motivation-layer kinds, but retiring one lifts a rule that used to bind. Presenting that as declined scope would misread it, so they render as they always did. Flagging this as the judgment call most open to disagreement.
- **Which layer owns the rendering.** Put in the renderers, not the projection evaluator. The evaluator answers "what is in the slice"; presentation is a rendering concern, and routing it through the evaluator would have entangled projection membership with export formatting.
- **The brief change reaches `ask` and `design` too**, since they share `renderBrief`. Deliberate and consistent: bounded implementation context should say what not to build.
- **Catalogue 0.5 to 0.6 (a minor bump).** Per ADR 0063 a minor bump only adds questions or loosens triggers. This diff changes neither: it extends two `resolution` prose fields. The 0.5 bump set the precedent with an identical resolution-prose-only diff. No completed interview reopens and every `since` annotation stands. The alternative, no bump at all, would leave the shipped catalogue's prose differing from its version, so the version was moved.
- **`renderProjectionMarkdown` took an optional second parameter.** Additive and backwards compatible for library consumers; the predicate itself stays internal, since `index.ts` does not export the brief module.
- **ADR 0073 taken** (siblings hold 0071 and 0072 per the maintainer's assignment).
- The renderer's ` — ` bullet separator is kept in the new Non-goals output for consistency with the Concepts bullets directly above it. No em-dashes in prose authored here.

## Verification

`rm -rf dist && pnpm verify` clean from a removed `dist`: **349 tests across 34 files** (4 new), `self:check` green (199 concepts, 268 relationships), `likec4 validate` green.

New tests cover the four required behaviors: markdown and briefs render Non-goals deterministically (byte-identical across two runs), the section is absent when nothing is retired, `excludeStatuses: [retired]` still suppresses the subjects entirely, and non-motivation retired subjects (a retired `applicationService`) plus retired principles never appear under Non-goals.

The repository's own self-model has no retired motivation subjects, only retired application services, components, and relationships, so its exports are unchanged and every pinned self-model expectation held without regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
