### PR TITLE
A review rubric for model and profile growth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,16 @@ Do not reproduce restricted definitions, matrices, diagrams, or derivation
 rules from external standards. Compatibility work must establish its own
 licensing and provenance boundary first.
 
+## Reviewing model growth
+
+`check` decides correctness, `reconcile` reports drift, and `ask --open`
+reports which questions are still open. None of them decides whether a new
+distinction is worth the contract surface it costs. `docs/MODEL-REVIEW.md`
+carries the questions a reviewer puts to the author of a new concept kind,
+profile kind, or catalogue question. It is judgment support rather than a
+gate, and it applies to a proposal that widens the vocabulary here as much as
+to a model in a consuming repository.
+
 ## Pull requests
 
 All repository changes are contributed through pull requests. Do not push

--- a/docs/MODEL-REVIEW.md
+++ b/docs/MODEL-REVIEW.md
@@ -1,0 +1,188 @@
+# Reviewing model and profile growth
+
+Three deterministic gates run against a YarraMate model, and none of them asks
+whether a distinction earns its place. `check` decides correctness.
+`reconcile` reports drift between declared intent and observed evidence.
+`ask --open` reports which catalogue questions are still unanswered. A model
+can accumulate concepts nobody needs and pass all three.
+
+What remains is review at the Git boundary, where a person reads a diff and
+decides. This document is written for that reader. It is a set of questions to
+put to an author, not a rule set for an author to satisfy in advance.
+
+## Why growth needs a brake
+
+The spec-build benchmark measured the problem. Three designer runs were given
+the same specification and declared 47, 44, and 27 planned concepts
+(`research/context-benchmark/spec-build/RESULTS-2026-07-31.md`). Nothing in
+the prompt or the question catalogue constrained granularity, and the results
+record the consequence plainly: the model does not currently make two
+designers converge on how finely to model. Every one of those models passed
+its checks. Correctness was never the variable.
+
+That is the best available demonstration that unconstrained modelling varies
+widely, and the variance is in judgment rather than in tooling.
+
+Prior art names the discipline. Gruber's ontology design criteria are clarity,
+coherence, extendibility, minimal encoding bias, and minimal ontological
+commitment. The last is the relevant brake: commit to as little as possible
+while still supporting the intended sharing. Make the smallest set of claims
+that lets the parties using the model do their work, and leave the rest free
+for them to decide. Applied here, it argues against modelling everything that
+can be modelled and for modelling what changes a decision.
+
+## What this document is not
+
+It is not mechanizable, and no part of it should become a gate.
+
+A concept count is not a quality signal. The 27-concept benchmark model is not
+better than the 47-concept one because it is smaller, and nobody has
+established which of the three was right. Any threshold on size would be
+satisfied by collapsing two honest subjects into one dishonest one, which
+makes the model worse while making the number better. These questions need a
+reader who understands the domain, which is why this is a document and not a
+diagnostic.
+
+Failing one of these questions is not a defect. `check` decides defects. These
+questions decide whether a reviewer should ask for the rationale before a
+distinction becomes vocabulary that every later reader inherits.
+
+## Admission tests for a subject
+
+### 1. What decision does this distinction change?
+
+The question catalogue already holds itself to this bar. Every catalogue
+question carries a materiality statement, defined as the decision its answer
+changes, and those statements are concrete about consequence:
+
+> The hosting boundary decides latency, failure domain, scaling model, and
+> data residency; a component with no declared runtime is deployed by whoever
+> gets there first.
+
+Ask the author for a materiality statement of that shape for the new subject.
+Someone acts differently once the distinction exists, and a real answer names
+who and how. An answer that describes what the subject is, rather than what it
+decides, has not answered the question.
+
+Where a real answer exists it belongs in the model, as the subject's
+`description`, which compiles into a claim that evidence can later confirm or
+contradict. A rationale that lives only in a pull-request comment is not
+reviewable a year later.
+
+### 2. Would two authors classify the same instance the same way?
+
+Take an instance that sits near the new boundary, ask the author where it
+goes, then ask what rule put it there.
+
+If the rule needs the author present to adjudicate, the model carries a
+private convention rather than shared vocabulary, and the next author will
+draw the boundary somewhere else. This is Gruber's clarity and coherence
+criteria in review form: a definition should be independent of the
+conversation that produced it, and a reader who was not in that conversation
+should reach the same answer.
+
+The benchmark's granularity spread is what this failure looks like at scale.
+Three competent designers, one specification, no shared rule for how finely to
+cut.
+
+### 3. Can you point at an instance today?
+
+A subject introduced for a case that has not arrived commits every later
+reader to a distinction no instance has tested.
+
+The asymmetry favours waiting. Adding later is cheap, because `apply` lands
+additions as one atomic validated batch. Removing later is not, because by
+then the distinction has been cited by relationships, projections, evidence,
+and adapter mappings, and every referring input has to be found and updated
+before the identity can change.
+
+Anticipatory structure is not always wrong. A declared target state is
+deliberately about what does not exist yet, and `presentIn: [target]` is the
+honest way to say so. The question is whether the author can name the instance
+or the planning state. Neither answer is the problem.
+
+### 4. Is the distinction already carried by a field?
+
+Native documents carry `status`, `owner`, `constraints`, `references`,
+`description`, `mode` on access, and `content` on flow. A distinction that one
+of those already expresses does not need a new subject or a new kind.
+
+ADR 0073 is this test applied and recorded. A `declined` lifecycle value was
+proposed for non-goals and rejected, because it was contract surface across
+the schema, the projection vocabulary, the evaluator, and every adapter,
+bought only to distinguish "retired at birth" from "retired later", a
+distinction the description already carries in prose. The convention was kept
+and the vocabulary was not widened.
+
+## Additional tests for a profile kind
+
+A profile kind is heavier than a subject. It enters the vocabulary that every
+document under that profile may use, it is inherited by profiles extending
+that one, and its globally qualified identity appears in the compiled graph,
+so it reaches every consumer of the interchange. A subject is one claim among
+many. A kind is contract.
+
+### 5. What breaks if authors use the core parent instead?
+
+Every new kind declares a globally qualified semantic parent, inherits its
+aspect, inherits its endpoint constraints, and may only narrow them, never
+broaden them. So the question has a small number of good answers, and a
+reviewer should expect one of them:
+
+- the kind narrows an endpoint constraint through `sourceAspects` or
+  `targetAspects`, and the narrowing is one the author wants the compiler to
+  enforce on every future document;
+- a projection selects on the kind, and selecting the parent with
+  `kindMatching: descendants` would select too much;
+- an adapter renders it differently, through a kind mapping.
+
+"The name reads better" is not one of them. `name` and `description` on the
+concept already carry the label, they compile into claims, and they cost no
+contract surface.
+
+This repository's own profile is a fair standard to hold authors to.
+`.yarramate/profiles/yarramate-development.yaml` declares three kinds, two
+concept kinds and one relationship kind, for a self-model of roughly 470
+authored subjects.
+
+### 6. Do the inherited questions still make sense?
+
+Catalogue subject selectors match profile-derived kinds through their parents
+by default, so a new kind silently inherits every question written against its
+parent. That is usually right and occasionally not.
+
+Ask whether the inherited questions read sensibly for the new kind. The
+catalogue records one place where the answer was no: `component-unhosted`
+matches with `kindMatching: exact` by intent, because profile-derived module
+kinds inherit their deployable parent's hosting rather than answering
+separately. A kind whose inherited questions are mostly nonsense is evidence
+that the declared parent is wrong, not that the questions are.
+
+## Using this in review
+
+Ask the questions in the pull request. Record the answers where they will be
+read again: `description` on the subject for rationale about that subject, an
+identified `references` entry when the rationale depends on another subject,
+and an ADR when the decision governs future modelling rather than this model.
+
+An author may reasonably run the same questions against their own proposal
+before opening the pull request. That does not change what the document is.
+The questions are worth asking because someone independent asks them, and a
+self-review that answers all six is a well-prepared proposal, not an approved
+one.
+
+Approve growth that carries its rationale. The deliverable of this review is
+not a smaller model. It is a model whose distinctions someone can still defend
+on a day when the author is unavailable.
+
+## Boundaries
+
+- These questions govern additions to declared intent. Evidence is not
+  governed by them: an observation records what was seen and commits the model
+  to nothing.
+- Nothing here overrides `check`. A model that fails these questions and
+  passes `check` is correct, and possibly overgrown. A model that passes these
+  questions and fails `check` is broken.
+- There is no score, no threshold, and no command. A future proposal to
+  mechanize any part of this should carry evidence that the measurement means
+  something, which the benchmark does not currently provide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Case study: the model is the handover](CASE-STUDY-CROSS-HARNESS.md)
 - [Product contract](PRODUCT-CONTRACT.md)
 - [Product journeys](PRODUCT-JOURNEYS.md)
+- [Reviewing model and profile growth](MODEL-REVIEW.md)
 - [Consuming YarraMate](CONSUMING-YARRAMATE.md)
 - [Glossary](GLOSSARY.md)
 - [Roadmap](ROADMAP.md)


### PR DESCRIPTION
Closes #164

Nothing today governs whether a distinction is worth adding. The catalogue asks about coverage, `check` enforces correctness, `reconcile` reports drift, and a model can accumulate concepts nobody needs while every gate stays green. This adds the missing brake as a document for the reader at the Git boundary.

`docs/MODEL-REVIEW.md` carries six admission tests, phrased as questions a reviewer puts to an author rather than rules an author satisfies in advance:

1. What decision does this distinction change?
2. Would two authors classify the same instance the same way?
3. Can you point at an instance today?
4. Is the distinction already carried by a field?
5. (profile kinds) What breaks if authors use the core parent instead?
6. (profile kinds) Do the inherited catalogue questions still make sense?

## Decisions

**The vocabulary is the catalogue's own.** Test 1 asks for a materiality statement, which `docs/INTERROGATION.md` already defines as "the decision its answer changes". The document quotes the `component-unhosted` materiality verbatim as the shape of a good answer. The bar for admitting a subject is now the same bar the catalogue applies to itself, which is the consistency the issue asked for.

**Two tests beyond the four in the issue.** Test 4 (is a field already carrying this?) is not invented: ADR 0073 is that test applied and recorded, where a `declined` lifecycle value was rejected as contract surface bought to express what a description already carries. Test 6 exists because catalogue selectors match profile-derived kinds through their parents by default, so a new kind silently inherits questions, and `component-unhosted` is the recorded case where that inheritance was wrong and `kindMatching: exact` was chosen instead.

**The benchmark is the motivating evidence, and it is used carefully.** The document cites the 47/44/27 finding from `docs/research/context-benchmark/spec-build/RESULTS-2026-07-31.md` and immediately adds the part that matters: all three models passed their checks, so correctness was never the variable. It does not claim the 27-concept model was better.

**Nothing here is mechanizable, and the document says so twice.** A concept count is not a quality signal, and any threshold on size would be satisfied by collapsing two honest subjects into one dishonest one, which improves the number and worsens the model. The Boundaries section states that a future proposal to mechanize any of this should carry evidence that the measurement means something, which the benchmark does not currently provide.

**No ADR.** `CONTRIBUTING.md` requires an accepted ADR for a change to native meaning, identity, graph interchange, validation behaviour, or a stable CLI contract. A reviewer-facing document changes none of them: no schema, no diagnostic, no command, no vocabulary. ADR 0080 remains unclaimed. If a later change makes any of this a gate, that gate is the decision worth recording, not the prose.

**Not linked from the shipped skill.** `docs/` is not in the package `files` list, so a relative link from `skills/yarramate-architecture/**` would dangle for anyone consuming YarraMate from npm. The rubric is also aimed at the reviewer, not the authoring agent, so it would cost skill tokens for the wrong audience.

## Follow-up cross-links deferred

Both are files owned by sibling agents on concurrent branches, so they are not edited here:

- `docs/PROFILES.md` should link to `docs/MODEL-REVIEW.md` from its section on declaring new kinds. Tests 5 and 6 are written specifically against the inheritance rules that page documents.
- `docs/NATIVE-DOCUMENT.md` should link to it from the authoring guidance, since tests 1 to 4 govern what gets authored there.

## Verification

`rm -rf dist && pnpm verify` passes clean: 37 test files, 394 tests, plus the self-model check (199 concepts, 268 relationships) and LikeC4 validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
