### PR TITLE
Name the modelling patterns

### DIFF
--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -52,7 +52,13 @@ tools beyond the coverage boundary the output states.
 Read [references/journey-checklists.md](references/journey-checklists.md) for
 the minimum evidence and design questions. Read
 [references/native-authoring.md](references/native-authoring.md) when native
-document, projection, evidence, or architecture-state syntax is needed.
+document, projection, evidence, or architecture-state syntax is needed. Read
+[references/modelling-patterns.md](references/modelling-patterns.md) for the
+named solutions to recurring modelling problems: invocation chain, degraded
+edge, delivery with content, one answer many subjects, descoping by
+retirement, and hosting a component. Open it when a relationship is rejected,
+when one answer touches many subjects, or when a subject leaves scope, and
+cite the pattern by name when explaining the resulting model.
 
 ## Discover an existing project
 

--- a/skills/yarramate-architecture/references/modelling-patterns.md
+++ b/skills/yarramate-architecture/references/modelling-patterns.md
@@ -1,0 +1,207 @@
+# Modelling patterns
+
+Named solutions to problems that recur when authoring native documents. Each
+entry states the problem, the solution, what the pattern prevents, and a
+worked example.
+
+Cite a pattern by name in design prose and review comments. The names exist so
+that a recurring solution is quoted rather than re-derived.
+
+Every pattern here is already practiced in this repository, and each entry
+names its source so a reader can check it rather than trust the summary.
+
+## Invocation chain
+
+**Problem.** "The user invokes the command" and "this component invokes that
+one" are the two most natural sentences in an architecture conversation, and
+both fail when written as `triggering`. Triggering requires behavior at both
+ends. An actor and a component are active structure, so the compiler rejects
+the relationship.
+
+**Solution.** Name the behavior that is invoked, assign every performer to it,
+and reserve `triggering` for edges between behaviors. The invocation becomes
+two assignments, and the chain becomes a sequence of behavior-to-behavior
+steps. This is the model the diagnostic itself recommends: its repair hint
+reads `introduce a behavior concept and "assignment"`.
+
+**Prevents.** `YM404` on `triggering`, whose source and target must both be
+behavior.
+
+**Worked example.** `native-authoring.md`, section "Invocation chains".
+
+The named behavior is also what makes the step addressable later. A dynamic
+view orders relationships between behaviors, so a chain modelled as actors
+invoking components has nothing to order.
+
+## Degraded edge
+
+**Problem.** Aspect policy blocks the kind that carries the meaning you want.
+The common case is `triggering` between two components, where the relationship
+is real and the kind is illegal.
+
+**Solution.** Keep the edge legal with `kind: flow` and carry the invocation
+semantics on the edge's `name` and `description`. Both compile into claims, so
+evidence can later confirm or contradict the recorded semantics. The
+degradation loses no reviewable information: it moves the meaning from the
+kind to two fields that are still checked and still rendered.
+
+`serving` and `flow` declare no endpoint aspect constraints, so neither can
+raise `YM404`. That is what makes them available as the legal carrier.
+
+**Prevents.** `YM404`, and the worse alternative of dropping a real
+relationship because no kind fits.
+
+**Worked example.** `native-authoring.md`, section "Degrading a blocked kind".
+
+Reach for the invocation chain first. Degrading records that the edge exists;
+the chain records the behavior, which is the better model whenever the
+behavior has a name worth having.
+
+## Delivery with content
+
+**Problem.** Two behaviors are ordered and something is handed from the first
+to the second. Recording only the order loses what moved. Recording only the
+handover loses the sequence.
+
+**Solution.** Keep both edges. `triggering` records precedence, and `flow`
+with `content` records what was transferred.
+
+```yaml
+relationships:
+  - id: parse-triggers-structure-validation
+    kind: triggering
+    from: parse-document
+    to: validate-document-structure
+  - id: parser-flows-document
+    kind: flow
+    from: parse-document
+    to: validate-document-structure
+    content: Parsed document
+```
+
+**Prevents.** `YM405`, since `content` is valid only on `flow`, and the silent
+loss of the payload when only precedence is modelled.
+
+**Choosing between flow and serving.** These answer different questions rather
+than competing for the same edge. Serving makes behavior or an interface
+available, and answers "who consumes this". Flow transfers information, value,
+goods, or material, and answers "what moved, and which way". A service with a
+consumer wants serving. A handover whose content matters wants flow. A model
+often carries both between the same pair.
+
+**Source.** This repository's self-model pairs the two edges exactly this way
+through the compile pipeline, in `.yarramate/architecture/engine.yaml`.
+
+## One answer, many subjects
+
+**Problem.** The interview reports one question open against many subjects.
+Ownership is the classic case: twenty components, one question, "who owns
+this". Answering it as twenty interview turns spends twenty round trips
+landing a single policy decision.
+
+**Solution.** Collect the answer once at policy level, "who owns what, by
+area", then land it across every listed subject as one `apply` batch. Re-run
+`design` afterwards, because the next question is recomputed from the model.
+
+```yaml
+format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept: {id: checkout, owner: payments-team}
+  - op: update-concept
+    document: architecture/main.yaml
+    concept: {id: refunds, owner: payments-team}
+  - op: update-concept
+    document: architecture/main.yaml
+    concept: {id: catalogue, owner: merchandising-team}
+```
+
+**Prevents.** A partially answered model. Any invalid operation rejects the
+whole batch, so the model never holds half a policy decision.
+
+**Trigger.** A `design` step reporting several entries in `openSubjects` for
+one question. That list is the signal to stop interviewing and start batching.
+
+An owner is a reference, not a label: `payments-team` above must be a concept
+declared in the model, or the batch fails with `YM304` for an unresolved owner
+reference. Declare the accountable actors in the same batch when they do not
+exist yet.
+
+## Descoping by retirement
+
+**Problem.** A subject leaves scope. Deleting it destroys the record that it
+was ever considered, and leaves the catalogue asking about the hole it left.
+
+**Solution.** Set `status: retired` and put the reason in `description`.
+Retirement is a closed question: retired subjects leave the enrichment target
+set entirely, so no subject-scoped question stays open against them. They
+still participate as counterparts and still appear in reads. Delete only when
+the history itself is noise, and expect deletion to be rejected while anything
+still references the target.
+
+```yaml
+- id: offline-mode
+  kind: requirement
+  name: Offline mode
+  status: retired
+  description: >-
+    Descoped after the connectivity survey. Revisit if field usage exceeds
+    the assumption recorded on the driver.
+```
+
+**Prevents.** Permanently open questions against abandoned work, and the loss
+of a decision a later reader would otherwise re-litigate.
+
+### Declining at inception
+
+The same motion records a non-goal. A goal, outcome, or requirement authored
+`status: retired` from the start, with its rationale in the description, is
+the declared non-goal record. `export markdown` and `export briefs` render
+those under a Non-goals heading, so the decision reaches the stakeholder
+asking "what are we not doing" without a second status value existing to
+carry it.
+
+## Hosting a component
+
+**Problem.** A component is modelled with no runtime. The model then says what
+the system does and nothing about where it does it.
+
+**Solution.** Give the component a host with `serving` or `assignment` from a
+`node`, `device`, or `systemSoftware`. Give each build output an `artifact`,
+assigned to the node that deploys it, with `realization` to the component or
+data it materializes.
+
+```yaml
+concepts:
+  - id: delivery-api
+    kind: applicationComponent
+    name: Delivery API
+  - id: delivery-cluster
+    kind: node
+    name: Delivery cluster
+  - id: delivery-image
+    kind: artifact
+    name: Delivery container image
+relationships:
+  - id: cluster-hosts-api
+    kind: assignment
+    from: delivery-cluster
+    to: delivery-api
+  - id: cluster-deploys-image
+    kind: assignment
+    from: delivery-cluster
+    to: delivery-image
+  - id: image-realizes-api
+    kind: realization
+    from: delivery-image
+    to: delivery-api
+```
+
+**Prevents.** The technology-wave questions the interview will otherwise keep
+asking: "Where does X run?", "What does X host or serve?", and "What deploys
+X, and what does it materialize?"
+
+**Why it is material.** The hosting boundary decides latency, failure domain,
+scaling model, and data residency. A component with no declared runtime is
+deployed by whoever gets there first.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -88,6 +88,8 @@ The other kinds accept endpoints of any aspect.
 
 ## Invocation chains
 
+The **invocation chain** pattern; see `modelling-patterns.md`.
+
 "User invokes command" and "component invokes component" fail `YM404` when
 written as `triggering` between active-structure elements. Name the invoked
 behavior, assign the performers, and trigger between behaviors:
@@ -119,6 +121,8 @@ Chain steps with `triggering` only between behavior concepts, for example
 `run-check` triggering a downstream process owned by another component.
 
 ## Degrading a blocked kind
+
+The **degraded edge** pattern; see `modelling-patterns.md`.
 
 When aspect policy blocks the kind you want—`triggering` between two
 components is the common case—keep the edge legal with `kind: flow` and carry


### PR DESCRIPTION
Closes #165

The authoring guidance already was a pattern catalogue, just not organised or named as one. This harvests it into `skills/yarramate-architecture/references/modelling-patterns.md`: six patterns, each with a name, a problem, a solution, what it prevents, and a worked example.

- **Invocation chain**: user-to-service is assignment plus behavior, not triggering.
- **Degraded edge**: `flow` carrying invocation semantics on `name` and `description` when aspect policy blocks the kind you want.
- **Delivery with content**: `triggering` for precedence paired with `flow` plus `content` for the payload.
- **One answer, many subjects**: the batch motion for a question open against many subjects.
- **Descoping by retirement**, with **declining at inception** as the non-goal variant.
- **Hosting a component**: the node and artifact shape.

## Decisions

### The catalogue ships in the skill, not in docs

The issue leaned toward docs with the skill naming patterns and pointing at them. The package surface argues the other way, and it is decisive: `package.json` `files` is `dist`, `assets/likec4`, `schema`, `catalogues`, `skills/yarramate-architecture`, `docs/CONSUMING-YARRAMATE.md`, pinned with `toEqual` in `test/package-consumer.test.ts`. `docs/` does not reach a consumer. A docs-only catalogue would be unreachable by exactly the reader it is written for, which is the agent authoring a model in someone else's repository.

The token objection is real and is answered by placement *within* the skill rather than outside it. `SKILL.md` is read at turn one and re-billed every turn; `references/*` is read on demand. So the catalogue sits in `references/`, and `SKILL.md` gains ten lines that name the six patterns and say when to open the file. That buys the issue's intent (do not inflate the per-turn bill) without buying unreachability.

### Repair hints do not cite pattern names

Deliberate, not drift. Four reasons, in order of weight:

1. **There is no field to put it in.** `Diagnostic` is `severity`, `code`, `message`, `path`, `pointer`, `line`, `column`. A citation would be concatenated into `message`, which is the wire contract in `schema/yarramate-diagnostic-result.schema.json`.
2. **ADR 0039 already decided this.** It frames repair information as self-contained plain text within the existing contracts. There is no precedent anywhere in `src/` for user-facing message text referencing a document.
3. **The coupling is measurable, not hypothetical.** Message text is pinned byte-for-byte in `test/cli.test.ts` (serialized JSON), `test/compiler.test.ts` (deep equality), and `test/diagnostic-repair.test.ts` (six full-string assertions). Renaming a pattern would break the compiler suite.
4. **`SKILL.md` tells agents to preserve source-located diagnostics verbatim.** A dangling pattern reference inside a quoted diagnostic is worse than no reference, and every consumer can read the message while only skill users can reach the catalogue.

The payoff is kept by running the citation the other way: the catalogue cites `YM404`, `YM405`, `YM304`, and the technology-wave catalogue questions. **Documents may name stable identifiers; stable identifiers should not name documents.** A reader who hits `YM404` can search the catalogue for it, and the rename risk stays inside the document.

Worth noting: the existing repair strings already state the pattern inline. `triggering`'s hint is `use "flow" between active-structure elements, or introduce a behavior concept and "assignment"`, which is the degraded edge and the invocation chain in one sentence, delivered at the point of failure. The catalogue expands that; it does not need to replace it with a name the reader must go look up.

### "Delivery with content" is written as the repo practices it, not as the issue framed it

The issue described this as "flow over serving when the transferred information matters". Verified against the repo, that framing does not hold, so the entry does not claim it:

- `serving` and `flow` are both unconstrained in `src/profile.ts`, so neither can raise `YM404` and there is no legality pressure to choose between them.
- Their declared intents are different questions, not competing answers: serving is "make behavior or an interface available", flow is "transfer information, value, goods, or material".
- What the self-model actually does (`.yarramate/architecture/engine.yaml`) is pair `triggering` with `flow` plus `content` between the same two behaviors: precedence on one edge, payload on the other.

The entry documents that pairing and adds a short note on choosing flow versus serving, since the question is reasonable even though the framing was off.

### No ADR

`CONTRIBUTING.md` requires an accepted ADR for a change to native meaning, identity, graph interchange, validation behaviour, or a stable CLI contract. Naming existing guidance changes none of them. The one decision here that *would* have been contract, repair hints citing pattern names, was declined, and ADR 0039 already governs the ground it would have covered. ADR 0080 remains unclaimed.

## Every worked example was compiled before it shipped

Each YAML block was run through `dist/cli.js check` and the batch through `apply`. That caught two errors in the drafts: `owner` is a reference that must resolve to a declared concept (`YM304`), and a native document requires a `relationships` key. Both fixes are in the shipped text, and the owner trap is now called out in the pattern entry.

## Deliberately not moved

`native-authoring.md` keeps its "Invocation chains" and "Degrading a blocked kind" sections where they are, directly under the aspect-constraint table. The issue records that this placement works preventively: agents stopped hitting the traps after the guidance landed there. Moving a working fix for taxonomic tidiness is a bad trade, so those two entries reference the authoring section for their worked YAML instead of re-hosting it, and each section gained one line naming its pattern so the name is citable from where the guidance already lives.

## Follow-up cross-links deferred

Owned by sibling agents on concurrent branches, so not edited here:

- `docs/NATIVE-DOCUMENT.md` should reference the catalogue from its relationship-kind guidance, particularly for `content` on flow and the aspect constraints.
- `docs/README.md` could point human readers at the catalogue inside the skill, since nothing in `docs/` currently mentions it.

## Verification

`rm -rf dist && pnpm verify` passes clean: 37 test files, 394 tests, plus the self-model check and LikeC4 validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
