### PR TITLE
Write the dedup delimiter as an escape, not a raw NUL byte

### DIFF
--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -1292,7 +1292,7 @@ export function runAskCommand(
               .map(
                 (entry) =>
                   [
-                    `${entry.uri} ${entry.result} ${entry.provider} ${entry.message ?? ''}`,
+                    `${entry.uri}\u0000${entry.result}\u0000${entry.provider}\u0000${entry.message ?? ''}`,
                     entry,
                   ] as const,
               ),


### PR DESCRIPTION
`src/ask-command.ts` carried three raw U+0000 bytes as the delimiter in a reconciliation dedup key (line 1295). Consequences:

- `file src/ask-command.ts` reported `data`, not source.
- **grep and ripgrep silently skipped the entire file** without `-a`, returning no matches rather than an error. Two agents independently hit this during today's backlog sweep, each losing time to a search that came back empty on a file they knew contained the term.

Writing the delimiter as `\u0000` produces the identical runtime string, so the dedup key is byte-identical and behaviour is unchanged. After the change `file` reports UTF-8 text and a plain `grep` finds 14 matches where it previously found none.

One line changed. Verify clean at 438 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)