### PR TITLE
Release v0.15.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.14.0
-date-released: 2026-08-03
+version: 0.15.0
+date-released: 2026-08-06
 url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"
 license: MIT

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,7 +1,7 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.14.0
+v0.15.0
 a design interview any agent can resume.
 the map your coding agents share.
 architecture your CI can check.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to 0.15.0 (additive minor). Thirteen changes since v0.14.0.

**Requirements arc:** `export rtm` (#155, ADR 0071), stale attestations (#157, ADR 0074), value-bearing evidence (#158, ADR 0075), first-class non-goals (#154, ADR 0073), `design --facilitate` (#156, ADR 0072).

**Ontology-mapping arc:** aliases plus near-duplicate detection (#171, ADRs 0076/0077), succession claims (#173, ADR 0080), profile rigidity (#168, ADR 0078), conservative extension (#170, ADR 0079), model-review rubric (#167), modelling patterns (#169).

**Housekeeping:** README reordered human-first (#147), NUL-byte fix (#174), self-model declares the six shipped features (#176).

⚠️ **The one consumer-visible behaviour change:** the shipped catalogue moves 0.5 to 0.7 and gains `subjects-near-duplicate`. A model that previously reported the interview complete may now show an open question if it contains near-duplicate subjects. That is ADR 0063's honest-reopen discipline working as intended, and the answer path is either merging the duplicates or recording a `distinctFrom` dismissal.

No existing model becomes invalid. Every new diagnostic (YM310, YM311, YM312, YM313, YM413, YM504) fires only on fields a model must first author, so nothing that compiles today stops compiling.

Verify green: 438 tests / 41 files, self-check clean at 207 concepts and 293 relationships, tarball 110 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)