### PR TITLE
Model maintenance: declare six shipped features in the self-model

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -116,6 +116,7 @@ concepts:
     kind: applicationFunction
     name: Validate semantic claims
     status: current
+    description: "Checks reference integrity and consistency across compiled claims, including succession: a supersedes entry resolving to nothing, to itself, or into a cycle is an error, so a renamed, split, or merged subject keeps a history a reader can follow."
   - id: validate-adapter-mapping
     kind: applicationFunction
     name: Validate adapter mapping
@@ -138,12 +139,12 @@ concepts:
   - id: evaluate-evidence
     kind: applicationFunction
     name: Evaluate evidence overlay
-    description: Produces a deterministic report without modifying graph v2.
+    description: Produces a deterministic report without modifying graph v2, carrying any keyed value a provider observed alongside the confirmed or contradicted verdict, so a fact can leave prose and become checkable.
     status: current
   - id: reconcile-evidence
     kind: applicationFunction
     name: Reconcile workspace evidence
-    description: Aggregates evidence reports into deterministic unresolved findings without proposing or applying remediation.
+    description: Aggregates evidence reports into deterministic unresolved findings without proposing or applying remediation, and compares the value a constraint declares it expects against the value a provider observed, by string equality only. A mismatch is an ordinary contradiction that already fails strict checking; an expectation nobody observed is reported and never gates.
     status: current
   - id: observe-graphify
     kind: applicationFunction
@@ -332,7 +333,7 @@ concepts:
     kind: dataObject
     owner: yarramate-product#yarramate-maintainers
     name: Concept kind catalogue
-    description: Resolved concept kinds with aspects and lineage available to a compilation.
+    description: Resolved concept kinds with aspects, lineage, and the optional rigidity meta-property available to a compilation. A rigid kind may not specialize an anti-rigid one, so a profile author who parents a service under a role is told at resolution time instead of inheriting a distinction that cannot hold.
     status: current
   - id: relationship-policy-catalogue
     kind: dataObject
@@ -650,6 +651,49 @@ concepts:
     name: npm package
     description: The published yarramate package - compiled binaries, normative schemas, the internal catalogue, and the agent skill.
     owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: derive-traceability-matrix
+    kind: applicationFunction
+    name: Derive requirements traceability matrix
+    description: Derives requirement and constraint coverage from compiled claims, joining realization, evidence verdicts, attestations, and lineage into one bundle. Gaps are counted rather than omitted, and retired rows move to a descoped section outside the gap arithmetic. The output carries no timestamp, so identical inputs produce identical bytes and CI can diff it.
+    status: current
+  - id: requirements-traceability-matrix
+    kind: dataObject
+    name: Requirements traceability matrix
+    description: "The yarramate/rtm/v1 two-file bundle: RTM.md for a reader and rtm.json for a pipeline, both derived readings of the graph that are never authored by hand."
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: rtm-schema
+    kind: dataObject
+    name: Requirements traceability matrix JSON Schema
+    description: Normative structure for the yarramate/rtm/v1 contract.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: detect-stale-attestations
+    kind: applicationFunction
+    name: Detect stale attestations
+    description: "Reports a sign-off as stale when the attested subject's name or description changed in a commit dated after the attestation, so a reviewer learns which sign-offs no longer cover the wording they read. It is a reconcile finding only: it never reopens an evaluator verdict and never gates check --strict, because gating would reward backdating. Outside a git checkout it emits a note rather than silence, keeping \"not assessed\" distinguishable from \"clean\"."
+    status: current
+  - id: subject-identity
+    kind: compiler-module
+    name: Subject identity resolver
+    description: "Normalizes preferred labels and alternative labels into one deterministic index, so the same two subjects pair the same way regardless of the order they were authored in. Alternative labels are matchable and never renderable: they seed a slice, and no renderer spends context budget printing them."
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: detect-near-duplicate-subjects
+    kind: applicationFunction
+    name: Detect near-duplicate subjects
+    description: Pairs subjects whose labels collide above published lexical thresholds and opens a hygiene question, so two agents who invented two names for one subject are asked about it instead of both names surviving silently. It is never a check error, and a symmetric distinctFrom dismissal closes the question permanently on both sides.
+    status: current
+  - id: compose-subject-brief
+    kind: applicationFunction
+    name: Compose subject brief
+    description: Composes prose from sentence templates over declared intent, resolving custom kinds to their nearest core ancestor, with no language model involved, so the same model and projection always yield identical bytes. Motivation comes first and requirement bodies are quoted verbatim. Under a budget it drops whole paragraphs and announces the drop rather than truncating a sentence.
+    status: current
+  - id: derive-changed-slice
+    kind: applicationFunction
+    name: Derive changed slice
+    description: Derives a review slice from a git ref range by intersecting changed lines with each subject's current declaration span, then seeding the existing neighbourhood machinery, so a reviewer names a range instead of maintaining review tags that go stale. It carries a coverage note for changed subjects no authored projection contains, and it cannot express a decision grouping git never grouped.
     status: current
 relationships:
   - id: core-contract-checker-loads-contract
@@ -1361,3 +1405,113 @@ relationships:
     kind: serving
     from: nodejs-runtime
     to: mcp-adapter
+  - id: export-command-serves-traceability-matrix
+    kind: serving
+    from: export-command
+    to: derive-traceability-matrix
+    description: export rtm is the fifth derivation mode of the one export verb, not a verb of its own.
+  - id: traceability-derivation-reads-graph
+    kind: access
+    from: derive-traceability-matrix
+    to: semantic-graph
+    mode: read
+  - id: traceability-derivation-produces-matrix
+    kind: realization
+    from: derive-traceability-matrix
+    to: requirements-traceability-matrix
+  - id: rtm-schema-describes-matrix
+    kind: realization
+    from: rtm-schema
+    to: requirements-traceability-matrix
+  - id: traceability-derivation-reads-schema
+    kind: access
+    from: derive-traceability-matrix
+    to: rtm-schema
+    mode: read
+  - id: evidence-evaluator-detects-stale-attestations
+    kind: assignment
+    from: evidence-evaluator
+    to: detect-stale-attestations
+  - id: reconcile-command-serves-stale-attestations
+    kind: serving
+    from: reconcile-command
+    to: detect-stale-attestations
+  - id: stale-attestation-detection-reads-graph
+    kind: access
+    from: detect-stale-attestations
+    to: semantic-graph
+    mode: read
+  - id: stale-attestation-detection-writes-report
+    kind: access
+    from: detect-stale-attestations
+    to: reconciliation-report
+    mode: write
+  - id: subject-identity-detects-near-duplicates
+    kind: assignment
+    from: subject-identity
+    to: detect-near-duplicate-subjects
+  - id: near-duplicate-detection-reads-graph
+    kind: access
+    from: detect-near-duplicate-subjects
+    to: semantic-graph
+    mode: read
+  - id: design-command-serves-near-duplicate-question
+    kind: serving
+    from: design-command
+    to: detect-near-duplicate-subjects
+  - id: ask-command-serves-near-duplicate-question
+    kind: serving
+    from: ask-command
+    to: detect-near-duplicate-subjects
+    description: ask --open reports the same hygiene question design would serve next.
+  - id: ask-command-seeds-on-alternative-labels
+    kind: association
+    from: ask-command
+    to: subject-identity
+    description: Free-text seeding matches alternative labels, so a team's own word for a subject finds it without that word reaching any rendered output.
+  - id: brief-composition-reads-projection-result
+    kind: access
+    from: compose-subject-brief
+    to: projection-result
+    mode: read
+  - id: ask-command-serves-brief-composition
+    kind: serving
+    from: ask-command
+    to: compose-subject-brief
+  - id: export-command-serves-brief-composition
+    kind: serving
+    from: export-command
+    to: compose-subject-brief
+  - id: design-command-serves-brief-composition
+    kind: serving
+    from: design-command
+    to: compose-subject-brief
+  - id: changed-slice-reads-graph
+    kind: access
+    from: derive-changed-slice
+    to: semantic-graph
+    mode: read
+  - id: ask-command-serves-changed-slice
+    kind: serving
+    from: ask-command
+    to: derive-changed-slice
+  - id: export-command-serves-changed-slice
+    kind: serving
+    from: export-command
+    to: derive-changed-slice
+  - id: likec4-command-serves-changed-slice
+    kind: serving
+    from: likec4-export-command
+    to: derive-changed-slice
+  - id: compiler-derives-traceability-matrix
+    kind: assignment
+    from: compiler
+    to: derive-traceability-matrix
+  - id: compiler-composes-briefs
+    kind: assignment
+    from: compiler
+    to: compose-subject-brief
+  - id: compiler-derives-changed-slices
+    kind: assignment
+    from: compiler
+    to: derive-changed-slice

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -225,6 +225,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/compiler.ts
+  - subject: yarramate-engine#compose-subject-brief
+    result: confirmed
+    evidence:
+      uri: repo:src/brief.ts
   - subject: yarramate-engine#consumer-host
     result: confirmed
     evidence:
@@ -233,10 +237,26 @@ observations:
     result: confirmed
     evidence:
       uri: repo:.yarramate/contracts/yarramate-core-0.1.yaml
+  - subject: yarramate-engine#derive-changed-slice
+    result: confirmed
+    evidence:
+      uri: repo:src/changed.ts
+  - subject: yarramate-engine#derive-traceability-matrix
+    result: confirmed
+    evidence:
+      uri: repo:src/rtm.ts
   - subject: yarramate-engine#design-command
     result: confirmed
     evidence:
       uri: repo:src/design-command.ts
+  - subject: yarramate-engine#detect-near-duplicate-subjects
+    result: confirmed
+    evidence:
+      uri: repo:src/subject-identity.ts
+  - subject: yarramate-engine#detect-stale-attestations
+    result: confirmed
+    evidence:
+      uri: repo:src/attestation-staleness.ts
   - subject: yarramate-engine#diagnostic-result
     result: confirmed
     evidence:
@@ -349,10 +369,18 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/adapters/likec4-export.ts
+  - subject: yarramate-engine#requirements-traceability-matrix
+    result: confirmed
+    evidence:
+      uri: repo:src/rtm.ts
   - subject: yarramate-engine#resolve-workspace
     result: confirmed
     evidence:
       uri: repo:src/workspace.ts
+  - subject: yarramate-engine#rtm-schema
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-rtm.schema.json
   - subject: yarramate-engine#semantic-graph
     result: confirmed
     evidence:
@@ -365,6 +393,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/architecture-state.ts
+  - subject: yarramate-engine#subject-identity
+    result: confirmed
+    evidence:
+      uri: repo:src/subject-identity.ts
   - subject: yarramate-engine#validate-adapter-mapping
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1416,3 +1416,102 @@ mappings:
   - native: yarramate-engine#runtime-serves-mcp-adapter
     external: runtimeServesMcpAdapter
     type: relationship
+  - native: yarramate-engine#ask-command-seeds-on-alternative-labels
+    external: askCommandSeedsOnAlternativeLabels
+    type: relationship
+  - native: yarramate-engine#ask-command-serves-brief-composition
+    external: askCommandServesBriefComposition
+    type: relationship
+  - native: yarramate-engine#ask-command-serves-changed-slice
+    external: askCommandServesChangedSlice
+    type: relationship
+  - native: yarramate-engine#ask-command-serves-near-duplicate-question
+    external: askCommandServesNearDuplicateQuestion
+    type: relationship
+  - native: yarramate-engine#brief-composition-reads-projection-result
+    external: briefCompositionReadsProjectionResult
+    type: relationship
+  - native: yarramate-engine#changed-slice-reads-graph
+    external: changedSliceReadsGraph
+    type: relationship
+  - native: yarramate-engine#compose-subject-brief
+    external: composeSubjectBrief
+    type: concept
+  - native: yarramate-engine#derive-changed-slice
+    external: deriveChangedSlice
+    type: concept
+  - native: yarramate-engine#derive-traceability-matrix
+    external: deriveTraceabilityMatrix
+    type: concept
+  - native: yarramate-engine#design-command-serves-brief-composition
+    external: designCommandServesBriefComposition
+    type: relationship
+  - native: yarramate-engine#design-command-serves-near-duplicate-question
+    external: designCommandServesNearDuplicateQuestion
+    type: relationship
+  - native: yarramate-engine#detect-near-duplicate-subjects
+    external: detectNearDuplicateSubjects
+    type: concept
+  - native: yarramate-engine#detect-stale-attestations
+    external: detectStaleAttestations
+    type: concept
+  - native: yarramate-engine#evidence-evaluator-detects-stale-attestations
+    external: evidenceEvaluatorDetectsStaleAttestations
+    type: relationship
+  - native: yarramate-engine#export-command-serves-brief-composition
+    external: exportCommandServesBriefComposition
+    type: relationship
+  - native: yarramate-engine#export-command-serves-changed-slice
+    external: exportCommandServesChangedSlice
+    type: relationship
+  - native: yarramate-engine#export-command-serves-traceability-matrix
+    external: exportCommandServesTraceabilityMatrix
+    type: relationship
+  - native: yarramate-engine#likec4-command-serves-changed-slice
+    external: likec4CommandServesChangedSlice
+    type: relationship
+  - native: yarramate-engine#near-duplicate-detection-reads-graph
+    external: nearDuplicateDetectionReadsGraph
+    type: relationship
+  - native: yarramate-engine#reconcile-command-serves-stale-attestations
+    external: reconcileCommandServesStaleAttestations
+    type: relationship
+  - native: yarramate-engine#requirements-traceability-matrix
+    external: requirementsTraceabilityMatrix
+    type: concept
+  - native: yarramate-engine#rtm-schema
+    external: rtmSchema
+    type: concept
+  - native: yarramate-engine#rtm-schema-describes-matrix
+    external: rtmSchemaDescribesMatrix
+    type: relationship
+  - native: yarramate-engine#stale-attestation-detection-reads-graph
+    external: staleAttestationDetectionReadsGraph
+    type: relationship
+  - native: yarramate-engine#stale-attestation-detection-writes-report
+    external: staleAttestationDetectionWritesReport
+    type: relationship
+  - native: yarramate-engine#subject-identity
+    external: subjectIdentity
+    type: concept
+  - native: yarramate-engine#subject-identity-detects-near-duplicates
+    external: subjectIdentityDetectsNearDuplicates
+    type: relationship
+  - native: yarramate-engine#traceability-derivation-produces-matrix
+    external: traceabilityDerivationProducesMatrix
+    type: relationship
+  - native: yarramate-engine#traceability-derivation-reads-graph
+    external: traceabilityDerivationReadsGraph
+    type: relationship
+  - native: yarramate-engine#traceability-derivation-reads-schema
+    external: traceabilityDerivationReadsSchema
+    type: relationship
+  - native: yarramate-engine#compiler-composes-briefs
+    external: compilerComposesBriefs
+    type: relationship
+  - native: yarramate-engine#compiler-derives-changed-slices
+    external: compilerDerivesChangedSlices
+    type: relationship
+  - native: yarramate-engine#compiler-derives-traceability-matrix
+    external: compilerDerivesTraceabilityMatrix
+    type: relationship

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2579,7 +2579,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1223,
+            line: 1267,
             column: 5,
           },
           {
@@ -2590,7 +2590,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1227,
+            line: 1271,
             column: 5,
           },
           {


### PR DESCRIPTION
Six features merged in the last day without acquiring a declared subject. Every gate stayed green and silent, because the catalogue only asks about declared subjects and reconcile only checks declared claims. This brings the self-model level with its own code.

The judgment calls come from `docs/MODEL-REVIEW.md`, applied to this repository's own model. The rule that fell out of it: **a new subject when a new module carries new behaviour; a description update when already-declared behaviour widened.**

## Declared

| Feature | ADR | Declared as | Test 1: what decision it changes |
|---|---|---|---|
| `export rtm` | 0071 | `derive-traceability-matrix` (function), `requirements-traceability-matrix` + `rtm-schema` (data objects) | A compliance reader stops maintaining a spreadsheet; gaps are counted, not omitted, and CI can diff `rtm.json` |
| Stale attestations | 0074 | `detect-stale-attestations` (function) | A reviewer learns which sign-offs no longer cover the wording they read, without gating `check --strict` and rewarding backdating |
| Alternative labels, near-duplicates | 0076, 0077 | `subject-identity` (module) + `detect-near-duplicate-subjects` (function) | Two agents who invented two names for one subject get asked about it, instead of both names surviving silently |
| Composed briefs | 0055 | `compose-subject-brief` (function) | A consuming agent gets deterministic prose with no model in the loop; under budget whole paragraphs drop with an announcement |
| Git-derived review slices | 0065 | `derive-changed-slice` (function) | A reviewer names a ref range instead of maintaining review tags that go stale |

`export rtm` did **not** get its own service. Test 4: `export` already declares itself as deriving every persisted artifact, and `graph`, `markdown`, `briefs`, and `likec4` are all modes of it with no service each. A sixth verb would contradict ADR 0061. It is wired as `serving` from `export-command`, matching how `likec4-export-command` serves its five render functions.

## Deliberately not declared

| Feature | ADR | Rubric test that decided it |
|---|---|---|
| Value-bearing evidence | 0075 | **Test 4.** `expects` is a field on an existing constraint entry and `key`/`value` are fields on an existing observation. No new module, no new artifact. Landed as description updates to `evaluate-evidence` and `reconcile-evidence`, which already exist and are already observed. |
| Rigidity meta-properties, YM413 | 0078 | **Test 4.** `rigidity` is an optional field on a profile concept kind; enforcement is inside profile resolution, already carried by `profile-catalogue` and `kind-catalogue` (both already evidenced by `src/profile.ts`). Also **test 2**: the model declares no subject for any of its ~40 diagnostic codes, and no author could consistently decide which codes earn one. Landed as a description update to `kind-catalogue`. |
| Succession claims, YM312/313/504 | 0080 | **Test 4.** `supersedes` is a field on a concept, in the same family as `status` and `references`. The model already uses it (`apply-command supersedes add-command`), so it is self-evidencing. Landed as a description update to `validate-semantic-claims`. |
| `src/index.ts` (library entry) | n/a | **Test 1.** A re-export barrel changes no decision. The package surface is already carried by `yarramate-repository#consumer-package` and by the core contract's `packageExport` claims, which `core-contract-checker` verifies. A subject whose only content is "these other subjects are exported" earns nothing. |

The rubric's own boundary applies to the three fold-ins: they are not defects, and `check` was never going to catch them. Recording the rationale in `description` rather than in this PR is deliberate, per the rubric's closing section, so it is still readable a year from now.

## The catalogue caught something

The first batch left the three new derivations without a performer, on the assumption that an unassigned function was acceptable. `ask` immediately opened `behavior-unassigned` for all three. It was right: every other `applicationFunction` in the model declares a performer, including `evaluate-projection`, which lives in its own module and is still assigned to `compiler`. A second batch assigned all three to `compiler`, matching that precedent, and the interview closed.

## Counts

| | Before | After |
|---|---|---|
| Concepts | 199 | **207** (+8) |
| Relationships | 268 | **293** (+25) |
| Current subjects | 159 | **167** |
| Evidence observations | 160 | **168** |

## Verification

- `rm -rf dist && pnpm verify` clean from scratch: **438 passed (438)**, unchanged from the baseline on `main`.
- `reconcile`: **168 observations, 168 confirmed, 0 findings**, 0 contradicted, 0 not-observed, **`subjectsWithoutEvidence` 0**. PR #142's no-gap invariant holds; every new status-current subject has an observation pointing at its implementing file, and every path was verified to exist.
- `ask`: design interview complete, no open questions.
- `map --sync` run for the YMLC111 gate (33 mappings added); `likec4 validate` passes.
- Two pinned line numbers in `test/likec4-cli.test.ts` shifted as concepts were added (1223 to 1267, 1227 to 1271). Both regenerated from an actual `export-project` run, not guessed; pointers, order, and every other field were unchanged.

Model changes were written through two `apply` batches. Evidence documents are not addressable by `apply` (the operations schema covers concepts and relationships only), so the eight observations were added to `.yarramate/evidence/repository.yaml` directly, in the file's existing alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
