### PR TITLE
Succession claims: a renamed, split, or merged subject keeps its history

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -562,6 +562,9 @@ concepts:
     description: Applies an atomic batch of validated writes; the whole candidate workspace must compile before a single byte lands.
     owner: yarramate-product#yarramate-maintainers
     status: current
+    supersedes:
+      - add-command
+      - connect-command
   - id: apply-operations
     kind: dataObject
     name: Operations document
@@ -588,6 +591,8 @@ concepts:
     description: Serves exactly the top open catalogue question with its subject slice, recomputed statelessly from the model; the internal catalogue never crosses the harness boundary.
     owner: yarramate-product#yarramate-maintainers
     status: current
+    supersedes:
+      - interrogate-command
   - id: design-step
     kind: dataObject
     name: Design step
@@ -604,6 +609,12 @@ concepts:
     description: One entry point for every consumed-now read - orientation with the backlog-shaped verdict, the filterable roster, free-text-seeded slices, the advise composition, build order, open questions, and state comparison.
     owner: yarramate-product#yarramate-maintainers
     status: current
+    supersedes:
+      - status-command
+      - context-command
+      - next-command
+      - compare-command
+      - interrogate-command
   - id: ask-result
     kind: dataObject
     name: Ask result
@@ -620,6 +631,8 @@ concepts:
     description: Derives every persisted artifact - the canonical graph, projection markdown, the per-concept briefs handoff bundle, and the LikeC4 visualization project delegated to the sibling adapter binary in a separate process.
     owner: yarramate-product#yarramate-maintainers
     status: current
+    supersedes:
+      - compile-command
   - id: consumer-host
     kind: node
     name: Consumer host

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -202,6 +202,25 @@ context budget in a brief. Aliases also feed near-duplicate detection
 directly, because a genuine duplicate very often reuses the other
 subject's alias.
 
+## Recording where a subject went
+
+A subject that is renamed, split, or merged loses its history unless the
+succession is recorded, because nothing in two documents distinguishes a
+rename from a coincidence of naming. Concepts carry an optional
+`supersedes` list naming the subjects whose responsibility they took over
+(ADR 0080), compiled to `yarramate/lineage/supersedes` claims.
+
+A harness should write it at the moment it introduces the replacement,
+which is the moment it knows. One predicate covers every case: name one
+predecessor for a rename, several for a merge, and let several successors
+name one predecessor for a split. Do **not** retire the predecessor merely
+because it has a successor; retirement is its own decision and the
+transition period during which both run is real.
+
+Briefs read the claims in both directions, so the replacement reads
+"Succeeds ..." and the original reads "Superseded by ...", which is how a
+later session recovers the refactoring that a diff alone does not explain.
+
 ## Migration map (0.7.0 clean break — EXECUTED, ADR 0061)
 
 | Before 0.7.0 | Now |
@@ -278,3 +297,11 @@ vocabulary as a read.
   catalogue condition, deterministic and lexical, never a `check`
   error. A dismissal is a `distinctFrom` claim, read symmetrically, so
   it survives re-running the interview.
+- Succession: SETTLED (ADR 0080): one `supersedes` list on concepts
+  compiling to `yarramate/lineage/supersedes`, authored on the successor
+  and read both ways. Cardinality is the shape, so rename, split, and
+  merge need no separate vocabulary. Retirement is deliberately not
+  coupled. The RTM and a catalogue question about retired subjects with
+  no successor are deferred, the latter because retired subjects are
+  outside the interrogation index by ADR 0064 and because "it went
+  nowhere" is an answer the question would have to accept.

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -90,6 +90,40 @@ from either side, and it survives re-running the interview because it is
 part of the model rather than session state. `YM310` reports an unresolved
 reference and `YM311` a subject declared distinct from itself.
 
+A concept may record which subjects it took over from:
+
+```yaml
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - order-gateway
+```
+
+Each entry compiles to a `yarramate/lineage/supersedes` reference claim
+whose ID derives from the predecessor's identity, so reordering the list
+leaves the canonical graph byte-identical. One predicate carries every
+shape, because the shape is cardinality (ADR 0080): one entry is a rename,
+several entries on one successor are a merge, and one predecessor named by
+several successors is a split. Recording it on the successor means a new
+subject arrives complete, in one document, saying where its responsibility
+came from.
+
+A predecessor is **not** required to be retired. The transition period
+during which the old thing and the new thing both run is real, and both may
+equally be `planned` while a split is still being designed. Retirement
+stays the separate descoping decision it is under ADR 0064; succession says
+only where the responsibility went.
+
+`YM312` reports an unresolved succession reference, `YM313` a subject
+declaring that it supersedes itself, and `YM504` a succession cycle, which
+asserts that a subject is its own ancestor.
+
+Briefs read these claims in both directions, so a successor reads
+"Succeeds ..." and a predecessor reads "Superseded by ...". That is the
+answer to "where did this go?" a month after the refactoring.
+
 A concept may require multiple explicitly identified constraints:
 
 ```yaml
@@ -322,9 +356,9 @@ and one-based line and column.
 | --- | --- | --- |
 | `YM1xx` | YAML parsing | `YM101` malformed YAML |
 | `YM2xx` | Document structure | `YM201` JSON Schema violation |
-| `YM3xx` | Identity and references | `YM301` duplicate local ID; `YM302` unresolved concept reference; `YM303` duplicate document ID; `YM304` unresolved owner; `YM305` unresolved constraint; `YM306` duplicate constraint ID; `YM307` unresolved architecture state; `YM308` unresolved subject reference; `YM309` duplicate reference ID; `YM310` unresolved distinct-from reference; `YM311` self-referential distinct-from |
+| `YM3xx` | Identity and references | `YM301` duplicate local ID; `YM302` unresolved concept reference; `YM303` duplicate document ID; `YM304` unresolved owner; `YM305` unresolved constraint; `YM306` duplicate constraint ID; `YM307` unresolved architecture state; `YM308` unresolved subject reference; `YM309` duplicate reference ID; `YM310` unresolved distinct-from reference; `YM311` self-referential distinct-from; `YM312` unresolved succession reference; `YM313` self-referential succession |
 | `YM4xx` | Profile conformance | `YM401` unknown concept kind; `YM402` unknown relationship kind; `YM403` unavailable profile; `YM404` incompatible endpoint; `YM405` misplaced controlled field; `YM406` unavailable parent profile; `YM407`/`YM408` unavailable semantic parent; `YM409`/`YM410` inherited-name collision; `YM411` duplicate profile; `YM412` broadened constraint; `YM413` rigid kind specializing an anti-rigid one |
-| `YM5xx` | Claim consistency | `YM501` competing whole-part claims; `YM502` cyclic state ordering; `YM503` relationship present without an endpoint |
+| `YM5xx` | Claim consistency | `YM501` competing whole-part claims; `YM502` cyclic state ordering; `YM503` relationship present without an endpoint; `YM504` cyclic succession |
 | `YM6xx` | Adapter mapping integrity | `YM601` unknown native subject; `YM602` subject type mismatch; `YM603` duplicate native mapping; `YM604` duplicate external mapping; `YM605` duplicate versioned mapping |
 | `YM7xx` | Workspace resolution | `YM701` unsafe pattern; `YM702` unmatched pattern; `YM703` cross-category file |
 | `YM8xx` | Evidence integrity | `YM801` unknown subject; `YM802` unknown claim; `YM803` duplicate target; `YM804` duplicate evidence document |
@@ -403,8 +437,8 @@ The operations are `add-concept`, `add-relationship`, `update-concept`,
 `update-relationship`, `delete-concept`, and `delete-relationship`. Concept
 and relationship records accept the same
 optional fields as the authoring format — for example `status`,
-`description`, `aka`, `owner`, `distinctFrom`, `constraints`,
-`references`, `presentIn`, and the
+`description`, `aka`, `owner`, `distinctFrom`, `supersedes`,
+`constraints`, `references`, `presentIn`, and the
 controlled `mode` and `content` fields. `apply` writes by splicing minimal
 text edits into the authored source, so bytes an operation never touched —
 including folded prose and comments — stay byte-identical (ADR 0062). It

--- a/docs/SEMANTIC-GRAPH.md
+++ b/docs/SEMANTIC-GRAPH.md
@@ -45,6 +45,17 @@ reference claim. Both are ordinary claims in the existing envelope: no new
 field and no new structure, so a consumer that does not know either
 predicate keeps reading the graph, and the preferred name, correctly.
 
+A recorded succession emits one `yarramate/lineage/supersedes` reference
+claim per predecessor, authored on the successor and pointing back. One
+predicate carries rename, split, and merge, because the shape is
+cardinality rather than vocabulary: group the predicate's claims by object
+and a predecessor named once was renamed, a predecessor named by several
+successors was split, and a successor naming several predecessors is a
+merge. A superseded subject is not required to carry
+`yarramate/lifecycle/status` of `retired`, since the transition period
+during which both run is real. This too is an ordinary claim in the
+existing envelope.
+
 Concept and relationship descriptions use
 `yarramate/concept/description` and
 `yarramate/relationship/description`. Identified citations use
@@ -145,6 +156,7 @@ Core claim predicates:
 | `yarramate/constraint/expects` | value | Expected observation as `<provider> <key> <expected value>` |
 | `yarramate/reference/refers-to` | ref | Identified citation to any subject |
 | `yarramate/identity/distinct-from` | ref | Recorded judgment that a resembling subject is a different thing |
+| `yarramate/lineage/supersedes` | ref | Predecessor whose responsibility this subject took over |
 | `yarramate/access/mode` | value | Access mode of an access relationship |
 | `yarramate/flow/content` | value | Transferred content of a flow |
 | `yarramate/state/type` | value | `baseline`, `transition`, or `target` |

--- a/docs/adr/0080-cardinality-is-the-shape-of-a-succession.md
+++ b/docs/adr/0080-cardinality-is-the-shape-of-a-succession.md
@@ -1,0 +1,243 @@
+# Cardinality is the shape of a succession
+
+Status: accepted
+
+From the ontology-mapping exploration (2026-08-05, issue #162): the write
+surface covers assert, enrich, retract, retire, and delete, which is a
+subject's own lifecycle handled completely. What none of it can express is
+a subject becoming other subjects. When a service splits in two, the model
+records one retirement and two arrivals with nothing connecting them. When
+two components merge, the same in reverse. The refactoring that motivated
+the change is invisible a month later, and so is the answer to "where did
+this go?", which is the question a newcomer actually asks.
+
+Prior art is diachronic identity, the studied problem of what makes an
+entity the same entity across change. The practical answer in modelling
+systems is not inference. Nothing in two documents distinguishes a rename
+from a coincidence of naming, so the succession is recorded or it is lost.
+
+Decided: an optional `supersedes` list of subject references on concepts,
+compiled to `yarramate/lineage/supersedes` reference claims.
+
+## One predicate, not three
+
+Rename, split, and merge are one-to-one, one-to-many, and many-to-one over
+the same relation, so the obvious alternative was three predicates naming
+the three cases. It is worse, and not only because it is more vocabulary.
+
+**The shape is a global fact and the edit is local.** A subject that writes
+`splitFrom` is asserting that its predecessor went to more than one place,
+which it cannot see from inside its own document. The assertion also rots:
+delete one of two successors a year later and the survivor still claims it
+came from a split, which is now simply false. One predicate has no such
+failure mode, because nothing is asserted about cardinality. The shape is
+recomputed from whatever claims exist at the time somebody asks.
+
+**Three predicates need the derivation anyway.** To catch the rotted claim
+above, the compiler would have to count successors per predecessor and
+compare that count against the authored label. That is the cardinality
+derivation, plus a consistency check the one-predicate design does not need
+because it has nothing to be inconsistent with. Strictly more machinery for
+strictly less truth.
+
+**The set is not closed.** A subject that absorbs half of one predecessor
+and the whole of another is neither a split nor a merge, and arguing about
+which of three names it deserves is an argument the model should not host.
+Under one predicate it is two claims and the argument does not arise.
+
+**The cost to a reader is a group-by.** Every graph-v2 consumer already
+indexes claims by predicate, because that is the entire documented reading
+algorithm. Grouping one predicate's claims by object is the same work as
+learning three predicates, done once, by machine.
+
+## The claim points backwards
+
+`supersedes` lives on the successor and names the predecessor, rather than
+a `succeededBy` on the predecessor naming what replaced it. Both directions
+carry identical information, so the choice is about authoring and about
+precedent.
+
+**The authoring moment is the arrival of the new subject.** That is when
+somebody knows the succession, and at that moment they are editing the new
+subject. Pointing backwards means the new subject arrives complete, in one
+document, saying what it is and where it came from. Pointing forwards means
+reaching into the predecessor's document to add a field, and the
+predecessor frequently lives in a document owned by another team, or in one
+this change had no other reason to touch.
+
+**The engine already points backwards for ordering.** `yarramate/state/after`
+names the predecessor state, not the successor. Succession is the
+subject-level analogue of state ordering, and using the opposite direction
+for the same shape of fact would be a second idiom for no gain.
+
+**Reading the other direction is free.** "Where did X go?" is a scan for
+claims whose object is X, which any consumer holding the claim list can do.
+The brief does exactly this and renders both directions from one claim set,
+so the authoring convenience costs the reader nothing.
+
+## Asymmetric, unlike a dismissal
+
+ADR 0077 read `distinctFrom` symmetrically, and this deliberately does not.
+The reasoning there was that the *pair* is what the judgment is about, so
+demanding the same fact in two documents would be busywork with a failure
+mode, since half a dismissal is no dismissal.
+
+Succession is an ordered fact about time. The direction is the content, not
+an artifact of which document happened to record it. Reading it
+symmetrically would assert that the predecessor also succeeded its own
+successor, which is the cycle this ADR spends a diagnostic rejecting.
+
+## Referential integrity
+
+`YM312` reports an unresolved succession reference and `YM313` a subject
+declared to supersede itself, mirroring `YM310` and `YM311` exactly. The
+targets must resolve for the same reason `owner`, `constraints`, and
+`references` targets must: a lineage pointing at nothing is worse than no
+lineage, because it looks like an answer.
+
+`YM504` reports a succession cycle, mirroring `YM502` for cyclic state
+ordering. A cycle asserts that a subject is its own ancestor. It is
+tempting to read a two-step cycle as "we split it and then changed our
+mind", but the model has no time axis: both ends of the cycle are one
+snapshot, so what is actually recorded is that one subject both preceded
+and followed another, which cannot be true of a single pair.
+
+**Self-succession keeps its own code even though it is a cycle of length
+one.** It is the case that actually happens, being a copy-paste inside a
+single concept, and it deserves a diagnostic that says so rather than one
+about participating in a cycle. The cycle walk skips self-references, so
+exactly one diagnostic fires per defect and neither code doubles up on the
+other.
+
+## A superseded subject is not required to be retired
+
+Enforcement was considered and rejected.
+
+**The transition period is real.** A strangler migration runs the old thing
+and the new thing side by side for months, and during that window the
+predecessor is genuinely `current`. Requiring retirement would force the
+model to misstate reality in exactly the period where the model earns its
+keep, which is when two things are doing one job and somebody needs to know
+which.
+
+**Succession is often recorded before anything is retired at all.** The
+split is designed, then built, then cut over. Both subjects can legitimately
+be `planned`. A rule that fires at compile time cannot tell a plan from a
+lie about the present.
+
+**Retirement is its own decision with its own verb.** ADR 0064 made retired
+a closed question and the write surface gave it a dedicated verb, precisely
+so that descoping is a decision somebody takes rather than a side effect.
+Coupling would turn succession into a back door that forces a lifecycle
+transition nobody asked for.
+
+**A rule here would be a claim about the future.** "The predecessor will
+eventually be retired" is not checkable against a snapshot, and the engine
+does not assert things it cannot check.
+
+What the pairing buys is a reading rather than a rule. A retired subject
+with a successor is materially different from one retired into nothing, and
+the brief now says which, which was the point.
+
+## No catalogue question about retired subjects with no successor
+
+The issue floated this as a cheap follow-on. It is not cheap, and the
+reason is worth recording so it is not proposed again as an oversight.
+
+Retired concepts are excluded from the interrogation index outright, under
+ADR 0064: retirement is the recorded decision that a subject left the
+design conversation, so no question stays open against it. Asking anything
+at all about a retired subject means carving an exception into that
+exclusion, and the exception is not obviously containable, since the index
+is shared by every question in the catalogue.
+
+The second problem is worse. The honest answer is very often "nowhere, it
+was decommissioned", and a question that cannot accept its own commonest
+answer reopens on every run forever, which is the exact failure ADR 0077
+built the dismissal mechanism to prevent. `distinctFrom` cannot be reused,
+since its arity is binary and its meaning is wrong. Attestations do fit,
+being unary and keyed by a kebab-case topic that needs to carry no subject
+id, so if this is ever built the shape is a `decommissioned` attestation
+topic and not a new mechanism. Naming the shape is what this ADR owes the
+next person; building it is not in this change.
+
+## What renders it, and what does not
+
+**The brief renders lineage in both directions.** `supportSentences`
+already renders ownership and constraints alongside a subject's
+relationships, and succession joins them: "Succeeds X." on the successor,
+"Superseded by Y." on the predecessor, both derived from the same claims.
+This is the surface that answers "where did this go?", and it is the
+surface a newcomer reads, so it is the one place the feature is not
+optional.
+
+**Slices are not expanded to pull in predecessors.** Seeded slices cap
+their neighbourhood honestly (ADR 0070), and a succession edge would spend
+that cap on history at the expense of the current neighbourhood the slice
+was asked for. A brief that already names the predecessor gives a reader
+the id to seed a second slice on, which is the honest version of the same
+affordance.
+
+**The traceability matrix is not touched.** The RTM answers what covers a
+requirement now, and succession is a claim about the past; joining them
+widens what the artifact claims from current coverage to coverage history,
+which is a different artifact and deserves its own decision. The claims are
+in graph v2, so a later RTM revision joins realizers to their predecessors
+with a single predicate lookup and no new vocabulary. Shipping the
+vocabulary before the rendering is the order ADR 0076 used for aliases,
+which to this day no renderer displays.
+
+**Concepts only, not relationships.** Relationships are addressed by their
+endpoints and their kind, so a relationship whose endpoints are both
+superseded has a succession that is already derivable. This follows ADR
+0076 and widening later stays additive.
+
+## No structural change to graph v2
+
+A succession is an ordinary reference claim in the ordinary envelope: no
+new field, no new object shape, no new required structure. The
+compatibility rules are explicit that new source-language features may emit
+additional claims using the existing v2 claim structure, and that consumers
+must interpret predicates by identity and ignore predicates they do not
+understand. A renderer written before this ADR reads a model containing
+succession correctly, and simply does not mention it.
+
+Claim identity is `<subject>~supersedes-<hex of the predecessor id>`,
+content-derived the way alias and presence claims are, so reordering the
+YAML leaves the canonical graph byte-identical. Uniqueness is guaranteed by
+the schema, which requires `uniqueItems`.
+
+## What it said about our own model
+
+The 0.7.0 clean break to seven verbs (ADR 0061) retired ten command
+services in one commit and recorded the old-to-new mapping only in a
+migration table in `docs/AGENT-INTERFACE.md`. The model itself held ten
+retirements and no connections, which is precisely the loss this ADR
+describes, in this repository, for the past four days.
+
+Nine succession claims now record it, and all three shapes appear without
+any of them being named:
+
+- a **merge**, where `ask-command` names five predecessors: `status`,
+  `context`, `next`, `compare`, and `interrogate`;
+- a **split**, where `interrogate-command` is named by two successors,
+  `ask-command` taking the reporting half and `design-command` the
+  interview half;
+- a **rename**, where `export-command` names `compile-command` alone,
+  after ADR 0060 reframed the artifact as an export;
+- a second merge, where `apply-command` names `add-command` and
+  `connect-command`, collapsed into one atomic batch by ADR 0057.
+
+The brief now answers the motivating question directly. Seeding a slice on
+the dead subject returns "Superseded by "yarramate-engine#ask-command" and
+"yarramate-engine#design-command"", naming successors that the slice does
+not contain, by the ids a reader can seed on next.
+
+Two subjects were deliberately left with no successor, which matters more
+than the nine that got one. `new-command` was retired because ADR 0061
+decided that `new projection` gets no replacement at all: projections are
+authored directly and validated by `check`. `evidence-command` left the
+public surface without a specific successor, its machinery surviving inside
+`check` and `reconcile`. Inventing a destination for either would have been
+the model telling a story the ADRs do not support, and both are the reason
+this change ships no question demanding one.

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -118,6 +118,9 @@
         "distinctFrom": {
           "$ref": "#/$defs/subjectReferences"
         },
+        "supersedes": {
+          "$ref": "#/$defs/successionReferences"
+        },
         "constraints": {
           "type": "array",
           "items": {
@@ -215,6 +218,15 @@
       }
     },
     "subjectReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/reference"
+      }
+    },
+    "successionReferences": {
+      "description": "Subjects whose responsibility this one took over. One entry is a rename, several are a merge, and one predecessor named by several successors is a split. A predecessor need not be retired: the transition period is real.",
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -142,6 +142,13 @@
             "$ref": "#/$defs/nonEmptyText"
           }
         },
+        "supersedes": {
+          "description": "Subjects whose responsibility this one took over, recording a rename, split, or merge (ADR 0080).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyText"
+          }
+        },
         "constraints": {
           "type": "array",
           "items": {
@@ -340,6 +347,7 @@
                   "status",
                   "owner",
                   "distinctFrom",
+                  "supersedes",
                   "constraints",
                   "references",
                   "presentIn",

--- a/skills/yarramate-architecture/references/modelling-patterns.md
+++ b/skills/yarramate-architecture/references/modelling-patterns.md
@@ -205,3 +205,53 @@ X, and what does it materialize?"
 **Why it is material.** The hosting boundary decides latency, failure domain,
 scaling model, and data residency. A component with no declared runtime is
 deployed by whoever gets there first.
+
+## Recorded succession
+
+**Problem.** A component is renamed, split in two, or merged with another,
+and the model records one retirement and two arrivals with nothing joining
+them. A month later the refactoring is invisible, and so is the answer to
+"where did this go?" Nothing in two documents distinguishes a rename from a
+coincidence of naming, so the connection is recorded or it is lost.
+
+**Solution.** Name the predecessors on the subject that took the work over,
+using `supersedes`. One predicate covers every case, because the shape is
+cardinality (ADR 0080): one entry is a rename, several entries are a merge,
+and one predecessor named by several successors is a split.
+
+```yaml
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - order-gateway
+  - id: order-events
+    kind: applicationComponent
+    name: Order Events
+    supersedes:
+      - order-gateway
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    status: retired
+```
+
+Two successors naming one predecessor is the split. Write it on the
+successor, at the moment you introduce it, which is the moment you know:
+the new subject then arrives complete in one document, and the predecessor's
+document is not touched.
+
+**Prevents.** `YM312` when a lineage points at nothing, and the silent loss
+of the history that explains why the current model looks the way it does.
+
+**Do not retire the predecessor just because it has a successor.** The
+transition period during which both run is real, and both may be `planned`
+while the split is still being designed. Retirement is the separate
+descoping decision of ADR 0064. Equally, a retired subject with no
+successor is a legitimate record: some things are decommissioned into
+nothing, and the model should not invent a destination for them.
+
+**Worked example.** `.yarramate/architecture/engine.yaml`, where the 0.7.0
+clean break to seven verbs (ADR 0061) is recorded as a merge, a split, and
+a rename against the retired command services.

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -54,6 +54,7 @@ interface ConceptFields {
   readonly status?: string
   readonly owner?: string
   readonly distinctFrom?: readonly string[]
+  readonly supersedes?: readonly string[]
   readonly constraints?: readonly ConstraintReference[]
   readonly references?: readonly IdentifiedReference[]
   readonly presentIn?: readonly string[]
@@ -113,7 +114,7 @@ interface OperationsDocument {
 // An answer enriches what is there and may explicitly take back what it
 // asserted — it never silently shrinks anything.
 const SCALAR_CONCEPT_FIELDS = ['kind', 'name', 'description', 'status', 'owner'] as const
-const LIST_CONCEPT_FIELDS = ['aka', 'constraints', 'references', 'presentIn', 'attestations', 'distinctFrom'] as const
+const LIST_CONCEPT_FIELDS = ['aka', 'constraints', 'references', 'presentIn', 'attestations', 'distinctFrom', 'supersedes'] as const
 const SCALAR_RELATIONSHIP_FIELDS = ['kind', 'from', 'to', 'name', 'description', 'status', 'mode', 'content'] as const
 const LIST_RELATIONSHIP_FIELDS = ['references', 'presentIn'] as const
 

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -1166,7 +1166,7 @@ export function runAskCommand(
       }
       const rendered =
         budget === undefined
-          ? renderBrief(evaluated, compilation.profileContext)
+          ? renderBrief(evaluated, compilation.profileContext, undefined, compilation.graph.claims)
           : renderBudgetedContext(evaluated, budget)
       const lines = [
         `Review slice ${changed} — ${plural(derived.changed.concepts.length, 'concept')}, ` +
@@ -1234,7 +1234,7 @@ export function runAskCommand(
       return emit(
         result,
         budget === undefined
-          ? renderBrief(evaluated, compilation.profileContext)
+          ? renderBrief(evaluated, compilation.profileContext, undefined, compilation.graph.claims)
           : renderBudgetedContext(evaluated, budget),
       )
     }
@@ -1378,7 +1378,7 @@ export function runAskCommand(
       }
       const rendered =
         budget === undefined
-          ? renderBrief(evaluated, compilation.profileContext)
+          ? renderBrief(evaluated, compilation.profileContext, undefined, compilation.graph.claims)
           : renderBudgetedContext(evaluated, budget)
       const header =
         resolution.addressing === 'free-text'
@@ -1399,7 +1399,7 @@ export function runAskCommand(
     // --advise: the expert composition. The engine assembles ground
     // truth — slice, open questions, drift — and stops; the reading and
     // the advice belong to the LLM on top (ADR 0054).
-    const brief = renderBrief(evaluated, compilation.profileContext, budget)
+    const brief = renderBrief(evaluated, compilation.profileContext, budget, compilation.graph.claims)
     const sliceIds = new Set(
       evaluated.subjects
         .filter(({ type }) => type === 'concept')

--- a/src/brief.ts
+++ b/src/brief.ts
@@ -155,6 +155,12 @@ export function renderBrief(
   result: ProjectionResult,
   profileContext?: ResolvedProfileContext,
   budgetTokens?: number,
+  // A succession claim belongs to the successor (ADR 0080), so the claim
+  // that answers "where did this go?" about a slice's subject usually sits
+  // on a subject the slice does not contain. Passing the workspace's claims
+  // lets the brief name that successor by id without pulling it into the
+  // slice, which would spend the neighbourhood cap of ADR 0070 on history.
+  workspaceClaims?: readonly GraphClaim[],
 ): string {
   const stateIds = new Set(
     result.claims
@@ -260,6 +266,36 @@ export function renderBrief(
     )[0]
     if (owner !== undefined) {
       sentences.push(`Owned by "${nameOf(owner)}".`)
+    }
+    // A succession claim is authored on the successor and points back
+    // (ADR 0080), but "where did this go?" is asked of the predecessor, so
+    // the brief reads the same claims in both directions. This is the
+    // surface that answers the question the mechanism exists for.
+    const predecessors = claimReferences(
+      result.claims,
+      id,
+      'yarramate/lineage/supersedes',
+    )
+    if (predecessors.length > 0) {
+      sentences.push(
+        `Succeeds ${listPhrase(
+          predecessors.map((predecessor) => `"${nameOf(predecessor)}"`),
+        )}.`,
+      )
+    }
+    const successors = (workspaceClaims ?? result.claims).flatMap((claim) =>
+      claim.predicate === 'yarramate/lineage/supersedes' &&
+      'ref' in claim.object &&
+      claim.object.ref === id
+        ? [claim.subject]
+        : [],
+    )
+    if (successors.length > 0) {
+      sentences.push(
+        `Superseded by ${listPhrase(
+          successors.map((successor) => `"${nameOf(successor)}"`),
+        )}.`,
+      )
     }
     return sentences
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -45,6 +45,7 @@ interface NativeConcept {
   readonly status?: 'planned' | 'current' | 'retired'
   readonly owner?: string
   readonly distinctFrom?: readonly string[]
+  readonly supersedes?: readonly string[]
   readonly constraints?: ReadonlyArray<{
     readonly id: string
     readonly ref: string
@@ -210,6 +211,9 @@ const aliasClaimId = (subject: string, alias: string) =>
 
 const distinctFromClaimId = (subject: string, other: string) =>
   `${subject}~distinct-from-${Buffer.from(other, 'utf8').toString('hex')}`
+
+const supersedesClaimId = (subject: string, predecessor: string) =>
+  `${subject}~supersedes-${Buffer.from(predecessor, 'utf8').toString('hex')}`
 
 const describeAspect = (aspect: (typeof conceptKinds)[number]['aspect']) =>
   aspect.replace('-', ' ')
@@ -734,6 +738,48 @@ function compileWorkspaceResolved(
     }
     return false
   }
+  // A succession points backwards, from a successor to the predecessors it
+  // took over from (ADR 0080). Unlike state ordering it is a list, so the
+  // walk fans out rather than following a single link.
+  const supersededBy = new Map<string, readonly string[]>(
+    documents.flatMap(({ value }) =>
+      value.concepts.flatMap((concept) =>
+        concept.supersedes === undefined
+          ? []
+          : [
+              [
+                `${value.id}#${concept.id}`,
+                concept.supersedes.map((predecessor) =>
+                  qualifyReference(value.id, predecessor),
+                ),
+              ] as const,
+            ],
+      ),
+    ),
+  )
+  // Self-succession is a cycle of length one, but it has its own diagnostic
+  // because it is the case that actually happens; skipping it here keeps
+  // exactly one diagnostic firing per defect.
+  const participatesInSuccessionCycle = (start: string) => {
+    const visited = new Set<string>([start])
+    const pending = [
+      ...(supersededBy.get(start) ?? []).filter(
+        (predecessor) => predecessor !== start,
+      ),
+    ]
+    while (pending.length > 0) {
+      const current = pending.pop()!
+      if (current === start) return true
+      if (visited.has(current)) continue
+      visited.add(current)
+      pending.push(
+        ...(supersededBy.get(current) ?? []).filter(
+          (predecessor) => predecessor !== current,
+        ),
+      )
+    }
+    return false
+  }
 
   for (const { input, value, location } of documents) {
     const selectedProfile = profiles.get(value.profile)
@@ -959,6 +1005,56 @@ function compileWorkspaceResolved(
             severity: 'error',
             code: 'YM311',
             message: `Concept "${concept.id}" declares itself distinct from itself`,
+            path: input.path,
+            pointer,
+            line: source.line,
+            column: source.column,
+          })
+        }
+      }
+      for (const [supersedesIndex, predecessor] of (
+        concept.supersedes ?? []
+      ).entries()) {
+        const pointer = `/concepts/${index}/supersedes/${supersedesIndex}`
+        const predecessorIdentity = qualifyReference(value.id, predecessor)
+        const subjectIdentity = `${value.id}#${concept.id}`
+        if (!conceptByQualifiedId.has(predecessorIdentity)) {
+          const source = location(
+            ['concepts', index, 'supersedes', supersedesIndex],
+            pointer,
+          )
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM312',
+            message: `Unresolved succession reference "${predecessor}"`,
+            path: input.path,
+            pointer,
+            line: source.line,
+            column: source.column,
+          })
+        } else if (predecessorIdentity === subjectIdentity) {
+          const source = location(
+            ['concepts', index, 'supersedes', supersedesIndex],
+            pointer,
+          )
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM313',
+            message: `Concept "${concept.id}" declares that it supersedes itself`,
+            path: input.path,
+            pointer,
+            line: source.line,
+            column: source.column,
+          })
+        } else if (participatesInSuccessionCycle(subjectIdentity)) {
+          const source = location(
+            ['concepts', index, 'supersedes', supersedesIndex],
+            pointer,
+          )
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM504',
+            message: `Concept "${subjectIdentity}" participates in a succession cycle`,
             path: input.path,
             pointer,
             line: source.line,
@@ -1397,6 +1493,27 @@ function compileWorkspaceResolved(
           source: location(
             ['concepts', index, 'distinctFrom', distinctIndex],
             `/concepts/${index}/distinctFrom/${distinctIndex}`,
+          ),
+        })
+      }
+      // A succession says where a subject's responsibility came from
+      // (ADR 0080). One predicate carries rename, split, and merge, because
+      // the shape is derivable from how many claims point where, and a
+      // predecessor is not required to be retired: the transition period
+      // during which both are current is real.
+      for (const [supersedesIndex, predecessor] of (
+        concept.supersedes ?? []
+      ).entries()) {
+        const predecessorIdentity = qualifyReference(value.id, predecessor)
+        claims.push({
+          id: supersedesClaimId(subject, predecessorIdentity),
+          subject,
+          predicate: 'yarramate/lineage/supersedes',
+          object: { ref: predecessorIdentity },
+          origin: 'declared',
+          source: location(
+            ['concepts', index, 'supersedes', supersedesIndex],
+            `/concepts/${index}/supersedes/${supersedesIndex}`,
           ),
         })
       }

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -260,7 +260,12 @@ export function runDesignCommand(
         },
         compilation.profileContext,
       )
-      slice = renderBrief(projection, compilation.profileContext)
+      slice = renderBrief(
+        projection,
+        compilation.profileContext,
+        undefined,
+        compilation.graph.claims,
+      )
     }
 
     const result: DesignStepResult = {

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -404,6 +404,7 @@ export function runExportCommand(
         slice,
         compilation.profileContext,
         parsed.budget,
+        compilation.graph.claims,
       )
       writeFileSync(join(outDirectory, briefFileName(id)), brief, 'utf8')
       const name = claimValue(result.claims, id, 'yarramate/concept/name')

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2579,7 +2579,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1210,
+            line: 1223,
             column: 5,
           },
           {
@@ -2590,7 +2590,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1214,
+            line: 1227,
             column: 5,
           },
           {

--- a/test/succession.test.ts
+++ b/test/succession.test.ts
@@ -1,0 +1,381 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+import { compileWorkspace } from '../src/compiler.js'
+
+// ADR 0080: a subject that is renamed, split, or merged keeps its history
+// through one predicate, authored on the successor and pointing back. The
+// shape is cardinality, so these tests pin all three cases against the same
+// predicate rather than against three of them.
+describe('succession claims', () => {
+  const compile = (source: string) =>
+    compileWorkspace([{ path: 'main.yaml', source }])
+
+  const successions = (source: string) => {
+    const result = compile(source)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return []
+    return result.graph.claims.filter(
+      ({ predicate }) => predicate === 'yarramate/lineage/supersedes',
+    )
+  }
+
+  it('emits one reference claim per predecessor for a rename', () => {
+    const claims = successions(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - order-gateway
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    status: retired
+relationships: []
+`)
+    expect(claims).toHaveLength(1)
+    expect(claims[0]?.subject).toBe('main#order-api')
+    expect(claims[0]?.object).toEqual({ ref: 'main#order-gateway' })
+    expect(claims[0]?.origin).toBe('declared')
+    expect(claims[0]?.source.pointer).toBe('/concepts/0/supersedes/0')
+  })
+
+  it('reads a merge as several predecessors on one successor', () => {
+    const claims = successions(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: identity-service
+    kind: applicationComponent
+    name: Identity Service
+    supersedes:
+      - auth-service
+      - session-service
+  - id: auth-service
+    kind: applicationComponent
+    name: Auth Service
+    status: retired
+  - id: session-service
+    kind: applicationComponent
+    name: Session Service
+    status: retired
+relationships: []
+`)
+    // Many-to-one: one successor names two predecessors.
+    expect(new Set(claims.map(({ subject }) => subject))).toEqual(
+      new Set(['main#identity-service']),
+    )
+    expect(
+      claims.flatMap((claim) =>
+        'ref' in claim.object ? [claim.object.ref] : [],
+      ).sort(),
+    ).toEqual(['main#auth-service', 'main#session-service'])
+  })
+
+  it('reads a split as one predecessor named by several successors', () => {
+    const claims = successions(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: invoicing
+    kind: applicationComponent
+    name: Invoicing
+    supersedes:
+      - billing
+  - id: payments
+    kind: applicationComponent
+    name: Payments
+    supersedes:
+      - billing
+  - id: billing
+    kind: applicationComponent
+    name: Billing
+    status: retired
+relationships: []
+`)
+    // One-to-many: the shape is derivable from the objects, with no
+    // separate "splitFrom" vocabulary asserting a count no single document
+    // can see.
+    expect(
+      claims.flatMap((claim) =>
+        'ref' in claim.object ? [claim.object.ref] : [],
+      ),
+    ).toEqual(['main#billing', 'main#billing'])
+    expect(claims.map(({ subject }) => subject).sort()).toEqual([
+      'main#invoicing',
+      'main#payments',
+    ])
+  })
+
+  it('derives claim ids from the predecessor, not the list position', () => {
+    const ordered = successions(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: identity-service
+    kind: applicationComponent
+    name: Identity Service
+    supersedes:
+      - auth-service
+      - session-service
+  - id: auth-service
+    kind: applicationComponent
+    name: Auth Service
+  - id: session-service
+    kind: applicationComponent
+    name: Session Service
+relationships: []
+`)
+    const reordered = successions(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: identity-service
+    kind: applicationComponent
+    name: Identity Service
+    supersedes:
+      - session-service
+      - auth-service
+  - id: auth-service
+    kind: applicationComponent
+    name: Auth Service
+  - id: session-service
+    kind: applicationComponent
+    name: Session Service
+relationships: []
+`)
+    expect(reordered.map(({ id }) => id).sort()).toEqual(
+      ordered.map(({ id }) => id).sort(),
+    )
+  })
+
+  it('resolves a predecessor in another document', () => {
+    const result = compileWorkspace([
+      {
+        path: 'new.yaml',
+        source: `format: yarramate/v1
+id: new
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - legacy#order-gateway
+relationships: []
+`,
+      },
+      {
+        path: 'legacy.yaml',
+        source: `format: yarramate/v1
+id: legacy
+profile: yarramate/core@0.1
+concepts:
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    status: retired
+relationships: []
+`,
+      },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const claim = result.graph.claims.find(
+      ({ predicate }) => predicate === 'yarramate/lineage/supersedes',
+    )
+    expect(claim?.object).toEqual({ ref: 'legacy#order-gateway' })
+  })
+
+  it('does not require a superseded subject to be retired', () => {
+    // The transition period is real: a strangler migration runs both for
+    // months, and during that window the predecessor is genuinely current.
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    status: current
+    supersedes:
+      - order-gateway
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    status: current
+relationships: []
+`)
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects an unresolved succession reference with YM312', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - nowhere
+relationships: []
+`)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map(({ code }) => code)).toContain('YM312')
+  })
+
+  it('rejects self-succession with YM313 and not also as a cycle', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - order-api
+relationships: []
+`)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    const codes = result.diagnostics.map(({ code }) => code)
+    expect(codes).toContain('YM313')
+    // Exactly one diagnostic per defect: the cycle walk skips the
+    // self-reference that YM313 already owns.
+    expect(codes).not.toContain('YM504')
+  })
+
+  it('rejects a succession cycle with YM504', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+    supersedes:
+      - order-gateway
+  - id: order-gateway
+    kind: applicationComponent
+    name: Order Gateway
+    supersedes:
+      - order-api
+relationships: []
+`)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map(({ code }) => code)).toContain('YM504')
+  })
+
+  it('accepts a long chain, which is history rather than a cycle', () => {
+    const result = compile(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: third
+    kind: applicationComponent
+    name: Third
+    supersedes:
+      - second
+  - id: second
+    kind: applicationComponent
+    name: Second
+    supersedes:
+      - first
+  - id: first
+    kind: applicationComponent
+    name: First
+    status: retired
+relationships: []
+`)
+    expect(result.ok).toBe(true)
+  })
+})
+
+// The claim is authored on the successor, but "where did this go?" is asked
+// of the predecessor, so the brief reads it in both directions.
+describe('briefs render lineage from either end', () => {
+  const document =
+    'format: yarramate/v1\n' +
+    'id: main\n' +
+    'profile: yarramate/core@0.1\n' +
+    'concepts:\n' +
+    '  - id: order-api\n' +
+    '    kind: applicationComponent\n' +
+    '    name: Order API\n' +
+    '    status: current\n' +
+    '    supersedes:\n' +
+    '      - order-gateway\n' +
+    '  - id: order-gateway\n' +
+    '    kind: applicationComponent\n' +
+    '    name: Order Gateway\n' +
+    '    status: retired\n' +
+    'relationships: []\n'
+
+  const manifest =
+    'format: yarramate/workspace/v1\n' +
+    'id: succession-fixture\n' +
+    'documents:\n' +
+    '  - architecture/main.yaml\n' +
+    'profiles: []\n' +
+    'projections: []\n' +
+    'adapterMappings: []\n' +
+    'evidence: []\n'
+
+  const projection =
+    'format: yarramate/projection/v1\n' +
+    'id: orders-slice\n' +
+    'version: "1.0"\n' +
+    'query:\n' +
+    '  documents: [main]\n' +
+    'presentation:\n' +
+    '  title: Orders slice\n' +
+    '  description: The order surface and where it came from.\n'
+
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-succession-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(join(workspace, 'architecture/main.yaml'), document, 'utf8')
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest, 'utf8')
+    writeFileSync(join(workspace, 'projection.yaml'), projection, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('names the predecessor on the successor and the successor on the predecessor', () => {
+    const result = runCli(
+      ['ask', 'workspace.yaml', 'projection.yaml'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Succeeds "Order Gateway".')
+    expect(result.stdout).toContain('Superseded by "Order API".')
+  })
+
+  it('names a successor that the slice itself does not contain', () => {
+    // "Where did this go?" is asked by seeding on the dead subject, and
+    // nothing connects it to its replacement except the succession claim,
+    // which belongs to the replacement. The brief still answers, naming the
+    // successor by the id a reader can seed a second slice on, without the
+    // slice growing to contain it (ADR 0070, ADR 0080).
+    const result = runCli(
+      ['ask', 'workspace.yaml', 'main#order-gateway'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Superseded by')
+    expect(result.stdout).toContain('order-api')
+    expect(result.stdout).not.toContain('Order API", an application')
+  })
+})


### PR DESCRIPTION
Closes #162

The write surface covered assert, enrich, retract, retire, and delete: a subject's own lifecycle, handled completely. What none of it could express is a subject *becoming other subjects*. A split recorded one retirement and two arrivals with nothing joining them, so the refactoring was invisible a month later, and so was the answer to "where did this go?".

An optional `supersedes` list on concepts compiles to `yarramate/lineage/supersedes` reference claims through the existing graph-v2 envelope. ADR 0080.

## Design decisions, and why

**One predicate, not three.** The issue leaned this way and the reasoning held up. Rename, split, and merge are one-to-one, one-to-many, and many-to-one over one relation, so cardinality already carries the shape. Three predicates are worse for a specific reason: the shape is a global fact and the edit is local. A subject writing `splitFrom` asserts that its predecessor went to more than one place, which it cannot see from inside its own document, and the assertion rots when a sibling successor is deleted a year later. Catching that would require counting successors per predecessor and comparing against the authored label, which is the cardinality derivation plus a consistency check the one-predicate design does not need. The set is also not closed: a subject absorbing half of one predecessor and all of another is neither a split nor a merge.

**The claim points backwards, from successor to predecessor.** The authoring moment is the arrival of the new subject, so pointing back means it arrives complete in one document and the predecessor's document (often owned by another team) is never touched. `yarramate/state/after` already points backwards for the same shape of fact. Reading the other direction is a scan over claim objects, which the brief does.

**Read asymmetrically, unlike `distinctFrom`.** ADR 0077 read dismissals symmetrically because the *pair* was what the judgment was about. Succession is an ordered fact about time: direction is the content, not an artifact of where it was recorded. Reading it symmetrically would assert the predecessor also succeeded its own successor, which is the cycle YM504 rejects.

**Retirement is NOT coupled, per the issue's lean.** The transition period is real: a strangler migration runs both for months and the predecessor is genuinely `current` during it. Both subjects may equally be `planned` while a split is still being designed. Retirement is its own decision with its own verb under ADR 0064, and coupling would make succession a back door into a lifecycle transition nobody asked for. A rule here would also assert a fact about the future that a snapshot cannot check.

**Concepts only, not relationships**, following ADR 0076. Widening stays additive.

## Diagnostics

Took **YM312** (unresolved succession reference) as the next free code in the YM3xx identity-and-references range, plus **YM313** (self-succession), mirroring the YM310/YM311 pair that `distinctFrom` established.

Also added **YM504** (cyclic succession) in the claim-consistency range, mirroring **YM502** for cyclic state ordering, since that is the exact precedent for a cycle in a subject-to-subject ordering. A cycle asserts a subject is its own ancestor; the model has no time axis, so a two-step cycle is not "we changed our mind", it is one snapshot claiming a subject both preceded and followed another. Self-succession keeps its own code because it is the case that actually happens (a copy-paste inside one concept) and deserves a message that says so; the cycle walk skips self-references so exactly one diagnostic fires per defect.

## RTM: deferred, explicitly

**I did not touch `export rtm`.** The RTM answers what covers a requirement *now*; succession is a claim about the past. Joining them widens the artifact's contract from current coverage to coverage history, which is a different artifact and deserves its own decision rather than riding along with the mechanism it would consume. The claims are in graph v2, so a later RTM revision joins realizers to their predecessors with a single predicate lookup and no new vocabulary. Shipping vocabulary before rendering is the order ADR 0076 used for aliases, which no renderer displays to this day.

## The catalogue question: deferred, with the reason

The issue floated asking about retired subjects with no successor. It is not a cheap follow-on, and the reason is recorded in the ADR so it is not re-proposed as an oversight:

1. Retired concepts are excluded from the interrogation index outright under ADR 0064. Asking anything about them means carving an exception into an exclusion shared by every question in the catalogue.
2. The honest answer is very often "nowhere, it was decommissioned", and a question that cannot accept its own commonest answer reopens forever, which is the exact failure ADR 0077 built dismissals to prevent.

`distinctFrom` cannot be reused (binary arity, wrong meaning). Attestations do fit, being unary with a kebab-case topic, so the shape is a `decommissioned` topic if this is ever built. The ADR names the shape without building it.

## What `ask` and briefs do

Briefs render lineage in both directions from one claim set: "Succeeds ..." on the successor, "Superseded by ..." on the predecessor.

One gap surfaced during dogfooding and was fixed rather than documented away. A projection carries only claims whose *subject* is in the slice, and a succession claim belongs to the successor, so a slice seeded on a retired subject could not name its replacement, which is the headline use case. `renderBrief` now takes an optional workspace claim set, so it names the successor by qualified id **without pulling it into the slice**, which would spend the ADR 0070 neighbourhood cap on history. Slice selection itself is unchanged.

## Dogfooded on our own model

The 0.7.0 clean break (ADR 0061) retired ten command services in one commit with the mapping recorded only in a prose migration table. Nine succession claims now record it, and all three shapes appear without any being named:

- **merge**: `ask-command` names `status`, `context`, `next`, `compare`, `interrogate`
- **split**: `interrogate-command` is named by `ask-command` (reporting half) and `design-command` (interview half)
- **rename**: `export-command` names `compile-command`
- **merge**: `apply-command` names `add-command` and `connect-command`

`new-command` and `evidence-command` were deliberately left successorless, which matters more than the nine that got one: ADR 0061 decided `new projection` gets no replacement at all. Inventing a destination would be the model telling a story the ADRs do not support, and it is why this ships no question demanding one.

Also added a **Recorded succession** entry to `skills/yarramate-architecture/references/modelling-patterns.md` in the established format.

## Verification

`rm -rf dist && pnpm verify` passes clean from scratch: **438 tests** (426 baseline on main, +12 new), self-check clean, LikeC4 validate clean. The only pre-existing test touched is two pinned line numbers in `test/likec4-cli.test.ts`, shifted because `supersedes` blocks were added to the self-model; PR #171 made the same adjustment.

## Side finding, not fixed here

`src/ask-command.ts` contains a **literal NUL byte** around line 1295, used as a field delimiter in a dedup key but written as a raw byte rather than an escape sequence. `file` reports the file as `data`, and **grep and ripgrep silently skip it entirely** unless `-a` is passed. That means codebase searches quietly miss one of the largest source files in the repo. Functionally correct, unrelated to this PR, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
