### PR TITLE
Conservative extension: a profile extension adds subjects, never verdicts

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -77,3 +77,69 @@ Profiles define semantic vocabulary and deterministic constraints. They do not
 define adapter layout, organizational approval workflow, completeness taste,
 or external-language compatibility unless they are separately governed for
 that purpose.
+
+## Conservative extension
+
+Profiles are the extension point offered to users, so the safety property that
+makes extension sound is stated here rather than left to be discovered.
+
+> **Loading a profile extension adds subjects. It never changes verdicts.**
+>
+> Let `W` be a workspace and let `E` be an extension: one or more profile
+> documents that no document in `W` selects, together with any documents that
+> select them. Then for every subject present in `W`, every diagnostic,
+> catalogue evaluation, and projection result concerning that subject is the
+> same in `W` and in `W + E`. Loading `E` may add outcomes concerning the
+> subjects `E` itself introduces. It may change no outcome concerning a
+> subject that was already there.
+
+The prior art is the standard ontology-modularization criterion: a module is a
+conservative extension when it adds nothing about the original vocabulary.
+Everything the base said about base terms still holds, and nothing new about
+base terms becomes derivable. That is what lets someone import a module
+without auditing it.
+
+### Why the naive phrasing is wrong
+
+"A query about core kinds returns the same answer" is false here, and it is
+false by design. A core-kind selector with `kindMatching: descendants` returns
+more subjects once an extension exists: `yarramate/core@0.1#applicationComponent`
+matches an extension's `microservice`, which is exactly what ADR 0029 built it
+to do, and catalogue conditions resolve through lineage by default for the
+same reason. If the property forbade that, the property would be wrong rather
+than the behaviour.
+
+It survives because it is quantified over subjects, not over queries. The
+extra matches are subjects the extension brought with it. Nothing that was in
+the answer has left it, and nothing that was already in the model has changed
+kind, status, lineage, or diagnosis. An extension may enlarge the domain. It
+may not revise the domain it enlarged.
+
+### The testable form
+
+When `E` introduces no documents, a profile loaded but never selected, it adds
+no subjects at all. The property then collapses to exact output identity, and
+that is what `test/conservative-extension.test.ts` asserts: a core-only
+workspace compiles to a byte-identical graph, byte-identical diagnostics,
+byte-identical catalogue evaluation, and byte-identical projection results
+with and without an unrelated extension loaded. A fifth case covers the
+widening, asserting both that the answer grows and that every arrival is a
+subject the extension document introduced.
+
+This is a test discipline rather than a mechanical check. A general proof over
+every future feature would be out of proportion to a property that currently
+holds by construction.
+
+### What it rules out
+
+Any future profile feature that lets an extension restate, re-parent,
+re-annotate, or constrain a kind it did not declare would violate this, and
+would therefore need to be a deliberate decision with this section rewritten,
+not a discovered consequence. Today no such feature exists: an extension may
+only add kinds, and may only narrow constraints on the kinds it adds.
+
+The rigidity annotation (ADR 0078) sits on the right side of this line for
+extensions, since a profile may only annotate kinds it declares. Annotating
+the core profile's own kinds is a different matter, and it is honestly not
+conservative: it adds a fact about core vocabulary. That is why it was done in
+core, with a compatibility argument, rather than through a profile (ADR 0079).

--- a/docs/adr/0079-a-profile-extension-adds-subjects-never-verdicts.md
+++ b/docs/adr/0079-a-profile-extension-adds-subjects-never-verdicts.md
@@ -1,0 +1,127 @@
+# A profile extension adds subjects, never verdicts
+
+Status: accepted
+
+Profiles are the extension point YarraMate offers, and extension kinds
+specialize core kinds: the project's own development profile does exactly
+that. The property that makes importing one safe was never written down and
+never tested. Users were being asked to trust a modularization guarantee
+nobody had stated (#163).
+
+The prior art is the standard criterion: a module is a conservative extension
+of an ontology when it adds nothing about the original vocabulary. Everything
+the base said about base terms still holds, nothing new about base terms
+becomes derivable, and that is what lets someone import a module without
+auditing it.
+
+Decided: the property is stated in `docs/PROFILES.md` and defended by a
+property test, not by a mechanical check.
+
+> **Loading a profile extension adds subjects. It never changes verdicts.**
+>
+> Let `W` be a workspace and let `E` be an extension: one or more profile
+> documents that no document in `W` selects, together with any documents that
+> select them. Then for every subject present in `W`, every diagnostic,
+> catalogue evaluation, and projection result concerning that subject is the
+> same in `W` and in `W + E`. Loading `E` may add outcomes concerning the
+> subjects `E` itself introduces. It may change no outcome concerning a
+> subject that was already there.
+
+## The phrasing is the work
+
+The obvious statement, and the one the issue starts from, is that a query
+about core kinds returns the same answer with and without an extension
+loaded. It is false, and it is false by design. A core-kind selector with
+`kindMatching: descendants` returns more subjects once an extension exists.
+`yarramate/core@0.1#applicationComponent` matches an extension's
+`microservice`, which is precisely what ADR 0029 built descendant matching to
+do, and catalogue conditions resolve through lineage by default for the same
+reason (ADR 0063). A property that forbade this would not be catching a bug,
+it would be describing a different product.
+
+So the quantifier had to move. The property ranges over subjects, not over
+queries. Every extra match is a subject the extension brought with it, and
+about every subject that was already there the answer is unchanged: same
+kind, same status, same lineage, same claims, same diagnosis, same membership
+in the same projections. An extension may enlarge the domain. It may not
+revise the domain it enlarged.
+
+That is also the faithful reading of the original criterion rather than a
+weakening of it. Conservativity says the base theory gains no new consequences
+about base vocabulary. A new individual answering to a base predicate is not a
+new consequence about the base; it is a new individual. The naive phrasing
+conflated the vocabulary with the population, and the model is the population.
+
+## Documentation and a property test, not a proof
+
+The issue leaned this way and the reasoning holds. A general mechanical check
+would have to quantify over every future feature, which is a proof obligation
+on a codebase, not a test. What exists instead is a five-case test that
+compiles a core-only workspace with and without an unrelated extension and
+asserts byte identity across the graph, the diagnostics, the catalogue
+evaluation, and a descendant-matching projection, plus a fifth case that
+asserts the widening happens and that every arrival is a subject the extension
+document introduced.
+
+The degenerate case is what makes this testable at all. When `E` introduces no
+documents, a profile loaded but never selected, it adds no subjects, so "no
+verdict changes" collapses to exact output identity and a string comparison
+settles it.
+
+It is worth recording why the property holds today, because that is the list a
+future feature has to keep true. Profile resolution is additive by
+construction: an extension may only introduce new local names, since YM409 and
+YM410 reject shadowing an inherited one, and may only narrow endpoint
+constraints, since YM412 rejects broadening. It cannot reach a resolved core
+kind. Document diagnostics are computed against the profile the document
+selects, so a core-only document never has extension kinds in its resolved
+map. Profile source files mint no subjects and no claims. And `graph.profiles`
+derives from the profiles documents actually select, so an unselected profile
+leaves no trace.
+
+One place deserves naming because it is where a breach would most plausibly
+hide. The YM404 endpoint diagnostic enumerates the relationship kinds that
+would have worked, and that list is drawn from the selected profile rather
+than from every resolved kind. If it were ever drawn from the global map, a
+core-only workspace would start receiving repair advice naming kinds from an
+extension it does not use, and the property would be broken by a helpful
+message. The test asserts the message text, so that specific regression is
+caught.
+
+## Whether the rigidity work is conservative
+
+The issue asked, and the two answers differ.
+
+For extensions, yes. A profile may annotate only kinds it declares, since
+there is no syntax for annotating an inherited one, and the annotation is
+checked during profile resolution and then discarded before any graph, claim,
+or projection. An extension carrying rigidity annotations changes nothing
+about core.
+
+For core annotating core, no, and it should be said plainly rather than argued
+around. ADR 0078 adds `anti-rigid` to five core kinds, which is a new fact
+about core vocabulary and therefore not a conservative extension in the sense
+stated above. Calling it conservative because it happens to reject no
+currently-authorable input would be confusing compatibility with
+conservativity: it is backward compatible, and it is not conservative.
+
+That distinction is the useful one, and it is why the property is worth
+stating. Core is allowed to change core. Extensions are not. The rigidity
+annotations went into the core profile, in the open, with their own
+compatibility argument attached, instead of arriving through a profile that
+quietly redefined kinds it did not own. A rule that made both routes look
+equally acceptable would be a rule worth nothing.
+
+## Consequences
+
+The property constrains the roadmap, which is most of its value. Any future
+profile feature that lets an extension restate, re-parent, re-annotate, or
+constrain a kind it did not declare violates it, and now has to be argued for
+against a written statement rather than discovered afterwards by whoever
+imported the profile. Overrides, deprecations of core kinds from an extension,
+and extension-supplied constraints on core kinds are all in that category.
+
+The cost is a test that can only ever check the degenerate case, and the
+honest limit is that it checks the four surfaces named here on one fixture. It
+would not catch a breach in a surface added later that nobody thought to
+include. The statement is what the test is measured against, not the reverse.

--- a/test/conservative-extension.test.ts
+++ b/test/conservative-extension.test.ts
@@ -1,0 +1,250 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspace,
+  compileWorkspaceWithProfileContext,
+  evaluateProjection,
+  type ProjectionDefinition,
+  type WorkspaceSource,
+} from '../src/index.js'
+import {
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/interrogate-command.js'
+
+// The safety property profile extension rests on (ADR 0079):
+//
+//   Loading a profile extension adds subjects. It never changes verdicts.
+//
+// The test form is the degenerate case: an extension that introduces no
+// documents adds no subjects, so "no verdict changes" collapses to exact
+// output identity. The final test covers the case the naive phrasing gets
+// wrong, where descendant matching legitimately widens an answer.
+
+const coreOnly: WorkspaceSource = {
+  path: 'architecture/core-only.yaml',
+  source: `format: yarramate/v1
+id: core-only
+profile: yarramate/core@0.1
+concepts:
+  - id: checkout
+    kind: applicationComponent
+    name: Checkout
+    status: current
+  - id: settle
+    kind: applicationService
+    name: Settlement
+    status: current
+  - id: fast-settlement
+    kind: goal
+    name: Fast settlement
+    status: current
+relationships:
+  - id: checkout-realizes-settle
+    kind: realization
+    from: checkout
+    to: settle
+    status: current
+`,
+}
+
+// Unrelated in the strongest sense available: it specializes core kinds the
+// core-only workspace uses, and no document selects it.
+const unrelatedExtension: WorkspaceSource = {
+  path: 'profiles/delivery.yaml',
+  source: `format: yarramate/profile/v1
+id: example/delivery
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+relationshipKinds:
+  - id: implements
+    name: Implements
+    parent: yarramate/core@0.1#realization
+`,
+}
+
+const extensionDocument: WorkspaceSource = {
+  path: 'architecture/delivery.yaml',
+  source: `format: yarramate/v1
+id: delivery
+profile: example/delivery@1.0
+concepts:
+  - id: orders
+    kind: microservice
+    name: Orders
+    status: current
+  - id: dispatch
+    kind: applicationService
+    name: Dispatch
+    status: current
+relationships:
+  - id: orders-implements-dispatch
+    kind: implements
+    from: orders
+    to: dispatch
+    status: current
+`,
+}
+
+const componentsProjection: ProjectionDefinition = {
+  format: 'yarramate/projection/v1',
+  id: 'components',
+  version: '1.0',
+  query: {
+    kinds: ['yarramate/core@0.1#applicationComponent'],
+    kindMatching: 'descendants',
+    relationships: 'connected',
+  },
+}
+
+const catalogueSource: WorkspaceSource = {
+  path: 'catalogues/core-enrichment.yaml',
+  source: readFileSync(
+    fileURLToPath(new URL('../catalogues/core-enrichment.yaml', import.meta.url)),
+    'utf8',
+  ),
+}
+
+const catalogue = (() => {
+  const loaded = loadQuestionCatalogue(catalogueSource)
+  if (!loaded.ok) throw new Error('the bundled catalogue must load')
+  return loaded.catalogue
+})()
+
+describe('a profile extension is conservative over the workspace it joins', () => {
+  it('changes no compiled graph for a workspace that instantiates only core kinds', () => {
+    const without = compileWorkspace([coreOnly])
+    const withExtension = compileWorkspace([unrelatedExtension, coreOnly])
+
+    expect(withExtension.ok).toBe(true)
+    expect(JSON.stringify(withExtension)).toBe(JSON.stringify(without))
+  })
+
+  it('changes no diagnostic, including the ones about core kinds it specializes', () => {
+    const broken: WorkspaceSource = {
+      path: 'architecture/broken.yaml',
+      source: `format: yarramate/v1
+id: broken
+profile: yarramate/core@0.1
+concepts:
+  - id: settle
+    kind: applicationService
+    name: Settlement
+  - id: fast
+    kind: goal
+    name: Fast
+relationships:
+  - id: settle-assigns-fast
+    kind: assignment
+    from: settle
+    to: fast
+`,
+    }
+    const without = compileWorkspace([broken])
+    const withExtension = compileWorkspace([unrelatedExtension, broken])
+
+    expect(without.ok).toBe(false)
+    if (without.ok) return
+    expect(without.diagnostics.map(({ code }) => code)).toEqual(['YM404'])
+    // The YM404 message enumerates the relationship kinds that would have
+    // worked. That list is the likeliest place for an extension to leak into
+    // an answer about core, so the comparison below is load-bearing.
+    expect(without.diagnostics[0]?.message).toContain('valid candidates:')
+    expect(without.diagnostics[0]?.message).not.toContain('implements')
+    expect(JSON.stringify(withExtension)).toBe(JSON.stringify(without))
+  })
+
+  it('changes no catalogue evaluation', () => {
+    const without = compileWorkspaceWithProfileContext([coreOnly])
+    const withExtension = compileWorkspaceWithProfileContext([
+      unrelatedExtension,
+      coreOnly,
+    ])
+    expect(without.ok && withExtension.ok).toBe(true)
+    if (!without.ok || !withExtension.ok) return
+
+    const report = evaluateCatalogue(
+      catalogue,
+      without.graph,
+      without.profileContext,
+    )
+    const reportWithExtension = evaluateCatalogue(
+      catalogue,
+      withExtension.graph,
+      withExtension.profileContext,
+    )
+
+    expect(report.summary.openQuestions).toBeGreaterThan(0)
+    expect(JSON.stringify(reportWithExtension)).toBe(JSON.stringify(report))
+  })
+
+  it('changes no projection result, including one that opts into descendants', () => {
+    const without = compileWorkspaceWithProfileContext([coreOnly])
+    const withExtension = compileWorkspaceWithProfileContext([
+      unrelatedExtension,
+      coreOnly,
+    ])
+    expect(without.ok && withExtension.ok).toBe(true)
+    if (!without.ok || !withExtension.ok) return
+
+    const result = evaluateProjection(
+      without.graph,
+      componentsProjection,
+      without.profileContext,
+    )
+    const resultWithExtension = evaluateProjection(
+      withExtension.graph,
+      componentsProjection,
+      withExtension.profileContext,
+    )
+
+    expect(result.subjects.map(({ id }) => id)).toContain('core-only#checkout')
+    expect(JSON.stringify(resultWithExtension)).toBe(JSON.stringify(result))
+  })
+
+  it('permits descendant matching to widen an answer, because the arrivals are subjects the extension introduced', () => {
+    const without = compileWorkspaceWithProfileContext([coreOnly])
+    const withExtension = compileWorkspaceWithProfileContext([
+      unrelatedExtension,
+      coreOnly,
+      extensionDocument,
+    ])
+    expect(without.ok && withExtension.ok).toBe(true)
+    if (!without.ok || !withExtension.ok) return
+
+    const result = evaluateProjection(
+      without.graph,
+      componentsProjection,
+      without.profileContext,
+    )
+    const widened = evaluateProjection(
+      withExtension.graph,
+      componentsProjection,
+      withExtension.profileContext,
+    )
+
+    // The answer grows, and this is intended behaviour (ADR 0029), not a
+    // breach: the arrivals are subjects the extension document introduced.
+    const arrivals = widened.subjects
+      .map(({ id }) => id)
+      .filter((id) => !result.subjects.some((subject) => subject.id === id))
+    expect(arrivals).toContain('delivery#orders')
+    expect(arrivals.every((id) => id.startsWith('delivery#'))).toBe(true)
+
+    // Nothing that was already in the answer left it, and every claim about a
+    // subject that existed before is byte-identical.
+    for (const subject of result.subjects) {
+      expect(widened.subjects).toContainEqual(subject)
+    }
+    const preexisting = (claims: typeof result.claims) =>
+      JSON.stringify(
+        claims.filter(({ subject }) => subject.startsWith('core-only#')),
+      )
+    expect(preexisting(widened.claims)).toBe(preexisting(result.claims))
+  })
+})


### PR DESCRIPTION
Closes #163

Profiles are the extension point offered to users, and extension kinds
specialize core kinds. The property that makes importing one safe was never
written down and never tested, so users were being asked to trust a
modularization guarantee nobody had stated.

## The property

> **Loading a profile extension adds subjects. It never changes verdicts.**
>
> Let `W` be a workspace and let `E` be an extension: one or more profile
> documents that no document in `W` selects, together with any documents that
> select them. Then for every subject present in `W`, every diagnostic,
> catalogue evaluation, and projection result concerning that subject is the
> same in `W` and in `W + E`. Loading `E` may add outcomes concerning the
> subjects `E` itself introduces. It may change no outcome concerning a
> subject that was already there.

## What lands

- `docs/PROFILES.md` gains a Conservative extension section: the statement,
  why the naive phrasing is wrong, the testable form, and what it rules out.
- `test/conservative-extension.test.ts`, 5 tests, no shared fixture touched.
- ADR 0079.

## Design decisions

**The phrasing is the whole job.** "A query about core kinds returns the same
answer" is false, and false by design: a core-kind selector with
`kindMatching: descendants` returns more subjects once an extension exists,
which is what ADR 0029 built it to do, and catalogue conditions resolve
through lineage by default for the same reason (ADR 0063). A property that
forbade that would be describing a different product.

**So the quantifier moved from queries to subjects.** Every extra match is a
subject the extension brought with it. About every subject that was already
there, the answer is unchanged: same kind, status, lineage, claims, diagnosis,
projection membership. An extension may enlarge the domain; it may not revise
the domain it enlarged. That is the faithful reading of the original
criterion, not a weakening: a new individual answering to a base predicate is
not a new consequence about the base vocabulary, it is a new individual. The
naive phrasing conflated the vocabulary with the population.

**Documentation plus a property test, not a mechanical check**, as the issue
leaned. A general check would have to quantify over every future feature,
which is a proof obligation on a codebase rather than a test.

**The degenerate case is what makes it testable.** An extension that
introduces no documents adds no subjects, so the property collapses to exact
output identity and a string comparison settles it. Four cases assert byte
identity across the graph, the diagnostics, the catalogue evaluation (against
the real bundled catalogue), and a descendant-matching projection. The fifth
asserts the widening is real and that every arrival is a subject the extension
document introduced, so the permissive clause is exercised rather than merely
written down.

**One near-breach is named and guarded.** The YM404 endpoint diagnostic
enumerates the relationship kinds that would have worked. That list is drawn
from the selected profile, not the global resolved map. If it were ever drawn
globally, a core-only workspace would get repair advice naming kinds from an
extension it does not use, and the property would be broken by a helpful
message. The test asserts the message text, including that the extension's
`implements` does not appear in it.

**Is the rigidity work (#161, ADR 0078) conservative?** Two answers, and the
difference is the point.

- For extensions, yes. A profile may annotate only kinds it declares, and the
  annotation is checked at resolution then discarded before any graph, claim,
  or projection.
- For core annotating core, no, and this PR says so plainly rather than
  arguing around it. Adding `anti-rigid` to five core kinds is a new fact about
  core vocabulary. It is backward compatible; it is not conservative. Calling
  it conservative because it rejects no currently-authorable input would
  confuse the two.

That distinction is why the property is worth stating: core is allowed to
change core, extensions are not, and the rigidity annotations went into core in
the open rather than arriving through a profile that quietly redefined kinds it
did not own.

## Honest limits

The test checks four surfaces on one fixture and can only ever check the
degenerate case. It would not catch a breach in a surface added later that
nobody thought to include. The statement is what the test is measured against,
not the reverse.

## Verification

`rm -rf dist && pnpm verify` passes clean from scratch on this branch: 399
tests, up from 394. Independent of #161's branch; the two touch
`docs/PROFILES.md` in separate regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)