### PR TITLE
Subject identity: alternative labels and near-duplicate detection

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -406,6 +406,8 @@ concepts:
     name: Multi-view generated LikeC4 project marker JSON Schema
     description: Normative marker structure guarding multi-view generated LikeC4 projects.
     status: current
+    distinctFrom:
+      - likec4-generated-project-schema
   - id: likec4-kind-mapping
     kind: dataObject
     owner: yarramate-product#yarramate-maintainers

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.6"
+version: "0.7"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -1027,6 +1027,37 @@ questions:
     resolution: >-
       Add a lifecycle status claim; planned subjects should also appear in a
       target architecture state where states are used.
+
+  - id: subjects-near-duplicate
+    wave: hygiene
+    since: "0.7"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#capability
+        - yarramate/core@0.1#businessService
+        - yarramate/core@0.1#applicationService
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#businessActor
+        - yarramate/core@0.1#dataObject
+        - yarramate/core@0.1#businessObject
+    trigger:
+      - condition: near-duplicate
+    question: >-
+      {subject.name} closely resembles {counterparts}. Is this one subject
+      recorded twice, or are they genuinely different things?
+    materiality: >-
+      Identity is the first thing the model promises: one subject, one name,
+      one place to change it. Two records for one thing silently fork every
+      decision made about it, and both halves still pass check.
+    authority: human
+    resolution: >-
+      If they are the same subject, keep one and delete or retire the other,
+      moving its relationships across, and record the discarded name in the
+      survivor's aka list so the old word still finds it. If they are
+      genuinely different, say so in the model: add the counterpart's id to
+      this subject's distinctFrom list. That answer is itself a claim, so it
+      closes the question permanently and survives re-running the interview.
 
   - id: states-undefined
     wave: hygiene

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -162,8 +162,8 @@ others; graphify analogues: `--wiki` / `--svg` / `--neo4j`.
 
 ## Adequacy: how "filled" becomes "filled adequately"
 
-Two mechanisms, layered, both deterministic (decision 2026-07-31),
-living inside `design`'s internal catalogue:
+Three mechanisms, layered, all deterministic (decision 2026-07-31,
+extended 2026-08-05), living inside `design`'s internal catalogue:
 
 1. **Linkage-depth conditions** — a question stays open until the
    blank's *neighbourhood* exists: a goal needs a realizing element, a
@@ -177,8 +177,30 @@ living inside `design`'s internal catalogue:
    Content thinness caught by explicit, auditable sign-off — the engine
    still never reads words.
 
+3. **Distinctness claims**: the same pattern applied to identity
+   (ADR 0077). The `near-duplicate` condition opens a hygiene question
+   when two subjects of one kind resemble each other closely enough to be
+   the same thing under two names. This is not the engine judging a name:
+   it compares two strings under a stated normalization, deterministically
+   and with no model involved. A false positive is dismissed by recording
+   a `distinctFrom` reference, which is itself a claim, so the answer
+   lives in the model, is read symmetrically from either side of the pair,
+   and survives re-running the interview.
+
 Text heuristics (length, name-mention) were considered and rejected:
 they erode the wiring-not-words boundary for little gain.
+
+## Naming a subject more than one way
+
+Concepts carry an optional `aka` list of alternative labels (ADR 0076),
+compiled to `yarramate/concept/alias` claims. A harness should record the
+words a team actually uses for a subject, including abbreviations, legacy
+names, and codenames: `ask` free-text seeding matches them at the same
+weight as the name, so the team's own vocabulary addresses the model.
+Renderers keep printing the preferred `name` only, so aliases cost no
+context budget in a brief. Aliases also feed near-duplicate detection
+directly, because a genuine duplicate very often reuses the other
+subject's alias.
 
 ## Migration map (0.7.0 clean break — EXECUTED, ADR 0061)
 
@@ -248,3 +270,11 @@ vocabulary as a read.
 - Catalogue versioning: SETTLED (ADR 0063, with the 0.4 waves) —
   honest reopen, `since` delta annotations, semver discipline (minor
   is additive), no pinning.
+- Alternative labels: SETTLED (ADR 0076): an optional `aka` list
+  compiling to `yarramate/concept/alias` claims, matched by `ask`
+  seeding at the same weight as the name, never rendered. Hidden labels
+  and relationship aliases deliberately deferred; both stay additive.
+- Near-duplicate subjects: SETTLED (ADR 0077): the `near-duplicate`
+  catalogue condition, deterministic and lexical, never a `check`
+  error. A dismissal is a `distinctFrom` claim, read symmetrically, so
+  it survives re-running the interview.

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -34,8 +34,12 @@ questions. Each question binds:
   `missing-linkage` (no relationship of given kinds, in a given
   direction, whose counterpart is of a given kind — the linkage-depth
   primitive), `missing-reference` (no reference-bearing claim such as a
-  constraint binding, by direction), or `missing-attestation` (no
-  recorded `yarramate/attestation/<topic>` claim; see ADR 0056).
+  constraint binding, by direction), `missing-attestation` (no
+  recorded `yarramate/attestation/<topic>` claim; see ADR 0056), or
+  `near-duplicate` (the subject resembles another subject of the same
+  kind closely enough to be the same thing under two names, and no
+  `yarramate/identity/distinct-from` claim dismisses the pair; the
+  algorithm and its thresholds are stated in ADR 0077).
   Relationship kinds in conditions resolve through profile lineage by
   default, the same rule as subject selectors;
 - a **scope** — `workspace` (asked once) or `subject` (asked per matching
@@ -47,6 +51,9 @@ questions. Each question binds:
 - an **authority** — `human`, `agent`, or `either` — declaring who may
   answer;
 - a **resolution** hint — how an answer is typically modelled;
+- a **question** phrasing interpolating `{subject.id}` and
+  `{subject.name}`, plus `{counterparts}` for questions whose trigger
+  names other subjects, such as `near-duplicate`;
 - an optional **askPlain** phrasing: the same question in plain
   workshop language, interpolating the same `{subject.id}` and
   `{subject.name}` placeholders. `design --facilitate` prefers it and

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -53,6 +53,43 @@ reference. It compiles to a stable `~owner` claim with predicate
 `yarramate/ownership/owner`. The claim expresses accountable stewardship,
 not approval authority or workflow. Core checks only that the subject exists.
 
+A concept may record the other names it is known by:
+
+```yaml
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    aka:
+      - OG
+      - the gateway
+```
+
+Each entry compiles to a `yarramate/concept/alias` value claim whose ID
+derives from the alias text, so reordering the list leaves the canonical
+graph byte-identical. Alternative labels are matchable, never renderable
+(ADR 0076): free-text seeding in `ask` matches them at the same weight as
+the name, and every renderer keeps printing the preferred `name` alone.
+
+A concept may also record that it has been judged genuinely different from
+another subject it resembles:
+
+```yaml
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    distinctFrom:
+      - orders-service
+```
+
+This compiles to a `yarramate/identity/distinct-from` reference claim and
+permanently closes the `subjects-near-duplicate` hygiene question for that
+pair (ADR 0077). It is read symmetrically, so one entry settles the pair
+from either side, and it survives re-running the interview because it is
+part of the model rather than session state. `YM310` reports an unresolved
+reference and `YM311` a subject declared distinct from itself.
+
 A concept may require multiple explicitly identified constraints:
 
 ```yaml
@@ -285,7 +322,7 @@ and one-based line and column.
 | --- | --- | --- |
 | `YM1xx` | YAML parsing | `YM101` malformed YAML |
 | `YM2xx` | Document structure | `YM201` JSON Schema violation |
-| `YM3xx` | Identity and references | `YM301` duplicate local ID; `YM302` unresolved concept reference; `YM303` duplicate document ID; `YM304` unresolved owner; `YM305` unresolved constraint; `YM306` duplicate constraint ID; `YM307` unresolved architecture state; `YM308` unresolved subject reference; `YM309` duplicate reference ID |
+| `YM3xx` | Identity and references | `YM301` duplicate local ID; `YM302` unresolved concept reference; `YM303` duplicate document ID; `YM304` unresolved owner; `YM305` unresolved constraint; `YM306` duplicate constraint ID; `YM307` unresolved architecture state; `YM308` unresolved subject reference; `YM309` duplicate reference ID; `YM310` unresolved distinct-from reference; `YM311` self-referential distinct-from |
 | `YM4xx` | Profile conformance | `YM401` unknown concept kind; `YM402` unknown relationship kind; `YM403` unavailable profile; `YM404` incompatible endpoint; `YM405` misplaced controlled field; `YM406` unavailable parent profile; `YM407`/`YM408` unavailable semantic parent; `YM409`/`YM410` inherited-name collision; `YM411` duplicate profile; `YM412` broadened constraint; `YM413` rigid kind specializing an anti-rigid one |
 | `YM5xx` | Claim consistency | `YM501` competing whole-part claims; `YM502` cyclic state ordering; `YM503` relationship present without an endpoint |
 | `YM6xx` | Adapter mapping integrity | `YM601` unknown native subject; `YM602` subject type mismatch; `YM603` duplicate native mapping; `YM604` duplicate external mapping; `YM605` duplicate versioned mapping |
@@ -366,7 +403,8 @@ The operations are `add-concept`, `add-relationship`, `update-concept`,
 `update-relationship`, `delete-concept`, and `delete-relationship`. Concept
 and relationship records accept the same
 optional fields as the authoring format — for example `status`,
-`description`, `owner`, `constraints`, `references`, `presentIn`, and the
+`description`, `aka`, `owner`, `distinctFrom`, `constraints`,
+`references`, `presentIn`, and the
 controlled `mode` and `content` fields. `apply` writes by splicing minimal
 text edits into the authored source, so bytes an operation never touched —
 including folded prose and comments — stay byte-identical (ADR 0062). It

--- a/docs/SEMANTIC-GRAPH.md
+++ b/docs/SEMANTIC-GRAPH.md
@@ -39,6 +39,12 @@ verbatim. It is an ordinary value claim in the existing envelope: no new
 field, no new structure, and a consumer that does not know the predicate keeps
 reading the graph correctly.
 
+Alternative labels emit one `yarramate/concept/alias` value claim each, and
+a recorded distinctness judgment emits one `yarramate/identity/distinct-from`
+reference claim. Both are ordinary claims in the existing envelope: no new
+field and no new structure, so a consumer that does not know either
+predicate keeps reading the graph, and the preferred name, correctly.
+
 Concept and relationship descriptions use
 `yarramate/concept/description` and
 `yarramate/relationship/description`. Identified citations use
@@ -130,6 +136,7 @@ Core claim predicates:
 | `yarramate/concept/kind` | value | Globally qualified kind of a concept |
 | `yarramate/concept/name` | value | Display name |
 | `yarramate/concept/description` | value | Narrative meaning claim |
+| `yarramate/concept/alias` | value | Alternative label, matchable but never rendered |
 | `yarramate/relationship/name` | value | Display name |
 | `yarramate/relationship/description` | value | Narrative meaning claim |
 | `yarramate/lifecycle/status` | value | `planned`, `current`, or `retired` |
@@ -137,6 +144,7 @@ Core claim predicates:
 | `yarramate/constraint/requires` | ref | Binding constraint subject |
 | `yarramate/constraint/expects` | value | Expected observation as `<provider> <key> <expected value>` |
 | `yarramate/reference/refers-to` | ref | Identified citation to any subject |
+| `yarramate/identity/distinct-from` | ref | Recorded judgment that a resembling subject is a different thing |
 | `yarramate/access/mode` | value | Access mode of an access relationship |
 | `yarramate/flow/content` | value | Transferred content of a flow |
 | `yarramate/state/type` | value | `baseline`, `transition`, or `target` |

--- a/docs/adr/0076-an-alias-is-matchable-never-renderable.md
+++ b/docs/adr/0076-an-alias-is-matchable-never-renderable.md
@@ -1,0 +1,80 @@
+# An alias is matchable, never renderable
+
+Status: accepted
+
+From the ontology-mapping exploration (2026-08-05, issue #160): a concept
+carried exactly one name. Real vocabularies do not. A subject has an
+abbreviation, a legacy name, a project codename, and whatever the team
+actually says in standup, and the model had nowhere to put any of it. The
+gap paid twice. Free-text seeding in `ask` matched ids, names, and
+descriptions, so a user typing the team's own word for a subject got
+nothing back and fell through to the roster. Near-duplicate detection
+(ADR 0077) lost its single strongest signal, because a genuine duplicate
+very often reuses the other subject's alias.
+
+Prior art is SKOS, which separates preferred, alternative, and hidden
+labels precisely because synonyms are the normal case rather than the
+exception.
+
+Decided: an optional `aka` list on concepts, compiled to one
+`yarramate/concept/alias` value claim per entry.
+
+**No structural change to graph v2.** The compatibility rules are explicit
+that new source-language features may emit additional claims using the
+existing v2 claim structure, and that consumers must interpret predicates
+by identity and ignore predicates they do not understand. An alias is an
+ordinary value claim in the ordinary envelope: no new field, no new
+object shape, no new required structure. A renderer written before this
+ADR reads a model containing aliases correctly, and reads the preferred
+name, because the preferred name is still the only
+`yarramate/concept/name` claim.
+
+**Claim identity derives from the alias text, not its position.** The
+claim id is `<subject>~alias-<hex of the alias>`, the same trick presence
+claims use for their state identity. Aliases are an unordered set with no
+authored ids, so an index-based id would churn every downstream claim
+identity when somebody inserts a new alias at the top of the list.
+Content-derived ids make reordering the YAML a byte-identical no-op in the
+canonical graph. Uniqueness is guaranteed by the schema, which requires
+`uniqueItems`.
+
+**Aliases match at the same weight as the name.** Seeding builds one flat
+haystack per concept from the id, the name, the aliases, and the
+description, and scores how many query terms appear in it. Nothing in that
+match is graded today, and introducing a weight for exactly one field
+would make aliases the single graded input to an otherwise ungraded
+score. It would also defeat the point: the reason to record that a
+component is called "OG" is so that typing "OG" finds it. Ranking the
+alias below the name would deliver a worse answer than the one the author
+explicitly asked for.
+
+**Briefs and every other renderer keep printing the preferred name only.**
+An alias is an index entry, not a display string. Rendering a subject as
+"Order Gateway (OG, the gateway, order-gw)" would spend context budget on
+lookup keys and put four names for one thing in front of a reader whose
+whole problem is that there are too many names for one thing.
+
+**Hidden labels are rejected for v1.** SKOS distinguishes alternative
+labels from hidden ones, the latter being matchable but never shown, for
+deprecated or misspelled forms. Since no YarraMate renderer shows aliases
+at all, `aka` already behaves exactly like a hidden label, and the
+distinction would buy nothing but a second field to explain. If a
+renderer later earns the right to display alternative labels, splitting
+the list then is additive; collapsing two lists into one afterwards would
+not be.
+
+**Concepts only, not relationships.** Relationships are addressed by their
+endpoints and their kind, `ask` indexes concepts alone for seeding, and
+attestations already established that judgment-bearing and identity-bearing
+records are subject-scoped. Widening to relationships later is additive.
+
+**An alias colliding with another subject's name or id is allowed, and is
+deliberately not its own diagnostic.** Making it an error would be wrong
+on the facts: two teams legitimately use one word for two different
+things, and no profile can know which case it is looking at. Making it a
+separate hygiene question would duplicate work, because a collision of
+that kind scores a perfect lexical match between two subjects of the same
+kind, which is exactly the condition ADR 0077 opens the near-duplicate
+question on. The collision case is therefore already answered, by
+construction, through the mechanism built to answer it, and the answer
+path is the same one every other near-duplicate gets.

--- a/docs/adr/0077-a-dismissal-is-a-claim-too.md
+++ b/docs/adr/0077-a-dismissal-is-a-claim-too.md
@@ -1,0 +1,199 @@
+# A dismissal is a claim too
+
+Status: accepted
+
+From the ontology-mapping exploration (2026-08-05, issue #159): the only
+duplicate rules in the engine were exact id collisions, for document ids,
+local ids, constraint ids, and reference ids. Nothing noticed that
+`order-gateway` and `orders-service` were one subject under two names.
+That matters more than a hygiene nit, because Identity is the first thing
+the product claims. The pitch says two sessions cannot invent two names
+for the same component; what actually enforced that was only that
+references must resolve. Two agents modelling the same subject in two
+documents produced a clean `check`, a clean `reconcile`, and a silently
+forked model.
+
+Decided: a hygiene-wave catalogue question, `subjects-near-duplicate`,
+fired by a new deterministic `near-duplicate` trigger condition, and
+dismissible by an ordinary claim recorded in the model.
+
+## The algorithm, exactly
+
+No embeddings, no model, no network, no dictionary, no stored state. The
+same documents produce the same pairs on every machine, forever.
+
+Candidate pairs are unordered pairs of distinct concepts **of the same
+qualified kind**. Kind is the cheapest structural disagreement available,
+and bucketing by it bounds the pairwise cost to the square of the largest
+kind bucket rather than of the whole model. Architecture states and
+retired subjects are already excluded from the interrogation index.
+
+1. **Labels.** `labels(X)` is the local id, the display name, and every
+   `aka` entry from ADR 0076.
+2. **Normalization.** Insert a boundary between a lowercase or digit
+   character and an uppercase one, lowercase, split on every run of
+   non-alphanumeric characters, drop empties, then singularize each token:
+   `ies` becomes `y`; `sses`, `shes`, `ches`, `xes`, `zes` lose `es`; a
+   trailing `s` that is not `ss` is dropped; tokens shorter than four
+   characters are left alone. `OrderGateway`, `order-gateway`,
+   `order_gateway` and `Order Gateway` all become `[order, gateway]`.
+3. **Head tokens.** Remove tokens in a closed, shipped list of type nouns
+   (service, component, api, gateway, system, app, application, module,
+   platform, server, daemon, worker, engine, store, db, database, cache,
+   queue, bus, proxy, adapter, connector, endpoint, svc, srv). If that
+   empties the list, keep the original tokens, so a subject genuinely
+   called "Gateway" survives.
+4. **Label score.** For two labels, the greater of the Jaccard overlap of
+   their head-token sets and `1 - levenshtein(a, b) / max(len(a), len(b))`
+   over their head tokens joined by single spaces.
+5. **Lexical score.** The maximum label score over every pair of labels
+   from the two subjects. The maximum, not the mean, because an alias
+   exists precisely to be an alternative way in: one label matching is the
+   match it was recorded for.
+6. **Decision.** The pair fires when the lexical score is at least
+   **0.95**, or when it is at least **0.80** and a structural signal
+   agrees: the two subjects declare the same owner, or their one-hop
+   relationship neighbourhoods intersect.
+
+Step 3 is what makes the motivating example work. `order-gateway` and
+`orders-service` share no raw token at all; after singularization and type
+noun removal both reduce to `[order]` and score 1.0.
+
+**Why two tiers.** A pair whose head labels are effectively the same
+string is worth one question with no further evidence, because that is the
+forked-model case verbatim. Between 0.80 and 0.95 lexical resemblance
+alone is too noisy to spend a human's attention on, so something
+structural must agree first. Below 0.80 nothing fires. The thresholds are
+constants in `src/subject-identity.ts`, stated here so that changing them
+is visibly a decision.
+
+**The stemmer is crude on purpose.** It turns "status" into "statu". It is
+wrong about English regularly, but it is wrong *identically* on both sides
+of every comparison, which is the only property a similarity signal
+actually needs. Correct morphology means shipping a dictionary, and a
+dictionary is versioned state that would have to reopen questions when it
+changed.
+
+**Never a `check` error, deliberately.** This is a heuristic about names.
+Gating CI on it would fail builds over a judgment call, and would teach
+people to rename subjects to appease a linter. `check --strict` still
+fails only on evidence contradictions, where a provider looked at reality
+and disagreed with the model.
+
+## The dismissal
+
+A false positive must be dismissible, and a dismissal is itself a claim
+that needs somewhere to live, or the question reopens on the next run and
+the interview becomes a machine for asking a question a human already
+answered.
+
+Attestations solved the analogous problem and were the model here: a human
+records acceptance in the model, the compiler emits one claim, and the
+trigger sees only that the claim exists (ADR 0056). Attestations cannot
+express this one, because their arity is wrong. An attestation says
+something about one subject; a dismissal says something about a pair, and
+the topic field is a kebab-case token that cannot carry a globally
+qualified subject id.
+
+Decided: an optional `distinctFrom` list of subject references on
+concepts, compiled to `yarramate/identity/distinct-from` reference claims.
+The model already expresses binary facts about a concept this way, in
+`owner`, `constraints`, `references`, and `presentIn`, so this adds a
+predicate rather than a mechanism. Referential integrity applies: an
+unresolved reference is `YM310` and a self-reference is `YM311`.
+
+**Read symmetrically.** One recorded judgment closes the pair from either
+side. The pair is what the question is about, and demanding the same fact
+be written into two documents would be busywork the model should not ask
+for, with the added failure mode that half a dismissal is no dismissal.
+
+**No `by` and no `on`, unlike an attestation.** An attestation carries a
+date because ADR 0074 built staleness on it: a sign-off covers the wording
+it read, and wording changes. Distinctness is not a claim about wording.
+Two subjects judged genuinely different do not become the same subject
+when one of them is renamed, so a date would imply a staleness semantic
+that does not exist and that nothing implements. Provenance is not lost:
+every graph-v2 claim already carries its document, path, pointer, line,
+and column, and git carries who wrote it and why. Revocation is deletion,
+reviewed at the git boundary, exactly as for an attestation.
+
+**No free-text reason field.** Attestations record no rationale either.
+The commit message is where "why" belongs, and a required prose field on a
+dismissal would mostly collect the word "different".
+
+## Shape of the finding
+
+**The question fires on both members of a pair.** The evaluator is
+one-subject-at-a-time by construction, and firing only on the lexically
+first member would be worse than untidy: `ask --advise` filters open
+questions to the subjects in the requested slice, so a finding recorded
+only against one member would silently vanish from a slice seeded on the
+other. Answering once closes both, because the dismissal is symmetric.
+
+**The counterpart is named in the rendered question, by qualified id.** A
+finding still references exactly one subject. `openSubject` is a closed
+shape shared by the interrogation report, the design step, and the advice
+projection, and widening all three for a single question is
+disproportionate. Naming the counterpart in the question text keeps the
+answer actionable anyway, because that qualified id is literally the value
+the answer writes back into `distinctFrom`. A new `{counterparts}`
+template placeholder does the interpolation, and it is computed only for
+questions whose trigger actually uses the condition.
+
+Catalogue version 0.6 becomes **0.7**: a minor bump, which under ADR 0063
+may only add questions or loosen triggers. One question is added, no
+existing trigger changes, and it records `since: "0.7"` so a model whose
+interview was complete can tell "the catalogue deepened" from "the model
+regressed".
+
+## Interaction with conservative extension (ADR 0079)
+
+ADR 0079 states that loading a profile extension adds subjects and never
+changes verdicts about subjects already present. A pairwise condition is
+the obvious place for that to break, so it was measured rather than
+assumed.
+
+The degenerate case holds, which is the case the property test covers and
+the one that makes importing a profile safe: an extension profile that no
+document selects introduces no subjects, so it creates no pairs and the
+catalogue evaluation is byte-identical. The merged property test loads the
+bundled catalogue, so it exercises this question directly.
+
+Bucketing by **exact** qualified kind rather than through lineage turns
+out to carry more weight than the cost argument that motivated it. An
+extension that declares its own kinds, which is the ordinary way to write
+one, puts its subjects in their own buckets, where they can never pair
+with a core subject that was already there. A near-duplicate arriving as
+`example/delivery@1.0#microservice` leaves every
+`yarramate/core@0.1#applicationComponent` verdict untouched. Descendant
+bucketing would have merged those buckets and made extension documents
+routinely reopen questions about subjects they had nothing to do with.
+
+The boundary is worth stating plainly rather than claiming more than is
+true. When an extension brings a document that declares an *inherited*
+core kind, its subject shares a bucket with core subjects, and a genuine
+near-duplicate there does open a question about a pre-existing subject.
+That is not special to this condition: `concept-isolated`,
+`missing-linkage`, `missing-relationship`, and `missing-reference` all
+respond the same way to a document that links to a subject already in the
+workspace, and they predate this work. Catalogue evaluation is
+workspace-scoped by construction. It is also the entire point of #159,
+since the failure being detected is two documents describing one subject;
+a detector that ignored newly added documents would detect nothing.
+
+## What it said about our own model
+
+Run against this repository's self-model, the question opened on exactly
+one pair: `likec4-generated-project-schema` ("Generated LikeC4 project
+marker JSON Schema") and `likec4-generated-project-v2-schema`
+("Multi-view generated LikeC4 project marker JSON Schema"). Lexical score
+roughly 0.91 from the ids, inside the moderate band, corroborated because
+both declare the same owner.
+
+That is a true detection and a genuine false positive, which is the
+distinction the whole design exists to handle. Both schema files really
+exist, one guards single-view generated projects and the other guards
+multi-view ones. The threshold was not tuned to make it go away. The
+dismissal was recorded in the self-model instead, which is the honest
+answer and also the first real use of the mechanism: one `distinctFrom`
+entry on the v2 subject closed both findings.

--- a/schema/yarramate-ask-result.schema.json
+++ b/schema/yarramate-ask-result.schema.json
@@ -786,6 +786,13 @@
         },
         "description": {
           "type": "string"
+        },
+        "aka": {
+          "description": "Alternative labels this subject is also known by. Free-text seeding matches them at the same weight as the name; renderers show the preferred name only.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -106,11 +106,17 @@
         "description": {
           "$ref": "#/$defs/nonEmptyText"
         },
+        "aka": {
+          "$ref": "#/$defs/alternativeLabels"
+        },
         "status": {
           "$ref": "#/$defs/lifecycleStatus"
         },
         "owner": {
           "$ref": "#/$defs/reference"
+        },
+        "distinctFrom": {
+          "$ref": "#/$defs/subjectReferences"
         },
         "constraints": {
           "type": "array",
@@ -197,6 +203,23 @@
       "minItems": 1,
       "items": {
         "$ref": "#/$defs/identifiedReference"
+      }
+    },
+    "alternativeLabels": {
+      "description": "Other names this subject is known by: abbreviations, legacy names, team jargon. The preferred label stays in name; renderers show only that.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyText"
+      }
+    },
+    "subjectReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/reference"
       }
     },
     "relationship": {

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -118,6 +118,13 @@
         "description": {
           "$ref": "#/$defs/nonEmptyText"
         },
+        "aka": {
+          "description": "Alternative labels appended to the subject's aka list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyText"
+          }
+        },
         "status": {
           "enum": [
             "planned",
@@ -127,6 +134,13 @@
         },
         "owner": {
           "$ref": "#/$defs/nonEmptyText"
+        },
+        "distinctFrom": {
+          "description": "Subjects this one has been judged genuinely different from, dismissing a near-duplicate question permanently (ADR 0077).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyText"
+          }
         },
         "constraints": {
           "type": "array",
@@ -322,8 +336,10 @@
                 "enum": [
                   "name",
                   "description",
+                  "aka",
                   "status",
                   "owner",
+                  "distinctFrom",
                   "constraints",
                   "references",
                   "presentIn",

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -333,6 +333,19 @@
               "pattern": "^[a-z][a-z0-9-]*$"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject resembles another subject of the same kind closely enough to be the same thing under two names, and no yarramate/identity/distinct-from claim dismisses the pair. Deterministic and lexical; the algorithm and thresholds are stated in ADR 0077. Questions using it may interpolate {counterparts}.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "near-duplicate"
+            }
+          }
         }
       ]
     },

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -50,8 +50,10 @@ interface ConceptFields {
   readonly kind?: string
   readonly name?: string
   readonly description?: string
+  readonly aka?: readonly string[]
   readonly status?: string
   readonly owner?: string
+  readonly distinctFrom?: readonly string[]
   readonly constraints?: readonly ConstraintReference[]
   readonly references?: readonly IdentifiedReference[]
   readonly presentIn?: readonly string[]
@@ -111,7 +113,7 @@ interface OperationsDocument {
 // An answer enriches what is there and may explicitly take back what it
 // asserted — it never silently shrinks anything.
 const SCALAR_CONCEPT_FIELDS = ['kind', 'name', 'description', 'status', 'owner'] as const
-const LIST_CONCEPT_FIELDS = ['constraints', 'references', 'presentIn', 'attestations'] as const
+const LIST_CONCEPT_FIELDS = ['aka', 'constraints', 'references', 'presentIn', 'attestations', 'distinctFrom'] as const
 const SCALAR_RELATIONSHIP_FIELDS = ['kind', 'from', 'to', 'name', 'description', 'status', 'mode', 'content'] as const
 const LIST_RELATIONSHIP_FIELDS = ['references', 'presentIn'] as const
 

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -74,6 +74,7 @@ interface ConceptEntry {
   readonly name?: string
   readonly status?: string
   readonly description?: string
+  readonly aka?: readonly string[]
 }
 
 interface OpenQuestionRef {
@@ -217,6 +218,17 @@ const conceptEntries = (graph: SemanticGraph): readonly ConceptEntry[] => {
         id,
         'yarramate/concept/description',
       )
+      // Alternative labels (ADR 0076) are matchable, not renderable: they
+      // widen what free-text seeding finds without changing the name any
+      // renderer prints.
+      const aka = graph.claims
+        .filter(
+          (claim) =>
+            claim.subject === id &&
+            claim.predicate === 'yarramate/concept/alias' &&
+            'value' in claim.object,
+        )
+        .map((claim) => ('value' in claim.object ? claim.object.value : ''))
       return {
         id,
         kind:
@@ -224,6 +236,7 @@ const conceptEntries = (graph: SemanticGraph): readonly ConceptEntry[] => {
         ...(name === undefined ? {} : { name }),
         ...(status === undefined ? {} : { status }),
         ...(description === undefined ? {} : { description }),
+        ...(aka.length === 0 ? {} : { aka }),
       }
     })
     .sort((left, right) => left.id.localeCompare(right.id))
@@ -238,9 +251,15 @@ interface SeedResolution {
 }
 
 // Free text is the default addressing mode: terms match concept ids,
-// names, and descriptions; matching concepts seed the slice. Exact
-// subject ids short-circuit to precise addressing — the seeding finds
-// what an explicit --subject flag would have named.
+// names, alternative labels, and descriptions; matching concepts seed the
+// slice. Exact subject ids short-circuit to precise addressing: the
+// seeding finds what an explicit --subject flag would have named.
+//
+// Aliases join the same flat haystack the id, name, and description
+// already share, so they score at equal weight (ADR 0076). Weighting only
+// aliases would be the one graded field in an otherwise ungraded match,
+// and the whole point of recording the team's actual word for a subject is
+// that it should find it.
 const resolveSeeds = (
   terms: readonly string[],
   entries: readonly ConceptEntry[],
@@ -261,7 +280,7 @@ const resolveSeeds = (
   const scored = entries
     .map((entry) => {
       const text =
-        `${entry.id} ${entry.name ?? ''} ${entry.description ?? ''}`.toLowerCase()
+        `${entry.id} ${entry.name ?? ''} ${(entry.aka ?? []).join(' ')} ${entry.description ?? ''}`.toLowerCase()
       return {
         id: entry.id,
         score: lowered.filter((term) => text.includes(term)).length,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -41,8 +41,10 @@ interface NativeConcept {
   readonly kind: string
   readonly name: string
   readonly description?: string
+  readonly aka?: readonly string[]
   readonly status?: 'planned' | 'current' | 'retired'
   readonly owner?: string
+  readonly distinctFrom?: readonly string[]
   readonly constraints?: ReadonlyArray<{
     readonly id: string
     readonly ref: string
@@ -198,6 +200,16 @@ const compareById = <T extends { readonly id: string }>(left: T, right: T) =>
 
 const presenceClaimId = (subject: string, state: string) =>
   `${subject}~present-in-${Buffer.from(state, 'utf8').toString('hex')}`
+
+// Alternative labels and distinctness records are unordered sets, not
+// authored lists with ids. Hex-encoding the value the way presence
+// encodes its state keeps the claim id derived from content rather than
+// position, so reordering the YAML leaves the graph byte-identical.
+const aliasClaimId = (subject: string, alias: string) =>
+  `${subject}~alias-${Buffer.from(alias, 'utf8').toString('hex')}`
+
+const distinctFromClaimId = (subject: string, other: string) =>
+  `${subject}~distinct-from-${Buffer.from(other, 'utf8').toString('hex')}`
 
 const describeAspect = (aspect: (typeof conceptKinds)[number]['aspect']) =>
   aspect.replace('-', ' ')
@@ -919,6 +931,41 @@ function compileWorkspaceResolved(
           column: source.column,
         })
       }
+      for (const [distinctIndex, other] of (
+        concept.distinctFrom ?? []
+      ).entries()) {
+        const pointer = `/concepts/${index}/distinctFrom/${distinctIndex}`
+        const otherIdentity = qualifyReference(value.id, other)
+        if (!conceptByQualifiedId.has(otherIdentity)) {
+          const source = location(
+            ['concepts', index, 'distinctFrom', distinctIndex],
+            pointer,
+          )
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM310',
+            message: `Unresolved distinct-from reference "${other}"`,
+            path: input.path,
+            pointer,
+            line: source.line,
+            column: source.column,
+          })
+        } else if (otherIdentity === `${value.id}#${concept.id}`) {
+          const source = location(
+            ['concepts', index, 'distinctFrom', distinctIndex],
+            pointer,
+          )
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM311',
+            message: `Concept "${concept.id}" declares itself distinct from itself`,
+            path: input.path,
+            pointer,
+            line: source.line,
+            column: source.column,
+          })
+        }
+      }
       const seenConstraintIds = new Set<string>()
       for (const [constraintIndex, constraint] of (
         concept.constraints ?? []
@@ -1305,6 +1352,22 @@ function compileWorkspaceResolved(
           ),
         })
       }
+      // An alternative label is a matchable name, never a rendered one
+      // (ADR 0076): one value claim each, so a consumer that does not know
+      // the predicate keeps reading the preferred name correctly.
+      for (const [akaIndex, alias] of (concept.aka ?? []).entries()) {
+        claims.push({
+          id: aliasClaimId(subject, alias),
+          subject,
+          predicate: 'yarramate/concept/alias',
+          object: { value: alias },
+          origin: 'declared',
+          source: location(
+            ['concepts', index, 'aka', akaIndex],
+            `/concepts/${index}/aka/${akaIndex}`,
+          ),
+        })
+      }
       if (concept.status !== undefined) {
         claims.push({
           id: `${subject}~status`,
@@ -1315,6 +1378,25 @@ function compileWorkspaceResolved(
           source: location(
             ['concepts', index, 'status'],
             `/concepts/${index}/status`,
+          ),
+        })
+      }
+      // A distinctness record is a human's dismissal of a near-duplicate
+      // question (ADR 0077), stored the way an attestation is: the claim's
+      // existence is the whole signal, and revocation is deletion.
+      for (const [distinctIndex, other] of (
+        concept.distinctFrom ?? []
+      ).entries()) {
+        const otherIdentity = qualifyReference(value.id, other)
+        claims.push({
+          id: distinctFromClaimId(subject, otherIdentity),
+          subject,
+          predicate: 'yarramate/identity/distinct-from',
+          object: { ref: otherIdentity },
+          origin: 'declared',
+          source: location(
+            ['concepts', index, 'distinctFrom', distinctIndex],
+            `/concepts/${index}/distinctFrom/${distinctIndex}`,
           ),
         })
       }

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -10,6 +10,7 @@ import {
   loadSourceDocument,
   locateSourcePath,
 } from './source-document.js'
+import { nearDuplicateIndex } from './subject-identity.js'
 import catalogueSchema from '../schema/yarramate-question-catalogue.schema.json' with {
   type: 'json',
 }
@@ -53,6 +54,7 @@ type CatalogueCondition =
       readonly direction: 'incoming' | 'outgoing'
     }
   | { readonly condition: 'missing-attestation'; readonly topic: string }
+  | { readonly condition: 'near-duplicate' }
 
 export interface CatalogueQuestion {
   readonly id: string
@@ -128,6 +130,9 @@ interface GraphIndex {
   readonly nameOf: ReadonlyMap<string, string>
   readonly statusOf: ReadonlyMap<string, string>
   readonly hasStates: boolean
+  // Memoized: pairwise identity comparison costs nothing for a catalogue
+  // that never asks about it, so it is only paid on first use.
+  readonly nearDuplicates: () => ReadonlyMap<string, readonly string[]>
 }
 
 const indexGraph = (graph: SemanticGraph): GraphIndex => {
@@ -147,6 +152,9 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
   const statusOf = new Map<string, string>()
   const relationshipClaims: GraphClaim[] = []
   const referenceClaims: GraphClaim[] = []
+  const aliasesOf = new Map<string, string[]>()
+  const ownerOf = new Map<string, string>()
+  const distinctFromOf = new Map<string, Set<string>>()
   for (const claim of graph.claims) {
     const forSubject = claimsBySubject.get(claim.subject)
     if (forSubject === undefined) {
@@ -159,6 +167,18 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
     } else if ('ref' in claim.object) {
       referenceClaims.push(claim)
     }
+    if ('ref' in claim.object) {
+      if (claim.predicate === 'yarramate/ownership/owner') {
+        ownerOf.set(claim.subject, claim.object.ref)
+      } else if (claim.predicate === 'yarramate/identity/distinct-from') {
+        const existing = distinctFromOf.get(claim.subject)
+        if (existing === undefined) {
+          distinctFromOf.set(claim.subject, new Set([claim.object.ref]))
+        } else {
+          existing.add(claim.object.ref)
+        }
+      }
+    }
     if ('value' in claim.object) {
       if (claim.predicate === 'yarramate/concept/kind') {
         kindOf.set(claim.subject, claim.object.value)
@@ -166,6 +186,10 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
         nameOf.set(claim.subject, claim.object.value)
       } else if (claim.predicate === 'yarramate/lifecycle/status') {
         statusOf.set(claim.subject, claim.object.value)
+      } else if (claim.predicate === 'yarramate/concept/alias') {
+        const existing = aliasesOf.get(claim.subject)
+        if (existing === undefined) aliasesOf.set(claim.subject, [claim.object.value])
+        else existing.push(claim.object.value)
       }
     }
   }
@@ -184,6 +208,42 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
       )
       .map(({ id }) => id),
   )
+  let pairs: ReadonlyMap<string, readonly string[]> | undefined
+  const nearDuplicates = (): ReadonlyMap<string, readonly string[]> => {
+    if (pairs !== undefined) return pairs
+    const neighboursOf = new Map<string, Set<string>>()
+    const link = (from: string, to: string) => {
+      const existing = neighboursOf.get(from)
+      if (existing === undefined) neighboursOf.set(from, new Set([to]))
+      else existing.add(to)
+    }
+    for (const claim of relationshipClaims) {
+      if (!('ref' in claim.object)) continue
+      link(claim.subject, claim.object.ref)
+      link(claim.object.ref, claim.subject)
+    }
+    pairs = nearDuplicateIndex(
+      [...concepts].map((id) => {
+        const owner = ownerOf.get(id)
+        return {
+          id,
+          kind: kindOf.get(id) ?? 'unknown',
+          // The local id is a label in its own right: an agent that named a
+          // subject `order-gateway` and gave it the display name "Gateway"
+          // still declared "order gateway" about it.
+          labels: [
+            id.slice(id.indexOf('#') + 1),
+            ...(nameOf.get(id) === undefined ? [] : [nameOf.get(id)!]),
+            ...(aliasesOf.get(id) ?? []),
+          ],
+          ...(owner === undefined ? {} : { owner }),
+          neighbours: neighboursOf.get(id) ?? new Set<string>(),
+          distinctFrom: distinctFromOf.get(id) ?? new Set<string>(),
+        }
+      }),
+    )
+    return pairs
+  }
   return {
     concepts,
     claimsBySubject,
@@ -193,6 +253,7 @@ const indexGraph = (graph: SemanticGraph): GraphIndex => {
     nameOf,
     statusOf,
     hasStates: stateSubjects.size > 0,
+    nearDuplicates,
   }
 }
 
@@ -355,20 +416,53 @@ const conditionHolds = (
         ({ predicate }) =>
           predicate === `yarramate/attestation/${condition.topic}`,
       )
+    case 'near-duplicate':
+      // A recorded distinctness judgment removes the pair upstream, in the
+      // index, so this reads exactly like every other condition: the claim's
+      // existence is the whole signal (ADR 0056).
+      return (index.nearDuplicates().get(subjectId!) ?? []).length > 0
   }
 }
 
 // Shared with design: question templates (standard and askPlain alike)
-// interpolate the same two subject placeholders.
+// interpolate the same subject placeholders.
+//
+// `{counterparts}` is the one placeholder that names other subjects. A
+// finding still references exactly one subject, because openSubject is a
+// closed shape shared by three report contracts and widening all of them
+// for one question would be disproportionate. Naming the counterpart by
+// qualified id inside the rendered question keeps the answer actionable
+// anyway: that id is literally the value the answer writes back into
+// distinctFrom.
 export const renderQuestion = (
   template: string,
   subjectId: string,
   subjectName: string | undefined,
+  counterparts?: readonly string[],
 ): string =>
   template
     .trim()
     .replaceAll('{subject.name}', subjectName ?? subjectId)
     .replaceAll('{subject.id}', subjectId)
+    .replaceAll('{counterparts}', (counterparts ?? []).join(', '))
+
+// Only the pairwise condition has counterparts to name, so nothing is
+// computed for the other thirty-eight questions.
+const describeCounterparts = (
+  index: GraphIndex,
+  question: CatalogueQuestion,
+  subjectId: string,
+): readonly string[] | undefined => {
+  if (
+    !question.trigger.some(({ condition }) => condition === 'near-duplicate')
+  ) {
+    return undefined
+  }
+  return (index.nearDuplicates().get(subjectId) ?? []).map((id) => {
+    const name = index.nameOf.get(id)
+    return name === undefined ? id : `${name} (${id})`
+  })
+}
 
 export function evaluateCatalogue(
   catalogue: QuestionCatalogue,
@@ -425,7 +519,12 @@ export function evaluateCatalogue(
             return {
               id,
               ...(name === undefined ? {} : { name }),
-              question: renderQuestion(question.question, id, name),
+              question: renderQuestion(
+                question.question,
+                id,
+                name,
+                describeCounterparts(index, question, id),
+              ),
             }
           }),
         }

--- a/src/subject-identity.ts
+++ b/src/subject-identity.ts
@@ -1,0 +1,269 @@
+// Deterministic near-duplicate subject detection (ADR 0077).
+//
+// The engine never reads words to judge quality (ADR 0056). This module
+// does not break that rule: it does not assess whether a name is good, it
+// asks whether two names are mechanically the same string after a stated
+// normalization. The output is a hygiene question a human answers, never a
+// `check` error, and every step below is pure, ordered, and reproducible on
+// any machine. No embeddings, no model, no network.
+
+// Type tokens name what a subject *is* rather than what it is *about*.
+// `order-gateway` and `orders-service` disagree on every raw token yet name
+// one subject; stripping the type noun is what makes that visible. The list
+// is deliberately closed, short, and confined to deployment and application
+// nouns: domain words an architecture actually reasons about (actor,
+// process, contract, product) are never stripped. Entries are singular
+// because normalization singularizes first.
+const typeTokens: ReadonlySet<string> = new Set([
+  'adapter',
+  'api',
+  'app',
+  'application',
+  'bus',
+  'cache',
+  'component',
+  'connector',
+  'daemon',
+  'database',
+  'db',
+  'endpoint',
+  'engine',
+  'gateway',
+  'module',
+  'platform',
+  'proxy',
+  'queue',
+  'server',
+  'service',
+  'srv',
+  'store',
+  'svc',
+  'system',
+  'worker',
+])
+
+// A crude, symmetric stemmer. It is wrong about English often enough that
+// calling it a stemmer flatters it ("status" becomes "statu"), but it is
+// wrong *identically* on both sides of every comparison, which is the only
+// property a similarity signal needs. Correct English morphology would add
+// a dictionary, and a dictionary is state that has to be versioned.
+const singularize = (token: string): string => {
+  if (token.length < 4) return token
+  if (token.endsWith('ies')) return `${token.slice(0, -3)}y`
+  if (
+    token.endsWith('sses') ||
+    token.endsWith('shes') ||
+    token.endsWith('ches') ||
+    token.endsWith('xes') ||
+    token.endsWith('zes')
+  ) {
+    return token.slice(0, -2)
+  }
+  if (token.endsWith('ss')) return token
+  if (token.endsWith('s')) return token.slice(0, -1)
+  return token
+}
+
+// Split on case boundaries, then on everything that is not alphanumeric.
+// `OrderGateway`, `order-gateway`, `order_gateway` and `Order Gateway` all
+// normalize to the same token list.
+export const normalizeLabel = (label: string): readonly string[] =>
+  label
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0)
+    .map(singularize)
+
+// Removing every token would erase a subject genuinely called "Gateway", so
+// a label that is nothing but type nouns keeps them.
+export const headTokens = (tokens: readonly string[]): readonly string[] => {
+  const head = tokens.filter((token) => !typeTokens.has(token))
+  return head.length === 0 ? tokens : head
+}
+
+const levenshtein = (left: string, right: string): number => {
+  if (left === right) return 0
+  if (left.length === 0) return right.length
+  if (right.length === 0) return left.length
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index)
+  for (let i = 0; i < left.length; i += 1) {
+    const current = [i + 1]
+    for (let j = 0; j < right.length; j += 1) {
+      current.push(
+        Math.min(
+          previous[j + 1]! + 1,
+          current[j]! + 1,
+          previous[j]! + (left[i] === right[j] ? 0 : 1),
+        ),
+      )
+    }
+    previous = current
+  }
+  return previous[right.length]!
+}
+
+// Edit distance normalized by the longer string: 1 is identical, 0 shares
+// nothing.
+export const similarity = (left: string, right: string): number => {
+  const longest = Math.max(left.length, right.length)
+  return longest === 0 ? 0 : 1 - levenshtein(left, right) / longest
+}
+
+const jaccard = (
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): number => {
+  if (left.size === 0 || right.size === 0) return 0
+  let shared = 0
+  for (const token of left) if (right.has(token)) shared += 1
+  return shared / (left.size + right.size - shared)
+}
+
+export interface IdentitySubject {
+  readonly id: string
+  readonly kind: string
+  // The local id, the display name, and every declared alias. Aliases are
+  // matched at the same weight as the name (ADR 0076): an alias exists
+  // precisely to be an alternative way in, and ranking it below the name
+  // would defeat the reason it was recorded.
+  readonly labels: readonly string[]
+  readonly owner?: string
+  readonly neighbours: ReadonlySet<string>
+  readonly distinctFrom: ReadonlySet<string>
+}
+
+export interface NearDuplicatePair {
+  readonly left: string
+  readonly right: string
+  readonly score: number
+  readonly corroboration: 'lexical' | 'owner' | 'neighbourhood'
+}
+
+// A pair whose head labels are effectively the same string is worth one
+// question with no further evidence. Below that, lexical resemblance alone
+// is too noisy to spend a human's attention on, so a structural signal must
+// agree before the question opens.
+export const strongLexicalThreshold = 0.95
+export const moderateLexicalThreshold = 0.8
+
+const labelScore = (left: string, right: string): number => {
+  const leftHead = headTokens(normalizeLabel(left))
+  const rightHead = headTokens(normalizeLabel(right))
+  if (leftHead.length === 0 || rightHead.length === 0) return 0
+  return Math.max(
+    jaccard(new Set(leftHead), new Set(rightHead)),
+    similarity(leftHead.join(' '), rightHead.join(' ')),
+  )
+}
+
+// The best matching pair of labels decides, because any one alias matching
+// is the match the alias was recorded for.
+export const lexicalScore = (
+  left: IdentitySubject,
+  right: IdentitySubject,
+): number => {
+  let best = 0
+  for (const leftLabel of left.labels) {
+    for (const rightLabel of right.labels) {
+      best = Math.max(best, labelScore(leftLabel, rightLabel))
+      if (best === 1) return 1
+    }
+  }
+  return best
+}
+
+const shareNeighbour = (
+  left: IdentitySubject,
+  right: IdentitySubject,
+): boolean => {
+  for (const neighbour of left.neighbours) {
+    if (right.neighbours.has(neighbour)) return true
+  }
+  return false
+}
+
+// Distinctness is read symmetrically: the pair is the subject of the
+// question, so one recorded judgment closes it from either side. Demanding
+// the same fact twice would be busywork the model should not ask for.
+const dismissed = (left: IdentitySubject, right: IdentitySubject): boolean =>
+  left.distinctFrom.has(right.id) || right.distinctFrom.has(left.id)
+
+/**
+ * Every candidate near-duplicate pair, sorted by subject id. Only subjects
+ * of the same qualified kind are compared: kind is the cheapest structural
+ * disagreement there is, and it also bounds the pairwise cost to the square
+ * of the largest kind bucket rather than of the whole model.
+ */
+export const findNearDuplicates = (
+  subjects: readonly IdentitySubject[],
+): readonly NearDuplicatePair[] => {
+  const buckets = new Map<string, IdentitySubject[]>()
+  for (const subject of subjects) {
+    const bucket = buckets.get(subject.kind)
+    if (bucket === undefined) buckets.set(subject.kind, [subject])
+    else bucket.push(subject)
+  }
+  const pairs: NearDuplicatePair[] = []
+  for (const bucket of buckets.values()) {
+    const ordered = [...bucket].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    )
+    for (const [index, left] of ordered.entries()) {
+      for (const right of ordered.slice(index + 1)) {
+        if (dismissed(left, right)) continue
+        const score = lexicalScore(left, right)
+        if (score < moderateLexicalThreshold) continue
+        if (score >= strongLexicalThreshold) {
+          pairs.push({ left: left.id, right: right.id, score, corroboration: 'lexical' })
+          continue
+        }
+        const sameOwner =
+          left.owner !== undefined && left.owner === right.owner
+        if (sameOwner) {
+          pairs.push({ left: left.id, right: right.id, score, corroboration: 'owner' })
+          continue
+        }
+        if (shareNeighbour(left, right)) {
+          pairs.push({
+            left: left.id,
+            right: right.id,
+            score,
+            corroboration: 'neighbourhood',
+          })
+        }
+      }
+    }
+  }
+  return pairs.sort(
+    (left, right) =>
+      left.left.localeCompare(right.left) ||
+      left.right.localeCompare(right.right),
+  )
+}
+
+/**
+ * Both members of every candidate pair, mapped to their counterparts. The
+ * question attaches to both sides deliberately: `ask --advise` filters open
+ * questions to the subjects in a slice, so a finding recorded only against
+ * the lexically-first member would vanish from a slice seeded on the other.
+ */
+export const nearDuplicateIndex = (
+  subjects: readonly IdentitySubject[],
+): ReadonlyMap<string, readonly string[]> => {
+  const index = new Map<string, string[]>()
+  for (const pair of findNearDuplicates(subjects)) {
+    for (const [subject, counterpart] of [
+      [pair.left, pair.right],
+      [pair.right, pair.left],
+    ] as const) {
+      const existing = index.get(subject)
+      if (existing === undefined) index.set(subject, [counterpart])
+      else existing.push(counterpart)
+    }
+  }
+  for (const counterparts of index.values()) {
+    counterparts.sort((left, right) => left.localeCompare(right))
+  }
+  return index
+}

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2579,7 +2579,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1208,
+            line: 1210,
             column: 5,
           },
           {
@@ -2590,7 +2590,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1212,
+            line: 1214,
             column: 5,
           },
           {

--- a/test/subject-identity.test.ts
+++ b/test/subject-identity.test.ts
@@ -1,0 +1,468 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+import {
+  compileWorkspace,
+  compileWorkspaceWithProfileContext,
+} from '../src/compiler.js'
+import {
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/interrogate-command.js'
+import {
+  findNearDuplicates,
+  headTokens,
+  normalizeLabel,
+  similarity,
+  type IdentitySubject,
+} from '../src/subject-identity.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const askResultSchema = JSON.parse(
+  readFileSync(
+    join(
+      resolve(fileURLToPath(new URL('.', import.meta.url)), '..'),
+      'schema/yarramate-ask-result.schema.json',
+    ),
+    'utf8',
+  ),
+) as object
+
+const subject = (
+  id: string,
+  labels: readonly string[],
+  extra: Partial<IdentitySubject> = {},
+): IdentitySubject => ({
+  id,
+  kind: 'yarramate/core@0.1#applicationComponent',
+  labels,
+  neighbours: new Set(),
+  distinctFrom: new Set(),
+  ...extra,
+})
+
+describe('label normalization', () => {
+  it('splits case, separators, and singularizes into one token list', () => {
+    expect(normalizeLabel('OrderGateway')).toEqual(['order', 'gateway'])
+    expect(normalizeLabel('order-gateway')).toEqual(['order', 'gateway'])
+    expect(normalizeLabel('order_gateway')).toEqual(['order', 'gateway'])
+    expect(normalizeLabel('Order Gateway')).toEqual(['order', 'gateway'])
+    expect(normalizeLabel('orders')).toEqual(['order'])
+    expect(normalizeLabel('policies')).toEqual(['policy'])
+  })
+
+  it('strips type nouns but never empties a label that is only type nouns', () => {
+    expect(headTokens(normalizeLabel('orders-service'))).toEqual(['order'])
+    expect(headTokens(normalizeLabel('gateway'))).toEqual(['gateway'])
+  })
+
+  it('scores edit similarity between 0 and 1', () => {
+    expect(similarity('order', 'order')).toBe(1)
+    expect(similarity('order', 'payment')).toBeLessThan(0.3)
+  })
+})
+
+describe('near-duplicate detection', () => {
+  it('finds the motivating pair: order-gateway and orders-service', () => {
+    const pairs = findNearDuplicates([
+      subject('doc#order-gateway', ['order-gateway', 'Order Gateway']),
+      subject('doc#orders-service', ['orders-service', 'Orders Service']),
+    ])
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0]!.left).toBe('doc#order-gateway')
+    expect(pairs[0]!.right).toBe('doc#orders-service')
+    expect(pairs[0]!.corroboration).toBe('lexical')
+  })
+
+  it('leaves genuinely different subjects alone', () => {
+    expect(
+      findNearDuplicates([
+        subject('doc#order-gateway', ['order-gateway']),
+        subject('doc#payment-gateway', ['payment-gateway']),
+        subject('doc#audit-log', ['audit-log']),
+      ]),
+    ).toEqual([])
+  })
+
+  it('never compares subjects of different kinds', () => {
+    expect(
+      findNearDuplicates([
+        subject('doc#orders', ['orders']),
+        subject('doc#order', ['order'], {
+          kind: 'yarramate/core@0.1#dataObject',
+        }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('requires structural corroboration in the moderate band', () => {
+    const left = [
+      'doc#payment-batch-processor',
+      ['payment-batch-processor'],
+    ] as const
+    const right = [
+      'doc#payment-batch-processor-v2',
+      ['payment-batch-processor-v2'],
+    ] as const
+    expect(
+      findNearDuplicates([subject(...left), subject(...right)]),
+    ).toEqual([])
+    const corroborated = findNearDuplicates([
+      subject(...left, { owner: 'doc#team' }),
+      subject(...right, { owner: 'doc#team' }),
+    ])
+    expect(corroborated).toHaveLength(1)
+    expect(corroborated[0]!.corroboration).toBe('owner')
+  })
+
+  it('accepts a shared one-hop neighbour as corroboration', () => {
+    const pairs = findNearDuplicates([
+      subject('doc#payment-batch-processor', ['payment-batch-processor'], {
+        neighbours: new Set(['doc#ledger']),
+      }),
+      subject('doc#payment-batch-processor-v2', ['payment-batch-processor-v2'], {
+        neighbours: new Set(['doc#ledger']),
+      }),
+    ])
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0]!.corroboration).toBe('neighbourhood')
+  })
+
+  it('matches through an alias the preferred names never share', () => {
+    expect(
+      findNearDuplicates([
+        subject('doc#auth', ['auth', 'Authentication']),
+        subject('doc#identity-provider', ['identity-provider', 'Identity Provider']),
+      ]),
+    ).toEqual([])
+    expect(
+      findNearDuplicates([
+        subject('doc#auth', ['auth', 'Authentication']),
+        subject('doc#identity-provider', [
+          'identity-provider',
+          'Identity Provider',
+          'auth',
+        ]),
+      ]),
+    ).toHaveLength(1)
+  })
+
+  it('is dismissed symmetrically by one recorded judgment', () => {
+    const declared = findNearDuplicates([
+      subject('doc#order-gateway', ['order-gateway'], {
+        distinctFrom: new Set(['doc#orders-service']),
+      }),
+      subject('doc#orders-service', ['orders-service']),
+    ])
+    expect(declared).toEqual([])
+    const reversed = findNearDuplicates([
+      subject('doc#order-gateway', ['order-gateway']),
+      subject('doc#orders-service', ['orders-service'], {
+        distinctFrom: new Set(['doc#order-gateway']),
+      }),
+    ])
+    expect(reversed).toEqual([])
+  })
+})
+
+describe('alternative labels and distinctness compile to claims', () => {
+  const compile = (source: string) =>
+    compileWorkspace([{ path: 'main.yaml', source }])
+
+  it('emits one alias claim per aka entry, ordered by content not position', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    aka:
+      - OG
+      - the gateway
+relationships: []
+`)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const aliases = result.graph.claims.filter(
+      ({ predicate }) => predicate === 'yarramate/concept/alias',
+    )
+    expect(aliases.map((claim) => ('value' in claim.object ? claim.object.value : ''))).toEqual([
+      'OG',
+      'the gateway',
+    ])
+    expect(aliases.every(({ subject }) => subject === 'main#order-gateway')).toBe(true)
+
+    const reordered = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    aka:
+      - the gateway
+      - OG
+relationships: []
+`)
+    expect(reordered.ok).toBe(true)
+    if (!reordered.ok) return
+    // Claim ids derive from the alias text, so reordering the YAML leaves
+    // the set of claim identities untouched.
+    expect(
+      reordered.graph.claims
+        .filter(({ predicate }) => predicate === 'yarramate/concept/alias')
+        .map(({ id }) => id)
+        .sort(),
+    ).toEqual(aliases.map(({ id }) => id).sort())
+  })
+
+  it('emits a distinct-from reference claim', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    distinctFrom:
+      - orders-service
+  - id: orders-service
+    kind: applicationComponent
+    name: Orders Service
+relationships: []
+`)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const claim = result.graph.claims.find(
+      ({ predicate }) => predicate === 'yarramate/identity/distinct-from',
+    )
+    expect(claim?.subject).toBe('main#order-gateway')
+    expect(claim?.object).toEqual({ ref: 'main#orders-service' })
+    expect(claim?.origin).toBe('declared')
+  })
+
+  it('rejects an unresolved or self-referential distinctFrom', () => {
+    const unresolved = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    distinctFrom:
+      - nowhere
+relationships: []
+`)
+    expect(unresolved.ok).toBe(false)
+    if (unresolved.ok) return
+    expect(unresolved.diagnostics.map(({ code }) => code)).toContain('YM310')
+
+    const itself = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    distinctFrom:
+      - order-gateway
+relationships: []
+`)
+    expect(itself.ok).toBe(false)
+    if (itself.ok) return
+    expect(itself.diagnostics.map(({ code }) => code)).toContain('YM311')
+  })
+})
+
+// ADR 0079 says loading a profile extension adds subjects and never changes
+// verdicts about subjects already present. A pairwise condition is the
+// obvious place for that to break, so the two safe cases are pinned here.
+describe('near-duplicate detection is conservative over profile extensions', () => {
+  const coreOnly = {
+    path: 'architecture/core-only.yaml',
+    source: `format: yarramate/v1
+id: core-only
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    description: Fronts ordering.
+    status: current
+relationships: []
+`,
+  }
+
+  const extensionProfile = {
+    path: 'profiles/delivery.yaml',
+    source: `format: yarramate/profile/v1
+id: example/delivery
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+relationshipKinds:
+  - id: implements
+    name: Implements
+    parent: yarramate/core@0.1#realization
+`,
+  }
+
+  const bundledCatalogue = (() => {
+    const loaded = loadQuestionCatalogue({
+      path: 'catalogues/core-enrichment.yaml',
+      source: readFileSync(
+        join(
+          resolve(fileURLToPath(new URL('.', import.meta.url)), '..'),
+          'catalogues/core-enrichment.yaml',
+        ),
+        'utf8',
+      ),
+    })
+    if (!loaded.ok) throw new Error('the bundled catalogue must load')
+    return loaded.catalogue
+  })()
+
+  const evaluate = (sources: readonly { path: string; source: string }[]) => {
+    const compiled = compileWorkspaceWithProfileContext([...sources])
+    expect(compiled.ok).toBe(true)
+    if (!compiled.ok) throw new Error('fixture must compile')
+    const report = evaluateCatalogue(
+      bundledCatalogue,
+      compiled.graph,
+      compiled.profileContext,
+    )
+    return report.waves
+      .flatMap((wave) => wave.questions)
+      .find((entry) => entry.id === 'subjects-near-duplicate')!
+  }
+
+  it('leaves the evaluation byte-identical when the extension adds no documents', () => {
+    expect(JSON.stringify(evaluate([extensionProfile, coreOnly]))).toBe(
+      JSON.stringify(evaluate([coreOnly])),
+    )
+  })
+
+  it('never pairs a core subject with an arrival declared under the extension own kind', () => {
+    // Exact-kind bucketing is what makes this safe: the arrival lands in its
+    // own bucket, so the pre-existing core subject keeps its verdict even
+    // though the two names would otherwise score a match.
+    const question = evaluate([
+      extensionProfile,
+      coreOnly,
+      {
+        path: 'architecture/delivery.yaml',
+        source: `format: yarramate/v1
+id: delivery
+profile: example/delivery@1.0
+concepts:
+  - id: orders-service
+    kind: microservice
+    name: Orders Service
+    description: Handles ordering.
+    status: current
+relationships: []
+`,
+      },
+    ])
+    expect(question.open).toBe(false)
+  })
+})
+
+describe('the near-duplicate question end to end', () => {
+  let workspace: string
+
+  const manifest =
+    'format: yarramate/workspace/v1\n' +
+    'id: identity-fixture\n' +
+    'documents:\n' +
+    '  - architecture/main.yaml\n' +
+    'profiles: []\n' +
+    'projections: []\n' +
+    'adapterMappings: []\n' +
+    'evidence: []\n'
+
+  const documentWith = (extra: string): string =>
+    'format: yarramate/v1\n' +
+    'id: main\n' +
+    'profile: yarramate/core@0.1\n' +
+    'concepts:\n' +
+    '  - id: order-gateway\n' +
+    '    kind: applicationComponent\n' +
+    '    name: Order Gateway\n' +
+    '    description: Fronts ordering.\n' +
+    '    status: current\n' +
+    extra +
+    '  - id: orders-service\n' +
+    '    kind: applicationComponent\n' +
+    '    name: Orders Service\n' +
+    '    description: Handles ordering.\n' +
+    '    status: current\n' +
+    'relationships: []\n'
+
+  const write = (extra: string) => {
+    writeFileSync(join(workspace, 'architecture/main.yaml'), documentWith(extra), 'utf8')
+  }
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-identity-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('opens on both members and names the counterpart by qualified id', () => {
+    write('')
+    const result = runCli(['ask', 'workspace.yaml', '--open', '--json'], workspace)
+    const report = JSON.parse(result.stdout).report
+    const question = report.waves
+      .flatMap((wave: { questions: unknown[] }) => wave.questions)
+      .find((entry: { id: string }) => entry.id === 'subjects-near-duplicate')
+    expect(question.open).toBe(true)
+    expect(question.subjects).toHaveLength(2)
+    expect(question.subjects[0].question).toContain('main#orders-service')
+    expect(question.subjects[1].question).toContain('main#order-gateway')
+  })
+
+  it('closes permanently once one side records the distinctness judgment', () => {
+    write('    distinctFrom:\n      - orders-service\n')
+    const result = runCli(['ask', 'workspace.yaml', '--open', '--json'], workspace)
+    const report = JSON.parse(result.stdout).report
+    const question = report.waves
+      .flatMap((wave: { questions: unknown[] }) => wave.questions)
+      .find((entry: { id: string }) => entry.id === 'subjects-near-duplicate')
+    expect(question.open).toBe(false)
+    expect(question.subjects).toBeUndefined()
+  })
+
+  it('seeds a free-text slice through an alias the name never mentions', () => {
+    write('    aka:\n      - OG\n')
+    const bare = runCli(['ask', 'workspace.yaml', 'OG', '--json'], workspace)
+    const seeded = JSON.parse(bare.stdout)
+    expect(seeded.mode).toBe('slice')
+    expect(seeded.seeds).toContain('main#order-gateway')
+  })
+
+  it('carries aliases through the roster within the ask-result contract', () => {
+    write('    aka:\n      - OG\n')
+    const result = runCli(['ask', 'workspace.yaml', '--subjects', '--json'], workspace)
+    const parsed = JSON.parse(result.stdout)
+    expect(
+      parsed.subjects.find((entry: { id: string }) => entry.id === 'main#order-gateway')
+        .aka,
+    ).toEqual(['OG'])
+    const validate = new Ajv2020({ allErrors: true }).compile(askResultSchema)
+    expect(validate(parsed)).toBe(true)
+  })
+})


### PR DESCRIPTION
Builds #160 and #159 as one arc, because the second depends on the first: aliases are the strongest signal near-duplicate detection has.

**One PR, two ADRs.** The decisions are genuinely separable (#160 stands on its own as a search improvement), so they get an ADR each rather than one combined: **0076** for alternative labels, **0077** for near-duplicate detection and the dismissal.

## What landed

**#160, alternative labels.** An optional `aka` list on concepts, compiled to one `yarramate/concept/alias` value claim per entry. `ask` free-text seeding matches aliases; briefs and every other renderer keep printing the preferred `name` alone.

**#159, near-duplicate detection.** A new `near-duplicate` catalogue trigger condition backing a hygiene-wave question, `subjects-near-duplicate`. Never a `check` error.

## The algorithm, plainly

Deterministic. No embeddings, no LLM, no network, no dictionary, no stored state.

Candidates are unordered pairs of distinct concepts **of the same qualified kind**. Kind is the cheapest structural disagreement available, and bucketing on it bounds cost to the square of the largest bucket rather than of the whole model.

1. **Labels** are the local id, the display name, and every `aka` entry.
2. **Normalize**: split camelCase, lowercase, split on non-alphanumeric runs, then singularize (`ies` to `y`; `sses`/`shes`/`ches`/`xes`/`zes` lose `es`; trailing `s` that is not `ss` is dropped; tokens under four characters untouched).
3. **Head tokens**: drop a closed, shipped list of type nouns (service, component, api, gateway, system, app, module, platform, server, store, db, cache, queue, bus, proxy, adapter, endpoint, and similar). If that empties the label, keep the original tokens, so a subject genuinely called "Gateway" survives.
4. **Label score**: the greater of Jaccard overlap of head-token sets, and `1 - levenshtein / max length` over head tokens joined by spaces.
5. **Lexical score**: the maximum over every pair of labels. Maximum, not mean, because an alias exists to be an alternative way in, so one label matching is the match it was recorded for.
6. **Fire** at lexical >= **0.95**, or at >= **0.80** when a structural signal agrees: same declared owner, or intersecting one-hop relationship neighbourhoods.

Step 3 is what makes the issue's own example work: `order-gateway` and `orders-service` share no raw token, but both reduce to `[order]` and score 1.0.

## Design decisions, honestly

- **Two tiers, not one threshold.** Effectively-identical head labels are worth a question on their own; between 0.80 and 0.95 lexical resemblance alone is too noisy to spend attention on. Thresholds are named constants, stated in the ADR, so changing them is visibly a decision.
- **The stemmer is crude on purpose.** It turns "status" into "statu". It is wrong about English often, but wrong *identically* on both sides of every comparison, which is the only property a similarity signal needs. Correct morphology means shipping a dictionary, and a dictionary is versioned state that would reopen questions when it changed.
- **The dismissal is `distinctFrom`, not an attestation.** Attestations were the model here and could not express it: their arity is unary, and the kebab-case `topic` cannot carry a globally qualified subject id. `distinctFrom` is a reference list compiling to `yarramate/identity/distinct-from`, which is how the model already expresses binary facts (`owner`, `constraints`, `references`, `presentIn`). So this adds a predicate, not a mechanism.
- **Read symmetrically.** One entry closes the pair from either side. Demanding the fact be written into two documents is busywork, with the failure mode that half a dismissal is no dismissal.
- **No `by`/`on`, unlike an attestation.** ADR 0074 built staleness on the attestation date because a sign-off covers the wording it read. Distinctness is not about wording: two subjects judged different do not become the same when one is renamed. A date would imply a staleness semantic nothing implements. Provenance is not lost, since every graph-v2 claim already carries document, path, pointer, line, and column, and git carries who and why.
- **No reason field.** Attestations record no rationale either. A required prose field would mostly collect the word "different".
- **Fires on both members of a pair.** Not tidiness: `ask --advise` filters open questions to the subjects in a slice, so a finding recorded only against the lexically-first member would silently vanish from a slice seeded on the other.
- **The counterpart is named in the rendered question by qualified id**, via a new `{counterparts}` placeholder, rather than widening `openSubject`. That shape is shared by the interrogation report, the design step, and the advice projection, and widening all three for one question is disproportionate. The id in the text is exactly the value the answer writes back into `distinctFrom`.
- **Aliases match at equal weight to the name.** Nothing in seeding is graded today; weighting one field would make aliases the single graded input. It would also defeat the point of recording the team's actual word.
- **Hidden labels rejected for v1.** Since no renderer shows aliases at all, `aka` already behaves like a hidden label.
- **An alias colliding with another subject's name or id is allowed, deliberately.** Making it an error would be wrong on the facts, and making it its own hygiene question would duplicate work: such a collision scores a perfect lexical match between two same-kind subjects, which is exactly what opens the near-duplicate question. The collision case is already answered, by construction.
- **Graph v2 grows additively.** Both are ordinary claims in the existing envelope, per the compatibility rules: no new field, no new structure, and consumers ignore predicates they do not understand. Alias claim ids derive from the alias text (hex-encoded, as presence claims do for state identity), so reordering the YAML leaves the canonical graph byte-identical.
- **Catalogue 0.6 to 0.7**, a minor bump: one question added, no existing trigger touched, recording `since: "0.7"` so a complete interview can tell "the catalogue deepened" from "the model regressed" (ADR 0063).

## What the check said about our own self-model

It fired. Reporting it rather than tuning it away.

One pair opened: `yarramate-engine#likec4-generated-project-schema` ("Generated LikeC4 project marker JSON Schema") and `yarramate-engine#likec4-generated-project-v2-schema` ("Multi-view generated LikeC4 project marker JSON Schema"). Lexical score roughly 0.91 from the ids, inside the moderate band, corroborated because both declare the same owner.

That is a true detection and a genuine false positive, which is precisely the distinction the design exists to handle: both schema files really exist, one guarding single-view generated projects and the other multi-view. The threshold was not touched. The dismissal was recorded in the self-model instead, which is the honest answer and the mechanism's first real use. One `distinctFrom` entry on the v2 subject closed both findings, confirming the symmetric read end to end on real data.

The self-model is back to 39 questions, 0 open.

## Verification

`rm -rf dist && pnpm verify` passes clean from scratch: **411 tests** (394 baseline plus 17 new), self-check clean, `likec4 validate` clean.

New diagnostics: `YM310` unresolved distinct-from reference, `YM311` subject declared distinct from itself.


Closes #160
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
