### PR TITLE
Rigidity meta-properties: a rigid kind may not specialize an anti-rigid one

### DIFF
--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -286,7 +286,7 @@ and one-based line and column.
 | `YM1xx` | YAML parsing | `YM101` malformed YAML |
 | `YM2xx` | Document structure | `YM201` JSON Schema violation |
 | `YM3xx` | Identity and references | `YM301` duplicate local ID; `YM302` unresolved concept reference; `YM303` duplicate document ID; `YM304` unresolved owner; `YM305` unresolved constraint; `YM306` duplicate constraint ID; `YM307` unresolved architecture state; `YM308` unresolved subject reference; `YM309` duplicate reference ID |
-| `YM4xx` | Profile conformance | `YM401` unknown concept kind; `YM402` unknown relationship kind; `YM403` unavailable profile; `YM404` incompatible endpoint; `YM405` misplaced controlled field; `YM406` unavailable parent profile; `YM407`/`YM408` unavailable semantic parent; `YM409`/`YM410` inherited-name collision; `YM411` duplicate profile; `YM412` broadened constraint |
+| `YM4xx` | Profile conformance | `YM401` unknown concept kind; `YM402` unknown relationship kind; `YM403` unavailable profile; `YM404` incompatible endpoint; `YM405` misplaced controlled field; `YM406` unavailable parent profile; `YM407`/`YM408` unavailable semantic parent; `YM409`/`YM410` inherited-name collision; `YM411` duplicate profile; `YM412` broadened constraint; `YM413` rigid kind specializing an anti-rigid one |
 | `YM5xx` | Claim consistency | `YM501` competing whole-part claims; `YM502` cyclic state ordering; `YM503` relationship present without an endpoint |
 | `YM6xx` | Adapter mapping integrity | `YM601` unknown native subject; `YM602` subject type mismatch; `YM603` duplicate native mapping; `YM604` duplicate external mapping; `YM605` duplicate versioned mapping |
 | `YM7xx` | Workspace resolution | `YM701` unsafe pattern; `YM702` unmatched pattern; `YM703` cross-category file |

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -33,6 +33,50 @@ endpoint constraints and may narrow them with `sourceAspects` or
 Local kind names may not shadow inherited names. Profiles may extend other
 explicit profiles, and resolution is independent of CLI/source order.
 
+## Rigidity
+
+A concept kind may declare one optional meta-property, `rigidity`, borrowed
+from OntoClean:
+
+```yaml
+conceptKinds:
+  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+    rigidity: rigid
+```
+
+A kind is `rigid` when being of that kind is essential to every instance: a
+thing IS an application component, and it stops existing before it stops being
+one. A kind is `anti-rigid` when it is essential to no instance: a role is
+played contingently, and the actor playing it survives giving it up. Most
+kinds are neither, so the annotation is optional and an unannotated kind
+constrains nothing in either direction.
+
+One rule follows mechanically, and it is the only one the compiler checks:
+
+> **A rigid kind may not specialize an anti-rigid one.**
+
+Person is not a subclass of Student. If everything of kind X is essentially X,
+and nothing of kind Y is essentially Y, then X cannot be a Y. Violating it is
+`YM413`, a compile error, and the whole lineage is checked rather than the
+immediate parent, because specialization is transitive and an unannotated kind
+in between does not launder the violation.
+
+The core profile annotates five of its own kinds, all `anti-rigid`, and only
+where the ArchiMate-inspired semantics make the answer plain:
+`stakeholder`, `businessRole`, `businessCollaboration`,
+`applicationCollaboration`, and `technologyCollaboration`. Nothing is
+essentially a role or a collaboration; both are held for as long as they are
+held. Core declares no `rigid` kinds: core kinds are lineage roots, so the
+annotation could never fire on them, and each one would be a fresh semantic
+claim about a stable profile bought for nothing.
+
+Rigidity is checked at profile-resolution time and then discarded. It reaches
+no graph, no claim, and no projection, so annotating a kind changes no
+compiled output. Identity and unity, OntoClean's other meta-properties, are
+out of scope: neither yields a check this cheap (ADR 0078).
+
 ## Authoring and compiled identity
 
 A document selects one profile and uses its local names:

--- a/docs/adr/0078-a-rigid-kind-may-not-specialize-an-anti-rigid-one.md
+++ b/docs/adr/0078-a-rigid-kind-may-not-specialize-an-anti-rigid-one.md
@@ -1,0 +1,157 @@
+# A rigid kind may not specialize an anti-rigid one
+
+Status: accepted
+
+The core profile has carried the actor/role distinction since ADR 0001:
+`businessActor`, `businessRole`, and `businessCollaboration` are all separate
+kinds. Nothing enforced the discipline behind them. A profile extension could
+declare a team, a service, or a squad and parent it under `businessRole` with
+no objection, and the resulting subjects then acquired owners, lifecycle
+status, evidence, and attestations that belong to things rather than to
+responsibilities. Every existing gate passed, because every existing gate
+checks aspects, endpoints, references, and completeness, and none of them
+looks at what a kind is for (#161).
+
+Decided: a profile concept kind may declare one optional meta-property,
+`rigidity`, with values `rigid` and `anti-rigid`, and the compiler enforces
+the single rule that follows from it.
+
+```yaml
+conceptKinds:
+  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+    rigidity: rigid
+```
+
+The prior art is OntoClean (Guarino and Welty), which annotates properties
+with meta-properties and derives mechanical constraints from them. A property
+is rigid when it is essential to every instance and anti-rigid when it is
+essential to none, and an anti-rigid property cannot subsume a rigid one:
+Person is not a subclass of Student. The rule needs no world knowledge and no
+prose. It compares two declared annotations across a lineage the compiler
+already resolves.
+
+## It is an error, not a hygiene question
+
+The issue left this open, noting that YM404 aspect rules are errors and that
+consistency argues for the same treatment. It does, and three further reasons
+agree.
+
+The diagnostic is about a profile document, and profile resolution has no
+advisory severity to join. YM406 through YM412 are all errors, because a
+profile that does not resolve cannot be used to compile anything. Inventing a
+first advisory severity for this one rule would make it the odd case in its
+own family, and it would put a profile-authoring defect in the same channel as
+model-completeness questions, which are a different thing addressed to a
+different person.
+
+Hygiene exists in this codebase for questions the engine cannot decide. The
+enrichment catalogue asks about missing linkage and unstated ownership because
+absence is not error, and ADR 0054 keeps the engine out of prose entirely for
+the same reason. This rule is decidable: two annotations, one lineage, no
+judgment and no missing information. A check that can be right is not a matter
+of taste.
+
+Most of all, the error is opt-in and self-inflicted. It fires only when an
+author has written `rigidity: rigid` on a kind whose ancestor someone has
+written `rigidity: anti-rigid` on, which is a contradiction in declared terms:
+this kind is one nothing can stop being, and it is a kind of thing nothing
+essentially is. Nobody who has not asked for the check can be stopped by it,
+and the repair is always available in the author's own file, either by
+reparenting or by removing an annotation they chose to add. That is the safest
+possible profile for a hard failure, and it is why the honest objection to
+making a research method a build gate does not land here: OntoClean is not
+being imposed, it is being offered.
+
+## The whole lineage is checked, not the parent
+
+Specialization is transitive, so subsumption is too, and an unannotated kind
+between a rigid child and an anti-rigid ancestor does not launder anything.
+The compiler walks the resolved parent lineage, which it already computes for
+descendant kind matching, and reports the first anti-rigid ancestor it finds
+by qualified identity, so the message names the kind that actually conflicts
+rather than the intermediate one that does not.
+
+An unannotated kind constrains nothing in either direction. It is not treated
+as rigid by default, and it does not inherit anti-rigidity from a parent as an
+effective value. Both would turn an opt-in annotation into a silent global
+assertion about the entire vocabulary, which is exactly the change that would
+have deserved a version bump.
+
+## Core is annotated, on one side only, and does not bump
+
+Annotating core was the other open question, and the case for doing it now is
+that the alternative is a feature that cannot fire. Almost every extension
+kind roots in core, so an unannotated core leaves the rule reachable only
+inside a single profile that annotates both sides itself. Shipping the
+machinery without the annotations would be shipping a rule that catches the
+mistake nobody makes and misses the one the issue was filed about.
+
+Five core kinds are annotated, all `anti-rigid`, and only where the
+ArchiMate-inspired semantics answer the question without interpretation.
+`businessRole` is a responsibility an actor is assigned and can be released
+from, which is the entire reason it is a separate kind from `businessActor`.
+`businessCollaboration`, `applicationCollaboration`, and
+`technologyCollaboration` are aggregates formed to perform collective
+behavior, and they stop existing when the collaborating stops.
+`stakeholder` is defined as the role of an individual, team, or organization
+with respect to one architecture, so it is a role by its own definition. Every
+other core kind is left unannotated, including ones that feel rigid, because
+"feels rigid" is the standard this change exists to avoid.
+
+Core declares no `rigid` kinds at all, which is a deliberate asymmetry. Core
+kinds are lineage roots, so no core kind can have an anti-rigid ancestor and
+no `rigid` annotation on one could ever fire. Each would be a new semantic
+claim about a stable vocabulary bought for exactly nothing.
+
+The core profile identity stays `yarramate/core@0.1`. A bump is the larger
+break by a wide margin: kind identity is written into every graph claim and
+every projection selector in every existing workspace, so `0.2` would rewrite
+all of them to label a change that rejects no input anyone can currently
+author. The compatibility argument is checkable rather than asserted. The only
+new rejection requires a `rigidity: rigid` annotation, the field did not exist
+before this change, so no profile that validates today can trigger it, and the
+annotation reaches no graph, no claim, and no projection.
+
+It should still be said plainly that annotating core is an addition to what
+core says about core vocabulary, which is not a conservative extension in the
+sense ADR 0079 states. That is precisely why it is done in core rather than
+smuggled in through a profile: a change to core is allowed to change core, in
+the open, with a compatibility argument attached.
+
+## What is deliberately left out
+
+Identity and unity, OntoClean's other meta-properties, are out of scope. The
+issue leaned that way and it is right: rigidity is the one with a mechanical,
+checkable consequence, and the others would buy annotation burden and a
+vocabulary discussion with no diagnostic at the end of it.
+
+Relationship kinds take no annotation, and the schema rejects one. Rigidity is
+a claim about what instances essentially are; endpoint aspect constraints
+already govern what a relationship kind may connect.
+
+Model-level `specialization` relationships between subjects are not checked,
+and this is the interesting omission. The rule would arguably apply, since a
+specialization relationship is a subsumption claim. It is left out because it
+would break the opt-in property that justifies making this an error at all. A
+model author would be stopped by an annotation written by whoever wrote their
+profile, in a file they may not own, with the repair somewhere other than
+where the error is reported, which ADR 0039 exists to prevent. The profile
+layer keeps the error in front of the person who asked for it. If the
+annotation earns adoption, the model-level rule can be revisited on its own
+merits.
+
+## Consequences
+
+The profile layer gains its first meta-property and its first diagnostic that
+is about meaning rather than structure, at a cost of one optional enum field
+and one lineage walk during profile resolution. Nothing in the model-authoring
+surface changes, no existing profile or document can newly fail, and no
+compiled output moves.
+
+What the project gains is a place to put a distinction it already made in its
+vocabulary and could not previously defend. What it takes on is the obligation
+to answer "why is this kind not annotated" for the rest of core, and the
+correct answer, for now, is that an unannotated kind asserts nothing and that
+silence is cheaper than a wrong annotation.

--- a/schema/yarramate-profile.schema.json
+++ b/schema/yarramate-profile.schema.json
@@ -59,6 +59,10 @@
         "composite"
       ]
     },
+    "rigidity": {
+      "description": "OntoClean rigidity. Optional: an unannotated kind constrains nothing.",
+      "enum": ["rigid", "anti-rigid"]
+    },
     "conceptKind": {
       "type": "object",
       "additionalProperties": false,
@@ -73,6 +77,9 @@
         },
         "parent": {
           "$ref": "#/$defs/qualifiedKindId"
+        },
+        "rigidity": {
+          "$ref": "#/$defs/rigidity"
         }
       }
     },

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,6 +3,7 @@ import { LineCounter, parseDocument } from 'yaml'
 import {
   conceptKinds,
   relationshipPolicies,
+  type Rigidity,
 } from './profile.js'
 import {
   closestCandidate,
@@ -104,6 +105,10 @@ interface NativeProfileKind {
   readonly parent: string
 }
 
+interface NativeProfileConceptKind extends NativeProfileKind {
+  readonly rigidity?: Rigidity
+}
+
 interface NativeProfileRelationshipKind extends NativeProfileKind {
   readonly sourceAspects?: readonly (typeof conceptKinds)[number]['aspect'][]
   readonly targetAspects?: readonly (typeof conceptKinds)[number]['aspect'][]
@@ -114,7 +119,7 @@ interface NativeProfile {
   readonly id: string
   readonly version: string
   readonly extends: string
-  readonly conceptKinds: readonly NativeProfileKind[]
+  readonly conceptKinds: readonly NativeProfileConceptKind[]
   readonly relationshipKinds: readonly NativeProfileRelationshipKind[]
 }
 
@@ -122,6 +127,7 @@ interface ResolvedConceptKind {
   readonly identity: string
   readonly aspect: (typeof conceptKinds)[number]['aspect']
   readonly lineage: readonly string[]
+  readonly rigidity?: Rigidity
 }
 
 interface ResolvedRelationshipKind {
@@ -259,6 +265,7 @@ function compileWorkspaceResolved(
       identity: `${coreProfile}#${kind.id}`,
       aspect: kind.aspect,
       lineage: [`${coreProfile}#${kind.id}`],
+      ...(kind.rigidity === undefined ? {} : { rigidity: kind.rigidity }),
     } satisfies ResolvedConceptKind
     coreConceptKinds.set(kind.id, resolved)
     conceptKindByIdentity.set(resolved.identity, resolved)
@@ -414,10 +421,34 @@ function compileWorkspaceResolved(
           })
           continue
         }
+        // OntoClean: an anti-rigid kind cannot subsume a rigid one. The
+        // parent's lineage is the full ancestor chain, and subsumption is
+        // transitive, so an unannotated kind sitting in between does not
+        // launder the violation (ADR 0078).
+        if (kind.rigidity === 'rigid') {
+          const antiRigidAncestor = parent.lineage.find(
+            (ancestor) =>
+              conceptKindByIdentity.get(ancestor)?.rigidity === 'anti-rigid',
+          )
+          if (antiRigidAncestor !== undefined) {
+            const position = positionFor(['conceptKinds', index, 'rigidity'])
+            profileDiagnostics.push({
+              severity: 'error',
+              code: 'YM413',
+              message: `Rigid concept kind "${kind.id}" specializes anti-rigid kind "${antiRigidAncestor}"; nothing is essentially of an anti-rigid kind, so parent "${kind.id}" under an entity kind, or drop its "rigid" annotation`,
+              path: input.path,
+              pointer: `/conceptKinds/${index}/rigidity`,
+              line: position.line,
+              column: position.col,
+            })
+            continue
+          }
+        }
         const resolved = {
           identity: `${identity}#${kind.id}`,
           aspect: parent.aspect,
           lineage: [...parent.lineage, `${identity}#${kind.id}`],
+          ...(kind.rigidity === undefined ? {} : { rigidity: kind.rigidity }),
         } satisfies ResolvedConceptKind
         resolvedConceptKinds.set(kind.id, resolved)
         conceptKindByIdentity.set(resolved.identity, resolved)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -20,11 +20,28 @@ export const aspects = [
 export type Layer = (typeof layers)[number]
 export type Aspect = (typeof aspects)[number]
 
+/**
+ * OntoClean rigidity, the one meta-property with a mechanical consequence.
+ * A kind is `rigid` when being of that kind is essential to every instance
+ * (a thing IS an application component); `anti-rigid` when it is essential
+ * to none (a role is played contingently and can be given up). Identity and
+ * unity are deliberately out of scope: neither yields a check (ADR 0078).
+ */
+export const rigidities = ['rigid', 'anti-rigid'] as const
+
+export type Rigidity = (typeof rigidities)[number]
+
 export interface ConceptKind {
   readonly id: string
   readonly name: string
   readonly layer: Layer
   readonly aspect: Aspect
+  /**
+   * Optional and opt-in. An unannotated kind constrains nothing, in either
+   * direction. Annotated, it feeds one rule: a rigid kind may not specialize
+   * an anti-rigid one, anywhere in its lineage (YM413).
+   */
+  readonly rigidity?: Rigidity
   /**
    * A compatibility pointer, not a claim of standards conformance.
    * Exact external identifiers can be added after licensing review.
@@ -35,19 +52,25 @@ export interface ConceptKind {
 const kind = (
   layer: Layer,
   aspect: Aspect,
-  entries: ReadonlyArray<readonly [id: string, name: string]>,
+  entries: ReadonlyArray<
+    readonly [id: string, name: string, rigidity?: Rigidity]
+  >,
 ): ConceptKind[] =>
-  entries.map(([id, name]) => ({
+  entries.map(([id, name, rigidity]) => ({
     id,
     name,
     layer,
     aspect,
+    ...(rigidity === undefined ? {} : { rigidity }),
     inspiredBy: `ArchiMate-inspired:${name}`,
   }))
 
 export const conceptKinds: readonly ConceptKind[] = [
   ...kind('motivation', 'motivation', [
-    ['stakeholder', 'Stakeholder'],
+    // "Represents the role of an individual, team, or organization": a
+    // stakeholder is a stance held towards one architecture, not a kind of
+    // thing anything essentially is.
+    ['stakeholder', 'Stakeholder', 'anti-rigid'],
     ['driver', 'Driver'],
     ['assessment', 'Assessment'],
     ['goal', 'Goal'],
@@ -66,8 +89,13 @@ export const conceptKinds: readonly ConceptKind[] = [
   ]),
   ...kind('business', 'active-structure', [
     ['businessActor', 'Business actor'],
-    ['businessRole', 'Business role'],
-    ['businessCollaboration', 'Business collaboration'],
+    // A role is a responsibility an actor is assigned and can be released
+    // from. Nothing is essentially a role, which is the whole point of
+    // separating it from the actor that plays it.
+    ['businessRole', 'Business role', 'anti-rigid'],
+    // A collaboration is an aggregate of active structure elements formed to
+    // perform collective behavior, and it dissolves when they stop.
+    ['businessCollaboration', 'Business collaboration', 'anti-rigid'],
     ['businessInterface', 'Business interface'],
   ]),
   ...kind('business', 'behavior', [
@@ -85,7 +113,7 @@ export const conceptKinds: readonly ConceptKind[] = [
   ]),
   ...kind('application', 'active-structure', [
     ['applicationComponent', 'Application component'],
-    ['applicationCollaboration', 'Application collaboration'],
+    ['applicationCollaboration', 'Application collaboration', 'anti-rigid'],
     ['applicationInterface', 'Application interface'],
   ]),
   ...kind('application', 'behavior', [
@@ -100,7 +128,7 @@ export const conceptKinds: readonly ConceptKind[] = [
     ['node', 'Node'],
     ['device', 'Device'],
     ['systemSoftware', 'System software'],
-    ['technologyCollaboration', 'Technology collaboration'],
+    ['technologyCollaboration', 'Technology collaboration', 'anti-rigid'],
     ['technologyInterface', 'Technology interface'],
     ['path', 'Path'],
     ['communicationNetwork', 'Communication network'],

--- a/test/profile-rigidity.test.ts
+++ b/test/profile-rigidity.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+import { compileWorkspace } from '../src/index.js'
+import { conceptKinds, rigidities } from '../src/profile.js'
+
+const profile = (kinds: string): string =>
+  `format: yarramate/profile/v1
+id: example/crew
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+${kinds}relationshipKinds: []
+`
+
+describe('rigidity meta-properties on concept kinds', () => {
+  it('annotates only the core kinds ArchiMate itself calls roles or collaborations', () => {
+    expect(
+      conceptKinds
+        .filter(({ rigidity }) => rigidity !== undefined)
+        .map(({ id, rigidity }) => `${id}:${rigidity}`),
+    ).toEqual([
+      'stakeholder:anti-rigid',
+      'businessRole:anti-rigid',
+      'businessCollaboration:anti-rigid',
+      'applicationCollaboration:anti-rigid',
+      'technologyCollaboration:anti-rigid',
+    ])
+    expect(
+      conceptKinds.every(
+        ({ rigidity }) => rigidity === undefined || rigidities.includes(rigidity),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a rigid kind that specializes an anti-rigid parent', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: crew
+    name: Crew
+    parent: yarramate/core@0.1#businessRole
+    rigidity: rigid
+`,
+        ),
+      },
+    ])
+
+    expect(result).toEqual({
+      ok: false,
+      diagnostics: [
+        {
+          severity: 'error',
+          code: 'YM413',
+          message:
+            'Rigid concept kind "crew" specializes anti-rigid kind "yarramate/core@0.1#businessRole"; nothing is essentially of an anti-rigid kind, so parent "crew" under an entity kind, or drop its "rigid" annotation',
+          path: 'profiles/crew.yaml',
+          pointer: '/conceptKinds/0/rigidity',
+          line: 9,
+          column: 15,
+        },
+      ],
+    })
+  })
+
+  it('follows the whole lineage, so an unannotated kind cannot launder the violation', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: duty
+    name: Duty
+    parent: yarramate/core@0.1#businessRole
+  - id: crew
+    name: Crew
+    parent: example/crew@1.0#duty
+    rigidity: rigid
+`,
+        ),
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'YM413',
+        message:
+          'Rigid concept kind "crew" specializes anti-rigid kind "yarramate/core@0.1#businessRole"; nothing is essentially of an anti-rigid kind, so parent "crew" under an entity kind, or drop its "rigid" annotation',
+        pointer: '/conceptKinds/1/rigidity',
+      }),
+    ])
+  })
+
+  it('accepts an anti-rigid kind under a kind nothing has annotated', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: on-call
+    name: On call
+    parent: yarramate/core@0.1#businessActor
+    rigidity: anti-rigid
+`,
+        ),
+      },
+    ])
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a rigid kind under an unannotated parent, and any unannotated kind anywhere', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+    rigidity: rigid
+  - id: squad
+    name: Squad
+    parent: yarramate/core@0.1#businessRole
+  - id: pairing
+    name: Pairing
+    parent: yarramate/core@0.1#applicationCollaboration
+`,
+        ),
+      },
+    ])
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a rigidity value outside the vocabulary', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: crew
+    name: Crew
+    parent: yarramate/core@0.1#businessActor
+    rigidity: sometimes
+`,
+        ),
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map(({ code }) => code)).toEqual(['YM201'])
+  })
+
+  it('rejects rigidity on a relationship kind, which has no instances to be essential to', () => {
+    const result = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: `format: yarramate/profile/v1
+id: example/crew
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds: []
+relationshipKinds:
+  - id: crews
+    name: Crews
+    parent: yarramate/core@0.1#assignment
+    rigidity: rigid
+`,
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'YM201',
+        message: 'Property "rigidity" is not allowed',
+      }),
+    ])
+  })
+
+  it('changes no compiled output, because the annotation is checked and then discarded', () => {
+    const document = {
+      path: 'architecture/crew.yaml',
+      source: `format: yarramate/v1
+id: crew
+profile: example/crew@1.0
+concepts:
+  - id: checkout
+    kind: microservice
+    name: Checkout
+relationships: []
+`,
+    }
+    const withoutAnnotation = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+`,
+        ),
+      },
+      document,
+    ])
+    const withAnnotation = compileWorkspace([
+      {
+        path: 'profiles/crew.yaml',
+        source: profile(
+          `  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+    rigidity: rigid
+`,
+        ),
+      },
+      document,
+    ])
+
+    expect(withAnnotation.ok).toBe(true)
+    expect(JSON.stringify(withAnnotation)).toBe(JSON.stringify(withoutAnnotation))
+  })
+})


### PR DESCRIPTION
Closes #161

The core profile has carried `businessActor`, `businessRole`, and
`businessCollaboration` as separate kinds since ADR 0001, and nothing enforced
the discipline behind them. A profile extension could parent a team or a
service under `businessRole` and no gate objected, so role-shaped subjects
acquired owners, lifecycle status, evidence, and attestations they should
never have had.

This adds OntoClean's rigidity meta-property to profile concept kinds and the
one rule that follows from it mechanically.

## What lands

- `rigidity: rigid | anti-rigid` as an optional field on a profile concept
  kind, in the schema and in `src/profile.ts`.
- `YM413`: a rigid kind that specializes an anti-rigid one, anywhere in its
  lineage. Reported against the `rigidity` field that triggered it, with both
  repairs named in the message.
- Five core kinds annotated `anti-rigid`: `stakeholder`, `businessRole`,
  `businessCollaboration`, `applicationCollaboration`,
  `technologyCollaboration`.
- `docs/PROFILES.md` gains a Rigidity section; `docs/NATIVE-DOCUMENT.md` gains
  the code; ADR 0078 records the reasoning.
- 8 new tests in `test/profile-rigidity.test.ts`. No existing fixture touched.

## Design decisions

**It is a compile error, not a hygiene question.** Profile resolution has no
advisory severity to join: YM406 through YM412 are all errors, and inventing a
first advisory one here would make it the odd case in its own family. The rule
is decidable from two annotations and a lineage, so it is not a matter of
taste. Above all it is opt-in and self-inflicted: it fires only when an author
has written `rigidity: rigid` themselves, and the repair is always in their own
file. Nobody who has not asked for the check can be stopped by it.

**The whole lineage is checked, not the immediate parent.** Subsumption is
transitive, so an unannotated kind in between does not launder the violation.
The message names the anti-rigid ancestor that actually conflicts.

**An unannotated kind constrains nothing, in either direction.** It is not
rigid by default and it does not inherit anti-rigidity as an effective value.
Either would turn an opt-in annotation into a silent global assertion about
the whole vocabulary.

**Core is annotated, on the anti-rigid side only.** Without core annotations
the rule is reachable only inside a single profile that annotates both sides
itself, which catches the mistake nobody makes and misses the one the issue is
about. Only kinds whose ArchiMate-inspired semantics answer without
interpretation are annotated: roles and collaborations, plus `stakeholder`,
which is defined as the role of an individual, team, or organization. Kinds
that merely feel rigid are left alone, because "feels rigid" is the standard
this change exists to avoid.

**No `rigid` annotations in core, deliberately.** Core kinds are lineage roots,
so no `rigid` annotation on one could ever fire. Each would be a fresh semantic
claim about a stable vocabulary bought for nothing.

**No version bump on the core profile.** Kind identity is written into every
graph claim and every projection selector in every existing workspace, so `0.2`
would rewrite all of them to label a change that rejects no input anyone can
currently author. The compatibility argument is checkable rather than asserted:
the new rejection requires a field that did not exist, and a test asserts that
adding the annotation changes no compiled output.

**Identity and unity are out of scope**, as the issue leaned. Rigidity is the
one with a mechanical consequence.

**Model-level `specialization` relationships are not checked.** The rule would
arguably apply, but it would break the opt-in property that justifies the
error: a model author would be stopped by an annotation written by whoever
owns their profile, with the repair somewhere other than where the error is
reported. Revisitable once the annotation earns adoption.

## Honest caveat

Annotating core is an addition to what core says about core vocabulary, so it
is not a conservative extension in the sense #163 states. That is why it is
done in core rather than through a profile: a change to core is allowed to
change core, in the open, with a compatibility argument attached. ADR 0079
takes that up.

## Verification

`rm -rf dist && pnpm verify` passes clean from scratch: 402 tests, 38 files,
up from 394. Self-check and LikeC4 validation unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)