### PR TITLE
Constraints carry expected observations: value-bearing evidence makes reconcile catch what check cannot

### DIFF
--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -36,6 +36,37 @@ The `evidence.uri` value is opaque to YarraMate Core. Its provider owns URI
 resolution and external validity. An optional non-empty message may explain
 the observation; arbitrary provider metadata is not accepted.
 
+## Value observations
+
+An observation may additionally report the value it read, by carrying an
+observed `key` and `value` together (ADR 0075):
+
+```yaml
+observations:
+  - subject: shop#customer-data
+    result: confirmed
+    key: region
+    value: us-east-1
+    evidence:
+      uri: repo:infra/main.tf#L12
+      message: aws_s3_bucket.customer_data region
+```
+
+The two fields are required together: a key without a value, or a value
+without a key, is rejected. The key is provider-owned naming with no
+whitespace; the value is any non-empty string, compared verbatim.
+
+`key` and `value` do not replace or reinterpret `result`. The result still
+answers whether the target holds up at all, which is a presence or absence
+judgment; the keyed value reports a fact that a declared expectation can be
+compared against. A provider that reads several facts in one place may report
+several keys at one target, and each key at a target at most once. Its
+presence result is still stated once per target.
+
+Providers own their key vocabulary. Core neither defines key names nor
+resolves them: it only compares the reported value with the value a
+constraint declared it expects.
+
 ## Evaluation
 
 Generic evaluation checks:
@@ -64,7 +95,9 @@ optional `evidence` category of a workspace manifest, in which case
 
 `yarramate check --strict` additionally fails the check (exit `1`) when any
 evidence observation is `contradicted`, rendering each contradiction as a
-source-located `YM901` diagnostic anchored at the declared claim. `unknown`
+source-located `YM901` diagnostic anchored at the declared claim. A
+contradicted expectation surfaces the same way, anchored at the authored
+expected value, with no gate semantics of its own. `unknown`
 and `not-observed` results stay advisory. A strict pass reports how many
 observations it evaluated, so a gate over zero evidence is visible rather
 than silently vacuous (ADR 0047).
@@ -111,6 +144,59 @@ the evidence is visible in the finding itself:
 
 Subject-targeted findings and findings on relationship sub-claims (such as
 `…~name`) do not carry `asserted`.
+
+### Declared expectations
+
+When a constraint declares an expected observation
+(`expects` in `docs/NATIVE-DOCUMENT.md`), reconciliation compares the declared
+value with what the named provider observed. A declared expectation is matched
+to observations by provider and key. The observation's own target anchors its
+provenance but does not narrow the match, because a keyed value is a fact
+about the project rather than about one subject, and several constraints may
+legitimately expect the same fact.
+
+A disagreement is an ordinary `contradicted` finding, rendered with both
+sides: the declared expectation with the source location where it was
+authored, and the observed value with its provider, evidence document, and
+locator.
+
+```json
+{
+  "target": {
+    "type": "claim",
+    "id": "shop#customer-data~expects-residency"
+  },
+  "expectation": {
+    "provider": "terraform-scan",
+    "key": "region",
+    "expected": "ap-southeast-2",
+    "observed": "us-east-1",
+    "declared": {
+      "document": "shop",
+      "path": "architecture/shop.yaml",
+      "pointer": "/concepts/1/constraints/0/expects/value",
+      "line": 18,
+      "column": 18
+    }
+  },
+  "result": "contradicted",
+  "provider": "terraform-scan",
+  "evidenceDocument": "shop-terraform@1.0",
+  "evidence": {
+    "uri": "repo:infra/main.tf#L12",
+    "message": "aws_s3_bucket.customer_data region"
+  }
+}
+```
+
+The summary counts `expectationsCompared`, the declared expectations a
+matching observation reached, and `expectationsWithoutObservation`, those no
+provider reported on. An expectation nobody observed is listed in a top-level
+`unobservedExpectations` array, sorted by claim then key, and never converted
+into a finding: no provider disagreed, so there is nothing to accuse, and the
+same discipline applies as for unobserved subjects (ADR 0049). An unobserved
+expectation is therefore reported honestly rather than passing as satisfied,
+and it does not fail `check --strict`.
 
 The summary also counts `current` concepts that appear in no observation at
 all — neither targeted directly, nor through a claim they own, nor as an
@@ -200,6 +286,11 @@ stable claim such as
 constraint assessment, not Core conformance. Core does not execute policy
 rules, interpret missing observations, manage exceptions, or convert a result
 into CI failure.
+
+A declared expectation does not change that boundary. Comparing two strings is
+not a rule engine: Core still holds no policy language, no waivers, no
+exceptions, and no opinion about which value is correct. It reports that the
+model and a provider disagree, and leaves the judgment to a reviewer.
 
 Diagnostics use `YM801` for an unknown subject, `YM802` for an unknown claim,
 `YM803` for a duplicate target, and `YM804` for a duplicate evidence document.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -89,6 +89,17 @@ _Avoid_: Embedded policy engine, compliance result, free-form metadata
 An evidence-provider observation about an existing constraint claim.
 _Avoid_: Core validation result, approval, canonical compliance status
 
+**Expected observation**:
+A constraint entry declaring the provider, key, and exact value the model
+expects an evidence provider to report. It makes a rule testable by string
+equality without giving Core a rule language.
+_Avoid_: Policy expression, assertion language, matching rule, waiver
+
+**Value observation**:
+An evidence observation carrying the key it read and the value it read there,
+alongside the presence or absence result it always carried.
+_Avoid_: Observed claim, model mutation, provider metadata bag
+
 **Concept kind**:
 A named semantic category available to elements, such as `goal`, `capability`,
 or `applicationComponent`.

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -79,6 +79,37 @@ evaluate the stable generated claim ID and report through an evidence overlay;
 the observation does not mutate declared intent or become a Core validation
 result.
 
+A constraint entry may also declare the observation it expects, which turns a
+rule stated in prose into a fact a provider can testify about:
+
+```yaml
+concepts:
+  - id: customer-data
+    kind: dataObject
+    name: Customer data
+    constraints:
+      - id: residency
+        ref: australia-only
+        expects:
+          provider: terraform-scan
+          key: region
+          value: ap-southeast-2
+```
+
+`expects` names the provider expected to report the fact, the key that
+provider reads, and the exact value the model expects to find there. It
+compiles to `<subject>~expects-<id>` with predicate
+`yarramate/constraint/expects`. Core checks nothing about the expectation
+beyond its shape: it does not contact the provider, resolve the key, or decide
+whether the value is architecturally correct. `yarramate reconcile` compares
+the declared value with what the named provider observed, and
+`yarramate check --strict` gates on a disagreement exactly as it gates on any
+other contradicted evidence (ADR 0075).
+
+The comparison is string equality. A provider that needs case folding, unit
+conversion, or pattern matching normalizes before it reports, so the model
+never carries a matching language of its own.
+
 `constraints` and `realization` express different claims. A constraint entry
 means the concept is bound by the referenced rule; a realization relationship
 means its source implements or fulfils its target. A component that must obey a

--- a/docs/SEMANTIC-GRAPH.md
+++ b/docs/SEMANTIC-GRAPH.md
@@ -31,6 +31,14 @@ references use `yarramate/constraint/requires`. Both point to globally
 qualified concept subjects and use stable claim IDs derived from authored
 syntax; neither adds fields to graph v2.
 
+A constraint that declares an expected observation emits one further claim,
+`yarramate/constraint/expects`, whose value is
+`<provider> <key> <expected value>`. Provider and key admit no whitespace, so
+the first two spaces delimit them and the remainder is the expected value
+verbatim. It is an ordinary value claim in the existing envelope: no new
+field, no new structure, and a consumer that does not know the predicate keeps
+reading the graph correctly.
+
 Concept and relationship descriptions use
 `yarramate/concept/description` and
 `yarramate/relationship/description`. Identified citations use
@@ -127,6 +135,7 @@ Core claim predicates:
 | `yarramate/lifecycle/status` | value | `planned`, `current`, or `retired` |
 | `yarramate/ownership/owner` | ref | Accountable concept subject |
 | `yarramate/constraint/requires` | ref | Binding constraint subject |
+| `yarramate/constraint/expects` | value | Expected observation as `<provider> <key> <expected value>` |
 | `yarramate/reference/refers-to` | ref | Identified citation to any subject |
 | `yarramate/access/mode` | value | Access mode of an access relationship |
 | `yarramate/flow/content` | value | Transferred content of a flow |

--- a/docs/adr/0075-constraints-carry-expected-observations.md
+++ b/docs/adr/0075-constraints-carry-expected-observations.md
@@ -1,0 +1,133 @@
+# Constraints carry expected observations
+
+Status: accepted
+
+A requirement rewritten to contradict the data-residency constraint sitting
+next to it passes `check` with exit 0. That is not a defect in the checker: the
+rule lives inside an opaque description string, and the engine deliberately
+does not read words (ADR 0054). The documented word-blindness boundary is
+therefore also a documented hole, and the fix is not to start parsing prose.
+
+Decided: a constraint entry may declare the observation it expects, and
+evidence providers may report the values they read. Reconciliation compares
+the two.
+
+```yaml
+constraints:
+  - id: residency
+    ref: australia-only
+    expects:
+      provider: terraform-scan
+      key: region
+      value: ap-southeast-2
+```
+
+## The authoring surface is a field that compiles to a claim
+
+`expects` is a structured field on a constraint entry, not a free-form claim
+predicate the author writes by hand. The field gives the shape a schema can
+reject at authoring time, and the compiler is where every stable claim
+identity in this codebase is minted. It compiles to `<subject>~expects-<id>`
+with predicate `yarramate/constraint/expects`, alongside the unchanged
+`yarramate/constraint/requires` claim. The claim ID is suffixed on the
+authored constraint ID, which `YM306` already keeps unique, so identity is
+reorder-safe for the same reason constraint claims are (ADR 0015).
+
+Graph v2 gains no field and no structure. The claim carries one string value,
+`<provider> <key> <expected value>`, exactly as an attestation carries
+`<by> <on>`. Provider and key admit no whitespace, so the first two spaces
+delimit them and the remainder is the expected value verbatim, spaces
+included. A consumer that has never heard of the predicate keeps reading the
+graph correctly, which is the whole additivity contract
+(`docs/SEMANTIC-GRAPH.md`). Encoding three parts in one value is the price of
+that contract; the alternative, a structured object in a claim, would be a
+graph v3.
+
+## Evidence gains values, not a second kind of observation
+
+An observation may carry an observed `key` and `value` together. This is
+additive within `yarramate/evidence/v1`: both fields are optional, required
+only in each other's presence, and every existing overlay stays valid.
+
+`result` is untouched and orthogonal. It still answers whether the target
+holds up at all, a presence or absence judgment; the keyed value reports a
+fact. A provider confirming a subject exists while reporting that its region
+is `us-east-1` is making both statements at once, and they are separate
+statements.
+
+One consequence had to be conceded: the duplicate-target rule (`YM803`) now
+keys on target plus observed key, because a provider that reads three facts in
+one file must be able to report three keyed values there. A target still
+carries at most one presence result and at most one observation per key.
+
+## Comparison is string equality, and stays that way
+
+Two strings are equal or they are not. No case folding, no numeric coercion,
+no globbing, no regular expressions, no ranges. A provider that needs any of
+that normalizes before it reports, which puts the interpretation in the
+component that already owns URI resolution and external validity.
+
+This is the boundary that keeps the feature honest. The moment Core acquires a
+matching language it has acquired a policy engine, and ADR 0016 exists
+precisely to keep that out. Requests for richer comparison should be answered
+by the provider, not by the model.
+
+## A disagreement is an ordinary contradicted finding
+
+A declared expectation is matched to observations by provider and key. The
+observation's own target anchors provenance but does not narrow the match: a
+keyed value is a fact about the project ("this deployment's region is X"), not
+about one subject, and several constraints on different subjects may
+legitimately expect the same fact. Requiring providers to enumerate every
+subject a keyed fact bears on would make a config reader model-aware for no
+gain in truth.
+
+Disagreement produces a `contradicted` finding with an additive optional
+`expectation` object rendering both sides: the declared provider, key, and
+expected value with the source location where it was authored, next to the
+observed value with its provider, evidence document, and locator. Findings
+already restate declared intent for contrast (ADR 0046); an expectation
+finding is the same move for a value rather than an endpoint pair, and it is
+equally advisory. No document is mutated and no remediation is authorized
+(ADR 0032).
+
+`check --strict` needed no new gate semantics, which was the point. A
+contradicted expectation is a contradicted finding, so it already failed the
+existing gate; only the diagnostic wording is specialized, because both sides
+of this disagreement are known values worth naming. It anchors at the authored
+expected value, so the failure is repairable where it is reported (ADR 0039).
+
+## Silence is reported as silence
+
+An expectation no provider observed is not a finding. Findings carry a
+provider and an evidence locator, and here no provider produced anything, so
+shoehorning the gap into `findings` would fabricate an accusation. It goes
+where ADR 0049 put the same problem: a top-level `unobservedExpectations`
+array, present only when non-empty, plus `expectationsCompared` and
+`expectationsWithoutObservation` counters that are always emitted. Both
+counters are optional in the schema, so reports produced before this change
+still validate.
+
+An unobserved expectation therefore does not fail `--strict`. Absence of
+evidence is not contradiction, and a gate that failed on it would punish
+authors for declaring expectations at all, which is the opposite of the
+incentive this feature needs.
+
+ADR 0074 reached the same conclusion independently for stale attestations: a
+freshness signal about a human process is not a contradiction, so it stays out
+of the gate too. The two land consistently. `--strict` fails on exactly one
+thing, a provider that looked at reality and disagreed with the model, and
+both new report additions grow the report without growing the gate. They also
+compose additively with each other: `unobservedExpectations` and
+`notes` are independent optional arrays, `expectationsCompared`,
+`expectationsWithoutObservation`, and `staleAttestations` are independent
+optional counters, and a report produced before either change still
+validates.
+
+## Consequences
+
+A constraint stops being prose and becomes a monitor: every fact moved out of
+a description and into a claim is a fact that can testify against a
+contradiction. The cost is that authors must state expectations explicitly and
+providers must report keyed values; nothing is inferred, and a model that
+declares nothing is exactly as blind as it was.

--- a/schema/yarramate-ask-result.schema.json
+++ b/schema/yarramate-ask-result.schema.json
@@ -924,6 +924,12 @@
         },
         "subjectsWithoutEvidence": {
           "type": "integer"
+        },
+        "expectationsCompared": {
+          "type": "integer"
+        },
+        "expectationsWithoutObservation": {
+          "type": "integer"
         }
       },
       "additionalProperties": false

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -146,8 +146,35 @@
         },
         "ref": {
           "$ref": "#/$defs/reference"
+        },
+        "expects": {
+          "$ref": "#/$defs/expectedObservation"
         }
       }
+    },
+    "expectedObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "key",
+        "value"
+      ],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/id"
+        },
+        "key": {
+          "$ref": "#/$defs/observationKey"
+        },
+        "value": {
+          "$ref": "#/$defs/nonEmptyText"
+        }
+      }
+    },
+    "observationKey": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
     },
     "identifiedReference": {
       "type": "object",

--- a/schema/yarramate-evidence-report.schema.json
+++ b/schema/yarramate-evidence-report.schema.json
@@ -46,16 +46,26 @@
         "message": { "type": "string", "minLength": 1 }
       }
     },
+    "observationKey": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+    },
     "observation": {
       "type": "object",
       "additionalProperties": false,
       "required": ["result", "evidence"],
+      "dependentRequired": {
+        "key": ["value"],
+        "value": ["key"]
+      },
       "properties": {
         "subject": { "$ref": "#/$defs/qualifiedIdentity" },
         "claim": { "$ref": "#/$defs/qualifiedIdentity" },
         "result": {
           "enum": ["confirmed", "contradicted", "unknown", "not-observed"]
         },
+        "key": { "$ref": "#/$defs/observationKey" },
+        "value": { "type": "string", "minLength": 1 },
         "evidence": { "$ref": "#/$defs/evidenceLocator" }
       },
       "oneOf": [

--- a/schema/yarramate-evidence.schema.json
+++ b/schema/yarramate-evidence.schema.json
@@ -50,10 +50,18 @@
         }
       }
     },
+    "observationKey": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+    },
     "observation": {
       "type": "object",
       "additionalProperties": false,
       "required": ["result", "evidence"],
+      "dependentRequired": {
+        "key": ["value"],
+        "value": ["key"]
+      },
       "properties": {
         "subject": {
           "$ref": "#/$defs/qualifiedIdentity"
@@ -68,6 +76,13 @@
             "unknown",
             "not-observed"
           ]
+        },
+        "key": {
+          "$ref": "#/$defs/observationKey"
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1
         },
         "evidence": {
           "$ref": "#/$defs/evidenceLocator"

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -42,6 +42,44 @@
         }
       }
     },
+    "constraintReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "ref"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "ref": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "expects": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "key",
+            "value"
+          ],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+            },
+            "key": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+            },
+            "value": {
+              "$ref": "#/$defs/nonEmptyText"
+            }
+          }
+        }
+      }
+    },
     "attestation": {
       "type": "object",
       "additionalProperties": false,
@@ -93,7 +131,7 @@
         "constraints": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/identifiedReference"
+            "$ref": "#/$defs/constraintReference"
           }
         },
         "references": {

--- a/schema/yarramate-reconciliation-report.schema.json
+++ b/schema/yarramate-reconciliation-report.schema.json
@@ -30,7 +30,9 @@
         "unknown": { "type": "integer", "minimum": 0 },
         "notObserved": { "type": "integer", "minimum": 0 },
         "subjectsWithoutEvidence": { "type": "integer", "minimum": 0 },
-        "staleAttestations": { "type": "integer", "minimum": 0 }
+        "staleAttestations": { "type": "integer", "minimum": 0 },
+        "expectationsCompared": { "type": "integer", "minimum": 0 },
+        "expectationsWithoutObservation": { "type": "integer", "minimum": 0 }
       }
     },
     "findings": {
@@ -40,6 +42,10 @@
     "unobservedSubjects": {
       "type": "array",
       "items": { "$ref": "#/$defs/subjectIdentity" }
+    },
+    "unobservedExpectations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/unobservedExpectation" }
     },
     "notes": {
       "type": "array",
@@ -92,6 +98,47 @@
         "name": { "type": "string", "minLength": 1 }
       }
     },
+    "observationKey": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$"
+    },
+    "declaredSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["document", "path", "pointer", "line", "column"],
+      "properties": {
+        "document": { "$ref": "#/$defs/id" },
+        "path": { "type": "string", "minLength": 1 },
+        "pointer": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "expectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "key", "expected", "observed", "declared"],
+      "properties": {
+        "provider": { "$ref": "#/$defs/id" },
+        "key": { "$ref": "#/$defs/observationKey" },
+        "expected": { "type": "string", "minLength": 1 },
+        "observed": { "type": "string", "minLength": 1 },
+        "declared": { "$ref": "#/$defs/declaredSource" }
+      }
+    },
+    "unobservedExpectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claim", "subject", "provider", "key", "expected", "declared"],
+      "properties": {
+        "claim": { "$ref": "#/$defs/qualifiedIdentity" },
+        "subject": { "$ref": "#/$defs/subjectIdentity" },
+        "provider": { "$ref": "#/$defs/id" },
+        "key": { "$ref": "#/$defs/observationKey" },
+        "expected": { "type": "string", "minLength": 1 },
+        "declared": { "$ref": "#/$defs/declaredSource" }
+      }
+    },
     "finding": {
       "oneOf": [
         { "$ref": "#/$defs/evidenceFinding" },
@@ -111,6 +158,7 @@
       "properties": {
         "target": { "$ref": "#/$defs/target" },
         "asserted": { "$ref": "#/$defs/assertedRelationship" },
+        "expectation": { "$ref": "#/$defs/expectation" },
         "result": {
           "enum": ["contradicted", "unknown", "not-observed"]
         },

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -37,6 +37,14 @@ interface IdentifiedReference {
   readonly ref: string
 }
 
+interface ConstraintReference extends IdentifiedReference {
+  readonly expects?: {
+    readonly provider: string
+    readonly key: string
+    readonly value: string
+  }
+}
+
 interface ConceptFields {
   readonly id: string
   readonly kind?: string
@@ -44,7 +52,7 @@ interface ConceptFields {
   readonly description?: string
   readonly status?: string
   readonly owner?: string
-  readonly constraints?: readonly IdentifiedReference[]
+  readonly constraints?: readonly ConstraintReference[]
   readonly references?: readonly IdentifiedReference[]
   readonly presentIn?: readonly string[]
   readonly attestations?: ReadonlyArray<{

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -36,6 +36,17 @@ const strictFindingMessage = (finding: EvidenceFinding): string => {
     finding.evidence.message === undefined
       ? finding.evidence.uri
       : `${finding.evidence.uri}: ${finding.evidence.message}`
+  // A contradicted expectation is gated exactly like any other contradicted
+  // finding (ADR 0075); only the wording differs, because both sides of the
+  // disagreement are known values worth naming.
+  if (finding.expectation !== undefined) {
+    const { key, expected, observed: observedValue } = finding.expectation
+    return (
+      `Evidence contradicts expectation "${finding.target.id}": the model expects ` +
+      `${key} to be "${expected}", but provider "${finding.provider}" observed ` +
+      `"${observedValue}" (${observed}); align the model or the evidence to pass --strict`
+    )
+  }
   const assertion =
     finding.asserted === undefined
       ? `Evidence contradicts ${finding.target.type} "${finding.target.id}"`

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -45,6 +45,7 @@ interface NativeConcept {
   readonly constraints?: ReadonlyArray<{
     readonly id: string
     readonly ref: string
+    readonly expects?: NativeExpectedObservation
   }>
   readonly references?: readonly NativeIdentifiedReference[]
   readonly presentIn?: readonly string[]
@@ -58,6 +59,12 @@ interface NativeConcept {
 interface NativeIdentifiedReference {
   readonly id: string
   readonly ref: string
+}
+
+interface NativeExpectedObservation {
+  readonly provider: string
+  readonly key: string
+  readonly value: string
 }
 
 interface NativeRelationship {
@@ -1311,6 +1318,33 @@ function compileWorkspaceResolved(
             `/concepts/${index}/constraints/${constraintIndex}/ref`,
           ),
         })
+        // An expected observation is a testable restatement of the rule the
+        // constraint names (ADR 0075). Provider and key cannot contain
+        // whitespace, so `<provider> <key> <expected value>` round-trips
+        // through the single string value graph v2 already carries; the
+        // reconciler mirrors this encoding when it parses the claim back.
+        if (constraint.expects !== undefined) {
+          claims.push({
+            id: `${subject}~expects-${constraint.id}`,
+            subject,
+            predicate: 'yarramate/constraint/expects',
+            object: {
+              value: `${constraint.expects.provider} ${constraint.expects.key} ${constraint.expects.value}`,
+            },
+            origin: 'declared',
+            source: location(
+              [
+                'concepts',
+                index,
+                'constraints',
+                constraintIndex,
+                'expects',
+                'value',
+              ],
+              `/concepts/${index}/constraints/${constraintIndex}/expects/value`,
+            ),
+          })
+        }
       }
       for (const [referenceIndex, reference] of (
         concept.references ?? []

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -30,17 +30,27 @@ export interface EvidenceLocator {
   readonly message?: string
 }
 
+// A value observation carries the key it read and the value it read there,
+// alongside the presence or absence result it always carried (ADR 0075).
+// The two are orthogonal: `result` still answers "does the target hold up",
+// while `key`/`value` report a fact a declared expectation can be compared
+// against.
+export interface EvidenceObservedValue {
+  readonly key: string
+  readonly value: string
+}
+
 export type EvidenceObservation =
-  | {
+  | ({
       readonly subject: string
       readonly result: EvidenceResult
       readonly evidence: EvidenceLocator
-    }
-  | {
+    } & Partial<EvidenceObservedValue>)
+  | ({
       readonly claim: string
       readonly result: EvidenceResult
       readonly evidence: EvidenceLocator
-    }
+    } & Partial<EvidenceObservedValue>)
 
 export interface EvidenceDocument {
   readonly format: 'yarramate/evidence/v1'
@@ -104,6 +114,9 @@ export function loadEvidence(source: WorkspaceSource): EvidenceLoadResult {
           ? { subject: observation.subject }
           : { claim: observation.claim }),
         result: observation.result,
+        ...(observation.key === undefined || observation.value === undefined
+          ? {}
+          : { key: observation.key, value: observation.value }),
         evidence: {
           uri: observation.evidence.uri,
           ...(observation.evidence.message === undefined
@@ -112,10 +125,14 @@ export function loadEvidence(source: WorkspaceSource): EvidenceLoadResult {
         },
       } as EvidenceObservation,
     }))
-    .sort((left, right) =>
-      observationTarget(left.observation).localeCompare(
-        observationTarget(right.observation),
-      ),
+    .sort(
+      (left, right) =>
+        observationTarget(left.observation).localeCompare(
+          observationTarget(right.observation),
+        ) ||
+        (left.observation.key ?? '').localeCompare(
+          right.observation.key ?? '',
+        ),
     )
   const evidence: EvidenceDocument = {
     format: value.format,
@@ -187,12 +204,20 @@ export function evaluateEvidence(
       })
     }
     const target = observationTarget(observation)
-    const targetKey = `${'subject' in observation ? 'subject' : 'claim'}:${target}`
+    // One target may carry several keyed values, because a provider reads
+    // several facts at one place; it may still state its presence result
+    // only once, and each key only once (ADR 0075).
+    const targetKey =
+      `${'subject' in observation ? 'subject' : 'claim'}:${target}` +
+      (observation.key === undefined ? '' : `#${observation.key}`)
     if (seenTargets.has(targetKey)) {
       diagnostics.push({
         severity: 'error',
         code: 'YM803',
-        message: `Evidence target "${target}" is evaluated more than once`,
+        message:
+          observation.key === undefined
+            ? `Evidence target "${target}" is evaluated more than once`
+            : `Evidence target "${target}" is evaluated more than once for key "${observation.key}"`,
         ...location,
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,18 +33,23 @@ export {
   type EvidenceLoadResult,
   type EvidenceLocator,
   type EvidenceObservation,
+  type EvidenceObservedValue,
   type EvidenceReport,
   type EvidenceResult,
   type EvidenceWorkspaceEvaluationResult,
 } from './evidence.js'
 export {
+  constraintExpectsPredicate,
   reconcileEvidenceReports,
   type AssertedRelationship,
   type AttestationStaleness,
+  type DeclaredSource,
   type EvidenceFinding,
+  type ExpectationComparison,
   type ReconciliationFinding,
   type ReconciliationReport,
   type StaleAttestationFinding,
+  type UnobservedExpectation,
 } from './reconciliation.js'
 export { deriveAttestationStaleness } from './attestation-staleness.js'
 export {

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -1,4 +1,4 @@
-import type { SemanticGraph } from './compiler.js'
+import type { GraphClaim, SemanticGraph } from './compiler.js'
 import type {
   EvidenceLocator,
   EvidenceReport,
@@ -12,12 +12,38 @@ export interface AssertedRelationship {
   readonly name?: string
 }
 
+export interface DeclaredSource {
+  readonly document: string
+  readonly path: string
+  readonly pointer: string
+  readonly line: number
+  readonly column: number
+}
+
+export interface ExpectationComparison {
+  readonly provider: string
+  readonly key: string
+  readonly expected: string
+  readonly observed: string
+  readonly declared: DeclaredSource
+}
+
+export interface UnobservedExpectation {
+  readonly claim: string
+  readonly subject: string
+  readonly provider: string
+  readonly key: string
+  readonly expected: string
+  readonly declared: DeclaredSource
+}
+
 export interface EvidenceFinding {
   readonly target: {
     readonly type: 'subject' | 'claim'
     readonly id: string
   }
   readonly asserted?: AssertedRelationship
+  readonly expectation?: ExpectationComparison
   readonly result: Exclude<EvidenceResult, 'confirmed'>
   readonly provider: string
   readonly evidenceDocument: string
@@ -64,9 +90,12 @@ export interface ReconciliationReport {
     readonly notObserved: number
     readonly subjectsWithoutEvidence: number
     readonly staleAttestations?: number
+    readonly expectationsCompared: number
+    readonly expectationsWithoutObservation: number
   }
   readonly findings: readonly ReconciliationFinding[]
   readonly unobservedSubjects?: readonly string[]
+  readonly unobservedExpectations?: readonly UnobservedExpectation[]
   readonly notes?: readonly string[]
 }
 
@@ -100,6 +129,114 @@ const assertedRelationshipsByClaim = (
     })
   }
   return asserted
+}
+
+export const constraintExpectsPredicate = 'yarramate/constraint/expects'
+
+// A finding is now a union (ADR 0074); only the evidence arm can carry an
+// expectation, so ordering reads it through one narrowing helper.
+const expectationOf = (
+  finding: ReconciliationFinding,
+): ExpectationComparison | undefined =>
+  'expectation' in finding ? finding.expectation : undefined
+
+interface DeclaredExpectation extends UnobservedExpectation {}
+
+// Mirrors the compiler encoding (ADR 0075). Provider and key admit no
+// whitespace, so the first two spaces delimit them and everything after the
+// second space is the expected value verbatim, spaces included.
+const parseExpectation = (
+  claim: GraphClaim,
+): DeclaredExpectation | undefined => {
+  if (
+    claim.predicate !== constraintExpectsPredicate ||
+    !('value' in claim.object)
+  ) {
+    return undefined
+  }
+  const match = /^(\S+) (\S+) ([\s\S]+)$/.exec(claim.object.value)
+  if (match === null) return undefined
+  return {
+    claim: claim.id,
+    subject: claim.subject,
+    provider: match[1]!,
+    key: match[2]!,
+    expected: match[3]!,
+    declared: {
+      document: claim.source.document,
+      path: claim.source.path,
+      pointer: claim.source.pointer,
+      line: claim.source.line,
+      column: claim.source.column,
+    },
+  }
+}
+
+interface ExpectationOutcome {
+  readonly findings: readonly EvidenceFinding[]
+  readonly unobserved: readonly UnobservedExpectation[]
+  readonly compared: number
+}
+
+// A declared expectation is matched to observations by provider and key. The
+// observation's own target anchors its provenance but does not narrow the
+// match: a keyed value is a fact about the project ("this deployment's region
+// is X"), and several constraints on different subjects may legitimately
+// expect the same fact. Comparison is string equality, deliberately; a
+// provider that needs richer matching normalizes before it reports.
+const compareExpectations = (
+  graph: SemanticGraph | undefined,
+  reports: readonly EvidenceReport[],
+): ExpectationOutcome => {
+  if (graph === undefined) {
+    return { findings: [], unobserved: [], compared: 0 }
+  }
+  const findings: EvidenceFinding[] = []
+  const unobserved: UnobservedExpectation[] = []
+  let compared = 0
+  for (const claim of graph.claims) {
+    const expectation = parseExpectation(claim)
+    if (expectation === undefined) continue
+    let matched = false
+    for (const report of reports) {
+      if (report.provider !== expectation.provider) continue
+      for (const observation of report.observations) {
+        if (
+          observation.key !== expectation.key ||
+          observation.value === undefined
+        ) {
+          continue
+        }
+        matched = true
+        if (observation.value === expectation.expected) continue
+        findings.push({
+          target: { type: 'claim', id: expectation.claim },
+          expectation: {
+            provider: expectation.provider,
+            key: expectation.key,
+            expected: expectation.expected,
+            observed: observation.value,
+            declared: expectation.declared,
+          },
+          result: 'contradicted',
+          provider: report.provider,
+          evidenceDocument: report.evidence,
+          evidence: observation.evidence,
+        })
+      }
+    }
+    if (!matched) unobserved.push(expectation)
+    else compared += 1
+  }
+  return {
+    findings,
+    unobserved: [...unobserved].sort(
+      (left, right) =>
+        left.claim.localeCompare(right.claim) ||
+        left.key.localeCompare(right.key),
+    ),
+    compared,
+  }
 }
 
 const unobservedCurrentConcepts = (
@@ -154,6 +291,7 @@ export function reconcileEvidenceReports(
 ): ReconciliationReport {
   const assertedByClaim = assertedRelationshipsByClaim(graph)
   const unobservedSubjects = unobservedCurrentConcepts(graph, reports)
+  const expectations = compareExpectations(graph, reports)
   const summary = {
     evidenceDocuments: reports.length,
     observations: 0,
@@ -170,6 +308,8 @@ export function reconcileEvidenceReports(
     ...(staleness === undefined
       ? {}
       : { staleAttestations: staleness.findings.length }),
+    expectationsCompared: expectations.compared,
+    expectationsWithoutObservation: expectations.unobserved.length,
   }
   const findings: ReconciliationFinding[] = [...(staleness?.findings ?? [])]
   for (const report of reports) {
@@ -200,6 +340,12 @@ export function reconcileEvidenceReports(
       })
     }
   }
+  // A disagreeing expectation is an ordinary contradicted finding: same
+  // taxonomy, same counters, same strict-check consequence (ADR 0075).
+  for (const finding of expectations.findings) {
+    summary.contradicted += 1
+    findings.push(finding)
+  }
   findings.sort((left, right) =>
     left.target.id.localeCompare(right.target.id) ||
     left.target.type.localeCompare(right.target.type) ||
@@ -209,6 +355,12 @@ export function reconcileEvidenceReports(
     ) ||
     ('attestation' in left ? left.attestation.topic : '').localeCompare(
       'attestation' in right ? right.attestation.topic : '',
+    ) ||
+    (expectationOf(left)?.key ?? '').localeCompare(
+      expectationOf(right)?.key ?? '',
+    ) ||
+    (expectationOf(left)?.observed ?? '').localeCompare(
+      expectationOf(right)?.observed ?? '',
     ),
   )
   summary.findings = findings.length
@@ -219,6 +371,9 @@ export function reconcileEvidenceReports(
     summary,
     findings,
     ...(unobservedSubjects.length === 0 ? {} : { unobservedSubjects }),
+    ...(expectations.unobserved.length === 0
+      ? {}
+      : { unobservedExpectations: expectations.unobserved }),
     ...(notes.length === 0 ? {} : { notes }),
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -543,6 +543,8 @@ describe('YarraMate CLI', () => {
         notObserved: 0,
         subjectsWithoutEvidence: 1,
         staleAttestations: 0,
+        expectationsCompared: 0,
+        expectationsWithoutObservation: 0,
       },
       unobservedSubjects: ['orders-project#order-service'],
       findings: [
@@ -599,6 +601,8 @@ describe('YarraMate CLI', () => {
         notObserved: 0,
         subjectsWithoutEvidence: 0,
         staleAttestations: 0,
+        expectationsCompared: 0,
+        expectationsWithoutObservation: 0,
       },
       findings: [
         {

--- a/test/constraint-expectations.test.ts
+++ b/test/constraint-expectations.test.ts
@@ -1,0 +1,624 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+import { compileWorkspace } from '../src/compiler.js'
+import { serializeSemanticGraph } from '../src/graph.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const schemaFor = async (name: string) =>
+  JSON.parse(
+    JSON.stringify(
+      await import(`../schema/yarramate-${name}.schema.json`, {
+        with: { type: 'json' },
+      }).then((module) => module.default),
+    ),
+  ) as object
+
+const evidenceSchema = await schemaFor('evidence')
+const reconciliationSchema = await schemaFor('reconciliation-report')
+
+const workspaceManifest =
+  'format: yarramate/workspace/v1\n' +
+  'id: shop\n' +
+  'documents:\n' +
+  '  - architecture/*.yaml\n' +
+  'profiles: []\n' +
+  'projections: []\n' +
+  'adapterMappings: []\n' +
+  'evidence:\n' +
+  '  - evidence/*.yaml\n'
+
+const architecture =
+  'format: yarramate/v1\n' +
+  'id: shop\n' +
+  'profile: yarramate/core@0.1\n' +
+  'concepts:\n' +
+  '  - id: australia-only\n' +
+  '    kind: constraint\n' +
+  '    name: Customer data remains in Australia\n' +
+  '  - id: customer-data\n' +
+  '    kind: dataObject\n' +
+  '    name: Customer data\n' +
+  '    status: current\n' +
+  '    constraints:\n' +
+  '      - id: residency\n' +
+  '        ref: australia-only\n' +
+  '        expects:\n' +
+  '          provider: terraform-scan\n' +
+  '          key: region\n' +
+  '          value: ap-southeast-2\n' +
+  'relationships: []\n'
+
+const observationEvidence = (value: string) =>
+  'format: yarramate/evidence/v1\n' +
+  'id: shop-terraform\n' +
+  'version: "1.0"\n' +
+  'provider: terraform-scan\n' +
+  'observations:\n' +
+  '  - subject: shop#customer-data\n' +
+  '    result: confirmed\n' +
+  '    key: region\n' +
+  `    value: ${value}\n` +
+  '    evidence:\n' +
+  '      uri: repo:infra/main.tf#L12\n' +
+  '      message: aws_s3_bucket.customer_data region\n'
+
+const writeWorkspace = (evidence?: string): string => {
+  const parent = mkdtempSync(join(tmpdir(), 'yarramate-expects-'))
+  mkdirSync(join(parent, 'architecture'))
+  mkdirSync(join(parent, 'evidence'))
+  writeFileSync(join(parent, 'workspace.yaml'), workspaceManifest)
+  writeFileSync(join(parent, 'architecture', 'shop.yaml'), architecture)
+  if (evidence !== undefined) {
+    writeFileSync(join(parent, 'evidence', 'terraform.yaml'), evidence)
+  }
+  return parent
+}
+
+const reconcile = (parent: string) => {
+  const result = runCli(['reconcile', 'workspace.yaml'], parent)
+  expect(result.stderr).toBe('')
+  expect(result.exitCode).toBe(0)
+  const report = JSON.parse(result.stdout)
+  expect(new Ajv2020({ strict: false }).compile(reconciliationSchema)(report))
+    .toBe(true)
+  return report as {
+    summary: Record<string, number>
+    findings: ReadonlyArray<Record<string, unknown>>
+    unobservedExpectations?: ReadonlyArray<Record<string, unknown>>
+  }
+}
+
+describe('constraints that declare an expected observation', () => {
+  it('compiles expects into one claim in the existing envelope', () => {
+    const compilation = compileWorkspace([
+      { path: 'architecture/shop.yaml', source: architecture },
+    ])
+
+    expect(compilation.ok).toBe(true)
+    if (!compilation.ok) return
+    const expectation = compilation.graph.claims.find(
+      ({ predicate }) => predicate === 'yarramate/constraint/expects',
+    )
+    expect(expectation).toEqual({
+      id: 'shop#customer-data~expects-residency',
+      subject: 'shop#customer-data',
+      predicate: 'yarramate/constraint/expects',
+      object: { value: 'terraform-scan region ap-southeast-2' },
+      origin: 'declared',
+      source: {
+        document: 'shop',
+        path: 'architecture/shop.yaml',
+        pointer: '/concepts/1/constraints/0/expects/value',
+        line: 18,
+        column: 18,
+      },
+    })
+    // The constraint reference itself is untouched by the expectation.
+    expect(
+      compilation.graph.claims.find(
+        ({ id }) => id === 'shop#customer-data~constraint-residency',
+      ),
+    ).toMatchObject({
+      predicate: 'yarramate/constraint/requires',
+      object: { ref: 'shop#australia-only' },
+    })
+  })
+
+  it('round-trips an authored expectation through apply and check', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-expects-apply-'))
+    try {
+      mkdirSync(join(parent, 'architecture'))
+      writeFileSync(
+        join(parent, 'workspace.yaml'),
+        workspaceManifest.replace('evidence:\n  - evidence/*.yaml\n', 'evidence: []\n'),
+      )
+      writeFileSync(
+        join(parent, 'architecture', 'shop.yaml'),
+        'format: yarramate/v1\n' +
+          'id: shop\n' +
+          'profile: yarramate/core@0.1\n' +
+          'concepts:\n' +
+          '  - id: australia-only\n' +
+          '    kind: constraint\n' +
+          '    name: Customer data remains in Australia\n' +
+          '  - id: customer-data\n' +
+          '    kind: dataObject\n' +
+          '    name: Customer data\n' +
+          'relationships: []\n',
+      )
+      writeFileSync(
+        join(parent, 'operations.yaml'),
+        'format: yarramate/operations/v1\n' +
+          'operations:\n' +
+          '  - op: update-concept\n' +
+          '    document: architecture/shop.yaml\n' +
+          '    concept:\n' +
+          '      id: customer-data\n' +
+          '      constraints:\n' +
+          '        - id: residency\n' +
+          '          ref: australia-only\n' +
+          '          expects:\n' +
+          '            provider: terraform-scan\n' +
+          '            key: region\n' +
+          '            value: ap-southeast-2\n',
+      )
+
+      const applied = runCli(
+        ['apply', 'operations.yaml', 'workspace.yaml'],
+        parent,
+      )
+      expect(applied.exitCode).toBe(0)
+
+      const written = readFileSync(
+        join(parent, 'architecture', 'shop.yaml'),
+        'utf8',
+      )
+      expect(written).toContain('expects:')
+      expect(written).toContain('value: ap-southeast-2')
+
+      const checked = runCli(['check', 'workspace.yaml'], parent)
+      expect(checked.exitCode).toBe(0)
+
+      const compilation = compileWorkspace([
+        { path: 'architecture/shop.yaml', source: written },
+      ])
+      expect(compilation.ok).toBe(true)
+      if (!compilation.ok) return
+      expect(
+        compilation.graph.claims.find(
+          ({ predicate }) => predicate === 'yarramate/constraint/expects',
+        )?.object,
+      ).toEqual({ value: 'terraform-scan region ap-southeast-2' })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('value observations in the evidence overlay', () => {
+  const validate = new Ajv2020({ strict: false }).compile(evidenceSchema)
+
+  it('accepts an observation carrying an observed key and value', () => {
+    expect(
+      validate({
+        format: 'yarramate/evidence/v1',
+        id: 'shop-terraform',
+        version: '1.0',
+        provider: 'terraform-scan',
+        observations: [
+          {
+            subject: 'shop#customer-data',
+            result: 'confirmed',
+            key: 'region',
+            value: 'ap-southeast-2',
+            evidence: { uri: 'repo:infra/main.tf' },
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps presence and absence observations valid without a value', () => {
+    expect(
+      validate({
+        format: 'yarramate/evidence/v1',
+        id: 'shop-terraform',
+        version: '1.0',
+        provider: 'terraform-scan',
+        observations: [
+          {
+            claim: 'shop#customer-data~constraint-residency',
+            result: 'not-observed',
+            evidence: { uri: 'repo:infra/main.tf' },
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects a key without a value and a value without a key', () => {
+    const observation = (extra: Record<string, unknown>) => ({
+      format: 'yarramate/evidence/v1',
+      id: 'shop-terraform',
+      version: '1.0',
+      provider: 'terraform-scan',
+      observations: [
+        {
+          subject: 'shop#customer-data',
+          result: 'confirmed',
+          ...extra,
+          evidence: { uri: 'repo:infra/main.tf' },
+        },
+      ],
+    })
+
+    expect(validate(observation({ key: 'region' }))).toBe(false)
+    expect(validate(observation({ value: 'ap-southeast-2' }))).toBe(false)
+  })
+
+  it('lets one provider report several keys at one target', () => {
+    const parent = writeWorkspace(
+      'format: yarramate/evidence/v1\n' +
+        'id: shop-terraform\n' +
+        'version: "1.0"\n' +
+        'provider: terraform-scan\n' +
+        'observations:\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    key: region\n' +
+        '    value: ap-southeast-2\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/main.tf\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    key: encryption\n' +
+        '    value: aes256\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/main.tf\n',
+    )
+    try {
+      expect(runCli(['check', 'workspace.yaml'], parent).exitCode).toBe(0)
+      expect(reconcile(parent).summary.observations).toBe(2)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('still rejects the same target and key evaluated twice', () => {
+    const parent = writeWorkspace(
+      'format: yarramate/evidence/v1\n' +
+        'id: shop-terraform\n' +
+        'version: "1.0"\n' +
+        'provider: terraform-scan\n' +
+        'observations:\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    key: region\n' +
+        '    value: ap-southeast-2\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/main.tf\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    key: region\n' +
+        '    value: us-east-1\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/other.tf\n',
+    )
+    try {
+      const result = runCli(['check', 'workspace.yaml'], parent)
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('YM803')
+      expect(result.stdout).toContain('for key "region"')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('reconciling declared expectations against observed values', () => {
+  it('contradicts a disagreeing value and renders both sides', () => {
+    const parent = writeWorkspace(observationEvidence('us-east-1'))
+    try {
+      const report = reconcile(parent)
+
+      expect(report.summary.contradicted).toBe(1)
+      expect(report.summary.expectationsCompared).toBe(1)
+      expect(report.summary.expectationsWithoutObservation).toBe(0)
+      expect(report.findings).toHaveLength(1)
+      expect(report.findings[0]).toEqual({
+        target: {
+          type: 'claim',
+          id: 'shop#customer-data~expects-residency',
+        },
+        expectation: {
+          provider: 'terraform-scan',
+          key: 'region',
+          expected: 'ap-southeast-2',
+          observed: 'us-east-1',
+          declared: {
+            document: 'shop',
+            path: 'architecture/shop.yaml',
+            pointer: '/concepts/1/constraints/0/expects/value',
+            line: 18,
+            column: 18,
+          },
+        },
+        result: 'contradicted',
+        provider: 'terraform-scan',
+        evidenceDocument: 'shop-terraform@1.0',
+        evidence: {
+          uri: 'repo:infra/main.tf#L12',
+          message: 'aws_s3_bucket.customer_data region',
+        },
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('confirms an agreeing value without raising a finding', () => {
+    const parent = writeWorkspace(observationEvidence('ap-southeast-2'))
+    try {
+      const report = reconcile(parent)
+
+      expect(report.findings).toEqual([])
+      expect(report.summary.contradicted).toBe(0)
+      expect(report.summary.expectationsCompared).toBe(1)
+      expect(report.summary.expectationsWithoutObservation).toBe(0)
+      expect(report.unobservedExpectations).toBeUndefined()
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports an expectation nobody observed instead of passing it', () => {
+    const parent = writeWorkspace(
+      'format: yarramate/evidence/v1\n' +
+        'id: shop-terraform\n' +
+        'version: "1.0"\n' +
+        'provider: terraform-scan\n' +
+        'observations:\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/main.tf\n',
+    )
+    try {
+      const report = reconcile(parent)
+
+      expect(report.findings).toEqual([])
+      expect(report.summary.expectationsCompared).toBe(0)
+      expect(report.summary.expectationsWithoutObservation).toBe(1)
+      expect(report.unobservedExpectations).toEqual([
+        {
+          claim: 'shop#customer-data~expects-residency',
+          subject: 'shop#customer-data',
+          provider: 'terraform-scan',
+          key: 'region',
+          expected: 'ap-southeast-2',
+          declared: {
+            document: 'shop',
+            path: 'architecture/shop.yaml',
+            pointer: '/concepts/1/constraints/0/expects/value',
+            line: 18,
+            column: 18,
+          },
+        },
+      ])
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('treats another provider reading the same key as no observation', () => {
+    const parent = writeWorkspace(
+      observationEvidence('us-east-1')
+        .replace('provider: terraform-scan', 'provider: manifest-scan')
+        .replace('id: shop-terraform', 'id: shop-manifest'),
+    )
+    try {
+      const report = reconcile(parent)
+
+      expect(report.findings).toEqual([])
+      expect(report.summary.expectationsWithoutObservation).toBe(1)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('is deterministic across repeated runs', () => {
+    const parent = writeWorkspace(observationEvidence('us-east-1'))
+    try {
+      const first = runCli(['reconcile', 'workspace.yaml'], parent)
+      const second = runCli(['reconcile', 'workspace.yaml'], parent)
+
+      expect(second.stdout).toBe(first.stdout)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('check --strict over a contradicted expectation', () => {
+  it('fails strict with a diagnostic anchored at the declared value', () => {
+    const parent = writeWorkspace(observationEvidence('us-east-1'))
+    try {
+      const strict = runCli(['check', 'workspace.yaml', '--strict'], parent)
+
+      expect(strict.exitCode).toBe(1)
+      expect(strict.stdout).toMatch(
+        /^architecture\/shop\.yaml:18:18 error YM901/,
+      )
+      expect(strict.stdout).toContain('expects region to be "ap-southeast-2"')
+      expect(strict.stdout).toContain('observed "us-east-1"')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves the default check passing, exactly like other evidence', () => {
+    const parent = writeWorkspace(observationEvidence('us-east-1'))
+    try {
+      const plain = runCli(['check', 'workspace.yaml'], parent)
+
+      expect(plain.exitCode).toBe(0)
+      expect(plain.stdout).toContain('no errors')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('passes strict when the observed value agrees', () => {
+    const parent = writeWorkspace(observationEvidence('ap-southeast-2'))
+    try {
+      const strict = runCli(['check', 'workspace.yaml', '--strict'], parent)
+
+      expect(strict.exitCode).toBe(0)
+      expect(strict.stdout).toContain('Strict: 1 observation, 0 contradicted')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('does not gate on an expectation nobody observed', () => {
+    const parent = writeWorkspace(
+      'format: yarramate/evidence/v1\n' +
+        'id: shop-terraform\n' +
+        'version: "1.0"\n' +
+        'provider: terraform-scan\n' +
+        'observations:\n' +
+        '  - subject: shop#customer-data\n' +
+        '    result: confirmed\n' +
+        '    evidence:\n' +
+        '      uri: repo:infra/main.tf\n',
+    )
+    try {
+      expect(
+        runCli(['check', 'workspace.yaml', '--strict'], parent).exitCode,
+      ).toBe(0)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('report growth composes with the stale-attestation additions', () => {
+  const validate = new Ajv2020({ strict: false }).compile(reconciliationSchema)
+
+  it('still validates a report produced before either change', () => {
+    // Neither this change nor ADR 0074 may retire an older report: every
+    // counter and array both added is optional.
+    expect(
+      validate({
+        format: 'yarramate/reconciliation-report/v1',
+        workspace: 'payments',
+        summary: {
+          evidenceDocuments: 1,
+          observations: 3,
+          confirmed: 1,
+          findings: 2,
+          contradicted: 2,
+          unknown: 0,
+          notObserved: 0,
+          subjectsWithoutEvidence: 0,
+        },
+        findings: [
+          {
+            target: { type: 'subject', id: 'payments#billing' },
+            result: 'contradicted',
+            provider: 'repository-inspection',
+            evidenceDocument: 'payments-repository@1.0',
+            evidence: { uri: 'repo:src/billing.ts' },
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('validates a report carrying both additions at once', () => {
+    expect(
+      validate({
+        format: 'yarramate/reconciliation-report/v1',
+        workspace: 'shop',
+        summary: {
+          evidenceDocuments: 1,
+          observations: 1,
+          confirmed: 1,
+          findings: 1,
+          contradicted: 0,
+          unknown: 0,
+          notObserved: 0,
+          subjectsWithoutEvidence: 0,
+          staleAttestations: 1,
+          expectationsCompared: 0,
+          expectationsWithoutObservation: 1,
+        },
+        findings: [
+          {
+            target: { type: 'subject', id: 'shop#customer-data' },
+            result: 'stale-attestation',
+            attestation: {
+              topic: 'signed-off',
+              by: 'Dana Okafor',
+              on: '2026-01-15',
+            },
+            provider: 'git',
+            evidence: { uri: 'git:9f2c1ab' },
+          },
+        ],
+        unobservedExpectations: [
+          {
+            claim: 'shop#customer-data~expects-residency',
+            subject: 'shop#customer-data',
+            provider: 'terraform-scan',
+            key: 'region',
+            expected: 'ap-southeast-2',
+            declared: {
+              document: 'shop',
+              path: 'architecture/shop.yaml',
+              pointer: '/concepts/1/constraints/0/expects/value',
+              line: 18,
+              column: 18,
+            },
+          },
+        ],
+        notes: ['No git repository was found; staleness was not assessed.'],
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('graph v2 for models that declare no expectation', () => {
+  it('serializes byte-identically to the pre-change canonical output', () => {
+    const path = 'test/fixtures/valid/governed-change.yaml'
+    const compilation = compileWorkspace([
+      { path, source: readFileSync(join(repositoryRoot, path), 'utf8') },
+    ])
+
+    expect(compilation.ok).toBe(true)
+    if (!compilation.ok) return
+    expect(serializeSemanticGraph(compilation.graph)).toBe(
+      readFileSync(
+        join(repositoryRoot, 'test/fixtures/valid/governed-change.graph.v2.json'),
+        'utf8',
+      ),
+    )
+  })
+})

--- a/test/fixtures/valid/governed-change.graph.v2.json
+++ b/test/fixtures/valid/governed-change.graph.v2.json
@@ -1,0 +1,2080 @@
+{
+  "format": "yarramate/graph/v2",
+  "profiles": [
+    "yarramate/core@0.1"
+  ],
+  "documents": [
+    {
+      "id": "governed-change",
+      "source": "test/fixtures/valid/governed-change.yaml"
+    }
+  ],
+  "subjects": [
+    {
+      "id": "governed-change#adoption-realizes-suite",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#ai-change-risk",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-artifact",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-decision",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-interface",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-record",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-requested",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#approval-supports-integrity",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#artifact-realizes-record",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#attributable-approval",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#board-member",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#conformance-suite",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#constraint-enforces-approval",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#control-plane",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#control-plane-assigned-to-edge",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#control-plane-performs-verification",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#control-plane-realizes-intent-match",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#decide-proposal",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#decision-gate-realizes-capability",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#decision-serves-process",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#drift-threatens-integrity",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#edge-composes-runtime",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#edge-runtime",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#execute-request",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#explicit-decision-gate",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#foundation",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#govern-ai-change",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#governed-publication",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#intent-digest",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#intent-match-fulfills-integrity",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#interface-serves-member",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#journey-realizes-capability",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#member-performs-process",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#no-anonymous-approval",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#owner-concerned-with-integrity",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#process-realizes-publication",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#process-writes-record",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#product-owner",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#proposal",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#proposal-drift",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#proposal-intent-match",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#publication-serves-member",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#request-triggers-verification",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#reviewed-change-integrity",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#risk-causes-drift",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#runtime-realizes-execution",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#safe-change-journey",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#structured-traceability",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#suite-realizes-traceability",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#traceability-associated-with-foundation",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#verification-reads-digest",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#verification-reads-proposal",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#verification-realizes-decision",
+      "type": "relationship"
+    },
+    {
+      "id": "governed-change#verify-intent",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#worker-runtime",
+      "type": "concept"
+    },
+    {
+      "id": "governed-change#yarramate-adoption",
+      "type": "concept"
+    }
+  ],
+  "claims": [
+    {
+      "id": "governed-change#adoption-realizes-suite",
+      "subject": "governed-change#yarramate-adoption",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#conformance-suite"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/25",
+        "line": 221,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#adoption-realizes-suite~name",
+      "subject": "governed-change#adoption-realizes-suite",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "delivers"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/25/name",
+        "line": 225,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#ai-change-risk~kind",
+      "subject": "governed-change#ai-change-risk",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#driver"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/1/kind",
+        "line": 9,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#ai-change-risk~name",
+      "subject": "governed-change#ai-change-risk",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Risk from AI-authored change"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/1/name",
+        "line": 10,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-artifact~kind",
+      "subject": "governed-change#approval-artifact",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#artifact"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/24/kind",
+        "line": 78,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-artifact~name",
+      "subject": "governed-change#approval-artifact",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Sealed approval artifact"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/24/name",
+        "line": 79,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-decision~kind",
+      "subject": "governed-change#approval-decision",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#applicationService"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/18/kind",
+        "line": 60,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-decision~name",
+      "subject": "governed-change#approval-decision",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Approval decision"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/18/name",
+        "line": 61,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-interface~kind",
+      "subject": "governed-change#approval-interface",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#applicationInterface"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/15/kind",
+        "line": 51,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-interface~name",
+      "subject": "governed-change#approval-interface",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Approval interface"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/15/name",
+        "line": 52,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-record~kind",
+      "subject": "governed-change#approval-record",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#businessObject"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/13/kind",
+        "line": 45,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-record~name",
+      "subject": "governed-change#approval-record",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Approval record"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/13/name",
+        "line": 46,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-requested~kind",
+      "subject": "governed-change#approval-requested",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#applicationEvent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/17/kind",
+        "line": 57,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-requested~name",
+      "subject": "governed-change#approval-requested",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Approval requested"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/17/name",
+        "line": 58,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#approval-supports-integrity",
+      "subject": "governed-change#attributable-approval",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#reviewed-change-integrity"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/4",
+        "line": 113,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#approval-supports-integrity~name",
+      "subject": "governed-change#approval-supports-integrity",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "supports"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/4/name",
+        "line": 117,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#artifact-realizes-record",
+      "subject": "governed-change#approval-artifact",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#approval-record"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/23",
+        "line": 211,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#artifact-realizes-record~name",
+      "subject": "governed-change#artifact-realizes-record",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "materializes"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/23/name",
+        "line": 215,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#attributable-approval~kind",
+      "subject": "governed-change#attributable-approval",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#principle"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/4/kind",
+        "line": 18,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#attributable-approval~name",
+      "subject": "governed-change#attributable-approval",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Every approval names a decision-maker"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/4/name",
+        "line": 19,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#board-member~kind",
+      "subject": "governed-change#board-member",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#businessRole"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/10/kind",
+        "line": 36,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#board-member~name",
+      "subject": "governed-change#board-member",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Board member"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/10/name",
+        "line": 37,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#conformance-suite~kind",
+      "subject": "governed-change#conformance-suite",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#deliverable"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/28/kind",
+        "line": 90,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#conformance-suite~name",
+      "subject": "governed-change#conformance-suite",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Profile conformance suite"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/28/name",
+        "line": 91,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#constraint-enforces-approval",
+      "subject": "governed-change#no-anonymous-approval",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#attributable-approval"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/5",
+        "line": 118,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#constraint-enforces-approval~name",
+      "subject": "governed-change#constraint-enforces-approval",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "enforces"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/5/name",
+        "line": 122,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#control-plane-assigned-to-edge",
+      "subject": "governed-change#control-plane",
+      "predicate": "yarramate/core@0.1#assignment",
+      "object": {
+        "ref": "governed-change#edge-runtime"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/21",
+        "line": 201,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#control-plane-assigned-to-edge~name",
+      "subject": "governed-change#control-plane-assigned-to-edge",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "deployed on"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/21/name",
+        "line": 205,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#control-plane-performs-verification",
+      "subject": "governed-change#control-plane",
+      "predicate": "yarramate/core@0.1#assignment",
+      "object": {
+        "ref": "governed-change#verify-intent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/12",
+        "line": 154,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#control-plane-performs-verification~name",
+      "subject": "governed-change#control-plane-performs-verification",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "performs"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/12/name",
+        "line": 158,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#control-plane-realizes-intent-match",
+      "subject": "governed-change#control-plane",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#proposal-intent-match"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/19",
+        "line": 191,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#control-plane-realizes-intent-match~name",
+      "subject": "governed-change#control-plane-realizes-intent-match",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "implements"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/19/name",
+        "line": 195,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#control-plane~kind",
+      "subject": "governed-change#control-plane",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#applicationComponent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/14/kind",
+        "line": 48,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#control-plane~name",
+      "subject": "governed-change#control-plane",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Control plane"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/14/name",
+        "line": 49,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#decide-proposal~kind",
+      "subject": "governed-change#decide-proposal",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#businessProcess"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/11/kind",
+        "line": 39,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#decide-proposal~name",
+      "subject": "governed-change#decide-proposal",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Decide proposal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/11/name",
+        "line": 40,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#decision-gate-realizes-capability",
+      "subject": "governed-change#explicit-decision-gate",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#govern-ai-change"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/6",
+        "line": 123,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#decision-gate-realizes-capability~name",
+      "subject": "governed-change#decision-gate-realizes-capability",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "implements strategy"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/6/name",
+        "line": 127,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#decision-serves-process",
+      "subject": "governed-change#approval-decision",
+      "predicate": "yarramate/core@0.1#serving",
+      "object": {
+        "ref": "governed-change#decide-proposal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/18",
+        "line": 186,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#decision-serves-process~name",
+      "subject": "governed-change#decision-serves-process",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "supports"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/18/name",
+        "line": 190,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#drift-threatens-integrity",
+      "subject": "governed-change#proposal-drift",
+      "predicate": "yarramate/core@0.1#influence",
+      "object": {
+        "ref": "governed-change#reviewed-change-integrity"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/2",
+        "line": 103,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#drift-threatens-integrity~name",
+      "subject": "governed-change#drift-threatens-integrity",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "threatens"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/2/name",
+        "line": 107,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#edge-composes-runtime",
+      "subject": "governed-change#edge-runtime",
+      "predicate": "yarramate/core@0.1#composition",
+      "object": {
+        "ref": "governed-change#worker-runtime"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/20",
+        "line": 196,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#edge-composes-runtime~name",
+      "subject": "governed-change#edge-composes-runtime",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "contains"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/20/name",
+        "line": 200,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#edge-runtime~kind",
+      "subject": "governed-change#edge-runtime",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#node"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/21/kind",
+        "line": 69,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#edge-runtime~name",
+      "subject": "governed-change#edge-runtime",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Edge runtime"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/21/name",
+        "line": 70,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#execute-request~kind",
+      "subject": "governed-change#execute-request",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#technologyService"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/23/kind",
+        "line": 75,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#execute-request~name",
+      "subject": "governed-change#execute-request",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Execute request"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/23/name",
+        "line": 76,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#explicit-decision-gate~kind",
+      "subject": "governed-change#explicit-decision-gate",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#courseOfAction"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/8/kind",
+        "line": 30,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#explicit-decision-gate~name",
+      "subject": "governed-change#explicit-decision-gate",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Use an explicit decision gate"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/8/name",
+        "line": 31,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#foundation~kind",
+      "subject": "governed-change#foundation",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#plateau"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/25/kind",
+        "line": 81,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#foundation~name",
+      "subject": "governed-change#foundation",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Governance foundation"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/25/name",
+        "line": 82,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#govern-ai-change~kind",
+      "subject": "governed-change#govern-ai-change",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#capability"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/7/kind",
+        "line": 27,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#govern-ai-change~name",
+      "subject": "governed-change#govern-ai-change",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Govern AI-authored change"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/7/name",
+        "line": 28,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#governed-publication~kind",
+      "subject": "governed-change#governed-publication",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#businessService"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/12/kind",
+        "line": 42,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#governed-publication~name",
+      "subject": "governed-change#governed-publication",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Governed publication"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/12/name",
+        "line": 43,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#intent-digest~kind",
+      "subject": "governed-change#intent-digest",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#dataObject"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/20/kind",
+        "line": 66,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#intent-digest~name",
+      "subject": "governed-change#intent-digest",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Intent digest"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/20/name",
+        "line": 67,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#intent-match-fulfills-integrity",
+      "subject": "governed-change#proposal-intent-match",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#reviewed-change-integrity"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/3",
+        "line": 108,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#intent-match-fulfills-integrity~name",
+      "subject": "governed-change#intent-match-fulfills-integrity",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "fulfills"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/3/name",
+        "line": 112,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#interface-serves-member",
+      "subject": "governed-change#approval-interface",
+      "predicate": "yarramate/core@0.1#serving",
+      "object": {
+        "ref": "governed-change#board-member"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/13",
+        "line": 159,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#interface-serves-member~name",
+      "subject": "governed-change#interface-serves-member",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "serves"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/13/name",
+        "line": 163,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#journey-realizes-capability",
+      "subject": "governed-change#safe-change-journey",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#govern-ai-change"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/7",
+        "line": 128,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#journey-realizes-capability~name",
+      "subject": "governed-change#journey-realizes-capability",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "delivers"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/7/name",
+        "line": 132,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#member-performs-process",
+      "subject": "governed-change#board-member",
+      "predicate": "yarramate/core@0.1#assignment",
+      "object": {
+        "ref": "governed-change#decide-proposal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/10",
+        "line": 143,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#member-performs-process~name",
+      "subject": "governed-change#member-performs-process",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "performs"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/10/name",
+        "line": 147,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#no-anonymous-approval~kind",
+      "subject": "governed-change#no-anonymous-approval",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#constraint"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/6/kind",
+        "line": 24,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#no-anonymous-approval~name",
+      "subject": "governed-change#no-anonymous-approval",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "The system cannot approve without an identity"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/6/name",
+        "line": 25,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#owner-concerned-with-integrity",
+      "subject": "governed-change#product-owner",
+      "predicate": "yarramate/core@0.1#association",
+      "object": {
+        "ref": "governed-change#reviewed-change-integrity"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/0",
+        "line": 93,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#owner-concerned-with-integrity~name",
+      "subject": "governed-change#owner-concerned-with-integrity",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "has concern"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/0/name",
+        "line": 97,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#process-realizes-publication",
+      "subject": "governed-change#decide-proposal",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#governed-publication"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/9",
+        "line": 138,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#process-realizes-publication~name",
+      "subject": "governed-change#process-realizes-publication",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "realizes"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/9/name",
+        "line": 142,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#process-writes-record",
+      "subject": "governed-change#decide-proposal",
+      "predicate": "yarramate/core@0.1#access",
+      "object": {
+        "ref": "governed-change#approval-record"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/11",
+        "line": 148,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#process-writes-record~mode",
+      "subject": "governed-change#process-writes-record",
+      "predicate": "yarramate/access/mode",
+      "object": {
+        "value": "write"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/11/mode",
+        "line": 153,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#process-writes-record~name",
+      "subject": "governed-change#process-writes-record",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "creates"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/11/name",
+        "line": 152,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#product-owner~kind",
+      "subject": "governed-change#product-owner",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#stakeholder"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/0/kind",
+        "line": 6,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#product-owner~name",
+      "subject": "governed-change#product-owner",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Product owner"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/0/name",
+        "line": 7,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal-drift~kind",
+      "subject": "governed-change#proposal-drift",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#assessment"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/2/kind",
+        "line": 12,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal-drift~name",
+      "subject": "governed-change#proposal-drift",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Intent can change after execution"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/2/name",
+        "line": 13,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal-intent-match~kind",
+      "subject": "governed-change#proposal-intent-match",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#requirement"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/5/kind",
+        "line": 21,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal-intent-match~name",
+      "subject": "governed-change#proposal-intent-match",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Proposal matches current intent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/5/name",
+        "line": 22,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal~kind",
+      "subject": "governed-change#proposal",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#dataObject"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/19/kind",
+        "line": 63,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#proposal~name",
+      "subject": "governed-change#proposal",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Proposal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/19/name",
+        "line": 64,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#publication-serves-member",
+      "subject": "governed-change#governed-publication",
+      "predicate": "yarramate/core@0.1#serving",
+      "object": {
+        "ref": "governed-change#board-member"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/8",
+        "line": 133,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#publication-serves-member~name",
+      "subject": "governed-change#publication-serves-member",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "serves"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/8/name",
+        "line": 137,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#request-triggers-verification",
+      "subject": "governed-change#approval-requested",
+      "predicate": "yarramate/core@0.1#triggering",
+      "object": {
+        "ref": "governed-change#verify-intent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/14",
+        "line": 164,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#request-triggers-verification~name",
+      "subject": "governed-change#request-triggers-verification",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "starts"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/14/name",
+        "line": 168,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#reviewed-change-integrity~kind",
+      "subject": "governed-change#reviewed-change-integrity",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#goal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/3/kind",
+        "line": 15,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#reviewed-change-integrity~name",
+      "subject": "governed-change#reviewed-change-integrity",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Published change matches reviewed change"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/3/name",
+        "line": 16,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#risk-causes-drift",
+      "subject": "governed-change#ai-change-risk",
+      "predicate": "yarramate/core@0.1#influence",
+      "object": {
+        "ref": "governed-change#proposal-drift"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/1",
+        "line": 98,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#risk-causes-drift~name",
+      "subject": "governed-change#risk-causes-drift",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "causes"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/1/name",
+        "line": 102,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#runtime-realizes-execution",
+      "subject": "governed-change#worker-runtime",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#execute-request"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/22",
+        "line": 206,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#runtime-realizes-execution~name",
+      "subject": "governed-change#runtime-realizes-execution",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "provides"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/22/name",
+        "line": 210,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#safe-change-journey~kind",
+      "subject": "governed-change#safe-change-journey",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#valueStream"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/9/kind",
+        "line": 33,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#safe-change-journey~name",
+      "subject": "governed-change#safe-change-journey",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Intent to governed publication"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/9/name",
+        "line": 34,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#structured-traceability~kind",
+      "subject": "governed-change#structured-traceability",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#gap"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/26/kind",
+        "line": 84,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#structured-traceability~name",
+      "subject": "governed-change#structured-traceability",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Structured traceability"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/26/name",
+        "line": 85,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#suite-realizes-traceability",
+      "subject": "governed-change#conformance-suite",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#structured-traceability"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/26",
+        "line": 226,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#suite-realizes-traceability~name",
+      "subject": "governed-change#suite-realizes-traceability",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "closes"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/26/name",
+        "line": 230,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#traceability-associated-with-foundation",
+      "subject": "governed-change#structured-traceability",
+      "predicate": "yarramate/core@0.1#association",
+      "object": {
+        "ref": "governed-change#foundation"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/24",
+        "line": 216,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#traceability-associated-with-foundation~name",
+      "subject": "governed-change#traceability-associated-with-foundation",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "identified in"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/24/name",
+        "line": 220,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-digest",
+      "subject": "governed-change#verify-intent",
+      "predicate": "yarramate/core@0.1#access",
+      "object": {
+        "ref": "governed-change#intent-digest"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/17",
+        "line": 180,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-digest~mode",
+      "subject": "governed-change#verification-reads-digest",
+      "predicate": "yarramate/access/mode",
+      "object": {
+        "value": "read"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/17/mode",
+        "line": 185,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-digest~name",
+      "subject": "governed-change#verification-reads-digest",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "reads"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/17/name",
+        "line": 184,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-proposal",
+      "subject": "governed-change#verify-intent",
+      "predicate": "yarramate/core@0.1#access",
+      "object": {
+        "ref": "governed-change#proposal"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/16",
+        "line": 174,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-proposal~mode",
+      "subject": "governed-change#verification-reads-proposal",
+      "predicate": "yarramate/access/mode",
+      "object": {
+        "value": "read"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/16/mode",
+        "line": 179,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verification-reads-proposal~name",
+      "subject": "governed-change#verification-reads-proposal",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "reads"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/16/name",
+        "line": 178,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verification-realizes-decision",
+      "subject": "governed-change#verify-intent",
+      "predicate": "yarramate/core@0.1#realization",
+      "object": {
+        "ref": "governed-change#approval-decision"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/15",
+        "line": 169,
+        "column": 5
+      }
+    },
+    {
+      "id": "governed-change#verification-realizes-decision~name",
+      "subject": "governed-change#verification-realizes-decision",
+      "predicate": "yarramate/relationship/name",
+      "object": {
+        "value": "realizes"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/relationships/15/name",
+        "line": 173,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verify-intent~kind",
+      "subject": "governed-change#verify-intent",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#applicationFunction"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/16/kind",
+        "line": 54,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#verify-intent~name",
+      "subject": "governed-change#verify-intent",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Verify proposal intent"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/16/name",
+        "line": 55,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#worker-runtime~kind",
+      "subject": "governed-change#worker-runtime",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#systemSoftware"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/22/kind",
+        "line": 72,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#worker-runtime~name",
+      "subject": "governed-change#worker-runtime",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Workers runtime"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/22/name",
+        "line": 73,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#yarramate-adoption~kind",
+      "subject": "governed-change#yarramate-adoption",
+      "predicate": "yarramate/concept/kind",
+      "object": {
+        "value": "yarramate/core@0.1#workPackage"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/27/kind",
+        "line": 87,
+        "column": 11
+      }
+    },
+    {
+      "id": "governed-change#yarramate-adoption~name",
+      "subject": "governed-change#yarramate-adoption",
+      "predicate": "yarramate/concept/name",
+      "object": {
+        "value": "Adopt YarraMate profile"
+      },
+      "origin": "declared",
+      "source": {
+        "document": "governed-change",
+        "path": "test/fixtures/valid/governed-change.yaml",
+        "pointer": "/concepts/27/name",
+        "line": 88,
+        "column": 11
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #149

A requirement rewritten to contradict the data-residency constraint next to it still passes `check` with exit 0, because the rule lives in an opaque description string. This does not teach the engine to read words. It lets a constraint declare the observation it expects, lets providers report the values they read, and has `reconcile` compare the two.

```yaml
constraints:
  - id: residency
    ref: australia-only
    expects:
      provider: terraform-scan
      key: region
      value: ap-southeast-2
```

```yaml
observations:
  - subject: shop#customer-data
    result: confirmed
    key: region
    value: us-east-1
    evidence:
      uri: repo:infra/main.tf#L12
```

```
architecture/shop.yaml:18:18 error YM901 Evidence contradicts expectation
"shop#customer-data~expects-residency": the model expects region to be
"ap-southeast-2", but provider "terraform-scan" observed "us-east-1"
(repo:infra/main.tf#L12); align the model or the evidence to pass --strict
```

## Design decisions

**Schema home: a structured field that compiles to a claim, not a hand-written claim predicate.** The field gives a schema something to reject at authoring time, and the compiler is where every stable claim identity in this codebase is minted. It emits `<subject>~expects-<id>` with predicate `yarramate/constraint/expects`, alongside the unchanged `yarramate/constraint/requires` claim.

**The claim value encodes three parts in one string: `<provider> <key> <expected value>`.** Graph v2 carries exactly one string value or one ref per claim, so a structured object would be a graph v3. Provider and key admit no whitespace, so the first two spaces delimit them and the remainder is the expected value verbatim. This mirrors the attestation encoding (`<by> <on>`) that already exists. No new field, no structural change, and a consumer that ignores the predicate stays correct. A byte-identity test on an existing fixture proves canonical serialization is unchanged for models without `expects`.

**`key`/`value` on observations are orthogonal to `result`, not a replacement for it.** The result still answers whether the target holds up at all; the keyed value reports a fact. Both fields are optional and required only in each other's presence, so every existing overlay stays valid.

**`YM803` now keys on target plus observed key.** A provider that reads three facts in one file must be able to report three keyed values there. A target still carries at most one presence result and at most one observation per key. This is the one behavioural concession in the change, and it only loosens a rule that would otherwise block legitimate authoring.

**Matching is by provider and key; the observation's target does not narrow it.** A keyed value is a fact about the project ("this deployment's region is X"), not about one subject, and several constraints on different subjects may legitimately expect the same fact. The target still anchors provenance in the finding. Requiring providers to enumerate every subject a keyed fact bears on would make a config reader model-aware for no gain in truth. This is the judgment call most open to challenge, and the ADR states it plainly.

**String equality only.** No case folding, numeric coercion, globbing, or regular expressions. A provider needing any of that normalizes before it reports. The ADR rejects richer comparison explicitly: the moment Core acquires a matching language it has acquired a policy engine, which ADR 0016 exists to keep out.

**A disagreement is an ordinary contradicted finding** with an additive optional `expectation` object rendering both sides: declared provider, key, and expected value with the source location where it was authored, next to the observed value with its provider, evidence document, and locator. Same move as ADR 0046, for a value rather than an endpoint pair, and equally advisory.

**`check --strict` gains no gate semantics.** A contradicted expectation already fails the existing gate as a contradicted finding; only the diagnostic wording is specialized, because both sides of this disagreement are known values worth naming. It anchors at the authored expected value, so the failure is repairable where it is reported.

**An expectation nobody observed is not a finding.** Findings carry a provider and a locator, and here no provider produced anything, so putting the gap in `findings` would fabricate an accusation. It goes where ADR 0049 put the same problem: a top-level `unobservedExpectations` array plus `expectationsCompared` and `expectationsWithoutObservation` counters. Both counters are always emitted but optional in the schema, so reports produced before this change still validate. An unobserved expectation does not fail `--strict`: absence of evidence is not contradiction, and gating on it would punish authors for declaring expectations at all.

## ADR

`docs/adr/0075-constraints-carry-expected-observations.md`. Four sibling agents are running in parallel worktrees with numbers assigned by the maintainer (0071 export-rtm, 0072 design-facilitate, 0073 non-goals, 0074 attestation-staleness); this PR took **0075**.

## Tests

17 new tests in `test/constraint-expectations.test.ts`: authoring round-trip through `apply` and compile, value-observation schema validity (accepted, rejected without its pair, several keys at one target, duplicate key still rejected), contradiction with both sides rendered and schema-valid, agreement confirming with no finding, missing observation reported honestly, another provider reading the same key treated as no observation, determinism across runs, strict-mode failure and pass, strict not gating on unobserved expectations, and graph-v2 byte-identity on `governed-change` for models without `expects`.

`rm -rf dist && pnpm verify` clean: **362 tests** (345 before, 17 new) across 35 files, self-check over the repository's own 199-concept model, and LikeC4 validation.

## Docs

`docs/EVIDENCE.md` (value-observation provider contract, declared-expectation reconciliation, strict interaction, boundary), `docs/NATIVE-DOCUMENT.md` (authoring surface), `docs/SEMANTIC-GRAPH.md` (predicate table and additivity note), `docs/GLOSSARY.md` (expected observation, value observation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
