### PR TITLE
Author Keycloak and Kafka context-benchmark suites

### DIFF
--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -58,9 +58,13 @@ subject repos. That authoring is still outstanding (#56).
 Suites reference the models published in
 [yarramate-gallery](https://github.com/yarrasys/yarramate-gallery) at pinned
 source commits. `yarramate-self.yaml` is `headline: false` and reported
-separately (self-serving ground truth). ⚠️ Headline pooling wants **N ≥ 5**
-external repositories; the gallery currently provides 4 — add a fifth showcase
-before publishing pooled numbers.
+separately (self-serving ground truth). The six external suites (fastify,
+httpie, miniflux, uptime-kuma, keycloak, kafka) cover every showcase currently
+in the gallery, clearing the **N ≥ 5** external-repository threshold for
+headline pooling. Keycloak and Kafka anchor the enterprise end of the gallery's
+CLI-to-enterprise spectrum; their comprehension tasks were authored multi-hop
+from the start (see "Suite versions" above on issue #56) rather than needing a
+later v2 errata round.
 
 ## Running
 

--- a/docs/research/context-benchmark/tasks/kafka.yaml
+++ b/docs/research/context-benchmark/tasks/kafka.yaml
@@ -1,0 +1,372 @@
+# Frozen benchmark task suite: kafka (yarramate/benchmark-suite/v1).
+# Authored before any condition run (DESIGN.md "Task suite"); ground truth was
+# verified by reading the source at the pinned commit — the code, not the
+# gallery model, is the authority. Comprehension and change prompts are
+# condition-neutral; model-maintenance prompts necessarily reference the
+# committed workspace and only run under model-present conditions.
+#
+# First version for this repository (no prior sweep, so no errata to correct).
+# Informed by issue #56 (the 2026-07-29 sweep found comprehension saturated at
+# both model tiers on the original four repos because the tasks were
+# single-hop): this suite is built with multi-hop tasks from the start rather
+# than needing a later v2 round. Two of the four comprehension tasks below
+# each require chaining 3+ hops across different files/modules:
+# - kf-comp-produce-acks-all-ack: the DelayedProduce purgatory operation ->
+#   its validator callback -> Partition's acks=-1 completion check -> the ISR
+#   membership condition that lets the high watermark satisfy it, plus the
+#   distinct error path when the ISR shrinks below min.insync.replicas after
+#   the record was already appended.
+# - kf-comp-consumer-rebalance: the consumer's own pre-join offset-commit and
+#   revoke sequence, the broker electing and briefing a group leader, and the
+#   leader-side client code that actually computes the new assignment before
+#   any member applies it.
+# The other two comprehension tasks are foundational (still real, but
+# effectively single-hop) so the family deliberately mixes both difficulties.
+#
+# Kafka 4.3.1 is KRaft-only (Apache ZooKeeper was removed in 4.0); no task in
+# this suite depends on ZooKeeper.
+type: yarramate/benchmark-suite/v1
+suite: kafka
+headline: true
+repository:
+  name: kafka
+  source: https://github.com/apache/kafka
+  commit: 26b251a451ce941d3d7a55e6487bcb7f16b5ad48
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/kafka
+
+tasks:
+  # --- Comprehension (foundational) -----------------------------------------
+  - id: kf-comp-isr-hw-ownership
+    family: comprehension
+    prompt: >-
+      For a single topic partition on its leader broker: (1) which class
+      holds the set of broker ids currently in the in-sync replica set, and
+      the exact method that returns that set; (2) which class tracks the
+      partition's high watermark, the name of the field backing it, and the
+      exact accessor method and its return type; (3) name one method on the
+      first class that can shrink the in-sync set and one that can grow it,
+      and state which of the two (if either) is a private method (do not
+      describe their internals, just identify them).
+    groundTruth:
+      answer: >-
+        (1) kafka.cluster.Partition
+        (core/src/main/scala/kafka/cluster/Partition.scala) via
+        inSyncReplicaIds: Set[Int], defined at line 267 as
+        "partitionState.isr.asScala.map(_.toInt).toSet". (2)
+        org.apache.kafka.storage.internals.log.UnifiedLog
+        (storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java)
+        tracks it via the private field highWatermarkMetadata (declared as
+        "private volatile LogOffsetMetadata highWatermarkMetadata" at line
+        160); the accessor is "public long highWatermark()" (lines 506-508),
+        returning highWatermarkMetadata.messageOffset. (3) On Partition:
+        maybeShrinkIsr() (line 1089, package-visible — no "private" modifier)
+        can shrink the ISR; maybeExpandIsr(followerReplica: Replica) (line
+        876, declared "private def") can grow it — of the two, only
+        maybeExpandIsr is private.
+      verifiedAgainst:
+        - core/src/main/scala/kafka/cluster/Partition.scala:267
+        - core/src/main/scala/kafka/cluster/Partition.scala:876
+        - core/src/main/scala/kafka/cluster/Partition.scala:1089
+        - storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java:160
+        - storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java:506-508
+    scoring:
+      method: ground-truth
+
+  - id: kf-comp-kraft-controller-classes
+    family: comprehension
+    prompt: >-
+      This cluster runs in KRaft mode (no ZooKeeper). Identify two distinct
+      classes involved in that: (1) the class that implements the Raft
+      consensus protocol itself (leader election, log replication of the
+      metadata log) — name it, the interface it implements, and its module
+      path; (2) the class that implements the active controller's metadata
+      mutation logic (the component that actually processes things like
+      topic creation and partition reassignment once this node is the
+      elected leader) — name it, the interface it implements, and its module
+      path. State which of the two is concerned with consensus/replication
+      versus which is concerned with the controller's business logic.
+    groundTruth:
+      answer: >-
+        (1) org.apache.kafka.raft.KafkaRaftClient<T>
+        (raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java:169),
+        which implements RaftClient<T> — this is the consensus/replication
+        layer: leader election and replicating the metadata log entries
+        across the controller quorum. (2)
+        org.apache.kafka.controller.QuorumController
+        (metadata/src/main/java/org/apache/kafka/controller/QuorumController.java:175),
+        which implements the Controller interface — this is the business-logic
+        layer that runs once a node's KafkaRaftClient has it acting as the
+        active/leader controller, translating admin requests (create topic,
+        reassign partitions, etc.) into metadata log records. KafkaRaftClient
+        is the consensus/replication component; QuorumController is the
+        controller business-logic component built on top of it.
+      verifiedAgainst:
+        - raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java:169
+        - metadata/src/main/java/org/apache/kafka/controller/QuorumController.java:175
+    scoring:
+      method: ground-truth
+
+  # --- Comprehension (multi-hop) ---------------------------------------------
+  - id: kf-comp-produce-acks-all-ack
+    family: comprehension
+    prompt: >-
+      A producer sends a record with acks=all (acks=-1) to a topic whose
+      min.insync.replicas is 2, on a partition with 3 replicas. Trace exactly
+      how and when the broker acknowledges this request, citing files,
+      classes and methods: (1) after the leader appends the record locally,
+      what kind of operation is created to track the pending
+      acknowledgement, and the interface/callback it uses to periodically
+      check whether it can complete; (2) the partition-level method that
+      callback ultimately reaches, and the exact condition (in terms of high
+      watermark and the required offset) under which it reports the request
+      as satisfied; (3) precisely what additional condition determines
+      whether that method reports success with no error versus success with
+      an explicit "not enough replicas" error, and under what real scenario
+      the latter happens even though the record was already durably
+      appended; (4) what value being compared to what causes the check to
+      report "still pending" rather than either success outcome; (5) once
+      every partition in the request is satisfied, what actually invokes the
+      callback that sends the response back for the whole request.
+    groundTruth:
+      answer: >-
+        (1) A DelayedProduce operation
+        (server/src/main/java/org/apache/kafka/server/purgatory/DelayedProduce.java)
+        is created and placed in the produce purgatory; it periodically has
+        tryComplete() (lines 139-171) invoked, which for each still-pending
+        partition calls a PartitionStatusValidator's validate(topicPartition,
+        requiredOffset) method (the @FunctionalInterface declared at lines
+        82-93) — this validator is supplied by
+        ReplicaManager#maybeAddDelayedProduce() (per the class-level comment
+        at lines 134-136, since DelayedProduce lives in the server module and
+        cannot reach ReplicaManager directly). (2) The validator ultimately
+        calls kafka.cluster.Partition.checkEnoughReplicasReachOffset(requiredOffset)
+        (core/src/main/scala/kafka/cluster/Partition.scala:947-982), whose
+        own doc comment states it is "only be called if requiredAcks = -1".
+        It reports the request satisfied once leaderLog.highWatermark >=
+        requiredOffset (line 969) — i.e. once the high watermark has advanced
+        past the offset the produced record was written at. (3) Even when
+        that condition is true, the method separately checks minIsr <=
+        curMaximalIsr.size (line 974, minIsr from effectiveMinIsr(leaderLog)
+        at line 968); if true it returns (true, Errors.NONE) (line 975,
+        success), but if the current ISR has shrunk below the configured
+        min.insync.replicas it returns (true,
+        Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND) (line 977) instead — the
+        code comment explains this happens when "the request was already
+        appended locally and then added to the purgatory before the ISR was
+        shrunk", i.e. the record is durably written but the client is told
+        the durability guarantee it asked for was not actually met at
+        acknowledgement time. (4) While leaderLog.highWatermark is still less
+        than requiredOffset, the method returns (false, Errors.NONE) (line
+        979) — "still pending", not yet an error. (5) Once every partition in
+        produceStatus is no longer acksPending, tryComplete() calls
+        forceComplete() (line 167 of DelayedProduce.java), which triggers
+        onComplete() (lines 186-195): it assembles the per-partition
+        PartitionResponse map and calls responseCallback.accept(...), which
+        is the callback that ultimately sends the ProduceResponse back to the
+        client.
+      verifiedAgainst:
+        - server/src/main/java/org/apache/kafka/server/purgatory/DelayedProduce.java:82-93
+        - server/src/main/java/org/apache/kafka/server/purgatory/DelayedProduce.java:134-171
+        - server/src/main/java/org/apache/kafka/server/purgatory/DelayedProduce.java:186-195
+        - core/src/main/scala/kafka/cluster/Partition.scala:947-982
+    scoring:
+      method: ground-truth
+
+  - id: kf-comp-consumer-rebalance
+    family: comprehension
+    prompt: >-
+      A third consumer joins an existing two-consumer group that uses the
+      classic (eager) group-membership protocol and auto-commit enabled.
+      Trace what happens on the client side before, during, and after the
+      resulting rebalance, citing files, classes and methods: (1) the method
+      each of the two existing consumers runs before rejoining the group,
+      and the two things it does, in order, regarding currently-owned
+      partitions and their offsets — including what governs how long it will
+      wait for an in-flight offset commit before proceeding anyway; (2) under
+      the eager protocol specifically, what happens to a consumer's assigned-partitions
+      set as part of that same method, and when (relative to the revoke
+      callback) that happens; (3) which client-side class and method is
+      invoked, only on the member elected group leader, once the broker has
+      collected every member's subscription — name the parameter that
+      carries the other members' subscription data into it; (4) inside that
+      method, how the leader determines which partition-assignment strategy
+      implementation to use for computing the new assignment.
+    groundTruth:
+      answer: >-
+        (1) Each consumer runs onJoinPrepare(timer, generation, memberId)
+        (clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java:752-864)
+        before rejoining. If auto-commit is enabled and no commit is already
+        in flight, it first attempts an asynchronous auto-commit of currently
+        owned partitions' offsets (maybeAutoCommitOffsetsAsync, lines
+        764-767) and only afterward proceeds to revoke; how long it will wait
+        for that commit is bounded by rebalanceTimeoutMs via a joinPrepareTimer
+        (lines 754-774) — if that timer expires the method logs an error and
+        proceeds to revoke anyway rather than blocking indefinitely (lines
+        784-785). (2) Under the EAGER branch of the protocol switch (lines
+        826-833), it revokes ALL currently assigned partitions — it collects
+        them into revokedPartitions, invokes rebalanceListenerInvoker.
+        invokePartitionsRevoked(revokedPartitions) (the user's revoke
+        callback), and only THEN calls
+        subscriptions.assignFromSubscribed(Collections.emptySet()) to clear
+        the local assignment (line 832) — the callback runs BEFORE the local
+        assignment is cleared, specifically so the callback can still see
+        which partitions it owned (e.g. to commit their offsets manually) at
+        the time it fires. (3) Only the elected leader has
+        onLeaderElected(leaderId, assignmentStrategy, allSubscriptions,
+        skipAssignment) invoked
+        (ConsumerCoordinator.java:653-714); allSubscriptions (a
+        List<JoinGroupResponseData.JoinGroupResponseMember>) carries every
+        member's subscription metadata, gathered by the broker-side
+        coordinator and handed to the leader once every member has joined.
+        (4) It calls lookupAssignor(assignmentStrategy) (line 657) to resolve
+        the ConsumerPartitionAssignor implementation matching the negotiated
+        assignmentStrategy name (e.g. the group's configured
+        partition.assignment.strategy, such as CooperativeStickyAssignor).
+        After first collecting every member's subscription and owned
+        partitions from allSubscriptions into local maps (lines 662-674), it
+        invokes assignor.assign(metadata.fetch(), new
+        GroupSubscription(subscriptions)).groupAssignment() (line 691) to
+        compute the actual new assignment.
+      verifiedAgainst:
+        - clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java:752-804
+        - clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java:826-833
+        - clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java:653-714
+    scoring:
+      method: ground-truth
+
+  # --- Change ----------------------------------------------------------------
+  - id: kf-change-partition-isr-below-minisr
+    family: change
+    prompt: >-
+      Add a method to the class that owns a partition's leader-side
+      replication state (in-sync-replica set and configured minimum
+      in-sync-replica count) that reports, for the current leader-local
+      state, whether the in-sync replica set size is currently at or below
+      the configured minimum in-sync-replica count for that partition — a
+      pure query with no side effects. It must reuse the same minimum-in-sync-replica
+      resolution logic already used elsewhere in this class (there is
+      existing code in this file that computes the effective minimum
+      in-sync-replica count for a log and compares it against the current
+      maximal in-sync-replica set size) rather than re-deriving that
+      threshold independently or hard-coding a config lookup. It should
+      return a definite false when this broker does not currently hold the
+      partition's leader-local log (rather than throwing).
+    touches:
+      - core/src/main/scala/kafka/cluster/Partition.scala
+      - replication
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          The new method lives on the Partition class (or an equivalent
+          leader-side replication-state owner in this file) and reuses the
+          existing effective-min-in-sync-replicas resolution already present
+          in this file rather than introducing a second, independent way of
+          computing or looking up that threshold.
+        - >-
+          The method is a pure query (no mutation of ISR state, no network
+          calls, no side effects) that returns true exactly when the current
+          maximal in-sync-replica set size is at or below the effective
+          minimum, and false otherwise.
+        - >-
+          When this broker does not currently hold the partition's
+          leader-local log, the method returns false rather than throwing an
+          exception.
+        - >-
+          Existing ISR expansion, shrinkage, and the acks=all completion
+          check (checkEnoughReplicasReachOffset) are unchanged in behavior.
+
+  - id: kf-change-follower-hw-lag
+    family: change
+    prompt: >-
+      In the class that owns a partition's leader-side replication state,
+      there is existing logic that determines whether a follower replica is
+      caught up by comparing that follower's fetched log-end-offset against
+      the leader log's high watermark. Extract that offset comparison into
+      its own named, reusable method that returns how far behind the high
+      watermark a given follower replica currently is, as a non-negative
+      count of offsets (0 when the follower has fully caught up to or passed
+      the high watermark). Update the existing caught-up-check logic to call
+      this new method instead of repeating the comparison inline, without
+      changing its observable behavior (a replica must still be considered
+      caught up under exactly the same condition as before, including the
+      leader-epoch requirement that check already applies). The new method
+      must handle the case where this broker does not currently hold the
+      partition's leader-local log without throwing.
+    touches:
+      - core/src/main/scala/kafka/cluster/Partition.scala
+      - replication
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new named method returns the follower's lag from the leader's
+          high watermark as a non-negative offset count, and is used by the
+          existing follower-caught-up check (isFollowerInSync or its
+          equivalent after the change) instead of that check repeating the
+          offset comparison inline.
+        - >-
+          The follower-caught-up check's observable behavior is unchanged:
+          it still additionally requires the follower to be within the
+          current leader epoch, exactly as before — the refactor does not
+          silently drop or relax that condition.
+        - >-
+          The new method does not throw when this broker does not currently
+          hold the partition's leader-local log; it returns a sensible
+          non-throwing result (e.g. 0 or another clearly-documented
+          sentinel) in that case.
+        - >-
+          No unrelated ISR-expansion or ISR-shrinkage behavior changes as a
+          side effect of the refactor.
+
+  # --- Model maintenance ------------------------------------------------------
+  - id: kf-model-producer-idempotence-view
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace models the produce path (producer
+      client through the partition leader) but does not model producer
+      idempotence at all — there is no concept for the client-side component
+      that tracks the producer id/epoch and per-partition sequence numbers
+      used to detect and deduplicate retried produce requests. Add a concept
+      for this client-side idempotence-tracking component, grounded in the
+      actual client source (there is a dedicated class for this under the
+      producer internals package, alongside a small value type pairing a
+      producer id with its epoch), and add the relationship(s) needed to
+      connect it into the existing produce-path concepts already in the
+      workspace (it sits on the producer side, ahead of a produce request
+      being sent). Do not claim broker-side deduplication state as part of
+      this concept — scope it to the client-side tracking component only.
+      Cite the real files/classes you used. The workspace must still pass
+      check, and the generated LikeC4 export must remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass
+          - catalogue-density-not-worse
+
+  - id: kf-model-transaction-coordinator-view
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace models the consumer-group
+      coordinator (for consumer group membership and offset commits) but has
+      no concept at all for the separate broker-side coordinator that
+      manages producer transactions — a distinct component from the
+      consumer-group coordinator, backed by its own internal topic, that
+      exists in this codebase as its own class. Add a concept for this
+      transaction coordinator, grounded in the actual broker source, and add
+      relationship(s) that place it correctly relative to existing concepts
+      already in the workspace (brokers, and the produce path) — without
+      merging it into or confusing it with the existing consumer-group
+      coordinator concept, which is a different component for a different
+      purpose. Cite the real files/classes you used. The workspace must
+      still pass check, and the generated LikeC4 export must remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass
+          - catalogue-density-not-worse

--- a/docs/research/context-benchmark/tasks/keycloak.yaml
+++ b/docs/research/context-benchmark/tasks/keycloak.yaml
@@ -1,0 +1,414 @@
+# Frozen benchmark task suite: keycloak (yarramate/benchmark-suite/v1).
+# Authored before any condition run (DESIGN.md "Task suite"); ground truth was
+# verified by reading the source at the pinned commit — the code, not the
+# gallery model, is the authority. Comprehension and change prompts are
+# condition-neutral; model-maintenance prompts necessarily reference the
+# committed workspace and only run under model-present conditions.
+#
+# First version for this repository (no prior sweep, so no errata to correct).
+# Informed by issue #56 (the 2026-07-29 sweep found comprehension saturated at
+# both model tiers on the original four repos because the tasks were
+# single-hop): this suite is built with multi-hop tasks from the start rather
+# than needing a later v2 round. Two of the four comprehension tasks below
+# each require chaining 3+ hops across different subsystems and files:
+# - kc-comp-ldap-auth-chain: login form -> credential-manager dispatch ->
+#   federation-linked storage-provider lookup -> the LDAP storage provider's
+#   CredentialInputValidator implementation -> the actual LDAP bind, plus the
+#   success/failure branches back up the chain.
+# - kc-comp-idp-delete-cascade: the admin delete endpoint -> its call order
+#   into the user-storage preRemove hook -> the JPA-layer bulk delete of
+#   federated-identity link rows -> what does and does not happen to the
+#   affected local user accounts.
+# The other two comprehension tasks are foundational (still real, but
+# effectively single-hop) so the family is not saturation-proof by omission —
+# it deliberately mixes both difficulties.
+type: yarramate/benchmark-suite/v1
+suite: keycloak
+headline: true
+repository:
+  name: keycloak
+  source: https://github.com/keycloak/keycloak
+  commit: 73f08b397f193712b26d317210dce99898129709
+  gallery: https://github.com/yarrasys/yarramate-gallery
+  model: showcases/keycloak
+
+tasks:
+  # --- Comprehension (foundational) -----------------------------------------
+  - id: kc-comp-idp-entrypoints
+    family: comprehension
+    prompt: >-
+      This server implements identity brokering — delegating login to
+      external identity providers such as Google or an external OIDC/SAML
+      IdP. Identify: (1) the single class that implements every broker-facing
+      HTTP endpoint (login, callback, account-linking, token retrieval); (2)
+      the URL path prefix under which it is mounted, and the file and line
+      where that mounting happens; (3) name the four distinct broker
+      operations it exposes as separate methods and, for each, the HTTP verb
+      and path segment used to reach it.
+    groundTruth:
+      answer: >-
+        (1) org.keycloak.services.resources.IdentityBrokerService
+        (services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java).
+        (2) It is mounted at {realm}/broker by
+        services/src/main/java/org/keycloak/services/resources/RealmsResource.java:210
+        (@Path("{realm}/broker")), instantiated as "new
+        IdentityBrokerService(session)" at RealmsResource.java:214 — combined
+        with RealmsResource's own realm-scoped base path this yields
+        /realms/{realm}/broker. (3) Four operations: login — GET and POST
+        {provider_alias}/login via performLogin (IdentityBrokerService.java:394-397)
+        and performPostLogin (:383-385); account linking —
+        {provider_alias}/link via clientInitiatedAccountLinking
+        (:222-226, GET) with a preflight OPTIONS-style check
+        clientIntiatedAccountLinkingPreflight (:216-217); the provider
+        callback/endpoint — {provider_alias}/endpoint via getEndpoint
+        (:464-465); and token retrieval — GET {provider_alias}/token via the
+        method at :483-485, with a preflight retrieveTokenPreflight at
+        :477-479.
+      verifiedAgainst:
+        - services/src/main/java/org/keycloak/services/resources/RealmsResource.java:210
+        - services/src/main/java/org/keycloak/services/resources/RealmsResource.java:214
+        - services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java:216-226
+        - services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java:383-397
+        - services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java:464-485
+    scoring:
+      method: ground-truth
+
+  - id: kc-comp-bruteforce-lockout
+    family: comprehension
+    prompt: >-
+      A user has failed to log in with the wrong password several times.
+      Explain how the server decides, on the next login attempt, whether that
+      user is temporarily locked out: (1) which class implements the check
+      and the exact method name; (2) what value on the stored failure record
+      the check compares the current time against; (3) name the interface and
+      method that reads the stored failure record, and state what happens if
+      no record exists for that user; (4) separately, name the condition
+      under which the account instead becomes *permanently* locked out rather
+      than temporarily, citing the two realm-level settings involved.
+    groundTruth:
+      answer: >-
+        (1) org.keycloak.services.managers.DefaultBruteForceProtector
+        (services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java),
+        method isTemporarilyDisabled(session, realm, user) at line 267. (2)
+        It compares the current time (Time.currentTimeMillis()/1000) against
+        userLoginFailure.getFailedLoginNotBefore() — if currTime is still
+        before that timestamp it returns true (lines 269-274). (3) The record
+        is read via getUserFailureModel, which calls
+        session.loginFailures().getUserLoginFailure(realm, userId) (line
+        182), where loginFailures() is a UserLoginFailureProvider
+        (server-spi/src/main/java/org/keycloak/models/UserLoginFailureProvider.java);
+        if no record exists, getUserLoginFailure returns null and
+        isTemporarilyDisabled's null check causes it to fall through to
+        "return false" (line 267-280) — no record means no lockout. (4)
+        isPermanentlyLockedOut (line 284) locks the account permanently when
+        realm.isPermanentLockout() is true AND the stored record's
+        getNumTemporaryLockouts() exceeds realm.getMaxTemporaryLockouts()
+        (line 292-293) — i.e. it takes more than the configured number of
+        separate temporary-lockout episodes before the realm's permanent-lockout
+        policy kicks in.
+      verifiedAgainst:
+        - services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java:180-182
+        - services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java:267-280
+        - services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java:284-294
+        - server-spi/src/main/java/org/keycloak/models/UserLoginFailureProvider.java:24-47
+        - server-spi/src/main/java/org/keycloak/models/UserLoginFailureModel.java:24-35
+    scoring:
+      method: ground-truth
+
+  # --- Comprehension (multi-hop) ---------------------------------------------
+  - id: kc-comp-ldap-auth-chain
+    family: comprehension
+    prompt: >-
+      A user account is federated from an LDAP directory and has no locally
+      stored password (LDAP is the sole password source for that account).
+      They submit the login form with a password. Trace the complete
+      call chain from the form submission to the LDAP server, and back to a
+      pass/fail decision, citing files, classes and methods at every hop: (1)
+      the authenticator class and method that first receives the submitted
+      password and what it checks before attempting any credential
+      validation; (2) the class and method it calls into to validate the
+      credential, and — since the user is federated — which storage provider
+      instance actually performs the check and how that instance is located;
+      (3) the SPI interface that storage provider implements to be eligible
+      for credential validation, and the method on it that is invoked; (4)
+      inside that method, which private method performs the actual LDAP bind,
+      and what happens if the LDAP entry for the user cannot be found at all;
+      (5) precisely what the authenticator does differently when validation
+      succeeds versus when it fails (name the two distinct outcomes it
+      produces in each case).
+    groundTruth:
+      answer: >-
+        (1) AbstractUsernameFormAuthenticator.validatePassword(context, user,
+        inputData, clearUser)
+        (services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java:211-225),
+        called from UsernamePasswordForm's form-validation path
+        (AbstractUsernameFormAuthenticator.java:143). Before validating
+        anything it checks the password field is non-empty (line 213-215,
+        else treated as a bad-password case) and calls
+        isDisabledByBruteForce(context, user) (line 217), returning false
+        immediately if the account is already locked out. (2) It calls
+        user.credentialManager().isValid(UserCredentialModel.password(password))
+        (line 219). credentialManager() returns a UserCredentialManager
+        (model/storage/src/main/java/org/keycloak/credential/UserCredentialManager.java);
+        its isValid(List<CredentialInput>) (lines 71-92) checks
+        user.isFederated() (line 78), and if true looks up the
+        federation-linked UserStorageProviderModel via
+        getStorageProviderModel(realm, user.getFederationLink()) (line 79)
+        and obtains a CredentialInputValidator instance for that model via
+        getStorageProviderInstance(model, CredentialInputValidator.class)
+        (line 82) — for an LDAP-federated user this resolves to the
+        LDAPStorageProvider instance registered for that federation link. (3)
+        The SPI interface is
+        org.keycloak.credential.CredentialInputValidator
+        (server-spi/src/main/java/org/keycloak/credential/CredentialInputValidator.java),
+        which LDAPStorageProvider implements
+        (federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java:115-116);
+        UserCredentialManager's private validate() helper (lines 282-294)
+        invokes validator.isValid(realm, user, input) (line 286), which for
+        LDAP is LDAPStorageProvider.isValid(realm, user, input)
+        (LDAPStorageProvider.java:942-949) — it returns false immediately for
+        a non-password credential or one already configured locally,
+        otherwise it calls the private validPassword(realm, user, password).
+        (4) validPassword (LDAPStorageProvider.java:813-871) performs
+        loadAndValidateUser to re-resolve the LDAP entry; if that returns
+        null (the user was removed from LDAP) it returns false immediately
+        without attempting a bind (lines 824-828). Otherwise it calls
+        ldapIdentityStore.validatePassword(ldapUser, password) (line 831) —
+        the actual LDAP bind — inside a try/catch that returns true on
+        success (line 832) and false (or a required-action flow, for a
+        forced password-policy change) on the various LDAP exception types.
+        (5) On success, validate()'s removeIf drops the input from the
+        toValidate list so isValid(user) returns toValidate.isEmpty() == true;
+        validatePassword then sets the auth-session note
+        AuthenticationManager.PASSWORD_VALIDATED = "true"
+        (AbstractUsernameFormAuthenticator.java:220) and returns true,
+        letting the flow proceed. On failure the input is not removed,
+        isValid returns false, and validatePassword calls
+        badPasswordHandler(context, user, clearUser, false)
+        (AbstractUsernameFormAuthenticator.java:223, :228-245), which raises
+        an INVALID_USER_CREDENTIALS event and calls
+        context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS,
+        challengeResponse) to fail the authentication flow with a challenge
+        response.
+      verifiedAgainst:
+        - services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java:143
+        - services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java:211-245
+        - model/storage/src/main/java/org/keycloak/credential/UserCredentialManager.java:71-92
+        - model/storage/src/main/java/org/keycloak/credential/UserCredentialManager.java:282-294
+        - federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java:115-116
+        - federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java:942-949
+        - federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java:813-848
+        - server-spi/src/main/java/org/keycloak/credential/CredentialInputValidator.java
+    scoring:
+      method: ground-truth
+
+  - id: kc-comp-idp-delete-cascade
+    family: comprehension
+    prompt: >-
+      An administrator deletes an identity provider that has users who
+      previously logged in through it (their accounts are linked to that
+      provider). Trace exactly what happens to those users' accounts and
+      their link to the deleted provider: (1) the admin REST resource and
+      method that handles the delete, the authorization check it requires,
+      and the exact order of the two data-layer calls it makes; (2) which of
+      those two calls is responsible for cleaning up the linkage data, the
+      interface method it implements, and the file where that implementation
+      lives; (3) exactly what that implementation does at the data layer —
+      quote or closely paraphrase the actual query/operation and state its
+      scope (which rows, for which realm and provider); (4) after the
+      deletion completes, are the previously-linked users' accounts deleted,
+      disabled, or left as ordinary local accounts — state which, and what
+      it implies for a user whose only credential was that identity
+      provider.
+    groundTruth:
+      answer: >-
+        (1)
+        org.keycloak.services.resources.admin.IdentityProviderResource.delete()
+        (services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java:126-147).
+        It requires auth.realm().requireManageIdentityProviders() (line 131).
+        The order is: session.users().preRemove(realm, identityProviderModel)
+        (line 138) FIRST, then session.identityProviders().remove(alias)
+        (line 139) SECOND, followed by removing any identity-provider mappers
+        for that alias (lines 141-142). (2) The first call,
+        preRemove(RealmModel, IdentityProviderModel), is the cleanup step. It
+        is declared on the UserProvider interface
+        (server-spi/src/main/java/org/keycloak/models/UserProvider.java) and
+        implemented in
+        model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java:224-229.
+        (3) The implementation runs the JPA named query
+        "deleteFederatedIdentityByProvider" — "delete from
+        FederatedIdentityEntity fdi where fdi.realmId = :realmId and
+        fdi.identityProvider = :providerAlias" (declared in
+        model/jpa/src/main/java/org/keycloak/models/jpa/entities/FederatedIdentityEntity.java,
+        the @NamedQuery block) — parameterised with the current realm's id
+        and the provider's alias (JpaUserProvider.java:226-228), i.e. it bulk
+        deletes every FEDERATED_IDENTITY link row for that realm and that
+        specific provider alias only. (4) The query only deletes rows in the
+        FEDERATED_IDENTITY link table; it does not touch the UserEntity/user
+        rows at all, so the local user accounts are left exactly as ordinary
+        , still-enabled local accounts — neither deleted nor disabled. For a
+        user whose only credential had been authentication through that
+        identity provider (no local password or other credential configured),
+        this means they still exist as a user but now have no way to
+        authenticate until an administrator grants them another credential.
+      verifiedAgainst:
+        - services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java:126-147
+        - server-spi/src/main/java/org/keycloak/models/UserProvider.java
+        - model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java:224-229
+        - model/jpa/src/main/java/org/keycloak/models/jpa/entities/FederatedIdentityEntity.java:42-46
+    scoring:
+      method: ground-truth
+
+  # --- Change ----------------------------------------------------------------
+  - id: kc-change-idp-linked-users-count
+    family: change
+    prompt: >-
+      Add a new admin REST endpoint for a single identity provider instance
+      that returns how many users are currently linked to it (i.e. have a
+      federated-identity record for that provider in the current realm):
+      GET on the identity provider instance's existing resource path with an
+      additional "/linked-users-count" segment, returning a small JSON body
+      containing the count. It must require the same authorization the
+      existing single-identity-provider GET endpoint requires. Do not
+      implement this by loading every linked user into memory in Java code —
+      add a proper counting query at the data-access layer (JPA), following
+      the pattern of the existing federated-identity queries for that
+      entity, and expose it through the existing storage-provider interface
+      that already declares other federated-identity operations for a
+      provider (rather than querying the entity manager directly from the
+      REST layer). Existing identity-provider CRUD behavior must be
+      unchanged.
+    touches:
+      - services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+      - model/jpa/src/main/java/org/keycloak/models/jpa/entities/FederatedIdentityEntity.java
+      - server-spi/src/main/java/org/keycloak/models/UserProvider.java
+      - model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+      - identity-provider-admin-api
+      - user-federation
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          A new GET endpoint under the existing identity-provider-instance
+          resource path with a "/linked-users-count" segment returns a JSON
+          body with the correct count of FEDERATED_IDENTITY rows for that
+          realm and provider alias, and requires the same authorization
+          check (requireViewIdentityProviders, matching the existing single
+          GET) as the existing single-provider GET endpoint.
+        - >-
+          The count is produced by a new counting query added at the JPA
+          layer (a new named/JPQL query following the style of the existing
+          federated-identity queries on FederatedIdentityEntity), not by
+          fetching and counting entities/users in Java.
+        - >-
+          The new count operation is exposed through the same
+          storage-provider interface (UserProvider or its JPA
+          implementation) that already owns the other federated-identity
+          operations for a provider, rather than the REST resource querying
+          the entity manager or repository directly.
+        - >-
+          Existing identity-provider CRUD endpoints (get, update, delete) and
+          their behavior are unchanged.
+
+  - id: kc-change-list-locked-out-users
+    family: change
+    prompt: >-
+      Today the brute-force-protection storage interface only supports
+      looking up, adding, or removing one user's login-failure record by
+      user id — there is no way to list every currently-locked-out user in a
+      realm. Add that capability: a new admin-facing way to retrieve the set
+      of users in a realm who are presently temporarily locked out (their
+      stored failure record's lockout-until value is still in the future).
+      Extend the storage-provider interface that already owns the per-user
+      login-failure operations with a new method that streams every stored
+      failure record for a realm (do not add a second, parallel storage
+      abstraction), implement it at the JPA layer, and use it — together with
+      the existing per-record check for whether the lockout window is still
+      active — to compute the locked-out set rather than re-deriving the
+      lockout logic separately. Existing single-user lockout checks and
+      login-failure recording must be unchanged.
+    touches:
+      - server-spi/src/main/java/org/keycloak/models/UserLoginFailureProvider.java
+      - model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+      - services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+      - brute-force-protection
+    scoring:
+      method: rubric
+      rubric:
+        - >-
+          UserLoginFailureProvider gains a new method that streams every
+          stored login-failure record for a given realm, implemented at the
+          JPA layer as a genuine query (not an in-memory scan of unrelated
+          data), and no second/parallel storage mechanism is introduced for
+          this.
+        - >-
+          The locked-out-user computation reuses the existing per-record
+          temporary-lockout check (the failedLoginNotBefore-vs-current-time
+          comparison already used by isTemporarilyDisabled) rather than
+          re-implementing separate, possibly-diverging lockout logic.
+        - >-
+          Existing behavior is unchanged: per-user lookup/add/remove of a
+          login-failure record and the existing isTemporarilyDisabled /
+          isPermanentlyLockedOut checks still work exactly as before.
+        - >-
+          The new capability is reachable from an admin-facing surface (a
+          new or extended admin REST endpoint, or an equivalent
+          admin-console-consumable API) rather than left as dead code only
+          callable from tests.
+
+  # --- Model maintenance ------------------------------------------------------
+  - id: kc-model-ldap-sync-dynamic-view
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace for this repository models LDAP
+      user federation (the user-federation bridge, the LDAP/Active Directory
+      server, and the JPA model store) but only through static
+      relationships — it has no dynamic (ordered flow) view walking through
+      what actually happens when a federated user's credential is checked
+      against LDAP and, on success, how that maps to the local JPA-backed
+      user record. Add a new dynamic projection to the workspace that walks
+      this path end to end: the authenticator receiving the submitted
+      credential, the credential-manager dispatch that resolves the
+      federation-linked storage provider, the LDAP storage provider's
+      CredentialInputValidator check culminating in the LDAP bind, and back
+      to the local user record the federated identity is tied to. Ground
+      every step in the actual source (cite real files/classes), do not
+      invent steps that aren't in the code, and do not contradict the
+      workspace's existing static relationships for this area — extend them
+      with the missing ordered flow. The workspace must still pass check,
+      and the generated LikeC4 export must remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass
+          - catalogue-density-not-worse
+
+  - id: kc-model-authz-decision-dynamic-view
+    family: model-maintenance
+    prompt: >-
+      The committed .yarramate workspace models authorization services
+      (resources, scopes, policies, and a policy enforcer) but its one
+      reconciliation finding already notes that the policy-enforcer runtime
+      is a separate client-side adapter artifact not present in this
+      repository — so the workspace has no dynamic view of how a resource
+      permission is actually decided on the server side for a confidential
+      client. Add a dynamic projection covering the server-side decision
+      path only (not the absent client-side enforcer): from the
+      authorization-services evaluation entry point, through the policy
+      evaluator that walks the configured policies for the requested
+      resource/scope, to the decision it produces. Ground every step in the
+      actual source (cite real files/classes such as the policy evaluator
+      and evaluation classes under the authorization package), and do not
+      claim the client-side enforcement step is present in this repository —
+      the workspace must continue to accurately reflect that boundary. The
+      workspace must still pass check, and the generated LikeC4 export must
+      remain valid.
+    scoring:
+      method: deterministic
+      deterministic:
+        expect:
+          - check-pass
+          - likec4-check-pass
+          - catalogue-density-not-worse


### PR DESCRIPTION
Brings the benchmark corpus in line with the gallery, which now has 6 showcases (was 4 when the corpus was last authored). Adds two frozen suites and fixes a now-stale README line.

## New suites
- `docs/research/context-benchmark/tasks/keycloak.yaml` — 8 tasks
- `docs/research/context-benchmark/tasks/kafka.yaml` — 8 tasks

Both `yarramate/benchmark-suite/v1`, pinned to the exact commits the gallery models were built against (`73f08b39…` / `26b251a4…`). 4 comprehension (2 foundational + 2 multi-hop) + 2 change + 2 model-maintenance each.

## Multi-hop from the start
Per issue #56 (comprehension saturated at both model tiers in the 2026-07-29 sweep because the original tasks were single-hop), these two suites are built with multi-hop tasks from day one rather than needing a later v2 errata round:
- **Keycloak**: the federated-LDAP credential-check chain (login form → credential-manager dispatch → LDAP storage provider's `CredentialInputValidator` → the actual bind), and the identity-provider-deletion cascade (admin endpoint → `UserProvider#preRemove` → the JPA bulk-delete of federated-identity links, and what does/doesn't happen to the affected local accounts).
- **Kafka**: the `acks=all` acknowledgement path (`DelayedProduce` purgatory operation → `Partition.checkEnoughReplicasReachOffset` → the high-watermark/ISR condition, including the distinct "durably written but not-enough-replicas" error), and classic-protocol consumer-group rebalance (per-consumer offset auto-commit before revoke → broker-elected leader → leader-side `ConsumerPartitionAssignor` invocation).

Model-maintenance tasks extend the workspace into gaps the gallery's own discovery journeys already documented as intentionally out of scope (Keycloak: LDAP sync/import and the authorization-decision path as dynamic views; Kafka: producer idempotence and the transaction coordinator).

## Verification
- `node runner/validate-suite.mjs` passes for both new suites individually and in the full 11-file regression (all existing v1/v2 suites unaffected).
- **Ground truth was independently re-verified** against the pinned clones after drafting (not just trusted from the drafting pass) — this caught and fixed 3 real defects: two off-by-N line-number citations in the Kafka multi-hop tasks (verified via fresh reads against `/tmp/kafka-4.3.1`), and one comprehension prompt that incorrectly implied a method was private when it isn't (`maybeShrinkIsr` is package-visible, not private — the prompt and ground truth now state this explicitly rather than asserting a false premise).
- Every `verifiedAgainst`/`touches` citation passed an automated file-exists + line-in-bounds check, plus manual re-verification of every inline line-number claim in all four comprehension tasks per suite.

## README
Removed the stale "gallery currently provides 4 — add a fifth showcase" corpus warning; it now correctly states all 6 gallery showcases have benchmark suites, clearing the N≥5 headline-pooling threshold from DESIGN.md.

## Process note
The two subagents I originally dispatched to author these in parallel both failed immediately on an account-level `429 Weekly/Monthly Limit Exhausted` (not transient —~73h retry-after), so this was authored solo in the primary session using the exact investigation-and-citation contract I'd written for them, then independently re-verified as above.