### PR TITLE
Declare the retired view command in the self-model

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -634,6 +634,7 @@ concepts:
     status: current
     supersedes:
       - compile-command
+      - view-command
   - id: consumer-host
     kind: node
     name: Consumer host
@@ -695,6 +696,12 @@ concepts:
     name: Derive changed slice
     description: Derives a review slice from a git ref range by intersecting changed lines with each subject's current declaration span, then seeding the existing neighbourhood machinery, so a reviewer names a range instead of maintaining review tags that go stale. It carries a coverage note for changed subjects no authored projection contains, and it cannot express a decision grouping git never grouped.
     status: current
+  - id: view-command
+    kind: applicationService
+    name: View command
+    description: Rendered a projection result as deterministic Markdown for reviewers, the human-facing counterpart to the JSON context of the same projection.
+    owner: yarramate-product#yarramate-maintainers
+    status: retired
 relationships:
   - id: core-contract-checker-loads-contract
     kind: assignment
@@ -1515,3 +1522,13 @@ relationships:
     kind: assignment
     from: compiler
     to: derive-changed-slice
+  - id: cli-provides-view
+    kind: implements
+    from: cli
+    to: view-command
+    status: retired
+  - id: view-command-serves-agent-harness
+    kind: serving
+    from: view-command
+    to: yarramate-product#agent-harness
+    status: retired

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2579,7 +2579,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1267,
+            line: 1274,
             column: 5,
           },
           {
@@ -2590,7 +2590,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1271,
+            line: 1278,
             column: 5,
           },
           {


### PR DESCRIPTION
Cross-checking ADR 0061's removal list against the self-model turned up one gap: of the eleven commands the 0.7.0 clean break removed, ten are declared as retired subjects and **`view` was never declared at all**. Git history confirms it never appeared in `.yarramate/`.

Meanwhile `docs/AGENT-INTERFACE.md` line 236 records the migration explicitly (`view` becomes `export markdown`), so the model contradicted a shipped document by omission. The likely cause is that `view` never had its own module, unlike `status-command.ts` and friends, so the per-command-subject pattern skipped it.

**Nothing could have caught this automatically**, which is the interesting part: the catalogue asks only about declared subjects, ADR 0064 excludes retired subjects from the interview anyway, and `check` cannot miss a subject nobody authored. It took reading the ADR against the model. Related to #175, which proposes the general detector.

Changes, authored through one `apply` batch rather than by hand:
- `view-command` as a retired `applicationService`, described from the v0.6.0 docs (it rendered a projection result as deterministic Markdown for reviewers, the human-facing counterpart to the JSON context of the same projection)
- its two retired edges, matching how `compile-command` is declared
- `view-command` appended to `export-command`'s `supersedes`, using the mechanism ADR 0080 shipped a day earlier for exactly this case

All eleven removed commands are now accounted for. `new` and `evidence` remain successorless, which is honest: they were removed outright rather than replaced.

Model: 207 to 208 concepts, 293 to 295 relationships. Check ok, reconcile 168 of 168 confirmed, interview still complete. Pinned YMLC104 positions regenerated from an actual run, per the house convention. Verify clean at 438 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)