### PR TITLE
feat: add visual architecture conversations

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -647,6 +647,12 @@ concepts:
     description: The Node.js 22+ runtime that executes every shipped binary on the consumer host.
     owner: yarramate-product#yarramate-maintainers
     status: current
+  - id: local-web-browser
+    kind: systemSoftware
+    name: Local web browser
+    description: The reviewer's own browser on the consumer host. It is the only place the visual conversation presentation runs, and it reaches nothing but the one authenticated loopback origin its session serves.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
   - id: npm-package
     kind: artifact
     name: npm package
@@ -741,6 +747,11 @@ concepts:
     kind: applicationFunction
     name: Recover visual conversation
     description: Derives the main-agent handoff from the append-only journal before shutdown or after failure.
+    status: current
+  - id: present-visual-conversation
+    kind: applicationFunction
+    name: Present the visual conversation
+    description: Draws the promoted views, the authority and connection state, the transcript, the structured choices, and End, and turns what the reviewer does with them into session events.
     status: current
 relationships:
   - id: core-contract-checker-loads-contract
@@ -1427,6 +1438,10 @@ relationships:
     kind: composition
     from: consumer-host
     to: nodejs-runtime
+  - id: consumer-host-composes-web-browser
+    kind: composition
+    from: consumer-host
+    to: local-web-browser
   - id: consumer-host-deploys-package
     kind: assignment
     from: consumer-host
@@ -1452,6 +1467,15 @@ relationships:
     kind: serving
     from: nodejs-runtime
     to: mcp-adapter
+  - id: runtime-serves-visual-runtime
+    kind: serving
+    from: nodejs-runtime
+    to: visual-runtime
+  - id: web-browser-serves-visual-browser
+    kind: serving
+    from: local-web-browser
+    to: visual-browser
+    description: The presentation runs in the reviewer's own browser on the same host; nothing about it is deployed anywhere else.
   - id: export-command-serves-traceability-matrix
     kind: serving
     from: export-command
@@ -1605,6 +1629,10 @@ relationships:
     to: visual-session-protocol
     mode: read-write
     description: The browser exchanges only versioned session documents. It cannot reach .yarramate, repository files, or the trusted compiler command vector, and no model provider is reachable from it.
+  - id: visual-browser-presents-conversation
+    kind: assignment
+    from: visual-browser
+    to: present-visual-conversation
   - id: visual-recovery-writes-handoff
     kind: access
     from: recover-visual-session

--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -702,6 +702,46 @@ concepts:
     description: Rendered a projection result as deterministic Markdown for reviewers, the human-facing counterpart to the JSON context of the same projection.
     owner: yarramate-product#yarramate-maintainers
     status: retired
+  - id: visual-runtime
+    kind: applicationComponent
+    name: Visual conversation runtime
+    description: Serves authenticated temporary LikeC4 explanations, browser chat transport, recovery, and cleanup without invoking a model provider.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-browser
+    kind: applicationComponent
+    name: Visual conversation browser
+    description: Custom React and LikeC4 presentation for diagrams, descriptions, choices, chat, status, and End.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-session-service
+    kind: applicationService
+    name: Visual session command
+    description: Starts, waits on, responds to, inspects, recovers, and stops one local visual conversation.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-session-protocol
+    kind: dataObject
+    name: Visual session protocol
+    description: Versioned browser, delegated-agent, model, status, and handoff documents for one temporary session.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-handoff
+    kind: dataObject
+    name: Visual conversation handoff
+    description: Recoverable summary of confirmed decisions, requested changes, unresolved questions, final views, termination, and optional transcript access.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: render-visual-model
+    kind: applicationFunction
+    name: Render temporary visual model
+    description: Validates, compiles, and atomically promotes a complete grounded or explicitly ad hoc LikeC4 model.
+    status: current
+  - id: recover-visual-session
+    kind: applicationFunction
+    name: Recover visual conversation
+    description: Derives the main-agent handoff from the append-only journal before shutdown or after failure.
+    status: current
 relationships:
   - id: core-contract-checker-loads-contract
     kind: assignment
@@ -1532,3 +1572,41 @@ relationships:
     from: view-command
     to: yarramate-product#agent-harness
     status: retired
+  - id: visual-runtime-renders-model
+    kind: assignment
+    from: visual-runtime
+    to: render-visual-model
+  - id: visual-runtime-recovers-session
+    kind: assignment
+    from: visual-runtime
+    to: recover-visual-session
+  - id: visual-runtime-provides-session-command
+    kind: implements
+    from: visual-runtime
+    to: visual-session-service
+    description: yarramate-visual is a sibling presentation binary beside yarramate-likec4, never a subcommand of the semantic CLI.
+  - id: visual-session-serves-agent-harness
+    kind: serving
+    from: visual-session-service
+    to: yarramate-product#agent-harness
+  - id: visual-runtime-serves-browser
+    kind: serving
+    from: visual-runtime
+    to: visual-browser
+    description: The runtime serves the browser over one authenticated local origin; in diagram-only mode this is the whole session and the conversation stays in the main harness.
+  - id: visual-rendering-reads-protocol
+    kind: access
+    from: render-visual-model
+    to: visual-session-protocol
+    mode: read
+  - id: visual-browser-exchanges-protocol
+    kind: access
+    from: visual-browser
+    to: visual-session-protocol
+    mode: read-write
+    description: The browser exchanges only versioned session documents. It cannot reach .yarramate, repository files, or the trusted compiler command vector, and no model provider is reachable from it.
+  - id: visual-recovery-writes-handoff
+    kind: access
+    from: recover-visual-session
+    to: visual-handoff
+    mode: write

--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -650,7 +650,7 @@ concepts:
   - id: local-web-browser
     kind: systemSoftware
     name: Local web browser
-    description: The reviewer's own browser on the consumer host. It is the only place the visual conversation presentation runs, and it reaches nothing but the one authenticated loopback origin its session serves.
+    description: The reviewer's own browser on the consumer host. It is the only place the visual conversation presentation runs, and that presentation page reaches nothing but the one authenticated loopback origin its session serves.
     owner: yarramate-product#yarramate-maintainers
     status: current
   - id: npm-package

--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -331,6 +331,74 @@ concepts:
     kind: repository-file
     name: .yarramate/evidence/repository.yaml
     status: current
+  - id: visual-session-server-source
+    kind: repository-file
+    name: src/adapters/visual/session-server.ts
+    status: current
+  - id: visual-session-store-source
+    kind: repository-file
+    name: src/adapters/visual/session-store.ts
+    status: current
+  - id: visual-likec4-compiler-source
+    kind: repository-file
+    name: src/adapters/visual/likec4-compiler.ts
+    status: current
+  - id: visual-protocol-source
+    kind: repository-file
+    name: src/adapters/visual/protocol.ts
+    status: current
+  - id: visual-cli-source
+    kind: repository-file
+    name: src/adapters/visual-cli.ts
+    status: current
+  - id: visual-browser-source
+    kind: repository-file
+    name: src/visual-app/App.tsx
+    status: current
+  - id: visual-browser-shell
+    kind: repository-file
+    name: src/visual-app/index.html
+    status: current
+  - id: visual-event-schema-source
+    kind: repository-file
+    name: schema/yarramate-visual-event.schema.json
+    status: current
+  - id: visual-handoff-schema-source
+    kind: repository-file
+    name: schema/yarramate-visual-handoff.schema.json
+    status: current
+  - id: visual-session-server-tests
+    kind: repository-file
+    name: test/visual-session-server.test.ts
+    status: current
+  - id: visual-session-store-tests
+    kind: repository-file
+    name: test/visual-session-store.test.ts
+    status: current
+  - id: visual-likec4-compiler-tests
+    kind: repository-file
+    name: test/visual-likec4-compiler.test.ts
+    status: current
+  - id: visual-protocol-tests
+    kind: repository-file
+    name: test/visual-protocol.test.ts
+    status: current
+  - id: visual-cli-tests
+    kind: repository-file
+    name: test/visual-cli.test.ts
+    status: current
+  - id: visual-browser-tests
+    kind: repository-file
+    name: test/visual-app-state.test.ts
+    status: current
+  - id: visual-journey-tests
+    kind: repository-file
+    name: test/visual-journey.test.ts
+    status: current
+  - id: visual-skill-reference
+    kind: repository-file
+    name: skills/yarramate-architecture/references/visual-conversations.md
+    status: current
 relationships:
   - id: backlog-disposition-qualifies-roadmap
     kind: association
@@ -687,3 +755,76 @@ relationships:
     kind: realization
     from: repository-evidence
     to: yarramate-engine#evidence-document
+  - id: visual-session-server-realizes-runtime
+    kind: realization
+    from: visual-session-server-source
+    to: yarramate-engine#visual-runtime
+  - id: visual-session-store-realizes-recovery
+    kind: realization
+    from: visual-session-store-source
+    to: yarramate-engine#recover-visual-session
+  - id: visual-likec4-compiler-realizes-rendering
+    kind: realization
+    from: visual-likec4-compiler-source
+    to: yarramate-engine#render-visual-model
+  - id: visual-protocol-source-realizes-protocol
+    kind: realization
+    from: visual-protocol-source
+    to: yarramate-engine#visual-session-protocol
+  - id: visual-cli-source-realizes-session-command
+    kind: realization
+    from: visual-cli-source
+    to: yarramate-engine#visual-session-service
+  - id: visual-browser-source-realizes-browser
+    kind: realization
+    from: visual-browser-source
+    to: yarramate-engine#visual-browser
+  - id: visual-browser-shell-realizes-browser
+    kind: realization
+    from: visual-browser-shell
+    to: yarramate-engine#visual-browser
+  - id: visual-event-schema-realizes-protocol
+    kind: realization
+    from: visual-event-schema-source
+    to: yarramate-engine#visual-session-protocol
+  - id: visual-handoff-schema-realizes-handoff
+    kind: realization
+    from: visual-handoff-schema-source
+    to: yarramate-engine#visual-handoff
+  - id: visual-server-tests-validate-runtime
+    kind: association
+    from: visual-session-server-tests
+    to: yarramate-engine#visual-runtime
+  - id: visual-store-tests-validate-recovery
+    kind: association
+    from: visual-session-store-tests
+    to: yarramate-engine#recover-visual-session
+  - id: visual-compiler-tests-validate-rendering
+    kind: association
+    from: visual-likec4-compiler-tests
+    to: yarramate-engine#render-visual-model
+  - id: visual-protocol-tests-validate-protocol
+    kind: association
+    from: visual-protocol-tests
+    to: yarramate-engine#visual-session-protocol
+  - id: visual-cli-tests-validate-session-command
+    kind: association
+    from: visual-cli-tests
+    to: yarramate-engine#visual-session-service
+  - id: visual-browser-tests-validate-browser
+    kind: association
+    from: visual-browser-tests
+    to: yarramate-engine#visual-browser
+  - id: visual-journey-tests-validate-handoff
+    kind: association
+    from: visual-journey-tests
+    to: yarramate-engine#visual-handoff
+  - id: visual-reference-documents-session-command
+    kind: association
+    from: visual-skill-reference
+    to: yarramate-engine#visual-session-service
+  - id: agent-skill-references-visual-conversations
+    kind: association
+    from: agent-skill-source
+    to: visual-skill-reference
+    description: The canonical skill routes a harness into the visual journey and decides delegated chat versus diagram-only mode before the runtime starts.

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -333,6 +333,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:package.json
+  - subject: yarramate-engine#local-web-browser
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/index.html
   - subject: yarramate-engine#npm-package
     result: confirmed
     evidence:
@@ -373,6 +377,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/adapters/likec4-export.ts
+  - subject: yarramate-engine#present-visual-conversation
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/App.tsx
   - subject: yarramate-engine#render-visual-model
     result: confirmed
     evidence:

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -361,6 +361,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/reconciliation.ts
+  - subject: yarramate-engine#recover-visual-session
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-store.ts
   - subject: yarramate-engine#relationship-policy-catalogue
     result: confirmed
     evidence:
@@ -369,6 +373,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/adapters/likec4-export.ts
+  - subject: yarramate-engine#render-visual-model
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/likec4-compiler.ts
   - subject: yarramate-engine#requirements-traceability-matrix
     result: confirmed
     evidence:
@@ -409,6 +417,26 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/compiler.ts
+  - subject: yarramate-engine#visual-browser
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/App.tsx
+  - subject: yarramate-engine#visual-handoff
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-handoff.schema.json
+  - subject: yarramate-engine#visual-runtime
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-server.ts
+  - subject: yarramate-engine#visual-session-protocol
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/protocol.ts
+  - subject: yarramate-engine#visual-session-service
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual-cli.ts
   - subject: yarramate-engine#workspace-loader
     result: confirmed
     evidence:
@@ -665,6 +693,74 @@ observations:
     result: confirmed
     evidence:
       uri: repo:schema/yarramate-state-comparison.schema.json
+  - subject: yarramate-repository#visual-browser-shell
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/index.html
+  - subject: yarramate-repository#visual-browser-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/App.tsx
+  - subject: yarramate-repository#visual-browser-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-app-state.test.ts
+  - subject: yarramate-repository#visual-cli-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual-cli.ts
+  - subject: yarramate-repository#visual-cli-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-cli.test.ts
+  - subject: yarramate-repository#visual-event-schema-source
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-event.schema.json
+  - subject: yarramate-repository#visual-handoff-schema-source
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-handoff.schema.json
+  - subject: yarramate-repository#visual-journey-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-journey.test.ts
+  - subject: yarramate-repository#visual-likec4-compiler-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/likec4-compiler.ts
+  - subject: yarramate-repository#visual-likec4-compiler-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-likec4-compiler.test.ts
+  - subject: yarramate-repository#visual-protocol-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/protocol.ts
+  - subject: yarramate-repository#visual-protocol-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-protocol.test.ts
+  - subject: yarramate-repository#visual-session-server-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-server.ts
+  - subject: yarramate-repository#visual-session-server-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-session-server.test.ts
+  - subject: yarramate-repository#visual-session-store-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-store.ts
+  - subject: yarramate-repository#visual-session-store-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-session-store.test.ts
+  - subject: yarramate-repository#visual-skill-reference
+    result: confirmed
+    evidence:
+      uri: repo:skills/yarramate-architecture/references/visual-conversations.md
   - subject: yarramate-repository#workspace-schema-source
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1392,12 +1392,21 @@ mappings:
   - native: yarramate-engine#consumer-host-composes-runtime
     external: consumerHostComposesRuntime
     type: relationship
+  - native: yarramate-engine#consumer-host-composes-web-browser
+    external: consumerHostComposesWebBrowser
+    type: relationship
   - native: yarramate-engine#consumer-host-deploys-package
     external: consumerHostDeploysPackage
     type: relationship
   - native: yarramate-engine#nodejs-runtime
     external: nodejsRuntime
     type: concept
+  - native: yarramate-engine#local-web-browser
+    external: localWebBrowser
+    type: concept
+  - native: yarramate-engine#web-browser-serves-visual-browser
+    external: webBrowserServesVisualBrowser
+    type: relationship
   - native: yarramate-engine#npm-package
     external: npmPackage
     type: concept
@@ -1406,6 +1415,9 @@ mappings:
     type: relationship
   - native: yarramate-engine#runtime-serves-cli
     external: runtimeServesCli
+    type: relationship
+  - native: yarramate-engine#runtime-serves-visual-runtime
+    external: runtimeServesVisualRuntime
     type: relationship
   - native: yarramate-engine#runtime-serves-graphify-adapter
     external: runtimeServesGraphifyAdapter
@@ -1524,6 +1536,12 @@ mappings:
   - native: yarramate-engine#visual-browser
     external: visualBrowser
     type: concept
+  - native: yarramate-engine#present-visual-conversation
+    external: presentVisualConversation
+    type: concept
+  - native: yarramate-engine#visual-browser-presents-conversation
+    external: visualBrowserPresentsConversation
+    type: relationship
   - native: yarramate-engine#visual-browser-exchanges-protocol
     external: visualBrowserExchangesProtocol
     type: relationship

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1515,3 +1515,153 @@ mappings:
   - native: yarramate-engine#compiler-derives-traceability-matrix
     external: compilerDerivesTraceabilityMatrix
     type: relationship
+  - native: yarramate-engine#recover-visual-session
+    external: recoverVisualSession
+    type: concept
+  - native: yarramate-engine#render-visual-model
+    external: renderVisualModel
+    type: concept
+  - native: yarramate-engine#visual-browser
+    external: visualBrowser
+    type: concept
+  - native: yarramate-engine#visual-browser-exchanges-protocol
+    external: visualBrowserExchangesProtocol
+    type: relationship
+  - native: yarramate-engine#visual-handoff
+    external: visualHandoff
+    type: concept
+  - native: yarramate-engine#visual-recovery-writes-handoff
+    external: visualRecoveryWritesHandoff
+    type: relationship
+  - native: yarramate-engine#visual-rendering-reads-protocol
+    external: visualRenderingReadsProtocol
+    type: relationship
+  - native: yarramate-engine#visual-runtime
+    external: visualRuntime
+    type: concept
+  - native: yarramate-engine#visual-runtime-provides-session-command
+    external: visualRuntimeProvidesSessionCommand
+    type: relationship
+  - native: yarramate-engine#visual-runtime-recovers-session
+    external: visualRuntimeRecoversSession
+    type: relationship
+  - native: yarramate-engine#visual-runtime-renders-model
+    external: visualRuntimeRendersModel
+    type: relationship
+  - native: yarramate-engine#visual-runtime-serves-browser
+    external: visualRuntimeServesBrowser
+    type: relationship
+  - native: yarramate-engine#visual-session-protocol
+    external: visualSessionProtocol
+    type: concept
+  - native: yarramate-engine#visual-session-serves-agent-harness
+    external: visualSessionServesAgentHarness
+    type: relationship
+  - native: yarramate-engine#visual-session-service
+    external: visualSessionService
+    type: concept
+  - native: yarramate-repository#agent-skill-references-visual-conversations
+    external: agentSkillReferencesVisualConversations
+    type: relationship
+  - native: yarramate-repository#visual-browser-shell
+    external: visualBrowserShell
+    type: concept
+  - native: yarramate-repository#visual-browser-shell-realizes-browser
+    external: visualBrowserShellRealizesBrowser
+    type: relationship
+  - native: yarramate-repository#visual-browser-source
+    external: visualBrowserSource
+    type: concept
+  - native: yarramate-repository#visual-browser-source-realizes-browser
+    external: visualBrowserSourceRealizesBrowser
+    type: relationship
+  - native: yarramate-repository#visual-browser-tests
+    external: visualBrowserTests
+    type: concept
+  - native: yarramate-repository#visual-browser-tests-validate-browser
+    external: visualBrowserTestsValidateBrowser
+    type: relationship
+  - native: yarramate-repository#visual-cli-source
+    external: visualCliSource
+    type: concept
+  - native: yarramate-repository#visual-cli-source-realizes-session-command
+    external: visualCliSourceRealizesSessionCommand
+    type: relationship
+  - native: yarramate-repository#visual-cli-tests
+    external: visualCliTests
+    type: concept
+  - native: yarramate-repository#visual-cli-tests-validate-session-command
+    external: visualCliTestsValidateSessionCommand
+    type: relationship
+  - native: yarramate-repository#visual-compiler-tests-validate-rendering
+    external: visualCompilerTestsValidateRendering
+    type: relationship
+  - native: yarramate-repository#visual-event-schema-realizes-protocol
+    external: visualEventSchemaRealizesProtocol
+    type: relationship
+  - native: yarramate-repository#visual-event-schema-source
+    external: visualEventSchemaSource
+    type: concept
+  - native: yarramate-repository#visual-handoff-schema-realizes-handoff
+    external: visualHandoffSchemaRealizesHandoff
+    type: relationship
+  - native: yarramate-repository#visual-handoff-schema-source
+    external: visualHandoffSchemaSource
+    type: concept
+  - native: yarramate-repository#visual-journey-tests
+    external: visualJourneyTests
+    type: concept
+  - native: yarramate-repository#visual-journey-tests-validate-handoff
+    external: visualJourneyTestsValidateHandoff
+    type: relationship
+  - native: yarramate-repository#visual-likec4-compiler-realizes-rendering
+    external: visualLikec4CompilerRealizesRendering
+    type: relationship
+  - native: yarramate-repository#visual-likec4-compiler-source
+    external: visualLikec4CompilerSource
+    type: concept
+  - native: yarramate-repository#visual-likec4-compiler-tests
+    external: visualLikec4CompilerTests
+    type: concept
+  - native: yarramate-repository#visual-protocol-source
+    external: visualProtocolSource
+    type: concept
+  - native: yarramate-repository#visual-protocol-source-realizes-protocol
+    external: visualProtocolSourceRealizesProtocol
+    type: relationship
+  - native: yarramate-repository#visual-protocol-tests
+    external: visualProtocolTests
+    type: concept
+  - native: yarramate-repository#visual-protocol-tests-validate-protocol
+    external: visualProtocolTestsValidateProtocol
+    type: relationship
+  - native: yarramate-repository#visual-reference-documents-session-command
+    external: visualReferenceDocumentsSessionCommand
+    type: relationship
+  - native: yarramate-repository#visual-server-tests-validate-runtime
+    external: visualServerTestsValidateRuntime
+    type: relationship
+  - native: yarramate-repository#visual-session-server-realizes-runtime
+    external: visualSessionServerRealizesRuntime
+    type: relationship
+  - native: yarramate-repository#visual-session-server-source
+    external: visualSessionServerSource
+    type: concept
+  - native: yarramate-repository#visual-session-server-tests
+    external: visualSessionServerTests
+    type: concept
+  - native: yarramate-repository#visual-session-store-realizes-recovery
+    external: visualSessionStoreRealizesRecovery
+    type: relationship
+  - native: yarramate-repository#visual-session-store-source
+    external: visualSessionStoreSource
+    type: concept
+  - native: yarramate-repository#visual-session-store-tests
+    external: visualSessionStoreTests
+    type: concept
+  - native: yarramate-repository#visual-skill-reference
+    external: visualSkillReference
+    type: concept
+  - native: yarramate-repository#visual-store-tests-validate-recovery
+    external: visualStoreTestsValidateRecovery
+    type: relationship

--- a/.yarramate/likec4-project.yaml
+++ b/.yarramate/likec4-project.yaml
@@ -24,6 +24,8 @@ views:
   # --- 2 · The agent contract -----------------------------------------
   - projection: projections/seven-verb-surface.yaml
     folder: "2 · Agent contract"
+  - projection: projections/visual-conversation-path.yaml
+    folder: "2 · Agent contract"
   # --- 3 · Engine internals -------------------------------------------
   - projection: projections/engine-components.yaml
     folder: "3 · Engine internals"

--- a/.yarramate/projections/visual-conversation-path.yaml
+++ b/.yarramate/projections/visual-conversation-path.yaml
@@ -1,0 +1,46 @@
+format: yarramate/projection/v1
+id: visual-conversation-path
+version: "1.0"
+query:
+  subjects:
+    - yarramate-engine#visual-runtime
+    - yarramate-engine#visual-browser
+    - yarramate-engine#visual-session-service
+    - yarramate-engine#visual-session-protocol
+    - yarramate-engine#visual-handoff
+    - yarramate-engine#render-visual-model
+    - yarramate-engine#recover-visual-session
+    - yarramate-product#agent-harness
+    - yarramate-repository#agent-skill-source
+    - yarramate-repository#visual-skill-reference
+    - yarramate-repository#visual-session-server-source
+    - yarramate-repository#visual-session-store-source
+    - yarramate-repository#visual-likec4-compiler-source
+    - yarramate-repository#visual-protocol-source
+    - yarramate-repository#visual-cli-source
+    - yarramate-repository#visual-browser-source
+    - yarramate-repository#visual-browser-shell
+    - yarramate-repository#visual-event-schema-source
+    - yarramate-repository#visual-handoff-schema-source
+    - yarramate-repository#visual-session-server-tests
+    - yarramate-repository#visual-session-store-tests
+    - yarramate-repository#visual-likec4-compiler-tests
+    - yarramate-repository#visual-protocol-tests
+    - yarramate-repository#visual-cli-tests
+    - yarramate-repository#visual-browser-tests
+    - yarramate-repository#visual-journey-tests
+  relationships: between
+presentation:
+  title: Visual architecture conversation
+  description: >-
+    One temporary local session the agent harness owns end to end. The
+    canonical skill and its visual-conversations reference set the authority
+    label and the mode, then drive the visual session command: the runtime
+    provides that command, renders the temporary model, serves the browser,
+    and derives the handoff on End or failure. Delegated path - a child agent
+    answers browser events over the versioned session protocol. Diagram-only
+    path - no child, the browser just navigates views and the conversation
+    stays in the main harness. Both end at the same recovered handoff. The
+    browser exchanges session protocol documents and nothing else: no
+    authority over canonical documents or repository files, and no model
+    provider inside the runtime.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ people, CI, skills, and agent harnesses.
 
 Optional adapters provide LikeC4 visualization from semantic projections,
 Graphify observations as evidence overlays, loopback-only visual
-conversations over a published protocol, and separately governed
+conversations over a published protocol (beta), and separately governed
 compatibility profiles for external languages. Core depends on none of them.
 
 YarraMate is not affiliated with or certified by The Open Group. ArchiMate®

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ projections, evidence, and architecture states; and exposes a stable CLI for
 people, CI, skills, and agent harnesses.
 
 Optional adapters provide LikeC4 visualization from semantic projections,
-Graphify observations as evidence overlays, and separately governed
+Graphify observations as evidence overlays, loopback-only visual
+conversations over a published protocol, and separately governed
 compatibility profiles for external languages. Core depends on none of them.
 
 YarraMate is not affiliated with or certified by The Open Group. ArchiMate®

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -151,6 +151,55 @@ Graphify extraction remains a separate installation and operation. The
 adapter observes only explicitly mapped nodes and never promotes them into
 canonical architecture.
 
+## Visual architecture conversations
+
+Ask the harness to use `$yarramate-architecture` to visually explain the
+architecture, show how a question relates to the model, or compare design
+choices. There is no command to learn: the skill orchestrates the
+`yarramate-visual` runtime that ships in this package, exactly as it
+orchestrates `yarramate` and `yarramate-likec4`.
+
+Installation and runtime stay separate here too. `npm install` provides the
+`yarramate-visual` binary and the prebuilt browser application; the skill
+provides the journey. Neither contains the other.
+
+What the journey guarantees:
+
+- **Authority is labelled.** Repository architecture is rendered only from a
+  workspace that passes `yarramate check`, through
+  `yarramate ask <workspace> "<topic>" --json`. Everything else — general
+  questions, hypotheticals, comparisons of undecided options — is rendered as
+  a temporary `ad-hoc` model the browser labels non-canonical. A choice
+  confirmed in the browser is a recorded selection, not declared intent; it
+  becomes canonical only through the normal design journey and Git review.
+- **The server is local only.** It binds `127.0.0.1` on a random port, issues
+  separate browser and agent credentials, ships no external assets, and stores
+  no provider credentials. Session state lives under the ignored
+  `.yarramate-out/visual/` directory and is never canonical.
+- **The renderer is consented.** The skill prefers a repository-local
+  `likec4` in `>=1.59.2 <1.60.0`. With none available it asks once before
+  resolving the pinned `likec4@1.59.2` runner, which needs Node `>=22.22.3`
+  and adds no dependency to your repository. The semantic binaries keep the
+  package's existing Node contract.
+- **Chat is capability-gated.** Where the harness can delegate a child agent,
+  deliver its completion back, and stay interruptible, the browser carries a
+  chat widget answered by a bounded visual agent. That agent may replace only
+  the temporary session model; it cannot edit repository files, `.yarramate/`,
+  credentials, or harness configuration.
+- **Otherwise you get diagram-only mode.** The same custom renderer and view
+  navigation, with the conversation continuing in the main harness.
+- **Recovery is the main agent's.** On End, cancellation, or any failure the
+  main agent recovers a structured handoff — confirmed decisions, requested
+  changes, unresolved questions, final views, termination reason — before
+  anything is torn down. The raw transcript is returned only on request.
+- **Cleanup is automatic.** Stopping shuts the server process tree down and
+  deletes the temporary session; a later start prunes any orphan older than
+  24 hours.
+
+Consumers validating the protocol can import the versioned documents directly,
+for example `yarramate/schema/visual-handoff` or
+`yarramate/schema/visual-session-request`.
+
 ## MCP server for agent harnesses
 
 Harnesses that load MCP servers can connect the bundled read-only adapter:

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 
 - [Adapter mappings and LikeC4](ADAPTER-MAPPINGS.md)
 - [Graphify evidence adapter](GRAPHIFY-ADAPTER.md)
+- [Visual conversation adapter](VISUAL-ADAPTER.md)
 
 ## Maintainer material
 

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -1,5 +1,12 @@
 # Visual conversation adapter
 
+> **Beta.** The browser workspace and the delegated-chat journey are new and
+> still settling — expect rougher edges than the rest of YarraMate. The wire
+> stays governed by the versioning rule in
+> [ADR 0081](adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md):
+> `yarramate/visual-*/v1` is closed and stable now: beta status describes the
+> browser experience, not the published contract.
+
 The optional visual adapter opens one local, loopback-only browser session
 that renders LikeC4 diagrams of a bounded slice and, when the host harness can
 delegate a long-lived child agent, carries a chat conversation about what is

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -1,0 +1,69 @@
+# Visual conversation adapter
+
+The optional visual adapter opens one local, loopback-only browser session
+that renders LikeC4 diagrams of a bounded slice and, when the host harness can
+delegate a long-lived child agent, carries a chat conversation about what is
+on screen. `yarramate-visual` is a sibling binary beside `yarramate-likec4`,
+`yarramate-graphify`, and `yarramate-mcp` — presentation and runtime, never a
+subcommand of the semantic `yarramate` CLI, and never a second claim origin.
+YarraMate Core does not depend on it and stays unaware of any session.
+
+## Authority is labeled, not inferred
+
+Every rendered model is either `canonical` — derived from a projection result
+of a workspace that already passed `check` — or explicitly `ad-hoc`, and the
+browser states which. A diagram drawn or a choice confirmed during a
+conversation never quietly becomes declared architecture; it becomes
+canonical only through the normal **Design a new solution** journey and Git
+review, after the user asks for that as its own step.
+
+## Commands
+
+```sh
+yarramate-visual start <request.json>
+yarramate-visual wait <descriptor.json> [--after <sequence>]
+yarramate-visual respond <descriptor.json> <response.json>
+yarramate-visual status <descriptor.json>
+yarramate-visual recover <descriptor.json> [--transcript]
+yarramate-visual stop <descriptor.json> <reason>
+```
+
+`start` is a managed foreground process, not a one-shot call: it publishes one
+`yarramate/visual-session-started/v1` line on stdout carrying `browserUrl` and
+`descriptorPath`, then blocks, serving the session until `stop` ends it. Every
+other command is an ordinary one-shot call against the printed
+`descriptorPath`. A harness with no facility for hosting a foreground process
+across tool calls cannot run this journey; fall back to `yarramate ask`,
+`export markdown`, or `yarramate-likec4 export-project`.
+
+## Wire
+
+Nine closed `yarramate/visual-*/v1` JSON documents, each with
+`additionalProperties: false`, published from `./schema`:
+session request, session started, session descriptor, event, response,
+status, handoff, model, and diagnostic result. `yarramate/visual-protocol/v1`
+is the version the started result, the descriptor, and status agree on. The
+wire is a published contract, not a process-local convention, because the
+journal that recovers a crashed session has to be readable by a process that
+did not write it — see
+[ADR 0081](adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md).
+
+## Boundary
+
+The adapter does not:
+
+- add a Core semantic verb, or widen native YarraMate meaning;
+- promote a rendered or chosen diagram to canonical architecture by itself;
+- call a model provider or hold credentials — the delegated chat agent
+  belongs to whatever harness hosts the session;
+- persist beyond the session: the server is loopback-only, ephemeral, and its
+  directory is deleted on `stop`;
+- accept a partial model patch — replacement is always the whole model, so
+  validation and recovery operate on one atomic candidate at a time.
+
+The full operating sequence — authority classification, compiler preflight,
+harness capability detection, delegating the visual agent, and end/failure
+recovery — is the canonical
+[`yarramate-architecture` skill's visual-conversations reference](../skills/yarramate-architecture/references/visual-conversations.md).
+Git review remains responsible for accepting any resulting architecture
+proposal.

--- a/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
+++ b/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
@@ -127,10 +127,22 @@ conversation back through a context window.
 ## Consequences
 
 The nine documents and the `yarramate-visual` binary are public surface
-from this point. An incompatible change to any of them is a new version,
-not an edit: `yarramate/visual-event/v2` beside v1, on the ADR 0018 rule.
-Additive optional fields remain additive, and consumers are expected to
-ignore what they do not recognize.
+from this point, and every one of the nine is closed:
+`additionalProperties: false` throughout, enforced by Ajv in the runtime,
+which parses every browser event, agent response, model, and handoff before
+accepting it. Nothing silently ignores a field it does not recognize, so
+there is no such thing as a quietly additive change here. Any change to a
+v1 field set — adding an optional field included — is
+compatibility-significant and lands as a coordinated schema-and-parser
+update across the parties that read it. Changes that cannot be made
+compatibly mint a new version beside v1: `yarramate/visual-event/v2` next
+to `yarramate/visual-event/v1`, on the ADR 0018 rule.
+
+Closing the schemas was the deliberate side of that trade. An open envelope
+would buy tolerant readers at the cost of accepting a typo'd field name as
+an unremarkable extension, in a protocol whose events are the recovery
+record. The cost is paid in release coordination, which is visible, rather
+than in silently dropped payloads, which is not.
 
 Core stays unaware of any of it. Nothing in the semantic CLI, the graph, or
 the native document format references a visual session, so the runtime can
@@ -139,7 +151,7 @@ property the sibling-binary boundary was chosen to buy.
 
 The deferred surface is deliberate and named in the design: one session per
 conversation, one child, one in-flight turn, whole-model replacement,
-localhost only. Each of those becomes reachable additively if it earns its
-way in. Partial model patches are the one that would be felt first, and
-they were excluded so that validation and recovery both operate on a single
-atomic replacement rather than on a history of diffs.
+localhost only. Each is reachable later under the versioning rule above.
+Partial model patches are the one that would be felt first, and they were
+excluded so that validation and recovery both operate on a single atomic
+replacement rather than on a history of diffs.

--- a/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
+++ b/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
@@ -1,0 +1,144 @@
+# A visual conversation is an adapter with a published protocol
+
+Status: accepted
+
+The approved visual-architecture-conversations design adds a browser
+application that renders LikeC4 diagrams, carries chat turns with a
+delegated visual agent, and returns a recoverable handoff to the main
+agent. Two questions had to be settled before any of it could be built:
+where the runtime sits relative to the semantic CLI, and whether the wire
+between skill, harness, browser, and delegated agent is a published
+contract or an internal detail.
+
+Decided: `yarramate-visual` is a sibling binary beside `yarramate-likec4`,
+`yarramate-graphify`, and `yarramate-mcp`, and its wire is nine closed
+versioned JSON documents exported from the package:
+
+- `./schema/visual-session-request` — what the trusted main agent asks for,
+  including authority mode, initial model, and the LikeC4 compiler command
+  vector;
+- `./schema/visual-session-started` — the public start result: session ID,
+  authenticated browser URL, descriptor path, protocol version, and
+  capabilities, never the agent credential;
+- `./schema/visual-session-descriptor` — the private mode `0600` handle the
+  one-shot commands authenticate with;
+- `./schema/visual-event` and `./schema/visual-response` — the two halves
+  of a turn;
+- `./schema/visual-model` — one complete candidate model, never a patch;
+- `./schema/visual-handoff` — what survives the session;
+- `./schema/visual-status` — lifecycle without mutation;
+- `./schema/visual-diagnostic-result` — every failure, in one shape.
+
+`yarramate/visual-protocol/v1` is the version the started result, the
+descriptor, and status agree on; each document additionally names its own
+`format`. Four parties have to agree on this wire — the canonical skill,
+the host harness, the browser bundle, and the delegated child — and no two
+of them ship together. That is what makes it a contract rather than an
+implementation.
+
+## Not a Core verb
+
+`yarramate visual` was the obvious shape and is wrong for the same reason
+`yarramate mcp` was (ADR 0044): the semantic CLI is the tool-neutral
+surface, and a long-lived localhost webserver driving a React bundle is
+presentation and runtime. ADR 0023 already drew this line for the smaller
+case, keeping comparison colors in the adapter while Core kept the
+classification.
+
+The concrete costs of crossing it are three. Core's release contract would
+acquire a browser bundle and a WebSocket transport as versioned surface,
+so a renderer change would become a Core compatibility event. Core's
+Node.js floor would have to rise to whatever the selected LikeC4 compiler
+requires — `>=22.22.3` for the currently pinned runner — punishing every
+`check` user for a feature they never open; as a sibling binary the same
+mismatch is a visual preflight diagnostic instead. And a verb implies a
+verb's semantics: `check`, `ask`, and `export` answer and exit, while this
+one blocks in the foreground until a human clicks End, which is a
+different kind of thing wearing the same word.
+
+## Not process-local JSON
+
+The cheaper alternative was to leave the wire unversioned and undocumented:
+whatever objects the skill and the runtime happened to exchange, private by
+convention. It fails on recovery, which is the feature.
+
+The journal has to be readable by a process that did not write it. The
+whole point of appending before acknowledging is that a runtime which died
+mid-turn can be recovered by a later `recover` — possibly a later build.
+An undocumented shape makes recovery a guess about the previous version of
+ourselves. The same argument applies across the other three parties: a
+harness that mis-parses a handoff silently loses confirmed decisions, and
+a browser bundle one release out of step with the runtime fails in a way
+nobody can attribute. ADR 0018 settled this for `check --json`, and the
+reasoning transfers unchanged: the alternative to a versioned envelope is
+not "no contract", it is an undeclared contract that breaks quietly.
+
+## The trade-offs the boundary makes
+
+**Authority is labeled, not inferred.** Every rendered model is either
+`canonical` — derived from a projection result of a workspace that passed
+`check` — or explicitly `ad-hoc`, and the browser says which. The cost is
+that a diagram drawn during a conversation can never quietly become
+declared intent; promoting it means authoring it through the normal write
+surface. That is the point. A renderer that blurred the two would make the
+model's central claim, that intent is declared, unverifiable by looking.
+
+**The server is loopback and ephemeral.** It binds `127.0.0.1` on a random
+port with separate high-entropy browser and agent capabilities, in a
+session directory created `0700` with sensitive files `0600`, and it is
+deleted on stop. Nothing is shareable, resumable, or reachable from another
+machine, which rules out the demo-link use case. In exchange there is no
+hosting story, no multi-tenancy, and no authorization model beyond two
+capabilities.
+
+**The journal is append-only and written before the acknowledgement.** An
+accepted browser event is appended before it is acknowledged and an
+accepted response before it is broadcast, so a crash cannot have
+acknowledged something recovery cannot see. The cost is that the journal
+records rejected-in-hindsight turns too, and that every limit — message
+size, model size, transcript size, queue depth — freezes input and routes
+the session through recovery rather than truncating an accepted event.
+Losing the tail is not available as a shortcut.
+
+**The child is provider-neutral.** `yarramate-visual` never calls a model
+provider and stores no credentials; inference belongs to whatever harness
+delegated the child. This means the runtime cannot answer a chat message on
+its own, and a harness without delegation gets no chat at all. It also
+means the runtime has no provider abstraction to maintain, no key handling,
+and nothing to leak.
+
+**The fallback is capability-detected, not name-detected.** The skill asks
+whether the running agent can actually delegate a long-lived child, let it
+block on CLI calls, and receive its completion or the user's interruption
+while it runs. A delegation tool alone is not enough. When any of that is
+missing the same renderer opens in diagram-only mode and the conversation
+stays in the main harness. Detection by harness name would be shorter and
+would be wrong the first time a harness changed, in the direction that
+strands a user in front of a chat box nobody is reading.
+
+**The transcript is opt-in.** `recover` returns the structured summary —
+decisions, requested changes, open questions, final views, last sequence,
+termination reason — and the raw transcript only when asked, until the
+handoff is accepted or the session stops. The main agent pays for the full
+text only when it wants it, and the default path does not force a whole
+conversation back through a context window.
+
+## Consequences
+
+The nine documents and the `yarramate-visual` binary are public surface
+from this point. An incompatible change to any of them is a new version,
+not an edit: `yarramate/visual-event/v2` beside v1, on the ADR 0018 rule.
+Additive optional fields remain additive, and consumers are expected to
+ignore what they do not recognize.
+
+Core stays unaware of any of it. Nothing in the semantic CLI, the graph, or
+the native document format references a visual session, so the runtime can
+be replaced or dropped without a Core compatibility event — which is the
+property the sibling-binary boundary was chosen to buy.
+
+The deferred surface is deliberate and named in the design: one session per
+conversation, one child, one in-flight turn, whole-model replacement,
+localhost only. Each of those becomes reachable additively if it earns its
+way in. Partial model patches are the one that would be felt first, and
+they were excluded so that validation and recovery both operate on a single
+atomic replacement rather than on a history of diffs.

--- a/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
+++ b/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
@@ -155,3 +155,29 @@ localhost only. Each is reachable later under the versioning rule above.
 Partial model patches are the one that would be felt first, and they were
 excluded so that validation and recovery both operate on a single atomic
 replacement rather than on a history of diffs.
+
+## What the schemas alone do not say
+
+Two invariants of this contract are not expressible in JSON Schema, and a
+consumer validating a document with the published schema and nothing else
+is holding a looser check than the runtime's:
+
+- **The 64 KiB chat bound is bytes, not characters.** `maxLength: 65536` on
+  `chatMessagePayload.text` counts Unicode characters, so a multi-byte
+  message can pass the schema at roughly three times the intended size. The
+  schema bound is a backstop; `VISUAL_LIMITS.messageBytes` measured with
+  `Buffer.byteLength` is the real limit, and the runtime enforces it on
+  every browser input, event, and response it parses. The same holds for
+  the 5 MiB model and transcript ceilings.
+- **A handoff's transcript belongs to the handoff's own session.** Each
+  entry validates independently as `visual-event/v1` or
+  `visual-response/v1`; nothing in the document relates it to the
+  `sessionId` that carries it. The runtime refuses a foreign entry, and
+  that is the one cross-session check no schema in the set can make.
+
+Both are enforced in `protocol.ts` beside the Ajv validators, so a document
+that reaches the runtime is held to the tighter rule. Tightening either
+schema would not be a clarification: byte length and cross-field ownership
+are not schema keywords, and inventing an approximation would refuse valid
+documents. A consumer that validates independently should measure bytes and
+check transcript ownership itself.

--- a/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
+++ b/docs/adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md
@@ -38,11 +38,11 @@ implementation.
 
 ## Not a Core verb
 
-`yarramate visual` was the obvious shape and is wrong for the same reason
-`yarramate mcp` was (ADR 0044): the semantic CLI is the tool-neutral
-surface, and a long-lived localhost webserver driving a React bundle is
-presentation and runtime. ADR 0023 already drew this line for the smaller
-case, keeping comparison colors in the adapter while Core kept the
+`yarramate visual` was the obvious shape and is wrong for the reason the
+MCP affordance ships as `yarramate-mcp` (ADR 0044): the semantic CLI is the
+tool-neutral surface, and a long-lived localhost webserver driving a React
+bundle is presentation and runtime. ADR 0023 drew the same line in the
+smaller case, keeping comparison colors in the adapter while Core kept the
 classification.
 
 The concrete costs of crossing it are three. Core's release contract would
@@ -94,11 +94,12 @@ capabilities.
 **The journal is append-only and written before the acknowledgement.** An
 accepted browser event is appended before it is acknowledged and an
 accepted response before it is broadcast, so a crash cannot have
-acknowledged something recovery cannot see. The cost is that the journal
-records rejected-in-hindsight turns too, and that every limit — message
-size, model size, transcript size, queue depth — freezes input and routes
-the session through recovery rather than truncating an accepted event.
-Losing the tail is not available as a shortcut.
+acknowledged something recovery cannot see. The cost is that nothing can be
+unsaid: an accepted event is in the record for the life of the session, and
+every limit — message size, model size, transcript size, queue depth —
+freezes input and routes the session through recovery rather than
+truncating an accepted event. Losing the tail is not available as a
+shortcut.
 
 **The child is provider-neutral.** `yarramate-visual` never calls a model
 provider and stores no credentials; inference belongs to whatever harness

--- a/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
+++ b/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
@@ -61,6 +61,7 @@
 - `schema/yarramate-visual-model.schema.json`
 - `schema/yarramate-visual-handoff.schema.json`
 - `schema/yarramate-visual-status.schema.json`
+- `schema/yarramate-visual-diagnostic-result.schema.json`
 
 ### Tests and fixtures
 
@@ -103,6 +104,7 @@
 - Create: `schema/yarramate-visual-model.schema.json`
 - Create: `schema/yarramate-visual-handoff.schema.json`
 - Create: `schema/yarramate-visual-status.schema.json`
+- Create: `schema/yarramate-visual-diagnostic-result.schema.json`
 - Create: `test/visual-protocol.test.ts`
 - Modify: `package.json:35-75`
 
@@ -168,7 +170,7 @@ Run: `pnpm exec vitest run test/visual-protocol.test.ts`
 
 Expected: FAIL because `src/adapters/visual/protocol.ts` and schemas do not exist.
 
-- [ ] **Step 3: Add the eight strict JSON Schemas and TypeScript validators**
+- [ ] **Step 3: Add the nine strict JSON Schemas and TypeScript validators**
 
 Use Draft 2020-12, `additionalProperties: false`, exact `format` constants, discriminated `oneOf` payloads, and `$defs` for reusable IDs, sequence numbers, capabilities, compiler vectors, diagnostics, and handoff decisions. Export every schema through `package.json` under `./schema/visual-*`.
 

--- a/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
+++ b/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
@@ -973,13 +973,13 @@ Document `start` through the harness's long-running process tool. Never recommen
 
 - [ ] **Step 4: Update consumer guidance and package exports**
 
-Document authority labels, the local-only server, consented pinned runner, chat-capable journey, diagram-only fallback, main-agent recovery, transcript-on-demand, and server cleanup. Add all eight schema exports and the binary. The prepack build already runs both Node and visual builds from Task 6.
+Document authority labels, the local-only server, consented pinned runner, chat-capable journey, diagram-only fallback, main-agent recovery, transcript-on-demand, and server cleanup. Add all nine schema exports and the binary. The prepack build already runs both Node and visual builds from Task 6.
 
 - [ ] **Step 5: Run skill/package tests and pack smoke**
 
 Run: `pnpm exec vitest run test/package-consumer.test.ts && pnpm build && npm pack --dry-run`
 
-Expected: PASS; dry-run lists `dist/adapters/visual-cli.js`, `dist/visual-app/index.html`, eight visual schemas, and the visual-conversation reference.
+Expected: PASS; dry-run lists `dist/adapters/visual-cli.js`, `dist/visual-app/index.html`, nine visual schemas, and the visual-conversation reference.
 
 - [ ] **Step 6: Commit the consumer journey**
 

--- a/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
+++ b/docs/superpowers/plans/2026-08-08-visual-architecture-conversations.md
@@ -1,0 +1,1244 @@
+# Visual Architecture Conversations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `yarramate-visual` sibling binary and guided skill journey that render checked or explicitly ad hoc LikeC4 explanations in a custom browser application, support delegated browser chat when the harness can provide it, and always recover control to the main agent.
+
+**Architecture:** `yarramate-visual` is a deep runtime module behind six blocking CLI commands: `start`, `wait`, `respond`, `status`, `recover`, and `stop`. It owns a localhost HTTP/WebSocket server, append-only session journal, LikeC4 compiler adapter, prebuilt React renderer, recovery, and cleanup; the canonical skill owns authority checks, capability detection, delegation, and main-agent handoff. Browser and child-agent inputs are untrusted and can mutate only a permission-restricted temporary visual session.
+
+**Tech Stack:** Node.js 22, TypeScript 7, Vitest, AJV 2020-12 JSON Schema, Node `http`/`crypto`/`fs`, `ws`, React 19, Vite 8, LikeC4 1.59 public model/React interfaces.
+
+## Global Constraints
+
+- Keep the public entry point in `yarramate-architecture`; do not add a visual subcommand to the tool-neutral `yarramate` CLI.
+- Ship `yarramate-visual` beside `yarramate-likec4` in the existing `yarramate` package.
+- Repository-architecture views require a passing workspace and facts from `yarramate ask --json`; a missing or invalid model routes to discovery.
+- Label question/choice models `ad-hoc` and non-canonical; never promote browser content into `.yarramate/` automatically.
+- The delegated visual agent may write only through the visual-session interface into its temporary directory.
+- Bind only to `127.0.0.1` on an OS-assigned random port; use separate browser and agent capabilities.
+- Initial compiler compatibility is `likec4 >=1.59.2 <1.60.0`; the consented fallback is pinned to `likec4@1.59.2`.
+- Starting the visual feature with the pinned compiler requires Node.js `>=22.22.3`; existing semantic binaries keep the current package floor.
+- One main conversation owns at most one visual session, one delegated child, and one in-flight chat turn.
+- Accept only complete `yarramate/visual-model/v1` replacements; preserve the last valid rendered model on compilation failure.
+- Limit chat messages to 64 KiB, complete candidate models to 5 MiB, raw transcripts to 5 MiB, and pending chat events to 32.
+- Browser disconnect grace is five minutes; stale marked session directories are pruned after 24 hours.
+- Default recovery returns a structured summary and temporary transcript handle; return the raw transcript only on request.
+- End, failure, or main-agent interruption must recover first, stop the entire server process tree, and remove temporary files.
+- If the harness cannot guarantee delegation, blocking child calls, completion delivery, and parent interruption, use diagram-only mode.
+- Browser assets are self-contained: no external scripts, fonts, telemetry, or model-provider credentials.
+
+---
+
+## File Structure
+
+### Runtime and protocol
+
+- `src/adapters/visual/protocol.ts` — TypeScript protocol types, AJV validators, limits, and diagnostic conversion.
+- `src/adapters/visual/session-store.ts` — temporary session layout, append-only journal, recovery, atomic model pointers, and stale-session pruning.
+- `src/adapters/visual/likec4-compiler.ts` — trusted command-vector execution, LikeC4 validation/export, candidate staging, and last-good promotion.
+- `src/adapters/visual/session-server.ts` — localhost HTTP/WebSocket server, authentication, queueing, long-poll agent endpoint, static assets, and shutdown.
+- `src/adapters/visual/client.ts` — one-shot agent clients used by `wait`, `respond`, `status`, `recover`, and `stop`.
+- `src/adapters/visual-cli.ts` — executable parsing, foreground `start`, one-shot command dispatch, version, usage, and process signals.
+
+### Browser application
+
+- `src/visual-app/index.html` — Vite entry document.
+- `src/visual-app/main.tsx` — React bootstrap and providers.
+- `src/visual-app/App.tsx` — diagram, authority/description, navigation, chat, choices, status, and End layout.
+- `src/visual-app/session-client.tsx` — bootstrap fetch, authenticated WebSocket lifecycle, reconnect, and event sends.
+- `src/visual-app/state.ts` — DOM-free reducer for deterministic browser state transitions.
+- `src/visual-app/styles.css` — self-contained responsive layout and status styling.
+- `vite.visual.config.ts` — prebuilt browser bundle to `dist/visual-app`.
+- `tsconfig.visual.json` — React/DOM typecheck boundary without changing Node compilation.
+
+### Schemas
+
+- `schema/yarramate-visual-session-request.schema.json`
+- `schema/yarramate-visual-session-started.schema.json`
+- `schema/yarramate-visual-session-descriptor.schema.json`
+- `schema/yarramate-visual-event.schema.json`
+- `schema/yarramate-visual-response.schema.json`
+- `schema/yarramate-visual-model.schema.json`
+- `schema/yarramate-visual-handoff.schema.json`
+- `schema/yarramate-visual-status.schema.json`
+
+### Tests and fixtures
+
+- `test/visual-protocol.test.ts`
+- `test/visual-session-store.test.ts`
+- `test/visual-likec4-compiler.test.ts`
+- `test/visual-session-server.test.ts`
+- `test/visual-cli.test.ts`
+- `test/visual-app-state.test.ts`
+- `test/visual-journey.test.ts`
+- `test/fixtures/visual/fake-likec4.mjs`
+- `test/fixtures/visual/model.json`
+- `test/fixtures/visual/browser-assets/index.html`
+
+### Guided journey, packaging, and model
+
+- `skills/yarramate-architecture/SKILL.md` — visual-request branch and handoff rules.
+- `skills/yarramate-architecture/references/visual-conversations.md` — complete capability/preflight/delegation loop.
+- `docs/CONSUMING-YARRAMATE.md` — user-facing visual conversation and fallback guidance.
+- `package.json` — binary, schemas, build scripts, browser dependencies, and package surface.
+- `.yarramate/architecture/engine.yaml` — visual runtime, functions, services, and data objects.
+- `.yarramate/architecture/repository.yaml` — new source, schema, fixture, test, and skill-reference artifacts.
+- `.yarramate/evidence/repository.yaml` — implementation evidence for new current subjects.
+- `.yarramate/projections/visual-conversation-path.yaml` — bounded visual-session story.
+- `.yarramate/likec4-project.yaml` — include the visual-session projection.
+- `.yarramate/integrations/likec4/subject-mapping.yaml` — synchronized mappings for new subjects.
+- `test/package-consumer.test.ts`, `test/self-model.test.ts` — packed and modeled product contracts.
+
+---
+
+### Task 1: Versioned visual protocol and schemas
+
+**Files:**
+- Create: `src/adapters/visual/protocol.ts`
+- Create: `schema/yarramate-visual-session-request.schema.json`
+- Create: `schema/yarramate-visual-session-started.schema.json`
+- Create: `schema/yarramate-visual-session-descriptor.schema.json`
+- Create: `schema/yarramate-visual-event.schema.json`
+- Create: `schema/yarramate-visual-response.schema.json`
+- Create: `schema/yarramate-visual-model.schema.json`
+- Create: `schema/yarramate-visual-handoff.schema.json`
+- Create: `schema/yarramate-visual-status.schema.json`
+- Create: `test/visual-protocol.test.ts`
+- Modify: `package.json:35-75`
+
+**Interfaces:**
+- Produces: `VisualCompilerCommand`, `VisualSessionRequest`, `VisualSessionStarted`, `VisualSessionDescriptor`, `VisualBrowserInput`, `VisualEvent`, `VisualResponse`, `VisualModel`, `VisualHandoff`, `VisualStatus`, `VisualDiagnostic`, `VISUAL_LIMITS`, and `parseVisual*` validators.
+- Consumes: existing AJV 2020 import/configuration and `CliResult` diagnostic conventions.
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Create fixtures that exercise one valid document of every format, every event/response discriminant, unsafe visual-model paths, cross-field authority requirements, unknown properties, and exact limits.
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  parseVisualModel,
+  parseVisualSessionRequest,
+  VISUAL_LIMITS,
+} from '../src/adapters/visual/protocol.js'
+
+const model = {
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    'model.likec4': 'model { system = system "System" }',
+    'views.likec4': 'views { view choices { include * } }',
+  },
+} as const
+
+describe('visual protocol', () => {
+  it('accepts a complete safe session request', () => {
+    expect(parseVisualSessionRequest({
+      format: 'yarramate/visual-session-request/v1',
+      authority: 'ad-hoc',
+      title: 'Choose a delivery design',
+      description: 'Temporary non-canonical comparison',
+      chatEnabled: true,
+      compiler: { command: '/usr/bin/node', args: ['fake-likec4.mjs'] },
+      initialModel: model,
+    })).toMatchObject({ ok: true })
+  })
+
+  it.each(['../secret.likec4', '/tmp/secret.likec4', 'asset.js'])(
+    'rejects unsafe model file %s',
+    (path) => {
+      expect(parseVisualModel({ ...model, files: { [path]: 'x' } })).toMatchObject({
+        ok: false,
+      })
+    },
+  )
+
+  it('rejects messages over the exact limit', () => {
+    expect(VISUAL_LIMITS.messageBytes).toBe(64 * 1024)
+  })
+})
+```
+
+- [ ] **Step 2: Run the protocol test and confirm red**
+
+Run: `pnpm exec vitest run test/visual-protocol.test.ts`
+
+Expected: FAIL because `src/adapters/visual/protocol.ts` and schemas do not exist.
+
+- [ ] **Step 3: Add the eight strict JSON Schemas and TypeScript validators**
+
+Use Draft 2020-12, `additionalProperties: false`, exact `format` constants, discriminated `oneOf` payloads, and `$defs` for reusable IDs, sequence numbers, capabilities, compiler vectors, diagnostics, and handoff decisions. Export every schema through `package.json` under `./schema/visual-*`.
+
+```ts
+export const VISUAL_LIMITS = {
+  messageBytes: 64 * 1024,
+  modelBytes: 5 * 1024 * 1024,
+  transcriptBytes: 5 * 1024 * 1024,
+  pendingEvents: 32,
+  reconnectMs: 5 * 60 * 1000,
+  staleSessionMs: 24 * 60 * 60 * 1000,
+} as const
+
+export interface VisualModel {
+  readonly format: 'yarramate/visual-model/v1'
+  readonly authority: 'canonical' | 'ad-hoc'
+  readonly initialView: string
+  readonly sourceDigests: Readonly<Record<string, string>>
+  readonly files: Readonly<Record<string, string>>
+}
+
+export interface VisualCompilerCommand {
+  readonly command: string
+  readonly args: readonly string[]
+}
+
+export interface VisualSessionRequest {
+  readonly format: 'yarramate/visual-session-request/v1'
+  readonly authority: VisualModel['authority']
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly compiler: VisualCompilerCommand
+  readonly initialModel: VisualModel
+}
+
+export type ParseResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] }
+
+export const parseVisualSessionRequest = (
+  input: unknown,
+): ParseResult<VisualSessionRequest> => parseWith(
+  validateVisualSessionRequest,
+  input,
+  'YMVS101',
+)
+```
+
+Path validation must normalize POSIX separators and reject absolute paths, `..`, empty segments, symlink declarations, and extensions other than `.c4`, `.likec4`, plus the exact root file `likec4.config.json`. Enforce byte limits with `Buffer.byteLength`, not JavaScript character counts.
+
+- [ ] **Step 4: Run protocol tests and typecheck**
+
+Run: `pnpm exec vitest run test/visual-protocol.test.ts && pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the protocol contract**
+
+```bash
+git add package.json schema/yarramate-visual-*.schema.json src/adapters/visual/protocol.ts test/visual-protocol.test.ts
+git commit -m "feat: define visual session protocol"
+```
+
+---
+
+### Task 2: Permission-restricted session journal and recovery
+
+**Files:**
+- Create: `src/adapters/visual/session-store.ts`
+- Create: `test/visual-session-store.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `VisualSessionRequest`, `VisualEvent`, `VisualResponse`, `VisualHandoff`, `VisualModel`, and `VISUAL_LIMITS`.
+- Produces: `createVisualSession`, `appendVisualEvent`, `appendVisualResponse`, `readActionableEventsAfter`, `recoverVisualSession`, `promoteCompiledModel`, `pruneStaleVisualSessions`, `removeVisualSession`, and `VisualSessionPaths`.
+
+- [ ] **Step 1: Write failing store tests for journal durability and cleanup**
+
+```ts
+it('recovers accepted events and the summary without exposing the transcript', async () => {
+  const session = await createVisualSession(request, {
+    baseDir: parent,
+    now: () => new Date('2026-08-08T00:00:00.000Z'),
+    randomBytes: () => Buffer.alloc(32, 7),
+  })
+  await appendVisualEvent(session.paths, chatEvent)
+  await appendVisualResponse(session.paths, chatResponse)
+  await appendVisualResponse(session.paths, handoffResponse)
+
+  expect(await recoverVisualSession(session.paths, false)).toMatchObject({
+    format: 'yarramate/visual-handoff/v1',
+    summary: handoffResponse.payload.summary,
+    transcript: undefined,
+    lastSequence: 1,
+  })
+  expect(await recoverVisualSession(session.paths, true)).toMatchObject({
+    transcript: [chatEvent, chatResponse],
+  })
+})
+
+it('prunes only marked sessions older than 24 hours', async () => {
+  const removed = await pruneStaleVisualSessions(parent, staleNow)
+  expect(removed).toEqual([session.paths.root])
+  expect(existsSync(unmarkedDirectory)).toBe(true)
+})
+```
+
+Also assert directory mode `0700`, descriptor/journal mode `0600` on POSIX, append ordering, recovery after a truncated final journal line, duplicate response idempotence, and exact 5 MiB transcript freeze behavior.
+
+- [ ] **Step 2: Run the store test and confirm red**
+
+Run: `pnpm exec vitest run test/visual-session-store.test.ts`
+
+Expected: FAIL because `session-store.ts` does not exist.
+
+- [ ] **Step 3: Implement the session filesystem and append-only journal**
+
+```ts
+export interface VisualSessionPaths {
+  readonly root: string
+  readonly marker: string
+  readonly descriptor: string
+  readonly journal: string
+  readonly candidates: string
+  readonly activeModel: string
+}
+
+export interface SessionDependencies {
+  readonly baseDir: string
+  readonly now: () => Date
+  readonly randomBytes: (size: number) => Buffer
+}
+
+export async function createVisualSession(
+  request: VisualSessionRequest,
+  deps: SessionDependencies,
+): Promise<{
+  readonly paths: VisualSessionPaths
+  readonly browserToken: string
+  readonly agentToken: string
+}> {
+  const id = deps.randomBytes(16).toString('hex')
+  const root = join(deps.baseDir, id)
+  await mkdir(root, { recursive: false, mode: 0o700 })
+  await writePrivateJson(join(root, 'session.json'), {
+    format: 'yarramate/visual-session-marker/v1',
+    id,
+    createdAt: deps.now().toISOString(),
+  })
+  await writeFile(join(root, 'journal.jsonl'), '', { mode: 0o600 })
+  return {
+    paths: visualSessionPaths(root),
+    browserToken: deps.randomBytes(32).toString('hex'),
+    agentToken: deps.randomBytes(32).toString('hex'),
+  }
+}
+```
+
+Append each JSON record as one UTF-8 line through a serialized per-session write queue. Ignore only a truncated last line during recovery; reject malformed complete lines. Stage model candidates under monotonically named directories and update `active-model.json` through write-then-rename after compilation succeeds.
+
+- [ ] **Step 4: Run store tests and typecheck**
+
+Run: `pnpm exec vitest run test/visual-session-store.test.ts && pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the durable session store**
+
+```bash
+git add src/adapters/visual/session-store.ts test/visual-session-store.test.ts
+git commit -m "feat: add recoverable visual sessions"
+```
+
+---
+
+### Task 3: Trusted LikeC4 compiler adapter
+
+**Files:**
+- Create: `src/adapters/visual/likec4-compiler.ts`
+- Create: `test/visual-likec4-compiler.test.ts`
+- Create: `test/fixtures/visual/fake-likec4.mjs`
+- Create: `test/fixtures/visual/model.json`
+
+**Interfaces:**
+- Consumes: Task 1 `VisualCompilerCommand`, `VisualModel`, and `VisualDiagnostic`; Task 2 candidate paths and promotion function.
+- Produces: `compileVisualModel`, `CompiledVisualModel`, and `LikeC4CompilationResult`.
+
+- [ ] **Step 1: Write failing compiler tests**
+
+Cover valid compilation, non-zero validation, malformed JSON export, process abort, absolute command enforcement, and last-good preservation.
+
+```ts
+it('validates, exports, and promotes one complete visual model', async () => {
+  const result = await compileVisualModel({
+    model,
+    command: { command: process.execPath, args: [fakeLikeC4] },
+    paths: session.paths,
+  })
+
+  expect(result).toMatchObject({
+    ok: true,
+    compiled: {
+      initialView: 'choices',
+      authority: 'ad-hoc',
+    },
+  })
+  expect(JSON.parse(readFileSync(session.paths.activeModel, 'utf8'))).toMatchObject({
+    initialView: 'choices',
+  })
+})
+
+it('leaves the active model unchanged after validation failure', async () => {
+  const before = readFileSync(session.paths.activeModel, 'utf8')
+  const failed = await compileVisualModel({
+    model: invalidModel,
+    command: { command: process.execPath, args: [fakeLikeC4] },
+    paths: session.paths,
+  })
+  expect(failed.ok).toBe(false)
+  expect(readFileSync(session.paths.activeModel, 'utf8')).toBe(before)
+})
+```
+
+- [ ] **Step 2: Run the compiler test and confirm red**
+
+Run: `pnpm exec vitest run test/visual-likec4-compiler.test.ts`
+
+Expected: FAIL because the compiler adapter and fixture do not exist.
+
+- [ ] **Step 3: Implement exact LikeC4 command execution**
+
+Stage Task 1's already validated file map, then execute without a shell:
+
+```ts
+const validateArgs = [
+  ...command.args,
+  'validate',
+  '--json',
+  '--no-layout',
+  ...sourceFiles.flatMap((file) => ['--file', file]),
+  candidateRoot,
+]
+
+const exportArgs = [
+  ...command.args,
+  'export',
+  'json',
+  '--pretty',
+  '-o',
+  outputPath,
+  candidateRoot,
+]
+```
+
+Use `spawn(command.command, args, { shell: false, signal, stdio: ['ignore', 'pipe', 'pipe'] })`. Require an absolute executable path. Parse LikeC4 validation JSON into source-located `YMVS2xx` diagnostics. Parse the exported JSON as an object containing a non-empty `views` collection and the requested initial view before promotion.
+
+The fake executable must inspect `validate` versus `export json`, emit deterministic diagnostics for a fixture marker, and copy `test/fixtures/visual/model.json` to the `-o` path on success.
+
+- [ ] **Step 4: Run compiler/store tests and typecheck**
+
+Run: `pnpm exec vitest run test/visual-likec4-compiler.test.ts test/visual-session-store.test.ts && pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the compiler adapter**
+
+```bash
+git add src/adapters/visual/likec4-compiler.ts test/visual-likec4-compiler.test.ts test/fixtures/visual/fake-likec4.mjs test/fixtures/visual/model.json
+git commit -m "feat: compile temporary LikeC4 views"
+```
+
+---
+
+### Task 4: Authenticated local session server
+
+**Files:**
+- Create: `src/adapters/visual/session-server.ts`
+- Create: `test/visual-session-server.test.ts`
+- Create: `test/fixtures/visual/browser-assets/index.html`
+- Modify: `package.json:107-116`
+- Modify: `pnpm-lock.yaml`
+
+**Interfaces:**
+- Consumes: Task 1 protocol parsers; Task 2 store/recovery; Task 3 compiler.
+- Produces: `startVisualServer(options): Promise<VisualServerHandle>`, where the handle exposes `started`, `closed`, `status()`, and `stop(reason)`.
+
+- [ ] **Step 1: Add `ws` and write failing authenticated transport tests**
+
+Run: `pnpm add ws@^8.18.3 && pnpm add -D @types/ws@^8.18.1`
+
+Test bootstrap token exchange, token-free redirect, strict cookie, host/origin rejection, authenticated WebSocket upgrade, long-poll wait, one-in-flight queueing, duplicate event rejection, queue overflow, static path traversal, and graceful stop.
+
+```ts
+it('exchanges the bootstrap token and accepts an authenticated browser socket', async () => {
+  const server = await startVisualServer(fixtureOptions)
+  const bootstrap = await fetch(server.started.browserUrl, { redirect: 'manual' })
+  expect(bootstrap.status).toBe(303)
+  expect(bootstrap.headers.get('location')).toBe('/')
+  expect(bootstrap.headers.get('set-cookie')).toMatch(
+    /^ym_visual=[^;]+; HttpOnly; SameSite=Strict; Path=\/$/,
+  )
+
+  const socket = new WebSocket(server.started.webSocketUrl, {
+    headers: {
+      Cookie: bootstrap.headers.get('set-cookie')!.split(';')[0]!,
+      Origin: server.started.origin,
+    },
+  })
+  await once(socket, 'open')
+  socket.send(JSON.stringify(chatEventInput))
+  await expect(waitForVisualEvent(server.started.descriptorPath, 0)).resolves.toMatchObject({
+    type: 'chat.message',
+    sequence: 1,
+  })
+})
+```
+
+- [ ] **Step 2: Run server tests and confirm red**
+
+Run: `pnpm exec vitest run test/visual-session-server.test.ts`
+
+Expected: FAIL because the server does not exist.
+
+- [ ] **Step 3: Implement the HTTP/WebSocket server and queue**
+
+Use `createServer`, `server.listen(0, '127.0.0.1')`, and `WebSocketServer({ noServer: true })`. Implement only these routes:
+
+```text
+GET  /bootstrap?key={one-time-token}
+GET  / and /assets/{hashed-file}
+GET  /api/session
+GET  /api/agent/events?after={sequence}
+POST /api/agent/responses
+GET  /api/agent/status
+POST /api/agent/stop
+```
+
+Browser events travel through the authenticated WebSocket. Agent routes require `Authorization: Bearer {agent capability}`. Compare capability hashes with `timingSafeEqual`. Validate `Host`, `Origin`, content type, body size, schema, session ID, and sequence before journaling.
+
+Return these headers on every browser response:
+```ts
+const browserHeaders = {
+  'Content-Security-Policy': `default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'`,
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'no-store',
+} as const
+```
+
+Hold agent long-polls until the next actionable event or a 30-second non-terminal idle result. Deliver no later chat event while one response is outstanding; navigation remains local unless its payload explicitly requests agent attention.
+
+- [ ] **Step 4: Run server, store, protocol, and type tests**
+
+Run: `pnpm exec vitest run test/visual-session-server.test.ts test/visual-session-store.test.ts test/visual-protocol.test.ts && pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the local server**
+
+```bash
+git add package.json pnpm-lock.yaml src/adapters/visual/session-server.ts test/visual-session-server.test.ts test/fixtures/visual/browser-assets/index.html
+git commit -m "feat: serve authenticated visual sessions"
+```
+
+---
+
+### Task 5: Blocking `yarramate-visual` CLI
+
+**Files:**
+- Create: `src/adapters/visual/client.ts`
+- Create: `src/adapters/visual-cli.ts`
+- Create: `test/visual-cli.test.ts`
+- Modify: `package.json:77-82`
+
+**Interfaces:**
+- Consumes: Task 4 server handle and authenticated routes; existing `versionResult`, `isMainModule`, and `CliResult` conventions.
+- Produces: executable `yarramate-visual`; low-level `waitForVisualEvent`, `sendVisualResponse`, `fetchVisualStatus`, `recoverVisualSessionClient`, and `stopVisualSessionClient`; `runVisualClientCli(args, cwd)` for one-shot command formatting; `runVisualStart(requestPath, cwd, io)` for the foreground server.
+
+- [ ] **Step 1: Write failing CLI tests**
+
+```ts
+it('prints the package version', async () => {
+  await expect(runVisualClientCli(['--version'], repositoryRoot)).resolves.toMatchObject({
+    exitCode: 0,
+    stdout: `yarramate-visual ${packageVersion}\n`,
+    stderr: '',
+  })
+})
+
+it('waits, responds, recovers, and stops through the descriptor', async () => {
+  const started = await startFixtureVisualProcess()
+  await sendBrowserEvent(started, chatEventInput)
+
+  const event = await runVisualClientCli(
+    ['wait', started.descriptorPath, '--after', '0'],
+    repositoryRoot,
+  )
+  expect(JSON.parse(event.stdout)).toMatchObject({ type: 'chat.message', sequence: 1 })
+
+  await writeJson(responsePath, chatResponse)
+  expect(await runVisualClientCli(
+    ['respond', started.descriptorPath, responsePath],
+    repositoryRoot,
+  )).toMatchObject({ exitCode: 0 })
+
+  expect(await runVisualClientCli(
+    ['stop', started.descriptorPath],
+    repositoryRoot,
+  )).toMatchObject({ exitCode: 0 })
+})
+```
+
+Also test usage exit 2, missing/unsafe descriptor, server-down `recover`, status fallback, repeated stop, and SIGTERM cleanup.
+
+- [ ] **Step 2: Run CLI tests and confirm red**
+
+Run: `pnpm exec vitest run test/visual-cli.test.ts`
+
+Expected: FAIL because the CLI and client do not exist.
+
+- [ ] **Step 3: Implement one-shot clients and foreground start**
+
+```ts
+export async function runVisualClientCli(
+  args: readonly string[],
+  cwd: string = process.cwd(),
+): Promise<CliResult> {
+  const [command, descriptor, ...rest] = args
+  if (command === '--version') return versionResult('yarramate-visual')
+  if (descriptor === undefined) return usageResult
+  switch (command) {
+    case 'wait': return waitCliCommand(descriptor, rest, cwd)
+    case 'respond': return respondCliCommand(descriptor, rest, cwd)
+    case 'status': return statusCliCommand(descriptor, cwd)
+    case 'recover': return recoverCliCommand(descriptor, rest, cwd)
+    case 'stop': return stopCliCommand(descriptor, cwd)
+    default: return usageResult
+  }
+}
+```
+
+`runVisualStart` parses and validates the request before filesystem or network effects, starts Task 4's server in the foreground, writes exactly one `yarramate/visual-session-started/v1` JSON line, installs SIGINT/SIGTERM handlers, and awaits `handle.closed`.
+
+The `stop` client calls recover first, POSTs the stop request, waits for the server to close, removes the marked session, and returns the recovered summary. If the server is already absent, it recovers locally and removes only a valid marked session.
+
+- [ ] **Step 4: Run CLI tests and build the binary**
+
+Run: `pnpm exec vitest run test/visual-cli.test.ts test/visual-session-server.test.ts && pnpm build`
+
+Expected: PASS and `dist/adapters/visual-cli.js` exists.
+
+Run: `node dist/adapters/visual-cli.js --version`
+
+Expected: the prefix is `yarramate-visual` and the semver exactly matches `package.json`.
+
+- [ ] **Step 5: Commit the sibling binary**
+
+```bash
+git add package.json src/adapters/visual/client.ts src/adapters/visual-cli.ts test/visual-cli.test.ts
+git commit -m "feat: add visual session CLI"
+```
+
+---
+
+### Task 6: Custom React and LikeC4 browser application
+
+**Files:**
+- Create: `src/visual-app/index.html`
+- Create: `src/visual-app/main.tsx`
+- Create: `src/visual-app/App.tsx`
+- Create: `src/visual-app/session-client.tsx`
+- Create: `src/visual-app/state.ts`
+- Create: `src/visual-app/styles.css`
+- Create: `vite.visual.config.ts`
+- Create: `tsconfig.visual.json`
+- Create: `test/visual-app-state.test.ts`
+- Modify: `package.json:87-116`
+- Modify: `pnpm-lock.yaml`
+- Modify: `src/adapters/visual/session-server.ts`
+
+**Interfaces:**
+- Consumes: Task 1 event/response/status/model JSON; Task 4 `/api/session` and WebSocket; LikeC4 `createLikeC4Model`, `LikeC4ModelProvider`, and `LikeC4View`.
+- Produces: prebuilt `dist/visual-app`; `visualAppReducer`; browser messages for chat, choice, navigation, and End.
+
+- [ ] **Step 1: Add direct build dependencies and write failing reducer tests**
+
+Run:
+
+```bash
+pnpm add -D react@^19.2.8 react-dom@^19.2.8 @types/react@^19.2.8 @types/react-dom@^19.2.3 vite@^8.1.5
+```
+
+```ts
+it('freezes input immediately when End is requested', () => {
+  const next = visualAppReducer(activeState, { type: 'end.requested' })
+  expect(next.lifecycle).toBe('ending')
+  expect(next.composerEnabled).toBe(false)
+})
+
+it('keeps the last rendered model when compilation fails', () => {
+  const next = visualAppReducer(activeState, {
+    type: 'diagnostic.received',
+    diagnostic: compileDiagnostic,
+  })
+  expect(next.model).toBe(activeState.model)
+  expect(next.diagnostics).toEqual([compileDiagnostic])
+})
+```
+
+- [ ] **Step 2: Run reducer tests and confirm red**
+
+Run: `pnpm exec vitest run test/visual-app-state.test.ts`
+
+Expected: FAIL because browser state does not exist.
+
+- [ ] **Step 3: Implement deterministic browser state and transport**
+
+The reducer states are `connecting`, `active`, `ending`, `disconnected`, and `closed`. Keep transcript records as plain text and render them through React text nodes; never use `dangerouslySetInnerHTML`.
+
+```ts
+export function visualAppReducer(
+  state: VisualAppState,
+  action: VisualAppAction,
+): VisualAppState {
+  switch (action.type) {
+    case 'session.loaded':
+      return { ...state, lifecycle: 'active', ...action.snapshot }
+    case 'model.received':
+      return { ...state, model: action.model, diagnostics: [] }
+    case 'diagnostic.received':
+      return { ...state, diagnostics: [action.diagnostic] }
+    case 'end.requested':
+      return { ...state, lifecycle: 'ending', composerEnabled: false }
+    case 'connection.lost':
+      return { ...state, lifecycle: 'disconnected', composerEnabled: false }
+    default:
+      return state
+  }
+}
+```
+
+`session-client.tsx` fetches `/api/session`, opens a same-origin WebSocket, reconnects only inside the five-minute server grace, and includes the last acknowledged sequence with every browser event.
+
+- [ ] **Step 4: Build the custom LikeC4 layout**
+
+```tsx
+const likec4model = useMemo(
+  () => snapshot.model === null ? null : createLikeC4Model(snapshot.model.compiled),
+  [snapshot.model],
+)
+
+return (
+  <main className="visual-shell">
+    <section className="diagram-pane">
+      <header>
+        <span className={`authority authority-${snapshot.authority}`}>
+          {snapshot.authority === 'canonical' ? 'Checked YarraMate model' : 'Ad hoc · non-canonical'}
+        </span>
+        <h1>{snapshot.title}</h1>
+        <p>{snapshot.description}</p>
+      </header>
+      {likec4model && (
+        <LikeC4ModelProvider likec4model={likec4model}>
+          <LikeC4View
+            viewId={snapshot.activeView}
+            onNavigateTo={(viewId) => sendNavigation(viewId)}
+            enableElementDetails
+            enableRelationshipDetails
+            enableNotes
+          />
+        </LikeC4ModelProvider>
+      )}
+    </section>
+    <ChatPanel
+      transcript={snapshot.transcript}
+      choices={snapshot.choices}
+      disabled={!snapshot.composerEnabled}
+      onSend={sendChat}
+      onChoice={sendChoice}
+      onEnd={endConversation}
+    />
+  </main>
+)
+```
+
+The End button remains visible in every responsive layout. On click, dispatch `end.requested`, send `session.end`, show “Returning control to the main agent”, and wait for server closure.
+
+- [ ] **Step 5: Add the isolated Vite build and serve its output**
+
+`tsconfig.visual.json` uses `moduleResolution: "Bundler"`, `jsx: "react-jsx"`, `lib: ["ES2022", "DOM", "DOM.Iterable"]`, and includes only `src/visual-app/**/*.ts`, `src/visual-app/**/*.tsx`, and `vite.visual.config.ts`.
+
+`vite.visual.config.ts` writes to `dist/visual-app`, uses `base: './'`, empties only that directory, and emits hashed JS/CSS assets. Update scripts:
+
+```json
+{
+  "build:node": "tsc -p tsconfig.build.json",
+  "build:visual": "vite build --config vite.visual.config.ts",
+  "build": "pnpm build:node && pnpm build:visual",
+  "typecheck": "tsc --noEmit && tsc -p tsconfig.visual.json"
+}
+```
+
+Change the production server's default asset root to `new URL('../../visual-app/', import.meta.url)` from `dist/adapters/visual/session-server.js`; tests continue injecting the fixture asset root.
+
+- [ ] **Step 6: Run UI state tests, typecheck, and production build**
+
+Run: `pnpm exec vitest run test/visual-app-state.test.ts test/visual-session-server.test.ts && pnpm typecheck && pnpm build`
+
+Expected: PASS; `dist/visual-app/index.html` and hashed local assets exist.
+
+- [ ] **Step 7: Commit the custom browser application**
+
+```bash
+git add package.json pnpm-lock.yaml tsconfig.visual.json vite.visual.config.ts src/visual-app src/adapters/visual/session-server.ts test/visual-app-state.test.ts
+git commit -m "feat: add visual conversation browser"
+```
+
+---
+
+### Task 7: End-to-end handoff, recovery, and shutdown
+
+**Files:**
+- Create: `test/visual-journey.test.ts`
+- Modify: `src/adapters/visual/session-server.ts`
+- Modify: `src/adapters/visual/session-store.ts`
+- Modify: `src/adapters/visual/client.ts`
+- Modify: `src/adapters/visual-cli.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1-6 complete runtime and browser protocol.
+- Produces: identical normal-End, child-failure, browser-timeout, main-cancel, and server-down recovery paths.
+
+- [ ] **Step 1: Write the failing complete journey**
+
+Use the fake LikeC4 command and authenticated WebSocket client; do not invoke an LLM.
+
+```ts
+it('returns a summary, optionally exposes the transcript, and removes the session on End', async () => {
+  const visual = await startVisualFixture({ chatEnabled: true })
+  const browser = await connectFixtureBrowser(visual)
+
+  browser.send(JSON.stringify(chatMessage('Explain option B')))
+  const message = await waitForVisualEvent(visual.descriptorPath, 0)
+  await sendVisualResponse(visual.descriptorPath, chatReply(message, 'Option B isolates rendering.'))
+
+  browser.send(JSON.stringify(choiceSelected('option-b')))
+  await sendVisualResponse(
+    visual.descriptorPath,
+    choiceAcknowledged(await waitForVisualEvent(visual.descriptorPath, 1)),
+  )
+
+  browser.send(JSON.stringify(sessionEnd()))
+  const ending = await waitForVisualEvent(visual.descriptorPath, 2)
+  await sendVisualResponse(visual.descriptorPath, completeHandoff(ending, {
+    summary: 'Selected option B.',
+    confirmedDecisions: ['option-b'],
+    requestedChanges: [],
+    unresolvedQuestions: [],
+    finalViews: ['choices', 'option-b'],
+  }))
+
+  expect(await recoverVisualSessionClient(
+    visual.descriptorPath,
+    { includeTranscript: false },
+  )).toMatchObject({
+    summary: 'Selected option B.',
+    transcript: undefined,
+  })
+  expect(await recoverVisualSessionClient(
+    visual.descriptorPath,
+    { includeTranscript: true },
+  )).toMatchObject({
+    transcript: expect.any(Array),
+  })
+
+  await stopVisualSessionClient(visual.descriptorPath)
+  expect(existsSync(visual.sessionRoot)).toBe(false)
+  await expect(fetch(visual.origin)).rejects.toThrow()
+})
+```
+
+- [ ] **Step 2: Add failing recovery matrix tests**
+
+Cover:
+
+- child disconnect before `handoff.complete` derives a partial summary with `terminationReason: 'child-failed'`;
+- five-minute browser grace expiry creates a terminal event and freezes chat;
+- direct main cancellation aborts an active compiler process;
+- runtime restart recovers from journal without acknowledging a truncated record;
+- repeated `stop` reports `alreadyStopped: true`;
+- two sessions reject each other's browser cookies, agent descriptors, event IDs, and response IDs;
+- diagram-only mode rejects chat writes while preserving navigation.
+
+- [ ] **Step 3: Run the journey test and confirm red**
+
+Run: `pnpm exec vitest run test/visual-journey.test.ts`
+
+Expected: FAIL at the first missing shared recovery transition.
+
+- [ ] **Step 4: Centralize terminal transition and recovery**
+
+Add one function called by End, failures, timeout, and cancellation:
+
+```ts
+export async function terminateVisualSession(
+  session: ActiveVisualSession,
+  reason: VisualTerminationReason,
+): Promise<VisualHandoff> {
+  if (session.lifecycle === 'stopped') return session.handoff
+  session.lifecycle = 'recovering'
+  session.acceptBrowserInput = false
+  session.compilerAbort.abort()
+  await appendTerminalEvent(session.paths, reason)
+  const handoff = await recoverVisualSession(session.paths, false)
+  session.handoff = handoff
+  return handoff
+}
+```
+
+Make `stop` call `terminateVisualSession` before closing sockets/server and removing the marked root. Preserve the transcript until `stop`; `recover --transcript` reads it without changing lifecycle.
+
+- [ ] **Step 5: Run all visual tests and typecheck**
+
+Run: `pnpm exec vitest run test/visual-*.test.ts && pnpm typecheck && pnpm build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the complete lifecycle**
+
+```bash
+git add src/adapters/visual src/adapters/visual-cli.ts test/visual-journey.test.ts
+git commit -m "feat: recover visual conversations"
+```
+
+---
+
+### Task 8: Skill orchestration, consumer guidance, and packed package
+
+**Files:**
+- Create: `skills/yarramate-architecture/references/visual-conversations.md`
+- Modify: `skills/yarramate-architecture/SKILL.md:15-260`
+- Modify: `docs/CONSUMING-YARRAMATE.md:60-170`
+- Modify: `test/package-consumer.test.ts:20-100,136-153`
+- Modify: `package.json:24-82`
+
+**Interfaces:**
+- Consumes: `yarramate-visual` protocol and capability rules from Tasks 1-7.
+- Produces: canonical natural-language journey and packed binary/assets/schemas.
+
+- [ ] **Step 1: Write failing package and skill contract assertions**
+
+```ts
+expect(packageJson.bin['yarramate-visual']).toBe('dist/adapters/visual-cli.js')
+expect(packageJson.files).toContain('dist')
+expect(files).toContain('package/dist/adapters/visual-cli.js')
+expect(files).toContain('package/dist/visual-app/index.html')
+expect(files).toContain('package/schema/yarramate-visual-event.schema.json')
+expect(files).toContain(
+  'package/skills/yarramate-architecture/references/visual-conversations.md',
+)
+expect(consumerGuide).toContain('visually explain')
+expect(consumerGuide).toContain('diagram-only mode')
+```
+
+In the packed consumer setup, add the `yarramate-visual` symlink and assert `--version` matches the package version.
+
+- [ ] **Step 2: Run package tests and confirm red**
+
+Run: `pnpm exec vitest run test/package-consumer.test.ts`
+
+Expected: FAIL because the package and skill do not expose visual conversations yet.
+
+- [ ] **Step 3: Add the visual request branch to the canonical skill**
+
+Add a concise section to `SKILL.md` that triggers on visual explanation/show/compare requests and loads the new reference. Keep the full loop in the reference:
+
+```text
+request
+  -> classify canonical or ad hoc authority
+  -> for repository architecture: yarramate check, then yarramate ask --json
+  -> resolve LikeC4 >=1.59.2 <1.60.0; ask before pinned runner
+  -> inspect actual harness delegation/recovery capabilities
+  -> start yarramate-visual as a managed foreground process
+  -> capable: delegate bounded visual agent and await handoff
+  -> incapable: diagram-only mode; continue conversation in main harness
+  -> End/failure: recover, optionally read transcript, stop, resume main
+```
+
+The child prompt in `visual-conversations.md` must state:
+
+```text
+You are the delegated YarraMate visual agent for one session.
+You may call read-only YarraMate commands and yarramate-visual wait/respond/status/recover.
+You may replace only the temporary yarramate/visual-model/v1 session model.
+You must not edit repository files, .yarramate/, credentials, or harness configuration.
+On session.end or any terminal diagnostic, publish handoff.complete and exit.
+```
+
+Document `start` through the harness's long-running process tool. Never recommend shell daemonization. Capability-detect from tools/lifecycle guarantees, not harness names.
+
+- [ ] **Step 4: Update consumer guidance and package exports**
+
+Document authority labels, the local-only server, consented pinned runner, chat-capable journey, diagram-only fallback, main-agent recovery, transcript-on-demand, and server cleanup. Add all eight schema exports and the binary. The prepack build already runs both Node and visual builds from Task 6.
+
+- [ ] **Step 5: Run skill/package tests and pack smoke**
+
+Run: `pnpm exec vitest run test/package-consumer.test.ts && pnpm build && npm pack --dry-run`
+
+Expected: PASS; dry-run lists `dist/adapters/visual-cli.js`, `dist/visual-app/index.html`, eight visual schemas, and the visual-conversation reference.
+
+- [ ] **Step 6: Commit the consumer journey**
+
+```bash
+git add package.json skills/yarramate-architecture docs/CONSUMING-YARRAMATE.md test/package-consumer.test.ts
+git commit -m "docs: guide visual architecture conversations"
+```
+
+---
+
+### Task 9: Declare and verify the YarraMate self-model
+
+**Files:**
+- Create: `.yarramate/projections/visual-conversation-path.yaml`
+- Modify: `.yarramate/architecture/engine.yaml`
+- Modify: `.yarramate/architecture/repository.yaml`
+- Modify: `.yarramate/evidence/repository.yaml`
+- Modify: `.yarramate/likec4-project.yaml`
+- Modify: `.yarramate/integrations/likec4/subject-mapping.yaml`
+- Modify: `test/self-model.test.ts`
+
+**Interfaces:**
+- Consumes: shipped files and responsibilities from Tasks 1-8.
+- Produces: checked current-state declarations, evidence, bounded projection, and rendered LikeC4 coverage for the visual-conversation path.
+
+- [ ] **Step 1: Write failing self-model assertions**
+
+```ts
+it('models the recoverable visual conversation path', () => {
+  const result = compileWorkspace(selfModelSources)
+  expect(result.ok).toBe(true)
+  if (!result.ok) return
+
+  expect(result.graph.concepts).toEqual(expect.arrayContaining([
+    expect.objectContaining({ id: 'yarramate-engine#visual-runtime' }),
+    expect.objectContaining({ id: 'yarramate-engine#visual-session-service' }),
+    expect.objectContaining({ id: 'yarramate-engine#visual-browser' }),
+    expect.objectContaining({ id: 'yarramate-engine#visual-session-protocol' }),
+    expect.objectContaining({ id: 'yarramate-engine#visual-handoff' }),
+  ]))
+
+  const projection = loadProjection(repositorySource(
+    '.yarramate/projections/visual-conversation-path.yaml',
+  ))
+  expect(projection.ok).toBe(true)
+  if (!projection.ok) return
+  const rendered = evaluateProjection(result.graph, projection.projection)
+  expect(rendered.concepts.map(({ id }) => id)).toContain(
+    'yarramate-engine#visual-runtime',
+  )
+})
+```
+
+- [ ] **Step 2: Run self-model tests and confirm red**
+
+Run: `pnpm exec vitest run test/self-model.test.ts`
+
+Expected: FAIL because the visual subjects and projection are absent.
+
+- [ ] **Step 3: Add the smallest coherent current-state model**
+
+Declare these owned/current subjects in `engine.yaml`:
+
+```yaml
+  - id: visual-runtime
+    kind: applicationComponent
+    name: Visual conversation runtime
+    description: Serves authenticated temporary LikeC4 explanations, browser chat transport, recovery, and cleanup without invoking a model provider.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-browser
+    kind: applicationComponent
+    name: Visual conversation browser
+    description: Custom React and LikeC4 presentation for diagrams, descriptions, choices, chat, status, and End.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-session-service
+    kind: applicationService
+    name: Visual session command
+    description: Starts, waits on, responds to, inspects, recovers, and stops one local visual conversation.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-session-protocol
+    kind: dataObject
+    name: Visual session protocol
+    description: Versioned browser, delegated-agent, model, status, and handoff documents for one temporary session.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: visual-handoff
+    kind: dataObject
+    name: Visual conversation handoff
+    description: Recoverable summary of confirmed decisions, requested changes, unresolved questions, final views, termination, and optional transcript access.
+    owner: yarramate-product#yarramate-maintainers
+    status: current
+  - id: render-visual-model
+    kind: applicationFunction
+    name: Render temporary visual model
+    description: Validates, compiles, and atomically promotes a complete grounded or explicitly ad hoc LikeC4 model.
+    status: current
+  - id: recover-visual-session
+    kind: applicationFunction
+    name: Recover visual conversation
+    description: Derives the main-agent handoff from the append-only journal before shutdown or after failure.
+    status: current
+```
+
+Add assignment, serving, and access relationships using existing profile kinds:
+
+```yaml
+  - id: visual-runtime-renders-model
+    kind: assignment
+    from: visual-runtime
+    to: render-visual-model
+  - id: visual-runtime-recovers-session
+    kind: assignment
+    from: visual-runtime
+    to: recover-visual-session
+  - id: visual-session-serves-agent-harness
+    kind: serving
+    from: visual-session-service
+    to: yarramate-product#agent-harness
+  - id: visual-rendering-reads-protocol
+    kind: access
+    from: render-visual-model
+    to: visual-session-protocol
+    mode: read
+  - id: visual-recovery-writes-handoff
+    kind: access
+    from: recover-visual-session
+    to: visual-handoff
+    mode: write
+```
+
+Add repository-file, schema, test, browser-asset, and skill-reference subjects in `repository.yaml`; link each stable subject to its real file through realization/association relationships. Add confirmed repository evidence only after the corresponding file exists.
+
+- [ ] **Step 4: Add the focused projection and LikeC4 project view**
+
+Create `visual-conversation-path.yaml` containing the engine subjects above, `yarramate-product#agent-harness`, `yarramate-repository#agent-skill-source`, visual runtime sources/tests/schemas, and `relationships: between`. Use title `Visual architecture conversation` and describe the delegated and diagram-only paths.
+
+Add the projection under the agent-contract story in `.yarramate/likec4-project.yaml`.
+
+- [ ] **Step 5: Observe mapping drift, synchronize, and verify the authored model**
+
+Run the read-only checks first:
+
+```bash
+yarramate check .yarramate/workspace.yaml --json
+yarramate-likec4 check .yarramate/likec4-project.yaml --json .yarramate/workspace.yaml
+```
+
+Expected: Core check passes; LikeC4 check reports only new intended unmapped subjects.
+
+Then repair and verify:
+
+```bash
+yarramate-likec4 map --sync .yarramate/integrations/likec4/subject-mapping.yaml .yarramate/workspace.yaml
+yarramate check .yarramate/workspace.yaml --json
+yarramate reconcile .yarramate/workspace.yaml
+yarramate ask .yarramate/workspace.yaml .yarramate/projections/visual-conversation-path.yaml
+yarramate-likec4 check .yarramate/likec4-project.yaml --json .yarramate/workspace.yaml
+yarramate-likec4 export-project .yarramate/likec4-project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml
+likec4 validate --json --no-layout --file .yarramate-out/likec4/model.likec4 --file .yarramate-out/likec4/specification.likec4 .yarramate-out/likec4
+```
+
+Expected: both read-only checks succeed after sync; reconciliation has no findings; the focused slice names the visual runtime/agent/browser/handoff path; LikeC4 validation reports `filteredErrors: 0`.
+
+- [ ] **Step 6: Run self-model and visual tests**
+
+Run: `pnpm exec vitest run test/self-model.test.ts test/visual-*.test.ts && pnpm typecheck && pnpm build`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the declared architecture**
+
+```bash
+git add .yarramate test/self-model.test.ts
+git commit -m "arch: declare visual conversation runtime"
+```
+
+---
+
+### Task 10: Real browser smoke and full verification
+
+**Files:**
+- None expected; confirmed defects return to the task that owns the failing contract.
+
+**Interfaces:**
+- Consumes: complete packed runtime, custom renderer, fake visual agent protocol, canonical skill, and checked self-model.
+- Produces: observed end-to-end evidence for the accepted user experience.
+
+- [ ] **Step 1: Build and create a temporary ad hoc smoke request**
+
+Run: `pnpm build`
+
+Run `node -p process.execPath` and use the printed absolute executable path in `/tmp/yarramate-visual-smoke/request.json`. The request uses format `yarramate/visual-session-request/v1`, `authority: "ad-hoc"`, `chatEnabled: true`, that compiler command plus the absolute `test/fixtures/visual/fake-likec4.mjs`, and a complete model containing a comparison overview linked to two detail views.
+
+- [ ] **Step 2: Start the real foreground server through the harness process manager**
+
+Run as a managed long-running process, not a shell background job:
+
+```bash
+node dist/adapters/visual-cli.js start /tmp/yarramate-visual-smoke/request.json
+```
+
+Expected first line: valid `yarramate/visual-session-started/v1` JSON with a secret localhost URL and descriptor path. Copy that line verbatim to `/tmp/yarramate-visual-smoke/started.json` with the file-writing tool, then keep the managed process running.
+
+- [ ] **Step 3: Drive the custom browser UI**
+
+Open the complete authenticated URL in the browser. Verify visually:
+
+- custom split diagram/chat layout loads without external requests;
+- authority label reads `Ad hoc · non-canonical`;
+- overview renders and navigates to both detail views;
+- description and connection state are visible;
+- chat composer, structured choices, and End remain usable at desktop and narrow viewport widths;
+- hostile `<img src=x onerror=alert(1)>` content renders as text and produces no dialog/console execution.
+
+- [ ] **Step 4: Exercise one browser-only delegated turn**
+
+Send `Explain the second option` in the browser. In a separate agent/terminal action:
+
+```bash
+DESCRIPTOR="$(node -p 'JSON.parse(require(\"node:fs\").readFileSync(\"/tmp/yarramate-visual-smoke/started.json\",\"utf8\")).descriptorPath')"
+node dist/adapters/visual-cli.js wait "$DESCRIPTOR" --after 0
+node dist/adapters/visual-cli.js respond "$DESCRIPTOR" /tmp/yarramate-visual-smoke/chat-response.json
+node dist/adapters/visual-cli.js respond "$DESCRIPTOR" /tmp/yarramate-visual-smoke/model-response.json
+```
+
+Create both response files with the session ID and triggering event ID printed by `wait`: `chat-response.json` contains `chat.response`; `model-response.json` contains a valid `model.replace` showing the selected option's detail. Give them distinct response IDs. Verify the browser receives both without a terminal user message.
+
+- [ ] **Step 5: Exercise End and main-agent recovery**
+
+Click End. Process the returned `session.end` with `handoff.complete`, then run:
+
+```bash
+DESCRIPTOR="$(node -p 'JSON.parse(require(\"node:fs\").readFileSync(\"/tmp/yarramate-visual-smoke/started.json\",\"utf8\")).descriptorPath')"
+node dist/adapters/visual-cli.js recover "$DESCRIPTOR"
+node dist/adapters/visual-cli.js recover "$DESCRIPTOR" --transcript
+node dist/adapters/visual-cli.js stop "$DESCRIPTOR"
+```
+
+Expected: first recovery contains the summary and transcript handle only; second contains the raw transcript; stop returns success, the managed server exits, the browser loses the local session, and the marked temporary directory no longer exists.
+
+- [ ] **Step 6: Run the complete repository verification**
+
+```bash
+pnpm verify
+pnpm exec vitest run test/package-consumer.test.ts test/self-model.test.ts test/visual-*.test.ts
+yarramate check .yarramate/workspace.yaml --json
+yarramate reconcile .yarramate/workspace.yaml
+yarramate-likec4 check .yarramate/likec4-project.yaml --json .yarramate/workspace.yaml
+```
+
+Expected: every command exits 0; Core and LikeC4 checks are valid; reconciliation has zero findings.
+
+- [ ] **Step 7: Confirm the smoke introduced no unreviewed changes**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no tracked changes. If the smoke exposed a defect, return to the task that owns that contract, add a failing automated test there, implement the fix, rerun Steps 1-6, and commit with that owning task's file list.

--- a/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
+++ b/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
@@ -18,7 +18,7 @@
 - One rendered edge may aggregate multiple model relationships; expose the count without inventing a canonical relationship ID.
 - Flatten LikeC4 `MarkdownOrString` descriptions to plain text and render them through React text nodes. Never inject HTML.
 - Description copy is three lines by default with real **Show more** and **Show less** controls when truncation is possible.
-- The desktop conversation width defaults to `clamp(320px, 28vw, 480px)`, has a 320px minimum and 640px maximum, and must leave at least 520px for the canvas.
+- The desktop conversation width defaults to `clamp(320px, 28vw, 480px)` and resizes between a 320px minimum and the design's `min(45vw, 640px)` maximum.
 - Below 900px, use a non-modal bottom sheet and remove the desktop resize separator.
 - Empty sessions start with conversation mode `auto` and visually collapsed. A direct subject click or explicit toggle opens it.
 - A manual close survives background chat, choices, and diagnostics; these increment an unread count instead of reopening the panel.
@@ -137,14 +137,14 @@ describe('visual workspace state', () => {
     expect(replaced.conversation.mode).toBe('open')
   })
 
-  it('clamps width to both the panel maximum and the canvas floor', () => {
+  it('clamps width to the design maximum of min(45vw, 640px)', () => {
     expect(conversationWidthBounds(1568)).toEqual({ min: 320, max: 640 })
-    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 370 })
+    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 405 })
+    expect(conversationWidthBounds(600)).toEqual({ min: 320, max: 320 })
 
     const widened = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
       type: 'conversation.resized',
       width: 900,
-      viewportWidth: 1568,
     })
     expect(widened.conversation.width).toBe(640)
 
@@ -152,7 +152,19 @@ describe('visual workspace state', () => {
       type: 'viewport.resized',
       viewportWidth: 900,
     })
-    expect(narrowedViewport.conversation.width).toBe(370)
+    expect(narrowedViewport.conversation.width).toBe(405)
+  })
+
+  it('tracks the viewport width even when the clamped panel width is unchanged', () => {
+    const initial = createVisualWorkspaceState(1568)
+    expect(initial.viewportWidth).toBe(1568)
+
+    const wider = visualWorkspaceReducer(initial, {
+      type: 'viewport.resized',
+      viewportWidth: 1600,
+    })
+    expect(wider.conversation.width).toBe(initial.conversation.width)
+    expect(wider.viewportWidth).toBe(1600)
   })
 })
 ```
@@ -229,7 +241,7 @@ describe('selected diagram subjects', () => {
 
   it('formats the exact visible text sent through the existing chat seam', () => {
     expect(formatContextualQuestion('What owns this?', elementSubject)).toBe(
-      'About “API” (system.api): What owns this?',
+      'About element “API” (system.api): What owns this?',
     )
 
     const relationship = normalizeSelectedRelationship(
@@ -397,8 +409,8 @@ Continue the same module with the exact actions below. Keep model replacement in
 ```ts
 export const CONVERSATION_MIN_WIDTH = 320
 export const CONVERSATION_MAX_WIDTH = 640
-export const CANVAS_MIN_WIDTH = 520
-const CONVERSATION_SEPARATOR_WIDTH = 10
+/** The share of the viewport the approved design lets the conversation take. */
+const CONVERSATION_MAX_VIEWPORT_SHARE = 0.45
 
 export interface VisualWorkspaceState {
   readonly conversation: {
@@ -406,6 +418,12 @@ export interface VisualWorkspaceState {
     readonly width: number
     readonly unread: number
   }
+  /**
+   * The viewport this state was last clamped against. Presentation reads its
+   * resize bounds from here rather than from `window`, so every viewport change
+   * reaches the separator's reported minimum and maximum.
+   */
+  readonly viewportWidth: number
   readonly selectedSubject: SelectedDiagramSubject | null
   readonly descriptionExpanded: boolean
   readonly detailsOpen: boolean
@@ -413,7 +431,7 @@ export interface VisualWorkspaceState {
 
 export type VisualWorkspaceAction =
   | { readonly type: 'conversation.toggled' }
-  | { readonly type: 'conversation.resized'; readonly width: number; readonly viewportWidth: number }
+  | { readonly type: 'conversation.resized'; readonly width: number }
   | { readonly type: 'viewport.resized'; readonly viewportWidth: number }
   | { readonly type: 'attention.received' }
   | { readonly type: 'subject.selected'; readonly subject: SelectedDiagramSubject }
@@ -422,13 +440,14 @@ export type VisualWorkspaceAction =
   | { readonly type: 'details.toggled' }
   | { readonly type: 'model.replaced' }
 
+// `min(45vw, 640px)`, never below the 320px floor the panel is usable at.
 export const conversationWidthBounds = (viewportWidth: number) => ({
   min: CONVERSATION_MIN_WIDTH,
   max: Math.max(
     CONVERSATION_MIN_WIDTH,
     Math.min(
       CONVERSATION_MAX_WIDTH,
-      viewportWidth - CANVAS_MIN_WIDTH - CONVERSATION_SEPARATOR_WIDTH,
+      viewportWidth * CONVERSATION_MAX_VIEWPORT_SHARE,
     ),
   ),
 })
@@ -458,6 +477,7 @@ export const createVisualWorkspaceState = (
     width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
     unread: 0,
   },
+  viewportWidth,
   selectedSubject: null,
   descriptionExpanded: false,
   detailsOpen: false,
@@ -479,16 +499,25 @@ export const visualWorkspaceReducer = (
         },
       }
     }
-    case 'conversation.resized':
-    case 'viewport.resized': {
-      const requested =
-        action.type === 'conversation.resized'
-          ? action.width
-          : state.conversation.width
-      const width = clampConversationWidth(requested, action.viewportWidth)
+    case 'conversation.resized': {
+      const width = clampConversationWidth(action.width, state.viewportWidth)
       return width === state.conversation.width
         ? state
         : { ...state, conversation: { ...state.conversation, width } }
+    }
+    case 'viewport.resized': {
+      const width = clampConversationWidth(
+        state.conversation.width,
+        action.viewportWidth,
+      )
+      return width === state.conversation.width &&
+        action.viewportWidth === state.viewportWidth
+        ? state
+        : {
+            ...state,
+            conversation: { ...state.conversation, width },
+            viewportWidth: action.viewportWidth,
+          }
     }
     case 'attention.received':
       if (state.conversation.mode === 'open') return state
@@ -536,7 +565,7 @@ export const formatContextualQuestion = (
   const text = question.trim()
   if (subject === null) return text
   if (subject.type === 'element') {
-    return `About “${subject.title}” (${subject.identity}): ${text}`
+    return `About element “${subject.title}” (${subject.identity}): ${text}`
   }
   const route = `${subject.sourceTitle} → ${subject.targetTitle}`
   const name = subject.label === null ? route : `${route} — ${subject.label}`
@@ -655,7 +684,7 @@ const CommandStrip = ({
       <span className={`authority authority-${state.authority}`}>
         {visualAuthorityLabel(state.authority)}
       </span>
-      <span className="connection-state">{connection}</span>
+      <span className="connection-state" role="status">{connection}</span>
     </div>
     <div className="command-actions">
       <label className="offscreen" htmlFor="active-view">Active view</label>
@@ -695,12 +724,18 @@ const CommandStrip = ({
         End
       </button>
     </div>
+    {/* Static prose is not worth the canvas: the disclosure is laid over the
+        workspace from the strip rather than taking a row of its own, so opening
+        it never reflows the diagram or the conversation. */}
     <div
       id="session-details"
       className="session-details"
       hidden={!detailsOpen}
     >
       <p>{state.description}</p>
+      <button type="button" className="details-close" onClick={onToggleDetails}>
+        Close details
+      </button>
     </div>
   </header>
 )
@@ -777,12 +812,17 @@ Add a private `ConversationSeparator`. Track the pointer-down coordinate and sta
 ```tsx
 const ConversationSeparator = ({
   width,
+  viewportWidth,
   onResize,
 }: {
   readonly width: number
-  readonly onResize: (width: number, viewportWidth: number) => void
+  readonly viewportWidth: number
+  readonly onResize: (width: number) => void
 }) => {
-  const bounds = conversationWidthBounds(window.innerWidth)
+  // From the state the reducer clamped against, never from `window`: a resize
+  // that leaves the panel width alone still changes what this may be dragged
+  // to, and a render that read the live global would only say so by accident.
+  const bounds = conversationWidthBounds(viewportWidth)
   const drag = useRef<{
     readonly pointerId: number
     readonly startX: number
@@ -791,10 +831,7 @@ const ConversationSeparator = ({
   const pointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
     const active = drag.current
     if (active?.pointerId !== event.pointerId) return
-    onResize(
-      active.startWidth + active.startX - event.clientX,
-      window.innerWidth,
-    )
+    onResize(active.startWidth + active.startX - event.clientX)
   }
   const pointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     drag.current = {
@@ -815,10 +852,7 @@ const ConversationSeparator = ({
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
     event.preventDefault()
     const step = event.shiftKey ? 32 : 8
-    onResize(
-      width + (event.key === 'ArrowLeft' ? step : -step),
-      window.innerWidth,
-    )
+    onResize(width + (event.key === 'ArrowLeft' ? step : -step))
   }
   return (
     <div
@@ -879,12 +913,9 @@ return (
       {conversationOpen ? (
         <ConversationSeparator
           width={workspace.conversation.width}
-          onResize={(width, viewportWidth) =>
-            dispatchWorkspace({
-              type: 'conversation.resized',
-              width,
-              viewportWidth,
-            })
+          viewportWidth={workspace.viewportWidth}
+          onResize={(width) =>
+            dispatchWorkspace({ type: 'conversation.resized', width })
           }
         />
       ) : null}
@@ -950,18 +981,101 @@ Keep the existing font imports, color tokens, reset, button/input typography, tr
 .command-actions select,
 .command-actions button {
   min-height: 32px;
+  padding: 0 0.7rem;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  cursor: pointer;
 }
 
+.command-actions select {
+  /* The native arrow is the one piece of OS chrome worth keeping: it is the
+     only affordance saying this control has a list behind it. */
+  padding-right: 0.35rem;
+}
+
+.command-actions select:hover:enabled,
+.command-actions button:hover:enabled {
+  border-color: var(--cobalt);
+}
+
+.command-actions select:disabled,
+.command-actions button:disabled {
+  color: var(--quiet);
+  background: transparent;
+  border-color: var(--rule);
+  cursor: not-allowed;
+}
+
+.command-actions button[aria-expanded='true'] {
+  color: var(--paper);
+  background: var(--cobalt);
+  border-color: var(--cobalt);
+}
+
+.command-actions .end-session:hover:enabled {
+  color: var(--paper);
+  background: var(--failure);
+  border-color: var(--failure);
+}
+
+.connection-state {
+  flex: none;
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+/* Laid over the workspace, never in it: static prose must not cost the diagram
+   a single pixel of height, so the disclosure hangs off the strip instead of
+   taking a row in the shell grid. */
 .session-details {
-  grid-column: 1 / -1;
-  padding-top: var(--step);
-  border-top: 1px solid var(--rule);
+  position: absolute;
+  top: 100%;
+  right: 0;
+  left: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--step) * 2);
+  padding: var(--step) calc(var(--step) * 2) calc(var(--step) * 1.5);
+  border-bottom: 1px solid var(--rule);
+  background: var(--sheet);
+  box-shadow: 0 12px 28px rgb(19 35 57 / 12%);
+}
+
+.session-details[hidden] {
+  display: none;
 }
 
 .session-details p {
   max-width: 90ch;
   margin: 0;
   color: var(--quiet);
+}
+
+.details-close {
+  flex: none;
+  margin-left: auto;
+  min-height: 28px;
+  padding: 0 0.6rem;
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.details-close:hover {
+  border-color: var(--cobalt);
 }
 
 .attention-count {
@@ -1098,10 +1212,10 @@ Rebuild, start the request from Step 1, and drive the page with the Browser tool
 2. Confirm no large title/description header or vertical fact rail remains.
 3. Confirm the diagram fills the viewport outside the open conversation.
 4. Collapse Conversation and confirm the canvas consumes the reclaimed width.
-5. Reopen it; pointer-drag the separator beyond both limits and confirm it settles within 320–640px while preserving at least 520px canvas.
+5. Reopen it; pointer-drag the separator beyond both limits and confirm it settles within 320px and `min(45vw, 640px)`.
 6. Focus the separator; verify ArrowLeft/ArrowRight move 8px and Shift+Arrow moves 32px within bounds.
 7. Close the panel, create background choice/diagnostic activity through the running visual session, and confirm an attention count appears without reopening the panel.
-8. Toggle Details and confirm the session description expands and collapses.
+8. Toggle Details and confirm the description is laid over the workspace, that the diagram and conversation keep the exact heights they had before the toggle, and that its labelled **Close details** action shuts it.
 
 Resize the same browser to 390×844 and confirm the open conversation is a bottom sheet, the separator is absent, the canvas remains the primary row, controls remain reachable, and `document.documentElement.scrollWidth === document.documentElement.clientWidth`.
 
@@ -1185,6 +1299,9 @@ This uses LikeC4's public `findView(viewId).$layouted` rendering model and never
   onEdgeClick={(edge) =>
     onSelect(normalizeSelectedRelationship(edge, nodeTitles))
   }
+  // LikeC4 1.59.2 never passes the originating node — it emits `navigateTo`
+  // with `viewId` alone — so this branch is dead against the pinned renderer
+  // and retention comes from the reducer keeping the prior selection.
   onNavigateTo={(viewId, _event, node) => {
     if (node !== undefined) onSelect(normalizeSelectedElement(node))
     onNavigate(viewId)

--- a/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
+++ b/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
@@ -87,7 +87,16 @@ describe('visual workspace state', () => {
     const state = createVisualWorkspaceState(1568)
     expect(state.conversation).toEqual({
       mode: 'auto',
-      width: 439.04,
+      width: expect.closeTo(439.04, 2),
+      unread: 0,
+    })
+  })
+
+  it('caps the default width at 480px on wide viewports', () => {
+    const state = createVisualWorkspaceState(1920)
+    expect(state.conversation).toEqual({
+      mode: 'auto',
+      width: 480,
       unread: 0,
     })
   })
@@ -429,12 +438,24 @@ const clampConversationWidth = (width: number, viewportWidth: number) => {
   return Math.min(max, Math.max(min, width))
 }
 
+// Initial width follows `clamp(320px, 28vw, 480px)` per the approved design;
+// only a manual drag may widen the panel up to CONVERSATION_MAX_WIDTH (640).
+const CONVERSATION_DEFAULT_MAX_WIDTH = 480
+
+const clampInitialConversationWidth = (
+  width: number,
+  viewportWidth: number,
+) => {
+  const { min, max } = conversationWidthBounds(viewportWidth)
+  return Math.min(Math.min(max, CONVERSATION_DEFAULT_MAX_WIDTH), Math.max(min, width))
+}
+
 export const createVisualWorkspaceState = (
   viewportWidth: number,
 ): VisualWorkspaceState => ({
   conversation: {
     mode: 'auto',
-    width: clampConversationWidth(viewportWidth * 0.28, viewportWidth),
+    width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
     unread: 0,
   },
   selectedSubject: null,

--- a/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
+++ b/docs/superpowers/plans/2026-08-08-visual-workspace-layout-and-subject-selection.md
@@ -1,0 +1,1559 @@
+# Visual Workspace Layout and Subject Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the visual-conversation page into a diagram-first workspace with a collapsible, resizable conversation panel and browser-local element or relationship context that can be attached to ordinary chat questions.
+
+**Architecture:** Add one pure `workspace-state.ts` deep module for conversation layout, selected-subject normalization, and contextual-question formatting. Keep transport and protocol state in the existing `state.ts`/`session-client.tsx` seam; refactor `App.tsx` into three private presentation surfaces that consume both states without adding a wire event. LikeC4 public click callbacks supply local selection records, and the existing `ask(text)` path remains the only chat submission path.
+
+**Tech Stack:** TypeScript 7, React 19, LikeC4 1.59.2, Vite 8, Vitest 4, CSS Grid, Pointer Events, ResizeObserver.
+
+## Global Constraints
+
+- Preserve all nine `yarramate/visual-*` v1 schemas, the existing browser/agent session protocol, recovery behavior, and journal semantics unchanged.
+- Do not add a runtime or development dependency.
+- Selection is browser-local: a click alone must not call `ask`, write a frame, or add a journal record.
+- Context enters the agent boundary only when the reviewer submits; the transcript must display the exact contextual text passed to `ask(text)`.
+- Element identity precedence is `modelRef`, then `deploymentRef`, then rendered node ID.
+- One rendered edge may aggregate multiple model relationships; expose the count without inventing a canonical relationship ID.
+- Flatten LikeC4 `MarkdownOrString` descriptions to plain text and render them through React text nodes. Never inject HTML.
+- Description copy is three lines by default with real **Show more** and **Show less** controls when truncation is possible.
+- The desktop conversation width defaults to `clamp(320px, 28vw, 480px)`, has a 320px minimum and 640px maximum, and must leave at least 520px for the canvas.
+- Below 900px, use a non-modal bottom sheet and remove the desktop resize separator.
+- Empty sessions start with conversation mode `auto` and visually collapsed. A direct subject click or explicit toggle opens it.
+- A manual close survives background chat, choices, and diagnostics; these increment an unread count instead of reopening the panel.
+- Active-model replacement clears selection. Session close preserves the selected subject for local inspection while disabling submission.
+- Do not persist workspace state in `localStorage`; it belongs to the ephemeral browser session.
+- Keep LikeC4 navigation, pan, zoom, fit-view, notes, reduced-motion behavior, last-good rendering, and CSP nonce behavior intact.
+
+---
+
+## File Structure
+
+- Create `src/visual-app/workspace-state.ts`: pure workspace reducer, width bounds, selected-subject types and normalization, description flattening, contextual-question formatting.
+- Create `test/visual-workspace-state.test.ts`: contract tests for panel transitions, clamping, identity precedence, relationship aggregation/fallbacks, description flattening, model replacement, and exact contextual text.
+- Modify `src/visual-app/App.tsx`: replace the header/rail/three-column composition with `CommandStrip`, `DiagramWorkspace`, and `ConversationPanel`; wire pointer/keyboard resize and LikeC4 selection callbacks.
+- Modify `src/visual-app/styles.css`: full-height diagram-first grid, compact command strip, resizable desktop panel, selected-subject inspector/chip, and sub-900px bottom sheet.
+- Modify `test/fixtures/visual/model.json`: add representative long element and relationship descriptions to the existing valid layouted fixture so real browser verification exercises expansion for both subject kinds.
+- No schema, protocol, adapter, package export, self-model, or user-facing CLI document changes are required: this feature changes only the private browser presentation and browser-local state.
+
+---
+
+### Task 1: Browser-Local Workspace State
+
+**Files:**
+- Create: `src/visual-app/workspace-state.ts`
+- Create: `test/visual-workspace-state.test.ts`
+
+**Interfaces:**
+- Consumes: `flattenMarkdownOrString(value: MarkdownOrString | null | undefined): string` from `@likec4/core/types`.
+- Produces: `VisualWorkspaceState`, `VisualWorkspaceAction`, `SelectedDiagramSubject`, `SelectedElement`, `SelectedRelationship`, `createVisualWorkspaceState(viewportWidth: number): VisualWorkspaceState`, `visualWorkspaceReducer(state, action): VisualWorkspaceState`, `conversationWidthBounds(viewportWidth: number): { min: number; max: number }`, `normalizeSelectedElement(node: DiagramElementInput): SelectedElement`, `normalizeSelectedRelationship(edge: DiagramRelationshipInput, nodeTitles: ReadonlyMap<string, string>): SelectedRelationship`, `visualDescriptionText(value): string | null`, and `formatContextualQuestion(question, subject): string`.
+- Invariant for later tasks: `conversation.mode === 'open'` is the only state that renders the panel; `auto` and `closed` are visually collapsed.
+
+- [ ] **Step 1: Write failing tests for workspace transitions and width limits**
+
+Create `test/visual-workspace-state.test.ts` with the reducer cases below. Keep every subject value explicit so a later type/property rename fails at compile time.
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  conversationWidthBounds,
+  createVisualWorkspaceState,
+  formatContextualQuestion,
+  normalizeSelectedElement,
+  normalizeSelectedRelationship,
+  visualDescriptionText,
+  visualWorkspaceReducer,
+  type SelectedDiagramSubject,
+} from '../src/visual-app/workspace-state.js'
+
+const elementSubject: SelectedDiagramSubject = {
+  type: 'element',
+  id: 'node-1',
+  modelRef: 'system.api',
+  deploymentRef: null,
+  identity: 'system.api',
+  title: 'API',
+  kind: 'service',
+  description: 'Handles requests.',
+  technology: 'TypeScript',
+  tags: ['public'],
+  navigateTo: 'api-detail',
+  metadata: null,
+}
+
+describe('visual workspace state', () => {
+  it('starts collapsed at the responsive default width', () => {
+    const state = createVisualWorkspaceState(1568)
+    expect(state.conversation).toEqual({
+      mode: 'auto',
+      width: 439.04,
+      unread: 0,
+    })
+  })
+
+  it('opens automatically for first activity but respects a manual close', () => {
+    const initial = createVisualWorkspaceState(1568)
+    const opened = visualWorkspaceReducer(initial, {
+      type: 'attention.received',
+    })
+    expect(opened.conversation.mode).toBe('open')
+
+    const closed = visualWorkspaceReducer(opened, {
+      type: 'conversation.toggled',
+    })
+    const waiting = visualWorkspaceReducer(closed, {
+      type: 'attention.received',
+    })
+    expect(waiting.conversation).toMatchObject({ mode: 'closed', unread: 1 })
+
+    const reopened = visualWorkspaceReducer(waiting, {
+      type: 'conversation.toggled',
+    })
+    expect(reopened.conversation).toMatchObject({ mode: 'open', unread: 0 })
+  })
+
+  it('opens for a direct selection and clears only on model replacement', () => {
+    const selected = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
+      type: 'subject.selected',
+      subject: elementSubject,
+    })
+    expect(selected.conversation.mode).toBe('open')
+    expect(selected.selectedSubject).toEqual(elementSubject)
+
+    const replaced = visualWorkspaceReducer(selected, {
+      type: 'model.replaced',
+    })
+    expect(replaced.selectedSubject).toBeNull()
+    expect(replaced.conversation.mode).toBe('open')
+  })
+
+  it('clamps width to both the panel maximum and the canvas floor', () => {
+    expect(conversationWidthBounds(1568)).toEqual({ min: 320, max: 640 })
+    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 370 })
+
+    const widened = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
+      type: 'conversation.resized',
+      width: 900,
+      viewportWidth: 1568,
+    })
+    expect(widened.conversation.width).toBe(640)
+
+    const narrowedViewport = visualWorkspaceReducer(widened, {
+      type: 'viewport.resized',
+      viewportWidth: 900,
+    })
+    expect(narrowedViewport.conversation.width).toBe(370)
+  })
+})
+```
+
+- [ ] **Step 2: Write failing tests for node/edge normalization and contextual text**
+
+Append these cases to the same test file:
+
+```ts
+describe('selected diagram subjects', () => {
+  it('prefers model identity and flattens element descriptions', () => {
+    const selected = normalizeSelectedElement({
+      id: 'rendered-node',
+      modelRef: 'system.api',
+      deploymentRef: 'prod.api',
+      title: 'API',
+      kind: 'service',
+      description: { txt: '  Handles requests.  ' },
+      technology: 'TypeScript',
+      tags: ['public'],
+      navigateTo: 'api-detail',
+      metadata: { owner: 'platform' },
+    })
+    expect(selected).toMatchObject({
+      identity: 'system.api',
+      description: 'Handles requests.',
+      modelRef: 'system.api',
+      deploymentRef: 'prod.api',
+    })
+  })
+
+  it('falls back through deployment identity to rendered node identity', () => {
+    expect(
+      normalizeSelectedElement({
+        id: 'deployment-node',
+        deploymentRef: 'prod.api',
+        title: 'Production API',
+      }).identity,
+    ).toBe('prod.api')
+    expect(
+      normalizeSelectedElement({ id: 'group-1', title: 'Services' }).identity,
+    ).toBe('group-1')
+  })
+
+  it('preserves edge endpoints, rendered description, and aggregate count', () => {
+    const selected = normalizeSelectedRelationship(
+      {
+        id: 'edge-1',
+        source: 'missing-source',
+        target: 'api',
+        label: 'routes to',
+        description: { txt: 'Requests cross this boundary.' },
+        kind: 'sync',
+        technology: 'HTTPS',
+        notation: 'request',
+        relations: ['relation-1', 'relation-2'],
+      },
+      new Map([['api', 'API']]),
+    )
+    expect(selected).toMatchObject({
+      sourceId: 'missing-source',
+      sourceTitle: 'missing-source',
+      targetTitle: 'API',
+      description: 'Requests cross this boundary.',
+      aggregateCount: 2,
+      relationshipIds: ['relation-1', 'relation-2'],
+    })
+  })
+
+  it('treats absent or blank descriptions as missing', () => {
+    expect(visualDescriptionText(undefined)).toBeNull()
+    expect(visualDescriptionText({ txt: '   ' })).toBeNull()
+  })
+
+  it('formats the exact visible text sent through the existing chat seam', () => {
+    expect(formatContextualQuestion('What owns this?', elementSubject)).toBe(
+      'About “API” (system.api): What owns this?',
+    )
+
+    const relationship = normalizeSelectedRelationship(
+      {
+        id: 'edge-1',
+        source: 'web',
+        target: 'api',
+        label: 'calls',
+        relations: ['one', 'two'],
+      },
+      new Map([
+        ['web', 'Web'],
+        ['api', 'API'],
+      ]),
+    )
+    expect(formatContextualQuestion('Why synchronous?', relationship)).toBe(
+      'About relationship “Web → API — calls” (2 model relationships): Why synchronous?',
+    )
+    expect(formatContextualQuestion('  General question  ', null)).toBe(
+      'General question',
+    )
+  })
+})
+```
+
+- [ ] **Step 3: Run the state test to verify RED**
+
+Run:
+
+```bash
+pnpm exec vitest run test/visual-workspace-state.test.ts
+```
+
+Expected: FAIL because `src/visual-app/workspace-state.ts` does not exist.
+
+- [ ] **Step 4: Implement selected-subject types and normalization**
+
+Create `src/visual-app/workspace-state.ts`. Use these public shapes so LikeC4 callback objects are structurally assignable without coupling the module to renderer internals:
+
+```ts
+import {
+  flattenMarkdownOrString,
+  type MarkdownOrString,
+} from '@likec4/core/types'
+
+export type ConversationMode = 'auto' | 'open' | 'closed'
+
+export interface DiagramElementInput {
+  readonly id: string
+  readonly modelRef?: string | null
+  readonly deploymentRef?: string | null
+  readonly title: string
+  readonly kind?: string | null
+  readonly description?: MarkdownOrString | null
+  readonly technology?: string | null
+  readonly tags?: readonly string[] | null
+  readonly navigateTo?: string | null
+  readonly metadata?: Readonly<Record<string, unknown>> | null
+}
+
+export interface DiagramRelationshipInput {
+  readonly id: string
+  readonly source: string
+  readonly target: string
+  readonly label?: string | null
+  readonly description?: MarkdownOrString | null
+  readonly kind?: string | null
+  readonly technology?: string | null
+  readonly notation?: string | null
+  readonly relations?: readonly string[] | null
+}
+
+export interface SelectedElement {
+  readonly type: 'element'
+  readonly id: string
+  readonly modelRef: string | null
+  readonly deploymentRef: string | null
+  readonly identity: string
+  readonly title: string
+  readonly kind: string | null
+  readonly description: string | null
+  readonly technology: string | null
+  readonly tags: readonly string[]
+  readonly navigateTo: string | null
+  readonly metadata: Readonly<Record<string, unknown>> | null
+}
+
+export interface SelectedRelationship {
+  readonly type: 'relationship'
+  readonly id: string
+  readonly sourceId: string
+  readonly sourceTitle: string
+  readonly targetId: string
+  readonly targetTitle: string
+  readonly label: string | null
+  readonly description: string | null
+  readonly kind: string | null
+  readonly technology: string | null
+  readonly notation: string | null
+  readonly relationshipIds: readonly string[]
+  readonly aggregateCount: number
+}
+
+export type SelectedDiagramSubject = SelectedElement | SelectedRelationship
+
+const optionalText = (value: string | null | undefined): string | null => {
+  const text = value?.trim() ?? ''
+  return text === '' ? null : text
+}
+
+export const visualDescriptionText = (
+  value: MarkdownOrString | null | undefined,
+): string | null => optionalText(flattenMarkdownOrString(value))
+
+export const normalizeSelectedElement = (
+  node: DiagramElementInput,
+): SelectedElement => {
+  const modelRef = optionalText(node.modelRef)
+  const deploymentRef = optionalText(node.deploymentRef)
+  return {
+    type: 'element',
+    id: String(node.id),
+    modelRef,
+    deploymentRef,
+    identity: modelRef ?? deploymentRef ?? String(node.id),
+    title: node.title,
+    kind: optionalText(node.kind),
+    description: visualDescriptionText(node.description),
+    technology: optionalText(node.technology),
+    tags: node.tags?.map(String) ?? [],
+    navigateTo: optionalText(node.navigateTo),
+    metadata: node.metadata ?? null,
+  }
+}
+
+export const normalizeSelectedRelationship = (
+  edge: DiagramRelationshipInput,
+  nodeTitles: ReadonlyMap<string, string>,
+): SelectedRelationship => {
+  const sourceId = String(edge.source)
+  const targetId = String(edge.target)
+  const relationshipIds = edge.relations?.map(String) ?? []
+  return {
+    type: 'relationship',
+    id: String(edge.id),
+    sourceId,
+    sourceTitle: nodeTitles.get(sourceId) ?? sourceId,
+    targetId,
+    targetTitle: nodeTitles.get(targetId) ?? targetId,
+    label: optionalText(edge.label),
+    description: visualDescriptionText(edge.description),
+    kind: optionalText(edge.kind),
+    technology: optionalText(edge.technology),
+    notation: optionalText(edge.notation),
+    relationshipIds,
+    aggregateCount: relationshipIds.length,
+  }
+}
+```
+
+- [ ] **Step 5: Implement panel state, clamping, and contextual formatting**
+
+Continue the same module with the exact actions below. Keep model replacement independent of panel visibility: clearing a stale subject must not unexpectedly close a conversation the reviewer opened.
+
+```ts
+export const CONVERSATION_MIN_WIDTH = 320
+export const CONVERSATION_MAX_WIDTH = 640
+export const CANVAS_MIN_WIDTH = 520
+const CONVERSATION_SEPARATOR_WIDTH = 10
+
+export interface VisualWorkspaceState {
+  readonly conversation: {
+    readonly mode: ConversationMode
+    readonly width: number
+    readonly unread: number
+  }
+  readonly selectedSubject: SelectedDiagramSubject | null
+  readonly descriptionExpanded: boolean
+  readonly detailsOpen: boolean
+}
+
+export type VisualWorkspaceAction =
+  | { readonly type: 'conversation.toggled' }
+  | { readonly type: 'conversation.resized'; readonly width: number; readonly viewportWidth: number }
+  | { readonly type: 'viewport.resized'; readonly viewportWidth: number }
+  | { readonly type: 'attention.received' }
+  | { readonly type: 'subject.selected'; readonly subject: SelectedDiagramSubject }
+  | { readonly type: 'subject.cleared' }
+  | { readonly type: 'description.toggled' }
+  | { readonly type: 'details.toggled' }
+  | { readonly type: 'model.replaced' }
+
+export const conversationWidthBounds = (viewportWidth: number) => ({
+  min: CONVERSATION_MIN_WIDTH,
+  max: Math.max(
+    CONVERSATION_MIN_WIDTH,
+    Math.min(
+      CONVERSATION_MAX_WIDTH,
+      viewportWidth - CANVAS_MIN_WIDTH - CONVERSATION_SEPARATOR_WIDTH,
+    ),
+  ),
+})
+
+const clampConversationWidth = (width: number, viewportWidth: number) => {
+  const { min, max } = conversationWidthBounds(viewportWidth)
+  return Math.min(max, Math.max(min, width))
+}
+
+export const createVisualWorkspaceState = (
+  viewportWidth: number,
+): VisualWorkspaceState => ({
+  conversation: {
+    mode: 'auto',
+    width: clampConversationWidth(viewportWidth * 0.28, viewportWidth),
+    unread: 0,
+  },
+  selectedSubject: null,
+  descriptionExpanded: false,
+  detailsOpen: false,
+})
+
+export const visualWorkspaceReducer = (
+  state: VisualWorkspaceState,
+  action: VisualWorkspaceAction,
+): VisualWorkspaceState => {
+  switch (action.type) {
+    case 'conversation.toggled': {
+      const mode = state.conversation.mode === 'open' ? 'closed' : 'open'
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          mode,
+          unread: mode === 'open' ? 0 : state.conversation.unread,
+        },
+      }
+    }
+    case 'conversation.resized':
+    case 'viewport.resized': {
+      const requested =
+        action.type === 'conversation.resized'
+          ? action.width
+          : state.conversation.width
+      const width = clampConversationWidth(requested, action.viewportWidth)
+      return width === state.conversation.width
+        ? state
+        : { ...state, conversation: { ...state.conversation, width } }
+    }
+    case 'attention.received':
+      if (state.conversation.mode === 'open') return state
+      if (state.conversation.mode === 'auto') {
+        return {
+          ...state,
+          conversation: { ...state.conversation, mode: 'open', unread: 0 },
+        }
+      }
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          unread: state.conversation.unread + 1,
+        },
+      }
+    case 'subject.selected':
+      return {
+        ...state,
+        conversation: { ...state.conversation, mode: 'open', unread: 0 },
+        selectedSubject: action.subject,
+        descriptionExpanded: false,
+      }
+    case 'subject.cleared':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, selectedSubject: null, descriptionExpanded: false }
+    case 'description.toggled':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, descriptionExpanded: !state.descriptionExpanded }
+    case 'details.toggled':
+      return { ...state, detailsOpen: !state.detailsOpen }
+    case 'model.replaced':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, selectedSubject: null, descriptionExpanded: false }
+  }
+}
+
+export const formatContextualQuestion = (
+  question: string,
+  subject: SelectedDiagramSubject | null,
+): string => {
+  const text = question.trim()
+  if (subject === null) return text
+  if (subject.type === 'element') {
+    return `About “${subject.title}” (${subject.identity}): ${text}`
+  }
+  const route = `${subject.sourceTitle} → ${subject.targetTitle}`
+  const name = subject.label === null ? route : `${route} — ${subject.label}`
+  const aggregate =
+    subject.aggregateCount > 1
+      ? ` (${subject.aggregateCount} model relationships)`
+      : ''
+  return `About relationship “${name}”${aggregate}: ${text}`
+}
+```
+
+- [ ] **Step 6: Run the focused state test to verify GREEN**
+
+Run:
+
+```bash
+pnpm exec vitest run test/visual-workspace-state.test.ts
+```
+
+Expected: PASS with every transition, normalization, and exact-text assertion green.
+
+- [ ] **Step 7: Run the visual TypeScript build**
+
+Run:
+
+```bash
+pnpm build:visual
+```
+
+Expected: Vite build succeeds; TypeScript accepts the new browser-private module.
+
+- [ ] **Step 8: Commit the state deep module**
+
+```bash
+git add src/visual-app/workspace-state.ts test/visual-workspace-state.test.ts
+git commit -m "feat: add visual workspace state"
+```
+
+---
+
+### Task 2: Diagram-First Workspace and Resizable Conversation
+
+**Files:**
+- Modify: `src/visual-app/App.tsx:1-368`
+- Modify: `src/visual-app/styles.css:1-595`
+
+**Interfaces:**
+- Consumes: `createVisualWorkspaceState`, `visualWorkspaceReducer`, and `conversationWidthBounds` from Task 1; existing `useVisualSession(): { state, connected, ask, choose, navigate, end }` remains unchanged.
+- Produces: private `CommandStrip`, `DiagramWorkspace`, `ConversationPanel`, and `ConversationSeparator` presentation functions in `App.tsx`.
+- Invariant for Task 3: `DiagramWorkspace` owns all LikeC4 callbacks; `ConversationPanel` owns transcript, diagnostics, choices, and composer; neither owns transport state.
+
+- [ ] **Step 1: Capture the current layout as the visual RED case**
+
+Build the feature worktree and generate the request without committing an absolute path:
+
+```bash
+pnpm build
+node --input-type=module -e "import { writeFileSync } from 'node:fs'; import { resolve } from 'node:path'; writeFileSync('/tmp/yarramate-workspace-smoke.json', JSON.stringify({ format: 'yarramate/visual-session-request/v1', authority: 'ad-hoc', title: 'Visual workspace smoke', description: 'Browser verification for the diagram-first workspace.', chatEnabled: true, compiler: { command: resolve('test/fixtures/visual/fake-likec4.mjs'), args: [] }, initialModel: { format: 'yarramate/visual-model/v1', authority: 'ad-hoc', initialView: 'choices', sourceDigests: {}, files: { 'model.likec4': '// workspace smoke\n', 'views.likec4': '// workspace smoke\n' } } }, null, 2))"
+```
+
+Start the long-running server with the Hub process manager, never as a blocking shell command:
+
+```json
+{
+  "op": "start",
+  "name": "visual-workspace-smoke",
+  "application": "node",
+  "args": [
+    "dist/adapters/visual/visual-cli.js",
+    "start",
+    "/tmp/yarramate-workspace-smoke.json"
+  ],
+  "cwd": ".",
+  "ready": {
+    "log": "yarramate/visual-session-started/v1",
+    "timeout": 30
+  }
+}
+```
+
+Read the started JSON with Hub logs, open its one-time `browserUrl` with the Browser tool at 1568×924, and record the RED observations: large descriptive header still consumes vertical space; fixed fact rail still consumes 56px; conversation cannot collapse or resize; canvas does not reclaim that space. Stop `visual-workspace-smoke` through Hub before editing.
+
+- [ ] **Step 2: Refactor `App.tsx` into the three approved presentation surfaces**
+
+Update React imports to add value imports `useEffect` and `useReducer`, plus type imports `CSSProperties` and `PointerEvent as ReactPointerEvent`. Task 3 will add `useLayoutEffect` when the description disclosure needs it. Import the Task 1 reducer functions. Remove `Rail` and the old page-header/view-tab composition.
+
+Use this command-strip interface and markup; keep `connectionOf` and `visualAuthorityLabel` as the existing sources of truth:
+
+```tsx
+const CommandStrip = ({
+  state,
+  connection,
+  views,
+  detailsOpen,
+  conversationOpen,
+  unread,
+  onNavigate,
+  onToggleDetails,
+  onToggleConversation,
+  onEnd,
+}: {
+  readonly state: VisualAppState
+  readonly connection: string
+  readonly views: readonly string[]
+  readonly detailsOpen: boolean
+  readonly conversationOpen: boolean
+  readonly unread: number
+  readonly onNavigate: (viewId: string) => void
+  readonly onToggleDetails: () => void
+  readonly onToggleConversation: () => void
+  readonly onEnd: () => void
+}) => (
+  <header className="command-strip">
+    <div className="command-identity">
+      <h1>{state.title === '' ? 'Opening the session' : state.title}</h1>
+      <span className={`authority authority-${state.authority}`}>
+        {visualAuthorityLabel(state.authority)}
+      </span>
+      <span className="connection-state">{connection}</span>
+    </div>
+    <div className="command-actions">
+      <label className="offscreen" htmlFor="active-view">Active view</label>
+      <select
+        id="active-view"
+        value={state.activeView}
+        onChange={(event) => onNavigate(event.target.value)}
+        disabled={views.length < 2}
+      >
+        {views.map((viewId) => (
+          <option key={viewId} value={viewId}>{viewId}</option>
+        ))}
+      </select>
+      <button
+        type="button"
+        aria-expanded={detailsOpen}
+        aria-controls="session-details"
+        onClick={onToggleDetails}
+      >
+        Details
+      </button>
+      <button
+        type="button"
+        aria-expanded={conversationOpen}
+        aria-controls="conversation-panel"
+        onClick={onToggleConversation}
+      >
+        Conversation
+        {unread === 0 ? null : <span className="attention-count">{unread}</span>}
+      </button>
+      <button
+        type="button"
+        className="end-session"
+        onClick={onEnd}
+        disabled={state.lifecycle !== 'active'}
+      >
+        End
+      </button>
+    </div>
+    <div
+      id="session-details"
+      className="session-details"
+      hidden={!detailsOpen}
+    >
+      <p>{state.description}</p>
+    </div>
+  </header>
+)
+```
+
+Rename `ChatPanel` to `ConversationPanel`, add a required `hidden: boolean` prop, and render `<section id="conversation-panel" className="talk" aria-label="Conversation" hidden={hidden}>`. Wrap the existing transcript `<ol>`, `Faults`, and conditional `Choices` in one `<div className="conversation-scroll">`; keep the composer form as its sibling. Preserve the existing transcript mapping, composer submission, Enter/Shift+Enter behavior, agent status, and disabled logic unchanged in this task. Keeping the panel mounted while hidden preserves an unsent draft across collapse.
+
+Move the current LikeC4 provider, renderer, waiting copy, and renderer-fault banner into `DiagramWorkspace`. Preserve every existing renderer prop except set `enableElementDetails={false}` and `enableRelationshipDetails={false}` so the custom inspector added in Task 3 is the only details surface. Keep `enableNotes`, `showNavigationButtons`, `styleNonce`, and `reduceGraphics` unchanged.
+
+- [ ] **Step 3: Wire reducer lifecycle, background attention, and responsive reclamping**
+
+In `App`, initialize workspace state once from the browser width and re-clamp it on viewport changes:
+
+```tsx
+const [workspace, dispatchWorkspace] = useReducer(
+  visualWorkspaceReducer,
+  window.innerWidth,
+  createVisualWorkspaceState,
+)
+
+useEffect(() => {
+  const resized = () =>
+    dispatchWorkspace({
+      type: 'viewport.resized',
+      viewportWidth: window.innerWidth,
+    })
+  window.addEventListener('resize', resized)
+  return () => window.removeEventListener('resize', resized)
+}, [])
+```
+
+Track only newly arrived transcript records, choices, and non-empty diagnostic sets. This effect opens mode `auto`, but the reducer converts activity in mode `closed` into unread attention:
+
+```tsx
+const attention = useRef({
+  transcriptLength: state.transcript.length,
+  choices: state.choices,
+  diagnostics: state.diagnostics,
+})
+
+useEffect(() => {
+  const previous = attention.current
+  let receivedTranscript = false
+  for (
+    let index = previous.transcriptLength;
+    index < state.transcript.length;
+    index += 1
+  ) {
+    if (state.transcript[index]?.speaker === 'agent') {
+      receivedTranscript = true
+      break
+    }
+  }
+  const received =
+    receivedTranscript ||
+    (state.choices !== null && state.choices !== previous.choices) ||
+    (state.diagnostics.length > 0 &&
+      state.diagnostics !== previous.diagnostics)
+  attention.current = {
+    transcriptLength: state.transcript.length,
+    choices: state.choices,
+    diagnostics: state.diagnostics,
+  }
+  if (received) dispatchWorkspace({ type: 'attention.received' })
+}, [state.transcript.length, state.choices, state.diagnostics])
+```
+
+Do not dispatch for agent status, socket lifecycle, view navigation, local choice submission, or local chat submission.
+
+- [ ] **Step 4: Implement the pointer and keyboard separator**
+
+Add a private `ConversationSeparator`. Track the pointer-down coordinate and starting panel width so grabbing any point inside the 10px handle does not introduce an offset. Pointer capture guarantees release even if the pointer leaves the handle. ArrowLeft expands, ArrowRight contracts, and Shift changes the step from 8px to 32px.
+
+```tsx
+const ConversationSeparator = ({
+  width,
+  onResize,
+}: {
+  readonly width: number
+  readonly onResize: (width: number, viewportWidth: number) => void
+}) => {
+  const bounds = conversationWidthBounds(window.innerWidth)
+  const drag = useRef<{
+    readonly pointerId: number
+    readonly startX: number
+    readonly startWidth: number
+  } | null>(null)
+  const pointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const active = drag.current
+    if (active?.pointerId !== event.pointerId) return
+    onResize(
+      active.startWidth + active.startX - event.clientX,
+      window.innerWidth,
+    )
+  }
+  const pointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    drag.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: width,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+  const pointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (drag.current?.pointerId !== event.pointerId) return
+    drag.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+  const keyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+    event.preventDefault()
+    const step = event.shiftKey ? 32 : 8
+    onResize(
+      width + (event.key === 'ArrowLeft' ? step : -step),
+      window.innerWidth,
+    )
+  }
+  return (
+    <div
+      className="conversation-separator"
+      role="separator"
+      aria-label="Resize conversation"
+      aria-orientation="vertical"
+      aria-valuemin={bounds.min}
+      aria-valuemax={bounds.max}
+      aria-valuenow={Math.round(width)}
+      tabIndex={0}
+      onPointerDown={pointerDown}
+      onPointerMove={pointerMove}
+      onPointerUp={pointerUp}
+      onPointerCancel={pointerUp}
+      onKeyDown={keyDown}
+    />
+  )
+}
+```
+
+Render the shell with an explicit open/closed grid class. Keep the conversation mounted but hidden while collapsed so the draft and `aria-controls` target survive:
+
+```tsx
+const conversationOpen = workspace.conversation.mode === 'open'
+const shellStyle = {
+  '--conversation-width': `${workspace.conversation.width}px`,
+} as CSSProperties
+
+return (
+  <main className="visual-shell" style={shellStyle}>
+    <CommandStrip
+      state={state}
+      connection={connectionOf(state, connected)}
+      views={state.model?.views ?? []}
+      detailsOpen={workspace.detailsOpen}
+      conversationOpen={conversationOpen}
+      unread={workspace.conversation.unread}
+      onNavigate={navigate}
+      onToggleDetails={() => dispatchWorkspace({ type: 'details.toggled' })}
+      onToggleConversation={() =>
+        dispatchWorkspace({ type: 'conversation.toggled' })
+      }
+      onEnd={end}
+    />
+    <div
+      className={`workspace workspace-conversation-${
+        conversationOpen ? 'open' : 'closed'
+      }`}
+    >
+      <DiagramWorkspace
+        state={state}
+        drawing={drawing}
+        waiting={waiting}
+        reduceGraphics={reduceGraphics}
+        onNavigate={navigate}
+      />
+      {conversationOpen ? (
+        <ConversationSeparator
+          width={workspace.conversation.width}
+          onResize={(width, viewportWidth) =>
+            dispatchWorkspace({
+              type: 'conversation.resized',
+              width,
+              viewportWidth,
+            })
+          }
+        />
+      ) : null}
+      <ConversationPanel
+        state={state}
+        hidden={!conversationOpen}
+        disabled={!state.composerEnabled}
+        onSend={ask}
+        onChoice={choose}
+      />
+    </div>
+  </main>
+)
+```
+
+- [ ] **Step 5: Replace the page layout CSS without restyling the application**
+
+Keep the existing font imports, color tokens, reset, button/input typography, transcript bubbles, choices, diagnostics, reduced-motion rule, and `@font-face` declarations. Replace `.desk`, `.plan`, `.rail`, `.talk`, `.canvas`, `.views`, and their old desktop/mobile layout rules with the following structural rules; delete every now-unused rail and view-tab selector.
+
+```css
+.visual-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.command-strip {
+  position: relative;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: calc(var(--step) * 2);
+  min-height: 48px;
+  padding: calc(var(--step) * 0.75) calc(var(--step) * 2);
+  border-bottom: 1px solid var(--rule);
+  background: var(--sheet);
+}
+
+.command-identity,
+.command-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--step);
+}
+
+.command-identity h1 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  font-family: var(--display);
+  font-size: 15px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-actions select,
+.command-actions button {
+  min-height: 32px;
+}
+
+.session-details {
+  grid-column: 1 / -1;
+  padding-top: var(--step);
+  border-top: 1px solid var(--rule);
+}
+
+.session-details p {
+  max-width: 90ch;
+  margin: 0;
+  color: var(--quiet);
+}
+
+.attention-count {
+  min-width: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: var(--cobalt);
+  color: white;
+  font-size: 11px;
+  text-align: center;
+}
+
+.workspace {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.workspace-conversation-open {
+  grid-template-columns: minmax(0, 1fr) auto var(--conversation-width);
+}
+
+.workspace-conversation-closed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.diagram-workspace {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.canvas,
+.diagram {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.conversation-separator {
+  position: relative;
+  z-index: 3;
+  width: 10px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.conversation-separator::before {
+  position: absolute;
+  inset: 0 auto 0 4px;
+  width: 1px;
+  background: var(--rule);
+  content: '';
+}
+
+.conversation-separator:hover::before,
+.conversation-separator:focus-visible::before {
+  width: 2px;
+  background: var(--cobalt);
+}
+
+.talk {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--rule);
+  background: var(--sheet);
+}
+
+.talk[hidden] {
+  display: none;
+}
+
+.conversation-scroll {
+  min-height: 0;
+  overflow: auto;
+}
+
+.ledger {
+  min-height: 0;
+  overflow: visible;
+}
+
+@media (max-width: 899px) {
+  .command-strip {
+    grid-template-columns: 1fr;
+    gap: calc(var(--step) * 0.5);
+    padding-inline: var(--step);
+  }
+
+  .command-identity,
+  .command-actions {
+    gap: calc(var(--step) * 0.5);
+  }
+
+  .command-actions {
+    overflow-x: auto;
+  }
+
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
+    min-height: 0;
+  }
+
+  .conversation-separator {
+    display: none;
+  }
+
+  .talk {
+    max-height: 56dvh;
+    border-top: 1px solid var(--rule);
+    border-left: 0;
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -12px 36px rgb(19 35 57 / 14%);
+  }
+}
+```
+
+The explicit closed class removes the panel column entirely, while the HTML `hidden` attribute keeps the panel subtree and unsent draft mounted without exposing it visually or to assistive technology.
+
+- [ ] **Step 6: Verify the layout in a real browser**
+
+Rebuild, start the request from Step 1, and drive the page with the Browser tool at 1568×924:
+
+1. Confirm the compact command strip contains title, authority, connection, active-view selector, Details, Conversation, and End.
+2. Confirm no large title/description header or vertical fact rail remains.
+3. Confirm the diagram fills the viewport outside the open conversation.
+4. Collapse Conversation and confirm the canvas consumes the reclaimed width.
+5. Reopen it; pointer-drag the separator beyond both limits and confirm it settles within 320–640px while preserving at least 520px canvas.
+6. Focus the separator; verify ArrowLeft/ArrowRight move 8px and Shift+Arrow moves 32px within bounds.
+7. Close the panel, create background choice/diagnostic activity through the running visual session, and confirm an attention count appears without reopening the panel.
+8. Toggle Details and confirm the session description expands and collapses.
+
+Resize the same browser to 390×844 and confirm the open conversation is a bottom sheet, the separator is absent, the canvas remains the primary row, controls remain reachable, and `document.documentElement.scrollWidth === document.documentElement.clientWidth`.
+
+Expected: all observations pass; Browser console contains no errors; Network contains no non-loopback requests.
+
+- [ ] **Step 7: Run focused regressions**
+
+Run:
+
+```bash
+pnpm exec vitest run test/visual-workspace-state.test.ts test/visual-app-state.test.ts
+pnpm build:visual
+```
+
+Expected: both test files pass and the visual app builds.
+
+- [ ] **Step 8: Commit the workspace layout**
+
+```bash
+git add src/visual-app/App.tsx src/visual-app/styles.css
+git commit -m "feat: make visual sessions diagram first"
+```
+
+---
+
+### Task 3: Element and Relationship Contextual Questions
+
+**Files:**
+- Modify: `src/visual-app/App.tsx`
+- Modify: `src/visual-app/styles.css`
+- Modify: `test/fixtures/visual/model.json`
+
+**Interfaces:**
+- Consumes: Task 1 normalization and formatting functions; Task 2 `DiagramWorkspace` and `ConversationPanel` ownership seams; LikeC4 `onNodeClick(node, event)`, `onEdgeClick(edge, event)`, and `onNavigateTo(viewId, event, node)` callbacks.
+- Produces: private `SelectedSubjectInspector` and `ExpandableDescription` functions; selected-subject composer chip; exact contextual text through the unchanged `ask(text)` callback.
+- Preserves: selected subject across view navigation and `state.lifecycle === 'closed'`; clears it when `state.model?.candidate` changes.
+
+- [ ] **Step 1: Extend the proven fixture with descriptions for browser verification**
+
+In `test/fixtures/visual/model.json`:
+
+- Set the existing `streaming` element description and all three rendered `streaming` node descriptions to `{ "txt": "This option delivers each committed change as an event and applies it as it arrives. The path favors fast feedback over batch coordination. Operators can replay the event stream after an interruption. Literal safety probe: <img src=x onerror=window.visualSubjectPwned=true>." }`. At a 320px panel width this must exceed three inspector lines.
+- Add `{ "txt": "The review compares an event-driven delivery path with the current decision context. This relationship exists only in the temporary explanatory model." }` as `description` on model relation `5l0pi9` and on both rendered edge objects with ID `18l3bv3`.
+- Do not change coordinates, IDs, view membership, or relation arrays.
+Use JSON `txt`, not HTML or Markdown rendering metadata. Run the existing compiler fixture test to ensure LikeC4 still accepts the export:
+
+```bash
+pnpm exec vitest run test/visual-likec4-compiler.test.ts
+```
+
+Expected: PASS; the layouted fixture remains a valid compiled model.
+
+- [ ] **Step 2: Wire LikeC4 clicks into browser-local selection**
+
+Import the value functions `formatContextualQuestion`, `normalizeSelectedElement`, and `normalizeSelectedRelationship`, plus `type SelectedDiagramSubject`, from `workspace-state.ts`.
+
+Inside `DiagramWorkspace`, build the title lookup once for the active rendered view:
+
+```tsx
+const activeRenderedView = useMemo(
+  () => drawing.drawn?.findView(state.activeView)?.$layouted ?? null,
+  [drawing.drawn, state.activeView],
+)
+const nodeTitles = useMemo(
+  () =>
+    new Map(
+      (activeRenderedView?.nodes ?? []).map(
+        (node) => [String(node.id), node.title] as const,
+      ),
+    ),
+  [activeRenderedView],
+)
+```
+
+This uses LikeC4's public `findView(viewId).$layouted` rendering model and never parses `state.model.compiled`. Add a required `onSelect(subject: SelectedDiagramSubject): void` prop to `DiagramWorkspace`, then wire public callbacks:
+
+```tsx
+<ReactLikeC4
+  viewId={state.activeView}
+  onNodeClick={(node) => onSelect(normalizeSelectedElement(node))}
+  onEdgeClick={(edge) =>
+    onSelect(normalizeSelectedRelationship(edge, nodeTitles))
+  }
+  onNavigateTo={(viewId, _event, node) => {
+    if (node !== undefined) onSelect(normalizeSelectedElement(node))
+    onNavigate(viewId)
+  }}
+  enableElementDetails={false}
+  enableRelationshipDetails={false}
+/>
+```
+
+Keep every other renderer prop from Task 2 unchanged. In `App`, implement `onSelect` only as:
+
+```tsx
+(subject) => dispatchWorkspace({ type: 'subject.selected', subject })
+```
+
+No handler may call `ask`, `choose`, `navigate` except the explicit `onNavigateTo` branch above, or a session-client method.
+
+Track promoted model identity separately and clear stale selection only when `candidate` changes:
+
+```tsx
+const activeCandidate = useRef(state.model?.candidate ?? null)
+useEffect(() => {
+  const candidate = state.model?.candidate ?? null
+  if (candidate !== activeCandidate.current) {
+    activeCandidate.current = candidate
+    dispatchWorkspace({ type: 'model.replaced' })
+  }
+}, [state.model?.candidate])
+```
+
+Do not dispatch on view changes or lifecycle changes.
+
+- [ ] **Step 3: Add an accessible progressively disclosed description**
+
+Add `useLayoutEffect` to React imports. Implement `ExpandableDescription` with actual overflow measurement; a character-count heuristic is not acceptable because panel width and font metrics vary.
+
+```tsx
+const ExpandableDescription = ({
+  text,
+  expanded,
+  onToggle,
+}: {
+  readonly text: string | null
+  readonly expanded: boolean
+  readonly onToggle: () => void
+}) => {
+  const description =
+    text ?? 'No description declared in this model'
+  const body = useRef<HTMLParagraphElement>(null)
+  const [canExpand, setCanExpand] = useState(false)
+
+  useLayoutEffect(() => {
+    const element = body.current
+    if (element === null || expanded) return
+    const measure = () =>
+      setCanExpand(element.scrollHeight > element.clientHeight + 1)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [description, expanded])
+
+  return (
+    <div className="subject-description">
+      <p
+        ref={body}
+        className={expanded ? 'description-expanded' : 'description-clamped'}
+      >
+        {description}
+      </p>
+      {canExpand || expanded ? (
+        <button type="button" aria-expanded={expanded} onClick={onToggle}>
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+```
+
+When `description` changes, the reducer has already reset `expanded` to false; ResizeObserver re-measures after panel resize. Missing descriptions remain explicit and do not offer a disclosure button.
+
+- [ ] **Step 4: Render element and relationship inspector content**
+
+Add `SelectedSubjectInspector` above the transcript inside `ConversationPanel`. Its root is a labelled region with a real heading and clear action. Render all optional fields only when non-null/non-empty.
+
+```tsx
+const SelectedSubjectInspector = ({
+  subject,
+  expanded,
+  onToggleDescription,
+  onClear,
+  onNavigate,
+}: {
+  readonly subject: SelectedDiagramSubject
+  readonly expanded: boolean
+  readonly onToggleDescription: () => void
+  readonly onClear: () => void
+  readonly onNavigate: (viewId: string) => void
+}) => (
+  <section className="subject-inspector" aria-labelledby="subject-heading">
+    <div className="subject-heading-row">
+      <div>
+        <p className="subject-type">
+          {subject.type === 'element' ? 'Selected element' : 'Selected relationship'}
+        </p>
+        <h2 id="subject-heading">
+          {subject.type === 'element'
+            ? subject.title
+            : `${subject.sourceTitle} → ${subject.targetTitle}`}
+        </h2>
+      </div>
+      <button type="button" className="subject-clear" onClick={onClear}>
+        Clear
+      </button>
+    </div>
+
+    {subject.type === 'element' ? (
+      <dl className="subject-facts">
+        <div><dt>Identity</dt><dd><code>{subject.identity}</code></dd></div>
+        {subject.kind === null ? null : <div><dt>Kind</dt><dd>{subject.kind}</dd></div>}
+        {subject.technology === null ? null : <div><dt>Technology</dt><dd>{subject.technology}</dd></div>}
+        {subject.tags.length === 0 ? null : <div><dt>Tags</dt><dd>{subject.tags.join(', ')}</dd></div>}
+      </dl>
+    ) : (
+      <dl className="subject-facts">
+        <div><dt>Label</dt><dd>{subject.label ?? 'Unlabelled relationship'}</dd></div>
+        {subject.kind === null ? null : <div><dt>Kind</dt><dd>{subject.kind}</dd></div>}
+        {subject.technology === null ? null : <div><dt>Technology</dt><dd>{subject.technology}</dd></div>}
+        {subject.notation === null ? null : <div><dt>Notation</dt><dd>{subject.notation}</dd></div>}
+        <div>
+          <dt>Model relations</dt>
+          <dd>{subject.aggregateCount}</dd>
+        </div>
+      </dl>
+    )}
+
+    <ExpandableDescription
+      text={subject.description}
+      expanded={expanded}
+      onToggle={onToggleDescription}
+    />
+
+    {subject.type === 'element' && subject.navigateTo !== null ? (
+      <button
+        type="button"
+        className="subject-navigate"
+        onClick={() => {
+          if (
+            subject.type === 'element' &&
+            subject.navigateTo !== null
+          ) {
+            onNavigate(subject.navigateTo)
+          }
+        }}
+      >
+        Open related view
+      </button>
+    ) : null}
+  </section>
+)
+```
+
+
+- [ ] **Step 5: Add the removable composer chip and contextual submit path**
+
+Extend `ConversationPanel` props with `selectedSubject`, `descriptionExpanded`, `onToggleDescription`, `onClearSubject`, and `onNavigate`. Render the inspector as the first child of the existing `.conversation-scroll`, immediately before `<ol className="ledger">`.
+
+Inside the existing `<form className="composer">`, render this chip before the textarea:
+
+```tsx
+{selectedSubject === null ? null : (
+  <div className="subject-chip">
+    <span>
+      {selectedSubject.type === 'element'
+        ? selectedSubject.title
+        : `${selectedSubject.sourceTitle} → ${selectedSubject.targetTitle}`}
+    </span>
+    <button
+      type="button"
+      aria-label="Remove selected diagram context"
+      onClick={onClearSubject}
+    >
+      Remove
+    </button>
+  </div>
+)}
+```
+
+Set placeholder copy from the subject kind while preserving the existing read-only copy:
+
+```tsx
+placeholder={
+  !state.chatEnabled
+    ? 'This session is read-only'
+    : selectedSubject?.type === 'element'
+      ? 'Ask about this element'
+      : selectedSubject?.type === 'relationship'
+        ? 'Ask about this relationship'
+        : 'Ask about this design'
+}
+```
+
+Keep `ConversationPanel` responsible only for trimming the reviewer draft. At the `App` callsite, format immediately before the unchanged seam:
+
+```tsx
+onSend={(text) => ask(formatContextualQuestion(text, workspace.selectedSubject))}
+```
+
+The existing `chat.sent` reducer records the same string `ask` sends, so the visible reviewer transcript becomes the audit of contextual text without a new event or state field.
+
+- [ ] **Step 6: Style the inspector and allow one panel scroll hierarchy**
+
+Keep `.talk` as the two-row `minmax(0, 1fr) auto` grid from Task 2. The inspector, transcript, diagnostics, and choices all live in `.conversation-scroll`, so expanded descriptions and long conversations share one vertical scrollbar while the composer stays reachable; do not restore overflow on `.ledger` or create nested horizontal scrolling.
+
+Add these styles using existing color/type tokens:
+
+```css
+.subject-inspector {
+  padding: calc(var(--step) * 1.5);
+  border-bottom: 1px solid var(--rule);
+  background: color-mix(in srgb, var(--sheet) 92%, var(--cobalt) 8%);
+}
+
+.subject-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--step);
+}
+
+.subject-type {
+  margin: 0 0 calc(var(--step) * 0.25);
+  color: var(--quiet);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.subject-heading-row h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.subject-facts {
+  display: grid;
+  gap: calc(var(--step) * 0.5);
+  margin: var(--step) 0;
+}
+
+.subject-facts > div {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr);
+  gap: var(--step);
+}
+
+.subject-facts dt {
+  color: var(--quiet);
+  font-size: 11px;
+}
+
+.subject-facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.subject-description p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.description-clamped {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.subject-description button,
+.subject-navigate,
+.subject-clear {
+  margin-top: calc(var(--step) * 0.5);
+  min-height: 28px;
+}
+
+.subject-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--step);
+  margin-bottom: calc(var(--step) * 0.75);
+  padding: calc(var(--step) * 0.5) calc(var(--step) * 0.75);
+  border: 1px solid var(--cobalt);
+  border-radius: 999px;
+  color: var(--cobalt);
+}
+
+.subject-chip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subject-chip button {
+  flex: none;
+  min-height: 24px;
+  padding: 0 calc(var(--step) * 0.5);
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+```
+
+On mobile, keep the inspector inside the same non-modal bottom sheet. Do not add `position: fixed`, a backdrop, `role="dialog"`, or focus trapping.
+
+- [ ] **Step 7: Run focused automated checks**
+
+Run:
+
+```bash
+pnpm exec vitest run test/visual-workspace-state.test.ts test/visual-app-state.test.ts test/visual-likec4-compiler.test.ts
+pnpm build:visual
+```
+
+Expected: all tests pass; TypeScript accepts `DiagramNode` and `DiagramEdge` callback payloads as the structural normalization inputs; the visual app build succeeds.
+
+- [ ] **Step 8: Exercise the full selection journey in a real browser**
+
+Start a fresh chat-enabled session with the Task 2 request and drive it at 1568×924:
+
+1. Click an element. Confirm the panel opens without focus theft and shows title, stable identity, kind/technology/tags when present, and its description.
+2. Use **Show more** and **Show less** on the long element description.
+3. Remove the composer chip. Confirm the inspector clears and the unsent draft remains unchanged.
+4. Click a relationship. Confirm endpoints, label, description, optional metadata, and model-relation count.
+5. Type `Why is this path preferred?`, submit once, and confirm the reviewer transcript is exactly `About relationship “Delivery design review → Option 1 - Event-driven delivery — compares”: Why is this path preferred?` for the one-relation fixture.
+6. Read the session journal before and after clicking a non-navigating element or relationship without submission; confirm the record count is unchanged.
+7. Submit a second contextual question, then follow `skills/yarramate-architecture/references/visual-conversations.md` with the running session descriptor: poll the accepted `chat.message` event and answer that same `eventId` with a valid `model.replace` response. Confirm the promoted replacement clears the subject and chip while leaving the panel open.
+8. Navigate through a node with `navigateTo`; confirm selection survives and identifies the originating node.
+9. Select a subject again and End the session. Confirm the closed session retains the inspector and diagram, while textarea and Send remain disabled.
+
+Repeat at 390×844. Confirm the same inspector/chip behavior inside the bottom sheet, **Show more** does not create horizontal overflow, controls remain keyboard reachable, and focus is not trapped.
+
+Check Browser console and network after both dimensions:
+
+- zero console errors;
+- zero non-loopback requests;
+- no DOM element created from description markup;
+- `document.documentElement.scrollWidth === document.documentElement.clientWidth`.
+
+- [ ] **Step 9: Remove superseded presentation artifacts**
+
+After the browser smoke is green, search `src/visual-app/App.tsx` and `src/visual-app/styles.css` for the exact obsolete symbols/selectors below:
+
+```text
+Rail
+ChatPanel
+className=\"desk\"
+className=\"plan\"
+className=\"rail\"
+className=\"views\"
+.desk
+.plan
+.rail
+.views
+```
+
+Delete any remaining declarations or rules owned by the replaced header/rail/view-tab layout. Search `src/visual-app` for `dangerouslySetInnerHTML`; expected result is empty. Do not remove current transcript, choice, diagnostic, renderer-fault, reduced-motion, or font rules. Confirm the smoke request and any model-replacement helper remain under `/tmp`, not the worktree.
+
+- [ ] **Step 10: Run final repository verification once**
+
+Run the project-wide checks only after the browser journey passes:
+
+```bash
+pnpm build
+pnpm test
+pnpm self:check
+pnpm validate
+```
+
+Expected: build succeeds; the full Vitest suite passes; self-model check returns `ok`; package validation succeeds. Existing nine visual protocol/schema tests remain unchanged and green.
+
+- [ ] **Step 11: Commit the contextual-selection feature**
+
+```bash
+git add src/visual-app/App.tsx src/visual-app/styles.css test/fixtures/visual/model.json
+git commit -m "feat: add visual subject context"
+```

--- a/docs/superpowers/plans/2026-08-09-visual-descriptor-and-chat-hardening.md
+++ b/docs/superpowers/plans/2026-08-09-visual-descriptor-and-chat-hardening.md
@@ -1,0 +1,193 @@
+# Visual Descriptor and Chat Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent visual client commands from blocking on FIFO descriptors and make embedded-chat capability require a real delegated visual LLM agent.
+
+**Architecture:** Keep the published visual protocol unchanged. Harden the private descriptor's existing open-then-`stat` boundary with non-blocking filesystem flags, and tighten the canonical harness journey so a transport-only responder cannot be presented as embedded chat.
+
+**Tech Stack:** Node.js 22, TypeScript, Vitest, POSIX `mkfifo`, YarraMate visual session protocol, Markdown skill instructions.
+
+## Global Constraints
+
+- No schema, protocol, browser UI, session lifecycle, or authority change.
+- The runtime remains model-provider-neutral.
+- Diagram-only fallback remains mandatory when the harness cannot attach and supervise a delegated visual LLM agent.
+- Repeated-stop semantics, generic symlink diagnostics, and the existing `O_NOFOLLOW` portability tradeoff remain unchanged.
+- FIFO descriptors must fail closed with `YMVS401` and must not expose the agent capability.
+
+---
+
+### Task 1: Make descriptor opening non-blocking
+
+**Files:**
+- Modify: `src/adapters/visual/client.ts:149-176`
+- Test: `test/visual-cli.test.ts:1-120,448-480`
+
+**Interfaces:**
+- Consumes: `readVisualSessionDescriptor(path: string, cwd?: string): Promise<ParseResult<VisualSessionDescriptor>>`
+- Produces: unchanged descriptor parsing API; hostile FIFO entries return the existing `YMVS401` refusal promptly.
+
+- [ ] **Step 1: Write the failing FIFO subprocess test**
+
+Add `execFileSync` and `spawnSync` from `node:child_process`, define the repository root from `import.meta.url`, and add this POSIX-only case under `descriptor confinement`:
+
+```ts
+it.runIf(process.platform !== 'win32')(
+  'refuses a FIFO descriptor without waiting for a writer',
+  async () => {
+    const fifo = join(workDir, 'descriptor.fifo')
+    execFileSync('mkfifo', [fifo])
+
+    const result = spawnSync(
+      process.execPath,
+      ['dist/adapters/visual-cli.js', 'status', fifo],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        timeout: 1000,
+      },
+    )
+
+    expect(result.signal).toBeNull()
+    expect(result.status).toBe(1)
+    expect(
+      parseVisualDiagnosticResult(JSON.parse(result.stderr)),
+    ).toMatchObject({
+      ok: true,
+      value: { diagnostics: [{ code: 'YMVS401' }] },
+    })
+  },
+)
+```
+
+Use:
+
+```ts
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+```
+
+The child-process timeout is part of the assertion: the pre-fix implementation is killed instead of hanging the Vitest worker.
+
+- [ ] **Step 2: Build the current implementation and prove the regression is red**
+
+Run:
+
+```sh
+pnpm build:node
+pnpm exec vitest run test/visual-cli.test.ts -t "refuses a FIFO descriptor"
+```
+
+Expected: FAIL because `spawnSync` reports `SIGTERM`/timeout rather than an exit-1 `YMVS401` diagnostic.
+
+- [ ] **Step 3: Add the minimal descriptor-open flag**
+
+Change the descriptor open flags to:
+
+```ts
+constants.O_RDONLY |
+  constants.O_NONBLOCK |
+  (constants.O_NOFOLLOW ?? 0)
+```
+
+Keep the single opened handle, `handle.stat()`, regular-file check, `handle.readFile('utf8')`, diagnostics, and close behavior unchanged.
+
+- [ ] **Step 4: Rebuild and prove the regression is green**
+
+Run:
+
+```sh
+pnpm build:node
+pnpm exec vitest run test/visual-cli.test.ts -t "descriptor confinement"
+```
+
+Expected: all descriptor-confinement tests pass; the FIFO child exits 1 with `YMVS401` before the 1000 ms timeout.
+
+- [ ] **Step 5: Commit the security hardening**
+
+```sh
+git add src/adapters/visual/client.ts test/visual-cli.test.ts
+git commit -m "fix: reject visual descriptor FIFOs without blocking"
+```
+
+---
+
+### Task 2: Tighten embedded-chat capability instructions
+
+**Files:**
+- Modify: `skills/yarramate-architecture/references/visual-conversations.md:68-82,154-188`
+
+**Interfaces:**
+- Consumes: the existing four-part harness capability gate and delegated-agent `wait`/`respond` loop.
+- Produces: an explicit orchestration invariant: `chatEnabled: true` means a real delegated visual LLM child will be attached; canned, scripted, and transport-only responders do not qualify.
+
+- [ ] **Step 1: Add the capability guard**
+
+Immediately after the four capability requirements, add:
+
+```markdown
+`chatEnabled: true` also means the parent will attach the delegated visual LLM
+agent described below. A canned, scripted, or transport-only responder may test
+the wire, but it does not satisfy this capability gate and must not be presented
+to the user as embedded chat. If no delegated LLM child will own the
+`wait`/`respond` loop, use diagram-only mode.
+```
+
+Under **Delegate the visual agent**, add one sentence before the child prompt:
+
+```markdown
+Do not replace this child with a fixed-response script: the protocol is
+model-provider-neutral, but the embedded conversation still requires the
+harness's delegated LLM.
+```
+
+- [ ] **Step 2: Check packaging still carries the canonical skill**
+
+Run:
+
+```sh
+pnpm build
+pnpm exec vitest run test/package-consumer.test.ts
+```
+
+Expected: package-consumer tests pass and the packed `yarramate/skill/yarramate-architecture` export resolves to the skill containing `references/visual-conversations.md`.
+
+- [ ] **Step 3: Commit the orchestration guard**
+
+```sh
+git add skills/yarramate-architecture/references/visual-conversations.md
+git commit -m "docs: require a delegated LLM for visual chat"
+```
+
+---
+
+### Task 3: Exercise the corrected journey and verify the PR
+
+**Files:**
+- No source changes expected.
+
+**Interfaces:**
+- Consumes: `yarramate-visual start/wait/respond/recover/stop`, a managed foreground process, and a real delegated visual LLM child.
+- Produces: browser-visible evidence that an arbitrary in-scope question reaches the delegated LLM, plus complete repository verification.
+
+- [ ] **Step 1: Start a canonical chat-enabled visual session**
+
+Use `.yarramate-out/visual-runtime-request.json`, launch `yarramate-visual start` through the harness's managed-process facility, and capture the emitted `browserUrl` and `descriptorPath`. Do not attach a scripted responder.
+
+- [ ] **Step 2: Attach the delegated visual LLM child**
+
+Delegate one child with the exact authority prompt from `skills/yarramate-architecture/references/visual-conversations.md`, the emitted descriptor path, and the checked `visual-conversation-path` slice. The child must loop on `wait`, generate answers from the bounded slice, and publish them with `respond`.
+
+- [ ] **Step 3: Exercise browser chat and End**
+
+Open `browserUrl`, send `What happens after I press End?`, and confirm the browser receives a generated answer explaining the handoff lifecycle rather than the former canned LikeC4 prompt. Press End, observe the preparing/handoff-ready/closed status progression, recover the structured handoff, and stop the managed process.
+
+- [ ] **Step 4: Run complete verification**
+
+Run:
+
+```sh
+pnpm verify
+```
+
+Expected: typecheck, build, all tests, self-check, and LikeC4 validation pass. The existing Vite chunk-size warning is non-failing and unchanged.

--- a/docs/superpowers/plans/2026-08-09-visual-end-transition-feedback.md
+++ b/docs/superpowers/plans/2026-08-09-visual-end-transition-feedback.md
@@ -1,0 +1,226 @@
+# Visual End Transition Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the command strip explain the observable handoff and return-to-main-agent stages after the reviewer presses End.
+
+**Architecture:** Derive presentation copy from the existing `VisualAppState.lifecycle` and `VisualAppState.handoff` fields inside the visual React application. Keep transport, schemas, and reducer behavior unchanged; render one persistent live region so assistive technology receives each stage transition.
+
+**Tech Stack:** TypeScript, React 19, server-rendered React regression tests, Vitest, CSS.
+
+## Global Constraints
+
+- Show compact, always-visible transition feedback in the command strip.
+- Do not change the versioned visual-session protocol.
+- Do not claim that the main harness has resumed; the browser cannot observe that event.
+- Keep the diagram visible; do not add a modal, overlay, or completion screen.
+- Preserve the existing transcript notice as the durable session record.
+- Preserve the uncommitted spinner changes already present in this PR worktree.
+
+---
+
+### Task 1: Render observable End-transition stages
+
+**Files:**
+- Modify: `test/visual-app-render.test.ts:1-74`
+- Modify: `src/visual-app/App.tsx:85-168`
+- Modify: `src/visual-app/styles.css:80-167`
+- Modify: `tsconfig.json`
+- Modify: `tsconfig.visual.json`
+
+**Interfaces:**
+- Consumes: `VisualAppState.lifecycle`, whose relevant values are `'active'`, `'ending'`, and `'closed'`; `VisualAppState.handoff`, which becomes non-null after `handoff.complete`.
+- Produces: a private `endTransitionStatus(state: VisualAppState): string` presentation helper and an always-mounted `.end-transition-status` live region in `CommandStrip`.
+
+- [ ] **Step 1: Make the real-App render fixture support lifecycle overrides**
+
+Import `VisualAppState` as a type, make the complete fixture the hoisted baseline, and add a helper that resets it before every render:
+
+```tsx
+import type { VisualAppState } from '../src/visual-app/state.js'
+
+const session = vi.hoisted(() => {
+  const baseState: VisualAppState = {
+    lifecycle: 'active',
+    authority: 'canonical',
+    title: 'Visual architecture conversation',
+    description: 'Checked architecture slice',
+    chatEnabled: true,
+    model: null,
+    styleNonce: '',
+    activeView: '',
+    transcript: [
+      { id: 'local-0', speaker: 'reviewer', text: 'What happens next?' },
+    ],
+    choices: null,
+    agentStatus: null,
+    diagnostics: [],
+    handoff: null,
+    composerEnabled: false,
+    awaitingAgent: true,
+    localRecords: 1,
+    lastSequence: 1,
+    frozen: false,
+    closedReason: null,
+  }
+  return { baseState, state: baseState }
+})
+
+const renderSession = (overrides: Partial<VisualAppState> = {}): string => {
+  session.state = { ...session.baseState, ...overrides }
+  return renderToStaticMarkup(createElement(App))
+}
+```
+
+The existing pending-agent test must call `renderSession()` so it continues defending the spinner change.
+
+- [ ] **Step 2: Write failing render tests for the three observable stages**
+
+Add these assertions to `test/visual-app-render.test.ts`:
+
+```tsx
+it('explains that End is preparing the main-agent handoff', () => {
+  const markup = renderSession({ lifecycle: 'ending', handoff: null })
+
+  expect(markup).toContain('role="status"')
+  expect(markup).toContain('aria-live="polite"')
+  expect(markup).toContain('Ending conversation — preparing a handoff for the main agent.')
+  expect(markup).toContain('>Ending…</button>')
+})
+
+it('reports when the handoff is ready for the main agent', () => {
+  const markup = renderSession({
+    lifecycle: 'ending',
+    handoff: {
+      summary: 'Option B confirmed.',
+      confirmedDecisions: ['option-b'],
+      requestedChanges: [],
+      unresolvedQuestions: [],
+      finalViews: ['overview'],
+    },
+  })
+
+  expect(markup).toContain('Handoff ready — returning control to the main agent.')
+})
+
+it('directs the reviewer to continue after the visual session closes', () => {
+  const markup = renderSession({ lifecycle: 'closed' })
+
+  expect(markup).toContain('Visual conversation ended. Continue in the main agent.')
+})
+```
+
+
+- [ ] **Step 3: Run the render test and verify the new contract fails**
+
+Run:
+
+```bash
+pnpm vitest run test/visual-app-render.test.ts
+```
+
+Expected: the existing pending-agent case passes; the new cases fail because the command strip has no End-transition live region and the button still reads `End`.
+
+- [ ] **Step 4: Add the lifecycle-to-copy mapping**
+
+In `src/visual-app/App.tsx`, add this private helper beside the command-strip presentation helpers:
+
+```tsx
+const endTransitionStatus = (state: VisualAppState): string => {
+  if (state.lifecycle === 'closed') {
+    return 'Visual conversation ended. Continue in the main agent.'
+  }
+  if (state.lifecycle !== 'ending') return ''
+  if (state.handoff !== null) {
+    return 'Handoff ready — returning control to the main agent.'
+  }
+  return 'Ending conversation — preparing a handoff for the main agent.'
+}
+```
+
+This ordering makes terminal closure authoritative, then distinguishes a received handoff from the immediate ending state. It does not infer that the parent harness resumed.
+
+- [ ] **Step 5: Render the persistent inline live region and action label**
+
+Inside `.command-actions`, before the existing view selector, render the live region on every lifecycle so it exists before its text changes:
+
+```tsx
+<span
+  className="end-transition-status"
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+>
+  {endTransitionStatus(state)}
+</span>
+```
+
+Change the End button content without changing its existing disabled rule:
+
+```tsx
+{state.lifecycle === 'active' ? 'End' : 'Ending…'}
+```
+
+Do not disable navigation or disclosure controls; the existing reducer already freezes conversation input, and the design does not expand that behavior.
+
+- [ ] **Step 6: Style the status as compact command-strip information**
+
+Add a focused rule in `src/visual-app/styles.css` near `.connection-state`:
+
+```css
+.end-transition-status {
+  max-width: 28rem;
+  font-family: var(--utility);
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--quiet);
+}
+
+.end-transition-status:empty {
+  display: none;
+}
+```
+
+Keep the existing narrow-screen `.command-actions` horizontal overflow behavior; do not introduce a new responsive layout.
+
+- [ ] **Step 7: Run the focused regression suite**
+
+Run:
+
+```bash
+pnpm vitest run test/visual-app-render.test.ts test/visual-app-state.test.ts test/visual-journey.test.ts
+```
+
+Expected: all three files pass, including the existing End journal/recovery assertions and pending-agent spinner assertion.
+
+- [ ] **Step 8: Verify type ownership and the visual build**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm build:visual
+```
+
+Expected: both commands exit 0. The existing visual bundle chunk-size warning is acceptable; new TypeScript or build diagnostics are not.
+
+- [ ] **Step 9: Smoke-test the real End transition in a fresh visual session**
+
+Start the canonical visual journey from the PR worktree with `.yarramate/projections/visual-conversation-path.yaml`, open the browser, and press End. Observe, in order:
+
+1. `Ending…` and `Ending conversation — preparing a handoff for the main agent.` appear immediately.
+2. Conversation input is unavailable while the diagram remains visible.
+3. If `handoff.complete` arrives before closure, `Handoff ready — returning control to the main agent.` appears.
+4. On the closing frame, `Visual conversation ended. Continue in the main agent.` appears.
+5. The main agent recovers the structured handoff, stops the runtime normally, and confirms temporary-session cleanup.
+
+Record only stages actually observed. A transition can be too fast to visually sample the handoff-ready intermediate copy; the render test remains deterministic coverage for that state.
+
+- [ ] **Step 10: Commit the implementation without absorbing unrelated worktree changes**
+
+```bash
+git add src/visual-app/App.tsx src/visual-app/styles.css test/visual-app-render.test.ts tsconfig.json tsconfig.visual.json
+git commit -m "feat: explain visual session handoff on end"
+```
+
+Before committing, inspect the staged file list and confirm it contains exactly the five cohesive spinner and End-feedback files named above.

--- a/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
@@ -147,11 +147,11 @@ yarramate-visual stop <session-descriptor.json>
 
 All machine-readable output uses versioned JSON documents. Commands return non-zero with a versioned diagnostic result on failure.
 
-`start` runs in the foreground so the harness can own the process tree. It writes the session descriptor as its first JSON line, then serves until `stop` or a termination signal. The skill must launch it through the harness's managed long-running-process facility rather than relying on daemonization.
+`start` runs in the foreground so the harness can own the process tree. Its first JSON line is a public `yarramate/visual-session-started/v1` result containing the session ID, authenticated browser URL, private descriptor path, protocol version, and capabilities; it never contains the agent capability. The private `yarramate/visual-session-descriptor/v1` file is mode `0600` and contains the local agent credential used by the one-shot commands. After emitting the public result, `start` serves until `stop` or a termination signal. The skill must launch it through the harness's managed long-running-process facility rather than relying on daemonization.
 
 The `yarramate/visual-session-request/v1` input contains the authority mode (`canonical` or `ad-hoc`), title and description, initial complete model, chat-enabled flag, trusted LikeC4 compiler command vector, and source digests for canonical input. Browser URLs, session identifiers, capabilities, ports, and filesystem locations are runtime outputs and cannot be supplied by the browser.
 
-- `start` creates the permission-restricted temporary session, starts the foreground localhost server, and emits a session descriptor containing the session ID, authenticated URL, protocol version, and capability metadata.
+- `start` creates the permission-restricted temporary session, starts the foreground localhost server, emits the public started result, and writes the private session descriptor.
 - `wait` blocks until the next event after the supplied sequence or until a terminal/timeout condition.
 - `respond` publishes an agent message, status update, choice set, or complete rendered-model revision correlated to one browser event.
 - `status` reports server, browser, child-agent, queue, and lifecycle state without mutation.

--- a/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
@@ -312,7 +312,7 @@ The raw transcript is returned only on demand and remains available until the ma
 | Browser disconnects | Retain the session for five minutes; do not infer End or approval. Recover and stop when the grace period expires. |
 | Runtime process exits | Recover from the append-only journal in the session directory. |
 | Main agent interrupts | Cancel child, recover confirmed state, then stop. |
-| Stop is repeated | Be idempotent and report the already-stopped state. |
+| Stop is repeated | Be idempotent and report the already-stopped state. A completed stop takes the descriptor with the session root, so a stop whose descriptor path **and** its containing session root are both absent reports that state: exit 0, no handoff document, because no session remains to hand one off. Every other unreadable, corrupt, redirected, or foreign descriptor still refuses. The fail-closed read is not relaxed to buy idempotency, and no credential is retained to make a later stop readable. |
 | Orphan session remains | Prune it when a later `start` finds it older than 24 hours. |
 
 Normal shutdown deletes immediately. A hard-killed process may leave a temporary directory; a later start removes it once its modification time is more than 24 hours old. The prune operation is confined to directories carrying a valid YarraMate visual-session marker.

--- a/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-architecture-conversations-design.md
@@ -1,0 +1,417 @@
+# Visual architecture conversations
+
+**Status:** Approved design
+**Date:** 2026-08-08
+**Scope:** YarraMate package, canonical `yarramate-architecture` skill, and self-model
+
+## Summary
+
+Add a user-facing visual explanation journey initiated through the `yarramate-architecture` skill. A user may ask YarraMate to visually explain checked repository architecture, a general question, or design choices. The journey opens a custom browser application that combines LikeC4 rendering, descriptions, linked overview/detail views, and a chat widget.
+
+A new sibling binary, `yarramate-visual`, owns the browser application, local transport, session journal, renderer lifecycle, recovery, and cleanup. It never calls a model provider. On capable agent harnesses, the main agent delegates a bounded visual agent that communicates with the browser through a blocking, versioned session protocol. On End or failure, the delegated agent returns a structured handoff and the main agent resumes. Unsupported harnesses receive the same renderer in diagram-only mode and continue the conversation in the main harness.
+
+The main agent remains authoritative throughout. The visual agent cannot edit repository files or canonical YarraMate documents.
+
+## Goals
+
+- Let a user request a visual explanation using natural language in an agent harness.
+- Render checked YarraMate architecture without converting inferred evidence into declared intent.
+- Support explicitly labeled ad hoc diagrams for general questions and design choices.
+- Present choices as a comparison overview linked to one detail view per option.
+- Keep diagram discussion, selections, and revisions inside the browser when the harness supports delegation.
+- Return control and a recoverable handoff to the main agent on End or any failure.
+- Stop the local webserver and delete temporary artifacts when the visual conversation ends.
+- Preserve a diagram-only fallback without additional model credentials.
+
+## Non-goals
+
+- A general-purpose browser coding agent.
+- Repository or `.yarramate/` writes from the delegated visual agent.
+- A model-provider client, credential store, or provider abstraction in `yarramate-visual`.
+- A hosted or remotely accessible visualization service.
+- Promotion of ad hoc conversation content into canonical architecture.
+- Replacement of the existing LikeC4 export adapter or the stable semantic CLI.
+- Resumable delegated agents after End; End terminates the child and server.
+
+## User experience
+
+### Entry point
+
+The user asks an agent using `yarramate-architecture`, for example:
+
+- “Visually explain this architecture.”
+- “Show how this question relates to the current model.”
+- “Compare these choices visually.”
+- “Open a visual conversation about this flow.”
+
+No new command is required from the user. The skill remains the public orchestration interface.
+
+### Source authority
+
+The journey is model-first:
+
+1. For repository architecture, require a workspace that passes `yarramate check`.
+2. Query the relevant canonical slice with `yarramate ask <workspace> "<topic>" --json`.
+3. Prefer an authored LikeC4 view when it answers the request.
+4. Otherwise generate a temporary grounded view containing only concepts, relationships, and descriptions present in the checked projection result.
+5. If no valid workspace exists, offer the existing discovery journey before depicting repository architecture.
+
+For general concepts, questions, and alternatives, the visual agent may create a temporary ad hoc LikeC4 representation. The browser must label that representation as ad hoc and non-canonical. It must not imply that conversational claims are declared YarraMate intent.
+
+### Choice presentation
+
+Design choices use:
+
+- one compact comparison overview containing the question, options, principal consequences, and any recommendation;
+- one linked detail view per option;
+- navigation from the overview to each detail view;
+- descriptions that state the source and authority of the rendered information.
+
+### Browser layout
+
+The custom browser application contains:
+
+- the active LikeC4 diagram;
+- view title, description, authority label, and navigation;
+- linked overview and drill-down views;
+- chat transcript and composer;
+- structured choice controls when the visual agent presents alternatives;
+- connection, compilation, and agent status;
+- an always-visible **End conversation** control.
+
+On End, input freezes immediately, the handoff completes, the browser session closes, the server stops, and control returns to the main harness.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    U[User] --> M[Main agent harness]
+    M --> S[yarramate-architecture skill]
+    S --> C{Harness can delegate?}
+    C -->|yes| V[yarramate-visual]
+    C -->|no| D[Diagram-only visual session]
+    S --> A[Delegated visual agent]
+    A <-->|wait / respond| V
+    V <-->|WebSocket / HTTP| B[Custom browser application]
+    V --> L[LikeC4 renderer]
+    V --> J[Append-only session journal]
+    A --> Q[yarramate check / ask]
+    Q --> A
+    B -->|End| V
+    V -->|terminal event| A
+    A -->|structured handoff| M
+    M -->|recover then stop| V
+    D --> M
+```
+
+### Runtime boundary
+
+`yarramate-visual` is a sibling binary in the existing `yarramate` package, beside `yarramate-likec4`. It is presentation/runtime behavior and does not become a subcommand of the tool-neutral `yarramate` semantic CLI.
+
+The package includes a prebuilt browser bundle using LikeC4's public React/model interfaces. LikeC4's React renderer is compiled into that bundle at package-build time. At session runtime, `yarramate-visual` invokes a separately resolved LikeC4 compiler command to validate, lay out, and export candidate models; the browser never parses source.
+
+The initial compatibility range is `likec4 >=1.59.2 <1.60.0`, and the consented fallback runner is pinned to `likec4@1.59.2`. The skill prefers a repository-local executable in that range. If none exists, it asks once before resolving the pinned runner for the session. The trusted main agent records the resolved command vector in the session request; browser and delegated-agent events cannot change it. No dependency is added to the target repository, and the visual runtime never downloads tooling without approval.
+
+The semantic YarraMate binaries retain the package's existing Node.js contract. Starting a visual session additionally requires the selected LikeC4 compiler's Node.js floor; for the initial pinned compiler this is Node.js `>=22.22.3`. An older compatible YarraMate host receives a visual-preflight diagnostic rather than a broken server.
+
+## Module interfaces
+
+### `yarramate-architecture` skill
+
+Responsibilities:
+
+- recognize visual explanation requests;
+- classify repository-grounded versus ad hoc content;
+- validate model authority and obtain a bounded slice;
+- detect harness delegation capability;
+- resolve a compatible LikeC4 runtime;
+- start the visual session and open the browser;
+- delegate and await the visual agent when supported;
+- recover the handoff before cleanup;
+- continue in the main harness after End or failure.
+
+The skill contains orchestration policy, not the server or renderer implementation.
+
+### `yarramate-visual` runtime
+
+The runtime exposes a small blocking CLI interface:
+
+```text
+yarramate-visual start <session-request.json>
+yarramate-visual wait <session-descriptor.json> --after <sequence>
+yarramate-visual respond <session-descriptor.json> <response.json>
+yarramate-visual status <session-descriptor.json>
+yarramate-visual recover <session-descriptor.json> [--transcript]
+yarramate-visual stop <session-descriptor.json>
+```
+
+All machine-readable output uses versioned JSON documents. Commands return non-zero with a versioned diagnostic result on failure.
+
+`start` runs in the foreground so the harness can own the process tree. It writes the session descriptor as its first JSON line, then serves until `stop` or a termination signal. The skill must launch it through the harness's managed long-running-process facility rather than relying on daemonization.
+
+The `yarramate/visual-session-request/v1` input contains the authority mode (`canonical` or `ad-hoc`), title and description, initial complete model, chat-enabled flag, trusted LikeC4 compiler command vector, and source digests for canonical input. Browser URLs, session identifiers, capabilities, ports, and filesystem locations are runtime outputs and cannot be supplied by the browser.
+
+- `start` creates the permission-restricted temporary session, starts the foreground localhost server, and emits a session descriptor containing the session ID, authenticated URL, protocol version, and capability metadata.
+- `wait` blocks until the next event after the supplied sequence or until a terminal/timeout condition.
+- `respond` publishes an agent message, status update, choice set, or complete rendered-model revision correlated to one browser event.
+- `status` reports server, browser, child-agent, queue, and lifecycle state without mutation.
+- `recover` returns the structured summary and, only when requested, the raw transcript.
+- `stop` first performs recoverable shutdown, terminates the server process tree, and deletes temporary artifacts.
+
+The runtime owns:
+
+- HTTP and WebSocket transport;
+- session authentication and isolation;
+- event sequencing, acknowledgement, and journaling;
+- browser application assets;
+- LikeC4 validation, compilation, layout, and last-good rendering state;
+- lifecycle and orphan cleanup.
+
+It does not own model inference, canonical architecture, agent credentials, or repository changes.
+
+### Custom browser application
+
+The browser application uses LikeC4's public `LikeC4View` and model-provider interfaces inside a YarraMate-owned React layout. It renders only versioned model payloads accepted by the runtime.
+
+Browser events are protocol messages. Browser input cannot choose executables, filesystem paths, repository writes, or shell commands.
+
+### Delegated visual agent
+
+The main harness provides:
+
+- the user's question;
+- the checked YarraMate slice or an explicit ad hoc authority marker;
+- read-only repository/model context needed for the explanation;
+- the session descriptor;
+- the temporary-write-only authority contract.
+
+The visual agent may:
+
+- call read-only YarraMate commands;
+- answer browser questions within the bounded context;
+- create or replace temporary visual model sources;
+- propose choices and record confirmed selections;
+- return requested repository changes for later main-agent review.
+
+It may not edit repository files, `.yarramate/`, credentials, or harness configuration.
+
+## Session protocol
+
+### Event properties
+
+Every event contains:
+
+- protocol format and version;
+- session ID;
+- monotonically increasing sequence;
+- unique event ID;
+- event type;
+- timestamp generated by the runtime;
+- payload validated for that event type.
+
+Agent responses additionally contain the triggering event ID. Duplicate response IDs are idempotent. Cross-session identifiers are rejected.
+
+### Browser event types
+
+The first release supports:
+
+- `chat.message`;
+- `choice.selected`;
+- `view.navigate`;
+- `session.end`;
+- `browser.connected` and `browser.disconnected`.
+
+Navigation events may be journaled for context but do not require an agent response unless explicitly marked as a user question or selection.
+
+### Agent response types
+
+The first release supports:
+
+- `chat.response`;
+- `agent.status`;
+- `choice.present`;
+- `model.replace`;
+- `handoff.complete`;
+- `diagnostic`.
+
+`model.replace` carries a complete candidate temporary model payload. Partial patches are excluded from the first release so validation and recovery operate on one atomic replacement.
+
+The candidate uses `yarramate/visual-model/v1`: an authority label, initial view ID, source digests, and a complete `files` map. File keys are normalized relative POSIX paths confined to the candidate root; accepted files are `likec4.config.json` and UTF-8 `.c4`/`.likec4` sources. Absolute paths, parent traversal, symlinks, binaries, and unknown file types are rejected. The runtime stages each accepted replacement in a fresh candidate directory and advances the active-model pointer only after successful validation and compilation.
+
+### Turn ordering
+
+One agent turn is in flight per session. The browser may continue diagram navigation while waiting, but additional chat messages are visibly queued. The next chat turn is released only after the current event receives a response or terminal diagnostic.
+
+The runtime appends an accepted browser event before acknowledging it. It appends an accepted agent response before broadcasting it. A crash therefore cannot acknowledge an event that recovery cannot see.
+
+## Rendering flow
+
+### Repository-grounded view
+
+1. Run the read-only YarraMate check.
+2. Obtain the topic slice as `yarramate/ask-result/v1` JSON.
+3. Reuse a relevant authored LikeC4 view when available.
+4. Otherwise produce a temporary grounded model using only facts from the projection result.
+5. Validate and compile the complete candidate.
+6. Replace the active rendered model only after successful validation.
+
+### Ad hoc view
+
+1. Create a temporary LikeC4 model for the question or alternatives.
+2. Add visible ad hoc/non-canonical authority metadata.
+3. Generate the overview and linked detail views.
+4. Validate and compile before display.
+5. Keep the model inside the session directory.
+
+Invalid candidates do not replace the last good rendered model. The runtime returns source-located diagnostics to the visual agent and displays a non-destructive error state in the browser.
+
+## End, handoff, and main-agent recovery
+
+The main agent remains the parent and source of authority. The delegated child is disposable.
+
+### Normal End
+
+1. User clicks **End conversation**.
+2. Browser input freezes and the runtime journals `session.end`.
+3. The child receives the terminal event, submits the structured handoff, and exits.
+4. The main harness, already awaiting the child, resumes.
+5. Main calls `recover` and receives the summary plus a temporary transcript handle.
+6. Main accepts the summary or requests the transcript.
+7. Main calls `stop`.
+8. Runtime stops the webserver and removes the temporary session.
+
+### Failure or manual return
+
+A child crash, server failure, timeout, protocol mismatch, browser disconnect policy, or direct user message in the main harness enters the same recovery path. The main agent can cancel the child at any time.
+
+If automatic parent interruption and child-completion delivery cannot be guaranteed by a harness, embedded chat is not enabled. The browser opens in diagram-only mode and the conversation remains in the main harness.
+
+### Handoff payload
+
+Default recovery returns:
+
+- confirmed decisions and selections;
+- requested repository or model changes;
+- unresolved questions;
+- final view IDs and authority labels;
+- last processed event sequence;
+- termination reason;
+- a temporary transcript handle.
+
+The raw transcript is returned only on demand and remains available until the main agent accepts/discards the handoff or stops the session.
+
+## Failure handling
+
+| Failure | Required behavior |
+|---|---|
+| Server cannot start | Do not delegate; continue in main harness with the diagnostic. |
+| Harness cannot delegate | Open diagram-only mode. |
+| Child fails to start | Freeze/close chat and continue in main harness. |
+| LikeC4 candidate is invalid | Preserve last good diagram; show diagnostics; allow correction. |
+| Child crashes or times out | Freeze chat; retain journal; notify and recover in main. |
+| Browser disconnects | Retain the session for five minutes; do not infer End or approval. Recover and stop when the grace period expires. |
+| Runtime process exits | Recover from the append-only journal in the session directory. |
+| Main agent interrupts | Cancel child, recover confirmed state, then stop. |
+| Stop is repeated | Be idempotent and report the already-stopped state. |
+| Orphan session remains | Prune it when a later `start` finds it older than 24 hours. |
+
+Normal shutdown deletes immediately. A hard-killed process may leave a temporary directory; a later start removes it once its modification time is more than 24 hours old. The prune operation is confined to directories carrying a valid YarraMate visual-session marker.
+
+## Security
+
+- Bind only to `127.0.0.1` on an available random port.
+- Use separate high-entropy browser and agent capabilities.
+- Exchange the one-time browser bootstrap token for an `HttpOnly`, `SameSite=Strict` cookie, then redirect to a token-free URL.
+- Validate `Host` and `Origin`; authenticate WebSocket upgrades.
+- Reject cross-session and stale event identifiers.
+- Create session directories with mode `0700` and sensitive files with mode `0600`.
+- Validate every event, response, model payload, and handoff against versioned JSON Schemas.
+- Limit each chat message to 64 KiB, each complete candidate model to 5 MiB, the raw transcript to 5 MiB, and the pending chat queue to 32 events. Reaching a limit freezes new input and routes the session through recovery; it never truncates an accepted event.
+- Sanitize Markdown and all model-derived rich text before rendering.
+- Apply a strict Content Security Policy and ship no external scripts, fonts, telemetry, or network assets.
+- Treat browser and child inputs as untrusted; neither can provide shell commands or arbitrary paths.
+- Stop the entire server process tree before deleting temporary files.
+- Store no provider credentials because the runtime never calls a model provider.
+
+## Compatibility and fallback
+
+The skill capability-detects whether the current harness supports:
+
+- delegating a long-lived child agent;
+- allowing the child to make blocking CLI calls;
+- delivering child completion or interruption back to the parent;
+- keeping the parent conversation recoverable while the child runs.
+
+Capability detection uses the running agent's actual tool inventory and lifecycle guarantees; it is not inferred from a harness name. A delegation tool alone is insufficient unless the parent can also receive child completion or user interruption while the child is active.
+
+If any required capability is absent, the visual runtime starts in diagram-only mode. The user still receives the custom renderer and can navigate views, but messages and changes continue through the main harness.
+
+## Verification
+
+### Unit contracts
+
+- Lifecycle state transitions and idempotent stop.
+- Sequencing, correlation, acknowledgement, duplicate suppression, and queue backpressure.
+- Session capability separation and isolation.
+- Schema validation, size limits, path rejection, and Markdown sanitization.
+- Atomic last-good model replacement.
+- Summary generation and transcript-on-demand recovery.
+
+### CLI integration
+
+- `start` emits a valid descriptor and serves an authenticated browser application.
+- `wait` blocks and releases on each supported browser event.
+- `respond` correlates a reply and publishes a valid model replacement.
+- `status` accurately reports lifecycle and connectivity.
+- `recover` works after child failure and runtime restart.
+- `stop` terminates the process tree and removes the session.
+
+### Browser smoke scenario
+
+1. Start from a checked YarraMate slice.
+2. Observe the custom overview, description, authority label, chat, and drill-down views.
+3. Send a message to a deterministic fixture visual agent.
+4. Receive a response and valid view revision without terminal interaction.
+5. Select a choice and verify it appears in the structured handoff.
+6. Click End.
+7. Verify child exit, main-agent handoff, server shutdown, and temporary-directory removal.
+
+The fixture exercises protocol behavior and uses no LLM or credentials.
+
+### Failure and security scenarios
+
+- Diagram-only fallback in an incapable harness.
+- Unauthorized HTTP and WebSocket requests.
+- Bootstrap-token replay, invalid host/origin, stale sequence, and cross-session IDs.
+- Oversized payload, queue overflow, hostile Markdown, and path traversal attempts.
+- Child crash, browser disconnect, runtime restart, main cancellation, and concurrent-session isolation.
+- Invalid LikeC4 revision preserving the last good view.
+- Summary-by-default and transcript-on-demand recovery.
+
+### Package and repository acceptance
+
+- Existing semantic and LikeC4 adapter behavior remains unchanged.
+- The packed package contains `yarramate-visual`, versioned schemas, and prebuilt browser assets.
+- Consumer documentation describes chat-capable and fallback journeys.
+- The canonical skill describes authority, preflight, delegation, recovery, and cleanup.
+- The YarraMate self-model declares the visual runtime, custom browser application, session protocol, delegated visual agent interaction, and recovery behavior.
+- Evidence, adapter mapping, focused projections, and generated self-model LikeC4 output remain consistent.
+
+## Acceptance criteria
+
+1. A user can ask the `yarramate-architecture` skill for a visual explanation without typing a CLI command.
+2. Checked repository architecture is rendered from canonical model facts; missing models route to discovery.
+3. General questions and alternatives render as visibly non-canonical temporary views.
+4. Alternatives use an overview plus linked detail views.
+5. A capable harness supports browser-only chat turns with a delegated visual agent.
+6. The visual child cannot modify repository or `.yarramate/` files.
+7. End and every supported failure return a recoverable summary to the main agent.
+8. The transcript is available on demand until handoff acceptance or cleanup.
+9. End stops the local webserver and deletes temporary artifacts.
+10. An incapable harness receives the custom renderer in diagram-only mode and continues in the main harness.
+11. No model-provider credentials are required by `yarramate-visual`.
+12. Browser, CLI, recovery, security, packaging, and self-model checks pass.
+
+## Rollout boundary
+
+The first release supports one local visual session per main-agent conversation, one delegated visual agent per session, one in-flight chat turn, complete model replacement, and localhost-only access. Multi-user hosting, remote access, partial model patches, resumable children, and canonical edits from the browser are deferred outside this design.

--- a/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
@@ -174,7 +174,7 @@ Relationship context shows:
 
 Descriptions show three lines by default. **Show more** expands the full text and **Show less** returns height to the transcript. The inspector has an explicit clear action.
 
-Selection survives view navigation within one rendered model. It clears when the user clears it, the model is replaced, or the session closes. A closed or read-only session remains inspectable while the composer stays disabled.
+Selection survives view navigation within one rendered model. It clears when the user clears it or a model replacement becomes active. Ending or closing the session preserves the current selection and permits further local inspection of the retained diagram, while the composer stays disabled.
 
 ## Contextual questions
 
@@ -251,8 +251,12 @@ submit with selected subject
   → existing ask(text)
   → existing chat.message/v1
 
-model replacement or session close
+model replacement
   → clear selected subject
+
+session close
+  → preserve local inspection
+  → disable contextual submission
 ```
 
 ## Failure and edge handling
@@ -303,7 +307,7 @@ Focused tests for `workspace-state.ts` cover:
 - relationship normalization, endpoint fallback, and aggregate count;
 - missing and flattened descriptions;
 - selection retained across view navigation;
-- selection cleared on model replacement and session close;
+- selection preserved for inspection but not submission after session close;
 - contextual element and relationship question formatting;
 - chip removal preserving the original question.
 
@@ -344,7 +348,7 @@ Run the focused browser/state checks, typecheck both TypeScript programs, build 
 7. Long descriptions expand on demand and missing descriptions are explicit.
 8. Selected-subject questions show exactly what context the visual agent receives.
 9. A click alone is browser-local and does not change the v1 journal.
-10. Selection cannot survive an active-model replacement or closed session.
+10. Active-model replacement clears selection; session close preserves inspection while preventing submission.
 11. The mobile layout preserves the canvas and uses an accessible non-modal bottom sheet.
 12. The nine v1 schemas, runtime behavior, recovery, and security boundaries remain unchanged.
 13. Focused state checks, browser verification, the visual suite, and repository verification pass.

--- a/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
@@ -151,6 +151,14 @@ The browser uses LikeC4's public callbacks:
 - `onEdgeClick(edge, event)` selects a relationship;
 - `onNavigateTo(viewId, event, node)` preserves the originating element before navigating when present.
 
+LikeC4 1.59.2 declares `onNavigateTo`'s originating node optional and never
+passes it: the renderer emits `navigateTo` with `viewId` alone. Against the
+pinned renderer the node branch is therefore dead, and a selection survives
+navigation because the reducer keeps it, not because the callback restores it.
+The branch stays because the declared contract allows the node; a renderer bump
+that starts passing it changes behaviour from "keep the prior selection" to
+"select the navigated node".
+
 A click changes only local workspace state. It emits no `VisualBrowserInput`, consumes no queue capacity, and adds no journal record.
 
 ### Inspector

--- a/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
+++ b/docs/superpowers/specs/2026-08-08-visual-workspace-layout-and-subject-selection-design.md
@@ -1,0 +1,350 @@
+# Visual workspace layout and subject selection
+
+**Status:** Approved design  
+**Date:** 2026-08-08  
+**Extends:** `2026-08-08-visual-architecture-conversations-design.md`
+
+## Summary
+
+Rework the visual-conversation browser so the LikeC4 diagram is the primary workspace rather than content below a large document header. Replace the permanent header and vertical status rail with a compact command strip, make the conversation user-controlled, resizable, and collapsible, and use a bottom sheet on narrow screens.
+
+Let the reviewer select either an element or a relationship in the LikeC4 renderer. Show stable identity and progressive description in the conversation panel, attach the selected subject to the composer, and include explicit readable context only when the user sends a question. Selection is local presentation state: a click alone is never journaled and the closed v1 protocol does not change.
+
+This design supersedes the original design's browser-layout details. Runtime, authority, protocol, recovery, security, packaging, and skill boundaries remain unchanged.
+
+## Problem
+
+At 1568×924, the current browser gives roughly 215px of vertical space to a static title and description, 56px of horizontal space to a vertical status rail, and a fixed 21rem–26vw column to an empty conversation. The diagram receives the remainder even when the user has asked nothing. View tabs consume another permanent row. The resulting canvas is substantially smaller than the viewport and the vertical rail is difficult to scan.
+
+The browser also enables LikeC4 element and relationship details but does not capture which rendered subject was clicked. The reviewer cannot carry that context into a question, and descriptions are not surfaced in the YarraMate-owned conversation workspace.
+
+## Goals
+
+- Make the LikeC4 canvas consume every pixel not actively used by controls or an open conversation.
+- Keep title, authority, active view, connection state, attention, and End persistently reachable.
+- Let the reviewer open, close, and resize the conversation without the application fighting that choice.
+- Show selected element and relationship identity and descriptions next to the conversation.
+- Make the exact selected-subject context sent to the visual agent visible in the transcript.
+- Preserve the existing closed v1 protocol and append-only journal semantics.
+- Preserve keyboard operation, responsive behavior, reduced motion, and safe text rendering.
+
+## Non-goals
+
+- Hover telemetry, click analytics, or journaling every diagram interaction.
+- A general model inspector or source-code editor.
+- Relationship editing, canonical model writes, or promotion of browser selection into declared intent.
+- A new visual protocol version or optional fields added to a v1 document.
+- Persisting panel preferences across visual sessions.
+- Replacing LikeC4's renderer, details surfaces, pan/zoom controls, or navigation history.
+- Adding a DOM-test framework solely for this change.
+
+## Visual direction
+
+Keep the existing drafting-desk palette, typography, square controls, and explicit authority colours. Change structure rather than re-theme the application. The command strip becomes the one signature element: dense enough to reclaim space, but each item encodes live session information or a user action.
+
+Remove decorative or duplicate structure. In particular, the command-strip view selector replaces the application-owned bottom view-tab row. LikeC4's own in-canvas navigation and controls remain.
+
+## Desktop workspace
+
+At widths above 900px, the application fills `100dvh` with two rows:
+
+```text
+┌──────────────────────── 48px command strip ───────────────────────────┐
+│ Title · authority · view ▾ · Details     Live · Conversation · End   │
+├──────────────────────────────────────────┬─┬──────────────────────────┤
+│                                          │↔│ Selected subject         │
+│                                          │ │ Conversation             │
+│              LikeC4 canvas               │ │ Choices / diagnostics    │
+│                                          │ │ Composer                 │
+│                                          │ │                          │
+└──────────────────────────────────────────┴─┴──────────────────────────┘
+```
+
+### Command strip
+
+The 48px strip contains:
+
+- session title, truncated rather than wrapped;
+- canonical/ad-hoc authority marker;
+- active-view selector;
+- **Details**, revealing the full session description without reserving canvas height;
+- connection state;
+- **Conversation**, including an attention count while closed;
+- always-reachable **End**.
+
+The vertical rail is removed. Authority, connection, and active view become horizontal, readable values. The application-owned view tabs are removed because the selector provides the same operation in less space.
+
+The Details disclosure is non-modal. It is keyboard reachable, has a labelled close action, and does not resize the workspace merely to display static prose.
+
+### Diagram and conversation split
+
+The remaining row contains:
+
+- diagram: `minmax(0, 1fr)`;
+- separator: 7px;
+- conversation: user-selected width.
+
+The conversation default is `clamp(320px, 28vw, 480px)`. Resizing is clamped to 320px minimum and `min(45vw, 640px)` maximum. Pointer resizing uses pointer capture so leaving the separator does not lose the drag. The focusable separator supports ArrowLeft/ArrowRight and larger Shift+Arrow steps.
+
+Collapsing the conversation removes both its column and separator; the diagram receives the entire remaining width. Empty sessions initially collapse the conversation. A direct element or relationship click opens it because that click explicitly asks to inspect a subject. Background chat, diagnostics, or choices do not override a manual close; they increment the Conversation attention count. Opening the panel marks current activity seen.
+
+Panel mode and width live only for the current page/session. No `localStorage` or protocol state is introduced.
+
+## Narrow workspace
+
+At 900px and below:
+
+- the compact command strip retains title, connection, Conversation, and End, with secondary values available through Details;
+- the canvas remains the primary viewport;
+- conversation becomes a non-modal bottom sheet;
+- selected-subject context remains at the top of the sheet;
+- the sheet opens and closes but does not expose a precision resize interaction;
+- the document does not become a vertical stack of header, diagram, rail, and conversation;
+- no horizontal overflow is permitted at 390×844.
+
+The bottom sheet is a complementary region, not a modal dialog. It does not trap focus or prevent diagram navigation when open.
+
+## Selected subjects
+
+### Local representation
+
+Selection is a separate browser-workspace concern:
+
+```ts
+type SelectedDiagramSubject =
+  | {
+      readonly type: 'element'
+      readonly nodeId: string
+      readonly identity: string
+      readonly title: string
+      readonly kind: string
+      readonly description: string | null
+      readonly technology: string | null
+      readonly navigateTo: string | null
+      readonly tags: readonly string[]
+    }
+  | {
+      readonly type: 'relationship'
+      readonly edgeId: string
+      readonly source: { readonly id: string; readonly title: string }
+      readonly target: { readonly id: string; readonly title: string }
+      readonly label: string | null
+      readonly description: string | null
+      readonly kind: string | null
+      readonly technology: string | null
+      readonly notation: string | null
+      readonly relationIds: readonly string[]
+    }
+```
+
+For elements, identity prefers `modelRef`, then `deploymentRef`, then diagram node ID. Groups and generated nodes therefore remain inspectable without being misrepresented as canonical elements.
+
+For relationships, source and target IDs are resolved against the active rendered view for display titles. Missing nodes fall back to stable IDs. One rendered edge may aggregate several model relationships; the inspector states the count and never fabricates one canonical relationship.
+
+LikeC4 `MarkdownOrString` descriptions are flattened to text and rendered by React. The application never injects HTML. Missing descriptions render **No description declared in this model**.
+
+### Renderer callbacks
+
+The browser uses LikeC4's public callbacks:
+
+- `onNodeClick(node, event)` selects an element;
+- `onEdgeClick(edge, event)` selects a relationship;
+- `onNavigateTo(viewId, event, node)` preserves the originating element before navigating when present.
+
+A click changes only local workspace state. It emits no `VisualBrowserInput`, consumes no queue capacity, and adds no journal record.
+
+### Inspector
+
+The selected-subject inspector is docked above the transcript.
+
+Element context shows:
+
+- title;
+- stable identity and kind;
+- description;
+- technology and tags when present.
+
+Relationship context shows:
+
+- source → target;
+- label, or source → target when unlabelled;
+- description;
+- kind, technology, and notation;
+- number of underlying model relationships.
+
+Descriptions show three lines by default. **Show more** expands the full text and **Show less** returns height to the transcript. The inspector has an explicit clear action.
+
+Selection survives view navigation within one rendered model. It clears when the user clears it, the model is replaced, or the session closes. A closed or read-only session remains inspectable while the composer stays disabled.
+
+## Contextual questions
+
+The composer displays a removable selected-subject chip. The chip changes placeholder copy to **Ask about this element** or **Ask about this relationship**.
+
+Submitting with a chip formats ordinary visible text before calling the existing `ask(text)` seam:
+
+```text
+About element “Visual Session Server” (yarramate.visual.server): <question>
+```
+
+```text
+About relationship “Visual Browser → Visual Session Server — sends authenticated input” (2 model relationships): <question>
+```
+
+The resulting transcript shows exactly this text. Only stable identity, title/label, endpoints, and aggregate count enter the question. Description, notes, tags, technology, notation, and arbitrary metadata are display-only and are not silently injected into the agent prompt.
+
+Removing the chip sends the unmodified question. Clicking without submitting sends nothing.
+
+## Module boundaries
+
+### Existing session state
+
+`src/visual-app/state.ts` remains the deep module for server/session truth: lifecycle, model, transcript, choices, diagnostics, acknowledgements, and composer availability. It does not gain panel geometry or click selection.
+
+### Workspace state
+
+Add `src/visual-app/workspace-state.ts` as the deep module for ephemeral presentation state. It owns:
+
+- conversation mode, width, and unread count;
+- selected-subject normalization;
+- description flattening;
+- resize clamping;
+- model-change and session-close clearing;
+- visible contextual-question formatting.
+
+Its reducer and formatters are pure and testable without a DOM.
+
+### Presentation
+
+Reshape `App.tsx` around three presentation surfaces:
+
+- `CommandStrip`;
+- `DiagramWorkspace`;
+- `ConversationPanel`.
+
+The components consume session and workspace state. They do not own WebSocket behavior or mutate protocol documents. Small sub-surfaces such as the selected-subject inspector and separator remain private to their owning presentation module rather than becoming a collection of shallow exported files.
+
+No new runtime dependency is required.
+
+## State transitions
+
+```text
+session starts empty
+  → conversation auto-collapsed
+
+Conversation toggle
+  → manual open / manual closed
+
+node or edge click
+  → normalize selected subject
+  → open conversation
+  → show inspector and composer chip
+
+background activity while manually closed
+  → keep closed
+  → increment attention
+
+open conversation
+  → mark current activity seen
+
+submit with selected subject
+  → format visible contextual text
+  → existing ask(text)
+  → existing chat.message/v1
+
+model replacement or session close
+  → clear selected subject
+```
+
+## Failure and edge handling
+
+- A missing description produces explicit empty-state copy rather than an empty block.
+- An unlabelled relationship uses its endpoints as the visible name.
+- An aggregate edge reports its underlying count without merging descriptions into an invented claim.
+- A node missing `modelRef` and `deploymentRef` falls back to diagram ID.
+- A missing source or target title falls back to node ID.
+- Invalid or oversized description content cannot execute because it is flattened and rendered as text.
+- A resize ending outside the separator still settles through pointer capture.
+- A viewport change reclamps an out-of-range desktop width.
+- The existing last-good drawing behavior remains authoritative; selection clears when a replacement becomes active.
+- Session ending disables contextual submission but does not hide the subject the reviewer was inspecting.
+
+## Accessibility
+
+- Conversation exposes `aria-expanded` and `aria-controls`.
+- The separator uses `role="separator"`, `aria-orientation="vertical"`, and current/minimum/maximum width values.
+- The separator is keyboard focusable and has visible focus treatment.
+- Details and description expansion are real buttons with accurate expanded state.
+- Selecting a subject does not steal focus from the diagram.
+- The inspector has a labelled heading and complementary-region semantics.
+- Attention count has an accessible name and is not announced repeatedly while unchanged.
+- Mobile bottom sheet is non-modal and does not trap focus.
+- Reduced-motion behavior remains unchanged.
+
+## Security and compatibility
+
+This change is browser-local until an existing chat submission occurs. It adds no browser event type, response type, schema field, endpoint, capability, filesystem input, external request, or persisted secret.
+
+The nine v1 schemas remain byte-for-byte unchanged. A future structured selected-subject payload would require a new version under ADR 0081's closed-schema rule; this design deliberately avoids it.
+
+Selected descriptions and metadata are never hidden prompt context. The outgoing contextual prefix is visible to the user and transcript. Content is rendered as React text; no `dangerouslySetInnerHTML` is introduced.
+
+## Verification
+
+### Pure contracts
+
+Focused tests for `workspace-state.ts` cover:
+
+- initial empty-panel collapse;
+- manual open and close;
+- background activity preserving manual close and incrementing attention;
+- opening marking activity seen;
+- resize clamping and viewport reclamping;
+- element normalization and identity fallback;
+- relationship normalization, endpoint fallback, and aggregate count;
+- missing and flattened descriptions;
+- selection retained across view navigation;
+- selection cleared on model replacement and session close;
+- contextual element and relationship question formatting;
+- chip removal preserving the original question.
+
+Existing visual protocol tests must remain unchanged and green.
+
+### Browser verification
+
+At 1568×924 and 390×844, exercise the real browser application and observe:
+
+1. The 48px command strip replaces the large header and vertical rail.
+2. The application-owned bottom view tabs are absent; the command-strip selector changes views.
+3. The canvas receives all space outside an open conversation.
+4. Collapse returns the conversation and separator width to the canvas.
+5. Pointer and keyboard resize remain within limits.
+6. Element click shows identity and progressive description.
+7. Relationship click highlights context and shows endpoints, label, description, and aggregate count.
+8. **Show more** and **Show less** change inspector height without losing selection.
+9. The composer chip follows the selected subject and can be removed.
+10. Submitted transcript text exactly matches the contextual text sent to the agent.
+11. Clicks without submission add no journal event.
+12. Model replacement clears stale selection.
+13. Mobile uses a non-modal bottom sheet with no horizontal overflow.
+14. Keyboard focus remains visible and no interaction steals diagram focus.
+15. No console errors, external requests, or executable description content appear.
+
+### Repository verification
+
+Run the focused browser/state checks, typecheck both TypeScript programs, build the browser bundle, run the existing visual suite, then run `pnpm verify`. The existing real-browser End/recovery smoke remains green because session and protocol semantics do not change.
+
+## Acceptance criteria
+
+1. At desktop size, the static header, vertical rail, and bottom view tabs no longer reserve diagram space.
+2. Empty sessions begin with the conversation collapsed.
+3. The reviewer can open, close, pointer-resize, and keyboard-resize the conversation.
+4. Manual close is respected while background activity remains visible as attention.
+5. Clicking any inspectable LikeC4 element shows stable identity and description.
+6. Clicking any inspectable relationship shows endpoints, label, description, and aggregate relation count.
+7. Long descriptions expand on demand and missing descriptions are explicit.
+8. Selected-subject questions show exactly what context the visual agent receives.
+9. A click alone is browser-local and does not change the v1 journal.
+10. Selection cannot survive an active-model replacement or closed session.
+11. The mobile layout preserves the canvas and uses an accessible non-modal bottom sheet.
+12. The nine v1 schemas, runtime behavior, recovery, and security boundaries remain unchanged.
+13. Focused state checks, browser verification, the visual suite, and repository verification pass.

--- a/docs/superpowers/specs/2026-08-09-visual-descriptor-and-chat-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-09-visual-descriptor-and-chat-hardening-design.md
@@ -1,0 +1,63 @@
+# Visual descriptor and chat hardening
+
+**Date:** 2026-08-09
+**Status:** Approved
+
+## Problem
+
+A visual client opens its private session descriptor with `O_RDONLY` and
+`O_NOFOLLOW`. A FIFO planted at that path is not a symlink, so opening it for
+reading blocks until a writer appears. Every one-shot visual client command can
+therefore hang before it validates that the descriptor is a regular file.
+
+A manual browser smoke also enabled embedded chat while attaching a scripted,
+canned responder rather than the delegated visual LLM required by the approved
+conversation design. The browser transport worked, but the setup presented the
+script as conversational capability and could answer only its hard-coded
+LikeC4 phrases.
+
+## Decision
+
+Harden the existing boundaries without changing the visual protocol.
+
+1. Open session descriptors with `O_RDONLY | O_NONBLOCK | O_NOFOLLOW` where
+   `O_NOFOLLOW` is available. Continue validating the opened handle with
+   `stat()` before reading it. Regular descriptor files behave as before; a
+   FIFO opens without waiting and is rejected as a non-regular file with the
+   existing `YMVS401` diagnostic.
+2. State explicitly in the canonical visual-conversation journey that
+   `chatEnabled: true` requires the parent to attach a real delegated visual
+   LLM agent implementing the documented `wait`/`respond` loop. A canned,
+   scripted, or transport-only responder does not satisfy capability
+   detection. Such smoke tests must not be presented as embedded chat.
+
+## Boundaries
+
+- No schema, protocol, browser UI, session lifecycle, or authority change.
+- The runtime remains model-provider-neutral and cannot determine whether an
+  authenticated protocol consumer is an LLM.
+- Diagram-only fallback remains the correct mode when the harness cannot attach
+  and supervise the delegated agent.
+- Repeated-stop semantics, generic symlink diagnostics, and the existing
+  `O_NOFOLLOW` portability tradeoff remain unchanged.
+
+## Verification
+
+- Add a subprocess regression test that creates a FIFO descriptor, invokes a
+  visual client command, and proves it exits promptly with `YMVS401`. The
+  subprocess boundary ensures a regression is killed and reported rather than
+  hanging the test worker.
+- Run the focused visual CLI tests.
+- Exercise a real browser chat turn with a delegated visual agent, verifying
+  that arbitrary in-scope text reaches the LLM and receives a generated
+  response.
+- Run `pnpm verify` before merge.
+
+## Acceptance criteria
+
+1. No visual client command blocks when its descriptor path names a FIFO.
+2. FIFO descriptors remain fail-closed and expose no capability.
+3. Regular descriptor behavior and diagnostics remain compatible.
+4. The canonical skill forbids advertising embedded chat through a canned or
+   transport-only responder.
+5. The PR's complete verification remains green.

--- a/docs/superpowers/specs/2026-08-09-visual-end-transition-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-09-visual-end-transition-feedback-design.md
@@ -1,0 +1,60 @@
+# Visual End Transition Feedback Design
+
+## Problem
+
+Pressing **End** freezes the visual conversation and records `Returning control to the main agent` in the transcript, but that record is visible only when the conversation panel is open. The always-visible command strip gives no explanation of the recovery and handoff now in progress.
+
+## Decision
+
+Show compact, always-visible transition feedback in the command strip. Derive it from lifecycle state already held by the browser; do not change the versioned visual-session protocol.
+
+The browser must describe only stages it can observe. It may say that it is preparing or has received the handoff and direct the reviewer back to the main agent. It must not claim that the main harness has resumed, because no browser-visible acknowledgment proves that event.
+
+## User Experience
+
+Before End, the command strip remains unchanged.
+
+After the reviewer presses **End**:
+
+1. Conversation input becomes unavailable through the current `ending` lifecycle behavior.
+2. The End button reads `Ending…` and remains disabled.
+3. An inline live status reads `Ending conversation — preparing a handoff for the main agent.`
+
+After the browser receives `handoff.complete`, the status reads `Handoff ready — returning control to the main agent.`
+
+After the runtime sends its closing frame, the status reads `Visual conversation ended. Continue in the main agent.`
+
+The existing transcript notice remains as the durable session record. The diagram stays visible throughout; no modal or blocking overlay is introduced.
+
+## State and Data Flow
+
+`src/visual-app/state.ts` remains the authority for browser lifecycle state:
+
+- `end.requested` sets `lifecycle` to `ending` synchronously.
+- `handoff.received` stores the structured handoff.
+- `session.closed` sets `lifecycle` to `closed`.
+
+`src/visual-app/App.tsx` maps those existing observable states to display copy. No new server response, schema field, or transport event is required.
+
+The handoff-ready message takes precedence while the lifecycle is `ending` and `state.handoff` is non-null. The closed message takes precedence once the lifecycle is `closed`.
+
+## Accessibility
+
+The transition copy uses `role="status"` and `aria-live="polite"`. The End button's text change exposes the action state without moving focus. Existing disabled-control semantics remain intact.
+
+## Failure Behavior
+
+If the connection closes without a completed handoff, the UI shows only the terminal closed-state message and does not claim a handoff was prepared. Existing diagnostics and recovery behavior remain unchanged.
+
+## Verification
+
+- Reducer/render coverage proves the immediate ending, handoff-ready, and closed messages.
+- Render coverage proves `role="status"`, `aria-live="polite"`, and the `Ending…` button label.
+- The visual journey exercises End through the real transport and confirms conversation input remains unavailable during transition.
+- A browser smoke test confirms the command strip communicates the transition while the diagram remains visible.
+
+## Non-goals
+
+- Adding harness-to-browser acknowledgment that the main agent resumed.
+- Changing the visual protocol or handoff schema.
+- Replacing the inline status with a modal, overlay, or completion screen.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "scripts": {
     "build:node": "tsc -p tsconfig.build.json",
-    "build:visual": "vite build --config vite.visual.config.ts",
+    "build:visual": "vite build --config vite.visual.config.ts --logLevel warn",
     "build": "pnpm build:node && pnpm build:visual",
     "prepack": "pnpm build",
     "docs:dev": "pnpm self:export:likec4 && likec4 serve .yarramate-out/likec4",

--- a/package.json
+++ b/package.json
@@ -115,10 +115,12 @@
   },
   "dependencies": {
     "ajv": "^8.17.1",
+    "ws": "^8.21.2",
     "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
+    "@types/ws": "^8.18.1",
     "likec4": "^1.59.2",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,16 @@
     "./schema/apply-result": "./schema/yarramate-apply-result.schema.json",
     "./schema/design-step": "./schema/yarramate-design-step.schema.json",
     "./schema/ask-result": "./schema/yarramate-ask-result.schema.json",
-    "./schema/rtm": "./schema/yarramate-rtm.schema.json"
+    "./schema/rtm": "./schema/yarramate-rtm.schema.json",
+    "./schema/visual-session-request": "./schema/yarramate-visual-session-request.schema.json",
+    "./schema/visual-session-started": "./schema/yarramate-visual-session-started.schema.json",
+    "./schema/visual-session-descriptor": "./schema/yarramate-visual-session-descriptor.schema.json",
+    "./schema/visual-event": "./schema/yarramate-visual-event.schema.json",
+    "./schema/visual-response": "./schema/yarramate-visual-response.schema.json",
+    "./schema/visual-model": "./schema/yarramate-visual-model.schema.json",
+    "./schema/visual-handoff": "./schema/yarramate-visual-handoff.schema.json",
+    "./schema/visual-status": "./schema/yarramate-visual-status.schema.json",
+    "./schema/visual-diagnostic-result": "./schema/yarramate-visual-diagnostic-result.schema.json"
   },
   "bin": {
     "yarramate": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,9 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build:node": "tsc -p tsconfig.build.json",
+    "build:visual": "vite build --config vite.visual.config.ts",
+    "build": "pnpm build:node && pnpm build:visual",
     "prepack": "pnpm build",
     "docs:dev": "pnpm self:export:likec4 && likec4 serve .yarramate-out/likec4",
     "format": "likec4 format assets/likec4",
@@ -112,7 +114,7 @@
     "validate": "pnpm self:export:likec4 && likec4 validate --no-layout .yarramate-out/likec4",
     "verify": "pnpm typecheck && pnpm build && pnpm test && pnpm self:check && pnpm validate",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.visual.json"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -120,10 +122,16 @@
     "yaml": "^2.8.1"
   },
   "devDependencies": {
+    "@likec4/core": "1.59.2",
     "@types/node": "^26.1.2",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@types/ws": "^8.18.1",
     "likec4": "^1.59.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^7.0.2",
+    "vite": "^8.1.5",
     "vitest": "^4.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "yarramate": "dist/cli.js",
     "yarramate-likec4": "dist/adapters/likec4-cli.js",
     "yarramate-graphify": "dist/adapters/graphify-cli.js",
-    "yarramate-mcp": "dist/adapters/mcp-cli.js"
+    "yarramate-mcp": "dist/adapters/mcp-cli.js",
+    "yarramate-visual": "dist/adapters/visual-cli.js"
   },
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,18 +18,36 @@ importers:
         specifier: ^2.8.1
         version: 2.9.0
     devDependencies:
+      '@likec4/core':
+        specifier: 1.59.2
+        version: 1.59.2
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
       likec4:
         specifier: ^1.59.2
         version: 1.59.2(@types/node@26.1.2)(picomatch@4.0.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(yaml@2.9.0)
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))
@@ -342,6 +360,14 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -553,6 +579,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1203,6 +1232,14 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.1.2
@@ -1356,6 +1393,8 @@ snapshots:
   color-name@1.1.4: {}
 
   convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
 
   detect-libc@2.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
+      ws:
+        specifier: ^8.21.2
+        version: 8.21.2
       yaml:
         specifier: ^2.8.1
         version: 2.9.0
@@ -18,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       likec4:
         specifier: ^1.59.2
         version: 1.59.2(@types/node@26.1.2)(picomatch@4.0.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(yaml@2.9.0)
@@ -335,6 +341,9 @@ packages:
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -971,6 +980,18 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -1181,6 +1202,10 @@ snapshots:
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -1691,6 +1716,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@8.21.2: {}
 
   y18n@5.0.8: {}
 

--- a/schema/yarramate-visual-diagnostic-result.schema.json
+++ b/schema/yarramate-visual-diagnostic-result.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-diagnostic-result/v1",
+  "title": "YarraMate visual diagnostic result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "diagnostics"],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-diagnostic-result/v1"
+    },
+    "diagnostics": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1000,
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    }
+  },
+  "$defs": {
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "severity",
+        "code",
+        "message",
+        "path",
+        "pointer",
+        "line",
+        "column"
+      ],
+      "properties": {
+        "severity": {
+          "const": "error"
+        },
+        "code": {
+          "type": "string",
+          "pattern": "^YMVS[0-9]{3}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "pointer": {
+          "type": "string",
+          "pattern": "^/"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/schema/yarramate-visual-event.schema.json
+++ b/schema/yarramate-visual-event.schema.json
@@ -148,12 +148,33 @@
         "requiresAttention": { "type": "boolean" }
       }
     },
+    "terminationReason": {
+      "description": "Why a visual session ended. The terminal event is where a reason is born, so it is declared here and reported by the handoff.",
+      "enum": [
+        "user-ended",
+        "child-failed",
+        "browser-timeout",
+        "main-cancelled",
+        "server-failed",
+        "compiler-failed"
+      ]
+    },
     "sessionEndPayload": {
+      "description": "Terminal event the runtime journals. Every termination reason is the runtime's to choose; the browser may only request the user-ended one.",
       "type": "object",
       "additionalProperties": false,
       "required": ["reason"],
       "properties": {
-        "reason": { "enum": ["user-ended", "browser-timeout"] }
+        "reason": { "$ref": "#/$defs/terminationReason" }
+      }
+    },
+    "browserSessionEndPayload": {
+      "description": "End as an untrusted browser may ask for it. A browser cannot claim a timeout, a child failure, or a cancellation it does not own.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "const": "user-ended" }
       }
     },
     "browserConnectedPayload": {
@@ -225,7 +246,7 @@
             "lastAcknowledgedSequence": {
               "$ref": "#/$defs/acknowledgedSequence"
             },
-            "payload": { "$ref": "#/$defs/sessionEndPayload" }
+            "payload": { "$ref": "#/$defs/browserSessionEndPayload" }
           }
         }
       ]

--- a/schema/yarramate-visual-event.schema.json
+++ b/schema/yarramate-visual-event.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-event/v1",
+  "title": "YarraMate visual session event",
+  "description": "One journaled browser or runtime event. Sequence, identifiers, and timestamps are runtime outputs; the browser supplies only the untrusted input in $defs/browserInput.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "sessionId",
+    "sequence",
+    "eventId",
+    "type",
+    "timestamp",
+    "payload"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-event/v1"
+    },
+    "sessionId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "sequence": {
+      "$ref": "#/$defs/sequence"
+    },
+    "eventId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "type": {
+      "enum": [
+        "chat.message",
+        "choice.selected",
+        "view.navigate",
+        "session.end",
+        "browser.connected",
+        "browser.disconnected"
+      ]
+    },
+    "timestamp": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "chat.message" },
+        "payload": { "$ref": "#/$defs/chatMessagePayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "choice.selected" },
+        "payload": { "$ref": "#/$defs/choiceSelectedPayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "view.navigate" },
+        "payload": { "$ref": "#/$defs/viewNavigatePayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "session.end" },
+        "payload": { "$ref": "#/$defs/sessionEndPayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "browser.connected" },
+        "payload": { "$ref": "#/$defs/browserConnectedPayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "browser.disconnected" },
+        "payload": { "$ref": "#/$defs/browserDisconnectedPayload" }
+      }
+    }
+  ],
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+    },
+    "shortId": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "chatMessagePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 65536
+        }
+      }
+    },
+    "choiceSelectedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["choiceId", "optionId"],
+      "properties": {
+        "choiceId": { "$ref": "#/$defs/shortId" },
+        "optionId": { "$ref": "#/$defs/shortId" }
+      }
+    },
+    "viewNavigatePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["viewId", "requiresAttention"],
+      "properties": {
+        "viewId": {
+          "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/viewId"
+        },
+        "requiresAttention": { "type": "boolean" }
+      }
+    },
+    "sessionEndPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "enum": ["user-ended", "browser-timeout"] }
+      }
+    },
+    "browserConnectedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["connectionId"],
+      "properties": {
+        "connectionId": { "$ref": "#/$defs/shortId" }
+      }
+    },
+    "browserDisconnectedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["connectionId", "code"],
+      "properties": {
+        "connectionId": { "$ref": "#/$defs/shortId" },
+        "code": {
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 4999
+        }
+      }
+    },
+    "browserInput": {
+      "description": "Untrusted browser message. It carries only a discriminant and payload; session identifiers, sequences, timestamps, and runtime-only event types are rejected.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "payload"],
+          "properties": {
+            "type": { "const": "chat.message" },
+            "payload": { "$ref": "#/$defs/chatMessagePayload" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "payload"],
+          "properties": {
+            "type": { "const": "choice.selected" },
+            "payload": { "$ref": "#/$defs/choiceSelectedPayload" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "payload"],
+          "properties": {
+            "type": { "const": "view.navigate" },
+            "payload": { "$ref": "#/$defs/viewNavigatePayload" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "payload"],
+          "properties": {
+            "type": { "const": "session.end" },
+            "payload": { "$ref": "#/$defs/sessionEndPayload" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schema/yarramate-visual-event.schema.json
+++ b/schema/yarramate-visual-event.schema.json
@@ -103,6 +103,11 @@
       "type": "integer",
       "minimum": 1
     },
+    "acknowledgedSequence": {
+      "description": "Highest journaled sequence the browser has seen acknowledged, or 0 before its first acknowledgement.",
+      "type": "integer",
+      "minimum": 0
+    },
     "timestamp": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
@@ -173,41 +178,53 @@
       }
     },
     "browserInput": {
-      "description": "Untrusted browser message. It carries only a discriminant and payload; session identifiers, sequences, timestamps, and runtime-only event types are rejected.",
+      "description": "Untrusted browser message. It carries a discriminant, the last sequence the browser saw acknowledged, and the payload; session identifiers, assigned sequences, timestamps, and runtime-only event types are rejected.",
       "oneOf": [
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type", "payload"],
+          "required": ["type", "lastAcknowledgedSequence", "payload"],
           "properties": {
             "type": { "const": "chat.message" },
+            "lastAcknowledgedSequence": {
+              "$ref": "#/$defs/acknowledgedSequence"
+            },
             "payload": { "$ref": "#/$defs/chatMessagePayload" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type", "payload"],
+          "required": ["type", "lastAcknowledgedSequence", "payload"],
           "properties": {
             "type": { "const": "choice.selected" },
+            "lastAcknowledgedSequence": {
+              "$ref": "#/$defs/acknowledgedSequence"
+            },
             "payload": { "$ref": "#/$defs/choiceSelectedPayload" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type", "payload"],
+          "required": ["type", "lastAcknowledgedSequence", "payload"],
           "properties": {
             "type": { "const": "view.navigate" },
+            "lastAcknowledgedSequence": {
+              "$ref": "#/$defs/acknowledgedSequence"
+            },
             "payload": { "$ref": "#/$defs/viewNavigatePayload" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type", "payload"],
+          "required": ["type", "lastAcknowledgedSequence", "payload"],
           "properties": {
             "type": { "const": "session.end" },
+            "lastAcknowledgedSequence": {
+              "$ref": "#/$defs/acknowledgedSequence"
+            },
             "payload": { "$ref": "#/$defs/sessionEndPayload" }
           }
         }

--- a/schema/yarramate-visual-handoff.schema.json
+++ b/schema/yarramate-visual-handoff.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-handoff/v1",
+  "title": "YarraMate visual conversation handoff",
+  "description": "Recoverable summary returned to the main agent. The raw transcript appears only when it was explicitly requested.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "sessionId",
+    "authority",
+    "decision",
+    "terminationReason",
+    "lastSequence",
+    "summary",
+    "confirmedDecisions",
+    "requestedChanges",
+    "unresolvedQuestions",
+    "finalViews",
+    "transcriptPath",
+    "completedAt"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-handoff/v1"
+    },
+    "sessionId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "authority": {
+      "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/authority"
+    },
+    "decision": {
+      "$ref": "#/$defs/handoffDecision"
+    },
+    "terminationReason": {
+      "$ref": "#/$defs/terminationReason"
+    },
+    "lastSequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "summary": {
+      "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/summaryText"
+    },
+    "confirmedDecisions": {
+      "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/statementList"
+    },
+    "requestedChanges": {
+      "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/statementList"
+    },
+    "unresolvedQuestions": {
+      "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/statementList"
+    },
+    "finalViews": {
+      "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/viewList"
+    },
+    "transcriptPath": {
+      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+    },
+    "transcript": {
+      "type": "array",
+      "maxItems": 100000,
+      "items": {
+        "$ref": "#/$defs/transcriptEntry"
+      }
+    },
+    "completedAt": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "required": ["decision"],
+        "properties": {
+          "decision": { "const": "completed" }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "terminationReason": { "const": "user-ended" }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "required": ["decision"],
+        "properties": {
+          "decision": { "enum": ["cancelled", "failed"] }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "terminationReason": {
+            "not": { "const": "user-ended" }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "handoffDecision": {
+      "enum": ["completed", "cancelled", "failed"]
+    },
+    "terminationReason": {
+      "enum": [
+        "user-ended",
+        "child-failed",
+        "browser-timeout",
+        "main-cancelled",
+        "server-failed",
+        "compiler-failed"
+      ]
+    },
+    "transcriptEntry": {
+      "oneOf": [
+        { "$ref": "https://yarramate.org/schema/visual-event/v1" },
+        { "$ref": "https://yarramate.org/schema/visual-response/v1" }
+      ]
+    }
+  }
+}

--- a/schema/yarramate-visual-handoff.schema.json
+++ b/schema/yarramate-visual-handoff.schema.json
@@ -108,14 +108,7 @@
       "enum": ["completed", "cancelled", "failed"]
     },
     "terminationReason": {
-      "enum": [
-        "user-ended",
-        "child-failed",
-        "browser-timeout",
-        "main-cancelled",
-        "server-failed",
-        "compiler-failed"
-      ]
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/terminationReason"
     },
     "transcriptEntry": {
       "oneOf": [

--- a/schema/yarramate-visual-model.schema.json
+++ b/schema/yarramate-visual-model.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-model/v1",
+  "title": "YarraMate visual model",
+  "description": "One complete, self-contained LikeC4 candidate rendered inside a visual session.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "authority", "initialView", "sourceDigests", "files"],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-model/v1"
+    },
+    "authority": {
+      "$ref": "#/$defs/authority"
+    },
+    "initialView": {
+      "$ref": "#/$defs/viewId"
+    },
+    "sourceDigests": {
+      "type": "object",
+      "maxProperties": 4096,
+      "propertyNames": {
+        "$ref": "#/$defs/relativePath"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/digest"
+      }
+    },
+    "files": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 4096,
+      "propertyNames": {
+        "$ref": "#/$defs/modelFilePath"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/textFile"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "required": ["authority"],
+        "properties": {
+          "authority": {
+            "const": "canonical"
+          }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "sourceDigests": {
+            "type": "object",
+            "minProperties": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "required": ["authority"],
+        "properties": {
+          "authority": {
+            "const": "ad-hoc"
+          }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "sourceDigests": {
+            "type": "object",
+            "maxProperties": 0
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "authority": {
+      "enum": ["canonical", "ad-hoc"]
+    },
+    "viewId": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "relativePath": {
+      "type": "string",
+      "maxLength": 1024,
+      "pattern": "^(?:[A-Za-z0-9_-][A-Za-z0-9._-]*/)*[A-Za-z0-9_-][A-Za-z0-9._-]*$"
+    },
+    "modelFilePath": {
+      "type": "string",
+      "maxLength": 1024,
+      "pattern": "^(?:likec4\\.config\\.json|(?:[A-Za-z0-9_-][A-Za-z0-9._-]*/)*[A-Za-z0-9_-][A-Za-z0-9._-]*\\.(?:c4|likec4))$"
+    },
+    "textFile": {
+      "type": "string",
+      "maxLength": 5242880,
+      "pattern": "^[^\\u0000]*$"
+    }
+  }
+}

--- a/schema/yarramate-visual-response.schema.json
+++ b/schema/yarramate-visual-response.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-response/v1",
+  "title": "YarraMate visual session response",
+  "description": "One agent response correlated to the browser event that triggered it.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "sessionId",
+    "responseId",
+    "eventId",
+    "type",
+    "timestamp",
+    "payload"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-response/v1"
+    },
+    "sessionId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "responseId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "eventId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "type": {
+      "enum": [
+        "chat.response",
+        "agent.status",
+        "choice.present",
+        "model.replace",
+        "handoff.complete",
+        "diagnostic"
+      ]
+    },
+    "timestamp": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "chat.response" },
+        "payload": { "$ref": "#/$defs/chatResponsePayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "agent.status" },
+        "payload": { "$ref": "#/$defs/agentStatusPayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "choice.present" },
+        "payload": { "$ref": "#/$defs/choicePresentPayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "model.replace" },
+        "payload": { "$ref": "#/$defs/modelReplacePayload" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "handoff.complete" },
+        "payload": { "$ref": "#/$defs/handoffSummary" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["type", "payload"],
+      "properties": {
+        "type": { "const": "diagnostic" },
+        "payload": { "$ref": "#/$defs/diagnosticPayload" }
+      }
+    }
+  ],
+  "$defs": {
+    "shortId": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "summaryText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20000
+    },
+    "statementList": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000
+      }
+    },
+    "viewList": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/viewId"
+      }
+    },
+    "chatResponsePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 65536
+        }
+      }
+    },
+    "agentStatusPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state"],
+      "properties": {
+        "state": {
+          "enum": ["thinking", "compiling", "waiting", "idle"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        }
+      }
+    },
+    "choicePresentPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["choiceId", "question", "options"],
+      "properties": {
+        "choiceId": { "$ref": "#/$defs/shortId" },
+        "question": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "options": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "label"],
+            "properties": {
+              "id": { "$ref": "#/$defs/shortId" },
+              "label": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 400
+              },
+              "description": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4000
+              }
+            }
+          }
+        }
+      }
+    },
+    "modelReplacePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model"],
+      "properties": {
+        "model": {
+          "$ref": "https://yarramate.org/schema/visual-model/v1"
+        }
+      }
+    },
+    "handoffSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary",
+        "confirmedDecisions",
+        "requestedChanges",
+        "unresolvedQuestions",
+        "finalViews"
+      ],
+      "properties": {
+        "summary": { "$ref": "#/$defs/summaryText" },
+        "confirmedDecisions": { "$ref": "#/$defs/statementList" },
+        "requestedChanges": { "$ref": "#/$defs/statementList" },
+        "unresolvedQuestions": { "$ref": "#/$defs/statementList" },
+        "finalViews": { "$ref": "#/$defs/viewList" }
+      }
+    },
+    "diagnosticPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["diagnostics"],
+      "properties": {
+        "diagnostics": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1000,
+          "items": {
+            "$ref": "https://yarramate.org/schema/visual-diagnostic-result/v1#/$defs/diagnostic"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/yarramate-visual-session-descriptor.schema.json
+++ b/schema/yarramate-visual-session-descriptor.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-session-descriptor/v1",
+  "title": "YarraMate visual session descriptor",
+  "description": "Private mode 0600 file that carries the local agent credential used by the one-shot `yarramate-visual` commands.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "protocolVersion",
+    "sessionId",
+    "origin",
+    "agentCapability",
+    "sessionRoot",
+    "journalPath",
+    "createdAt"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-session-descriptor/v1"
+    },
+    "protocolVersion": {
+      "const": "yarramate/visual-protocol/v1"
+    },
+    "sessionId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "origin": {
+      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/localOrigin"
+    },
+    "agentCapability": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "sessionRoot": {
+      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+    },
+    "journalPath": {
+      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+    },
+    "createdAt": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+    }
+  }
+}

--- a/schema/yarramate-visual-session-request.schema.json
+++ b/schema/yarramate-visual-session-request.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-session-request/v1",
+  "title": "YarraMate visual session request",
+  "description": "Trusted main-agent input that starts a visual session. Browser URLs, identifiers, capabilities, ports, and filesystem locations are runtime outputs and cannot be supplied here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "authority",
+    "title",
+    "description",
+    "chatEnabled",
+    "compiler",
+    "initialModel"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-session-request/v1"
+    },
+    "authority": {
+      "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/authority"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4000
+    },
+    "chatEnabled": {
+      "type": "boolean"
+    },
+    "compiler": {
+      "$ref": "#/$defs/compilerCommand"
+    },
+    "initialModel": {
+      "$ref": "https://yarramate.org/schema/visual-model/v1"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "required": ["authority"],
+        "properties": {
+          "authority": { "const": "canonical" }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "initialModel": {
+            "type": "object",
+            "properties": {
+              "authority": { "const": "canonical" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "required": ["authority"],
+        "properties": {
+          "authority": { "const": "ad-hoc" }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "initialModel": {
+            "type": "object",
+            "properties": {
+              "authority": { "const": "ad-hoc" }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "compilerCommand": {
+      "description": "Absolute executable plus argument vector executed without a shell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "args"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "maxLength": 4096,
+          "pattern": "^(?:/|[A-Za-z]:[\\\\/])[^\\u0000]+$"
+        },
+        "args": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "maxLength": 4096,
+            "pattern": "^[^\\u0000]*$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/yarramate-visual-session-started.schema.json
+++ b/schema/yarramate-visual-session-started.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-session-started/v1",
+  "title": "YarraMate visual session started",
+  "description": "Public first line printed by `yarramate-visual start`. It never carries the private agent capability.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "protocolVersion",
+    "sessionId",
+    "authority",
+    "title",
+    "chatEnabled",
+    "browserUrl",
+    "webSocketUrl",
+    "origin",
+    "descriptorPath",
+    "sessionRoot",
+    "capabilities",
+    "startedAt"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-session-started/v1"
+    },
+    "protocolVersion": {
+      "const": "yarramate/visual-protocol/v1"
+    },
+    "sessionId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "authority": {
+      "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/authority"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "chatEnabled": {
+      "type": "boolean"
+    },
+    "browserUrl": {
+      "type": "string",
+      "pattern": "^http://127\\.0\\.0\\.1:[0-9]{1,5}/bootstrap\\?key=[0-9a-f]{16,}$"
+    },
+    "webSocketUrl": {
+      "type": "string",
+      "pattern": "^ws://127\\.0\\.0\\.1:[0-9]{1,5}/[A-Za-z0-9._/-]*$"
+    },
+    "origin": {
+      "$ref": "#/$defs/localOrigin"
+    },
+    "descriptorPath": {
+      "$ref": "#/$defs/absolutePath"
+    },
+    "sessionRoot": {
+      "$ref": "#/$defs/absolutePath"
+    },
+    "capabilities": {
+      "$ref": "#/$defs/capabilities"
+    },
+    "startedAt": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "required": ["chatEnabled"],
+        "properties": {
+          "chatEnabled": { "const": false }
+        }
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "capabilities": {
+            "type": "object",
+            "properties": {
+              "chat": { "const": false }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "localOrigin": {
+      "type": "string",
+      "pattern": "^http://127\\.0\\.0\\.1:[0-9]{1,5}$"
+    },
+    "absolutePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^/[^\\u0000]*$"
+    },
+    "capabilities": {
+      "description": "Features the browser session may use. Diagram-only mode disables chat.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "chat",
+        "choices",
+        "navigation",
+        "modelReplacement",
+        "transcript"
+      ],
+      "properties": {
+        "chat": { "type": "boolean" },
+        "choices": { "type": "boolean" },
+        "navigation": { "type": "boolean" },
+        "modelReplacement": { "type": "boolean" },
+        "transcript": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schema/yarramate-visual-status.schema.json
+++ b/schema/yarramate-visual-status.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yarramate.org/schema/visual-status/v1",
+  "title": "YarraMate visual session status",
+  "description": "Non-mutating report of server, browser, agent, queue, and lifecycle state.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "protocolVersion",
+    "sessionId",
+    "lifecycle",
+    "alreadyStopped",
+    "server",
+    "browser",
+    "agent",
+    "queue",
+    "capabilities",
+    "transcriptBytes",
+    "updatedAt"
+  ],
+  "properties": {
+    "format": {
+      "const": "yarramate/visual-status/v1"
+    },
+    "protocolVersion": {
+      "const": "yarramate/visual-protocol/v1"
+    },
+    "sessionId": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+    },
+    "lifecycle": {
+      "enum": ["starting", "running", "draining", "stopped"]
+    },
+    "alreadyStopped": {
+      "type": "boolean"
+    },
+    "server": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["listening", "origin"],
+      "properties": {
+        "listening": { "type": "boolean" },
+        "origin": {
+          "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/localOrigin"
+        }
+      }
+    },
+    "browser": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["connected", "connections"],
+      "properties": {
+        "connected": { "type": "boolean" },
+        "connections": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 64
+        },
+        "lastSeenAt": {
+          "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+        },
+        "graceExpiresAt": {
+          "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attached", "inFlightEventId"],
+      "properties": {
+        "attached": { "type": "boolean" },
+        "inFlightEventId": {
+          "oneOf": [
+            {
+              "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
+            },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "queue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pendingEvents", "lastSequence", "frozen"],
+      "properties": {
+        "pendingEvents": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 32
+        },
+        "lastSequence": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "frozen": { "type": "boolean" },
+        "frozenReason": {
+          "enum": [
+            "message-bytes",
+            "model-bytes",
+            "transcript-bytes",
+            "pending-events",
+            "browser-disconnected",
+            "terminal-event"
+          ]
+        }
+      }
+    },
+    "capabilities": {
+      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/capabilities"
+    },
+    "transcriptBytes": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5242880
+    },
+    "updatedAt": {
+      "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"
+    }
+  }
+}

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yarramate-architecture
-description: Discover, design, or maintain repository architecture using native YarraMate documents and the stable CLI. Use when an agent needs to map a codebase, propose an evidence-backed architecture model, brainstorm solution alternatives, evolve a model that already validates, rename or replace semantic subjects safely, define current/transition/target architecture, reconcile intent with evidence, or provide bounded architecture context to implementation work.
+description: Discover, design, or maintain repository architecture using native YarraMate documents and the stable CLI. Use when an agent needs to map a codebase, propose an evidence-backed architecture model, brainstorm solution alternatives, evolve a model that already validates, rename or replace semantic subjects safely, define current/transition/target architecture, reconcile intent with evidence, provide bounded architecture context to implementation work, or visually explain, show, walk through, or compare architecture or design choices in a browser.
 ---
 
 # YarraMate architecture
@@ -48,6 +48,8 @@ tools beyond the coverage boundary the output states.
   requested: begin with discovery,
   preserve the declared model, then report supported, contradicted, unknown,
   and unobserved claims without silently rewriting it.
+- A user asks to see, walk through, or compare architecture or choices
+  visually: follow **Explain a model visually**.
 
 Read [references/journey-checklists.md](references/journey-checklists.md) for
 the minimum evidence and design questions. Read
@@ -228,6 +230,31 @@ yarramate-likec4 export-project .yarramate/likec4-project.yaml .yarramate-out/li
    edit. The maintained model must pass before handoff. Report changed
    identities, updated dependants, mapping repairs, generated output, and any
    intentionally deferred architecture work.
+
+## Explain a model visually
+
+Use this journey when the answer is a picture the user talks to: "visually
+explain this architecture", "show how this question relates to the model",
+"compare these choices visually", "open a visual conversation about this flow".
+No CLI command is asked of the user; this skill stays the public interface.
+
+```text
+request
+  -> classify canonical or ad hoc authority
+  -> for repository architecture: yarramate check, then yarramate ask --json
+  -> resolve LikeC4 >=1.59.2 <1.60.0; ask before the pinned runner
+  -> inspect actual harness delegation/recovery capabilities
+  -> start yarramate-visual as a managed foreground process
+  -> capable: delegate a bounded visual agent and await handoff
+  -> incapable: diagram-only mode; continue the conversation here
+  -> End or failure: recover, optionally read the transcript, stop, resume
+```
+
+Read [references/visual-conversations.md](references/visual-conversations.md)
+before starting a session. It owns the authority rules, the compiler consent
+step, the capability test, the exact commands and documents, the delegated
+child's prompt and authority limits, and the recovery order. A visual session
+renders a bounded slice; it never becomes declared intent on its own.
 
 ## Correctness and authority
 

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -210,7 +210,7 @@ disposable.
 ```sh
 yarramate-visual recover <descriptor.json>              # structured handoff
 yarramate-visual recover <descriptor.json> --transcript # only if the summary is not enough
-yarramate-visual stop <descriptor.json>                 # shuts down, then deletes
+yarramate-visual stop <descriptor.json>                 # shuts down, prints the handoff, then deletes
 ```
 
 1. `recover` first, always, before anything is torn down. It returns
@@ -221,9 +221,14 @@ yarramate-visual stop <descriptor.json>                 # shuts down, then delet
 2. Request `--transcript` only when the summary leaves a question open. It is
    available until you stop the session.
 3. `stop` performs recoverable shutdown, terminates the server process tree,
-   and deletes the session directory itself. Do not delete `sessionRoot`, and
-   do not signal the process tree by hand — `stop` owns both. A repeated `stop`
-   reports the already-stopped state.
+   and deletes the session directory itself. It prints the terminal
+   `yarramate/visual-handoff/v1` document on the way out — the runtime's own,
+   journaled terminal event and all — so recovering first is still the rule but
+   the stop is not silent. Do not delete `sessionRoot`, and do not signal the
+   process tree by hand — `stop` owns both. A repeated `stop` reports the
+   already-stopped state: exit 0 with no document, because the session it would
+   hand off is gone. A descriptor that is unreadable for any other reason still
+   fails.
 4. Stop the managed process by its registered name.
 5. Resume the main conversation. Report the handoff, then treat
    `requestedChanges` as proposals for the ordinary journeys — never as edits

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -76,6 +76,12 @@ guarantees rather than its name:
 3. child completion is delivered back to this parent conversation;
 4. this parent stays interruptible and recoverable while the child runs.
 
+`chatEnabled: true` also means the parent will attach the delegated visual LLM
+agent described below. A canned, scripted, or transport-only responder may test
+the wire, but it does not satisfy this capability gate and must not be presented
+to the user as embedded chat. If no delegated LLM child will own the
+`wait`/`respond` loop, use diagram-only mode.
+
 A delegation tool alone is not enough. If any one is false, set
 `chatEnabled: false`: the browser opens in **diagram-only mode**, the user
 navigates views, and the conversation continues here in the main harness. Say
@@ -155,6 +161,10 @@ Pass the descriptor **path** to the child, never its contents.
 
 Capable harness only. One main conversation owns at most one session, one
 child, and one in-flight turn. The child prompt states its authority verbatim:
+
+Do not replace this child with a fixed-response script: the protocol is
+model-provider-neutral, but the embedded conversation still requires the
+harness's delegated LLM.
 
 ```text
 You are the delegated YarraMate visual agent for one session.

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -45,16 +45,22 @@ and Git review, after the user asks for that as its own step.
 ## 2. Preflight the LikeC4 compiler
 
 The request carries a trusted command vector; the runtime executes it and
-nothing else. The browser and the child cannot change it.
+nothing else. The browser and the child cannot change it. The compiler command
+must be an absolute executable path; the runtime deliberately rejects relative
+paths and `PATH` lookup.
 
-1. Prefer a repository-local executable satisfying `>=1.59.2 <1.60.0`:
-   `./node_modules/.bin/likec4 --version`. Use it as
-   `{"command": "./node_modules/.bin/likec4", "args": []}`.
+1. Prefer a repository-local executable satisfying `>=1.59.2 <1.60.0`. Print
+   its absolute path with
+   `node -p "require('node:path').resolve('./node_modules/.bin/likec4')"`, run
+   `<printed-path> --version`, then use
+   `{"command": "<printed absolute path>", "args": []}`.
 2. No compatible local executable? Ask the user once, in this turn, before
-   resolving the pinned runner
-   `{"command": "npx", "args": ["--yes", "likec4@1.59.2"]}`. Name the pin and
-   say that it resolves into the npx cache and adds no repository dependency.
-   Consent is per session; an unpinned or `@latest` runner is never the answer.
+   resolving the pinned runner. Run `command -v npx`, require an absolute
+   result, then use
+   `{"command": "<printed absolute npx path>", "args": ["--yes", "likec4@1.59.2"]}`.
+   Name the pin and say that it resolves into the npx cache and adds no
+   repository dependency. Consent is per session; an unpinned or `@latest`
+   runner is never the answer.
 3. The pinned runner needs Node `>=22.22.3`. Below that floor, report the
    preflight diagnostic and stop — the semantic binaries keep the package's own
    Node contract, so nothing else is affected.
@@ -87,7 +93,7 @@ capabilities, and filesystem locations are runtime outputs — never supply them
   "title": "Delivery architecture",
   "description": "Checked slice of .yarramate/workspace.yaml",
   "chatEnabled": true,
-  "compiler": { "command": "./node_modules/.bin/likec4", "args": [] },
+  "compiler": { "command": "/absolute/path/to/node_modules/.bin/likec4", "args": [] },
   "initialModel": {
     "format": "yarramate/visual-model/v1",
     "authority": "canonical",

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -1,5 +1,9 @@
 # Visual architecture conversations
 
+Beta: the browser workspace and delegated-chat journey are new and still
+settling. Tell the user this is a beta feature when you hand over
+`browserUrl` — do not present it as a finished journey.
+
 One local browser session that renders LikeC4 views of a bounded slice, opened
 and owned by you. `yarramate-visual` is a sibling runtime binary beside
 `yarramate-likec4`; it is presentation, never a subcommand of the semantic
@@ -153,8 +157,10 @@ with `nohup`, `setsid`, `&`, `screen`, or a process manager is not the
 substitute — a detached server is one the harness can no longer stop, and
 `stop` is what deletes the session.
 
-Give the user `browserUrl` as soon as the log yields it. The started line never
-carries the agent capability; that lives only in the mode `0600` descriptor.
+Give the user `browserUrl` as soon as the log yields it, alongside a one-line
+beta disclosure — the browser workspace is new and still settling. The
+started line never carries the agent capability; that lives only in the mode
+`0600` descriptor.
 Pass the descriptor **path** to the child, never its contents.
 
 ## 6. Delegate the visual agent

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -1,0 +1,236 @@
+# Visual architecture conversations
+
+One local browser session that renders LikeC4 views of a bounded slice, opened
+and owned by you. `yarramate-visual` is a sibling runtime binary beside
+`yarramate-likec4`; it is presentation, never a subcommand of the semantic
+`yarramate` CLI, and it never becomes canonical architecture by itself.
+
+Run the phases in order. Each one decides an input the next phase needs.
+
+```text
+classify authority -> preflight the compiler -> check harness capability
+  -> write the session request -> start the managed process
+  -> capable: delegate the child and await handoff
+  -> incapable: diagram-only, conversation stays here
+  -> End or failure: recover, transcript on demand, stop, resume
+```
+
+## 1. Classify authority
+
+Decide `canonical` or `ad-hoc` before touching the runtime. The browser labels
+the rendering with this value, so it is a claim about where the picture came
+from.
+
+| Request | Authority | Source of the model |
+|---|---|---|
+| This repository's architecture, and a workspace passes `yarramate check` | `canonical` | `yarramate ask <workspace> "<topic>" --json`, or an authored LikeC4 view when one already answers the request |
+| This repository's architecture, but no workspace exists or `check` fails | neither yet | Offer **Discover an existing project** first; report the diagnostics. Do not depict repository architecture from a failing model |
+| A general concept, a hypothetical question, or a comparison of options that are not declared intent | `ad-hoc` | A temporary LikeC4 model you author inside the session |
+
+For `canonical`, render only concepts, relationships, and descriptions present
+in the checked result:
+
+```sh
+yarramate check .yarramate/workspace.yaml --json
+yarramate ask .yarramate/workspace.yaml "<the user's words>" --json
+```
+
+For `ad-hoc`, keep every source file inside the session model. Never write it
+into `.yarramate/`, and never let it reach `apply`.
+
+A choice confirmed in the browser is a recorded selection in the handoff, not
+declared intent. It becomes canonical only through **Design a new solution**
+and Git review, after the user asks for that as its own step.
+
+## 2. Preflight the LikeC4 compiler
+
+The request carries a trusted command vector; the runtime executes it and
+nothing else. The browser and the child cannot change it.
+
+1. Prefer a repository-local executable satisfying `>=1.59.2 <1.60.0`:
+   `./node_modules/.bin/likec4 --version`. Use it as
+   `{"command": "./node_modules/.bin/likec4", "args": []}`.
+2. No compatible local executable? Ask the user once, in this turn, before
+   resolving the pinned runner
+   `{"command": "npx", "args": ["--yes", "likec4@1.59.2"]}`. Name the pin and
+   say that it resolves into the npx cache and adds no repository dependency.
+   Consent is per session; an unpinned or `@latest` runner is never the answer.
+3. The pinned runner needs Node `>=22.22.3`. Below that floor, report the
+   preflight diagnostic and stop — the semantic binaries keep the package's own
+   Node contract, so nothing else is affected.
+
+## 3. Check harness capability
+
+Set `chatEnabled: true` only when all four are true of the harness you are
+actually running in, judged from its tool inventory and documented lifecycle
+guarantees rather than its name:
+
+1. it can delegate a long-lived child agent;
+2. that child can make blocking CLI calls;
+3. child completion is delivered back to this parent conversation;
+4. this parent stays interruptible and recoverable while the child runs.
+
+A delegation tool alone is not enough. If any one is false, set
+`chatEnabled: false`: the browser opens in **diagram-only mode**, the user
+navigates views, and the conversation continues here in the main harness. Say
+which capability was missing; a well-known harness name is not evidence.
+
+## 4. Write the session request
+
+`yarramate/visual-session-request/v1`. Session identifiers, ports, URLs,
+capabilities, and filesystem locations are runtime outputs — never supply them.
+
+```json
+{
+  "format": "yarramate/visual-session-request/v1",
+  "authority": "canonical",
+  "title": "Delivery architecture",
+  "description": "Checked slice of .yarramate/workspace.yaml",
+  "chatEnabled": true,
+  "compiler": { "command": "./node_modules/.bin/likec4", "args": [] },
+  "initialModel": {
+    "format": "yarramate/visual-model/v1",
+    "authority": "canonical",
+    "initialView": "overview",
+    "sourceDigests": { ".yarramate/workspace.yaml": "<sha256>" },
+    "files": {
+      "likec4.config.json": "{\"name\":\"delivery\"}",
+      "model.likec4": "model { … }",
+      "views/overview.likec4": "views { view overview { include * } }"
+    }
+  }
+}
+```
+
+`authority` on the request and on the model agree. `sourceDigests` records what
+a canonical rendering was derived from; leave it empty for `ad-hoc`.
+
+For design choices, build one compact comparison view carrying the question,
+the options, their principal consequences and any recommendation, then one
+linked detail view per option, and state each view's source and authority in
+its description.
+
+## 5. Start the managed process
+
+```text
+yarramate-visual start <request.json>
+yarramate-visual wait <descriptor.json> [--after <sequence>]
+yarramate-visual respond <descriptor.json> <response.json>
+yarramate-visual status <descriptor.json>
+yarramate-visual recover <descriptor.json> [--transcript]
+yarramate-visual stop <descriptor.json> [--transcript]
+```
+
+`start` publishes one `yarramate/visual-session-started/v1` line on stdout
+carrying `browserUrl`, `descriptorPath`, `sessionRoot`, and `capabilities`,
+then blocks, serving the session until it is stopped.
+
+It is a managed foreground process, not a shell job and not a daemon. Launch it
+through the harness's long-running-process facility: register it under a stable
+name with a readiness condition matching that first stdout line, read
+`browserUrl` and `descriptorPath` out of the process log, drive every other
+command as an ordinary one-shot call against `descriptorPath`, and terminate it
+by that same name once the session is over. An ordinary tool call cannot host
+`start` — it never returns, so a call timeout kills the session.
+
+A harness with no facility that can host a foreground process across tool calls
+cannot run this journey at all. Say so and answer with the semantic journeys
+instead: `yarramate ask`, `export markdown`, and `yarramate-likec4
+export-project` for a rendering the user opens themselves. Detaching `start`
+with `nohup`, `setsid`, `&`, `screen`, or a process manager is not the
+substitute — a detached server is one the harness can no longer stop, and
+`stop` is what deletes the session.
+
+Give the user `browserUrl` as soon as the log yields it. The started line never
+carries the agent capability; that lives only in the mode `0600` descriptor.
+Pass the descriptor **path** to the child, never its contents.
+
+## 6. Delegate the visual agent
+
+Capable harness only. One main conversation owns at most one session, one
+child, and one in-flight turn. The child prompt states its authority verbatim:
+
+```text
+You are the delegated YarraMate visual agent for one session.
+You may call read-only YarraMate commands and yarramate-visual wait/respond/status/recover.
+You may replace only the temporary yarramate/visual-model/v1 session model.
+You must not edit repository files, .yarramate/, credentials, or harness configuration.
+On session.end or any terminal diagnostic, publish handoff.complete and exit.
+```
+
+Add the user's question, the descriptor path, the authority label, and the
+checked slice or the ad-hoc marker. That authority is temporary and
+visual-model-only; it does not widen because the browser asks.
+
+The child loops on one event at a time:
+
+1. `wait <descriptor> --after <lastSequence>`. Empty stdout is an idle window,
+   not a failure — call again from the same sequence.
+2. Answer from the bounded slice. Outside it, say so rather than inferring.
+3. `respond <descriptor> <response.json>` with a
+   `yarramate/visual-response/v1` document whose `sessionId` is this session's
+   own identifier, `eventId` is the event being answered, `responseId` is a
+   fresh 32 lowercase hex string, and `timestamp` is an ISO instant with
+   exactly three millisecond digits. The type is `chat.response`,
+   `agent.status`, `choice.present`, `model.replace`, `handoff.complete`, or
+   `diagnostic`. A response for another session is rejected.
+4. Advance `--after` to that event's `sequence`.
+
+The next chat turn is released only once the current event has a response or a
+terminal diagnostic; the browser may keep navigating meanwhile. A rejected
+`model.replace` keeps the last good diagram and returns source-located
+diagnostics — correct the sources and replace again; never patch partially.
+
+Limits freeze input rather than truncate: 64 KiB per message, 5 MiB per
+candidate model, 5 MiB of transcript, 32 pending events. A frozen queue routes
+the session through recovery. `status` reports `lifecycle`, `frozen`,
+`frozenReason`, `inFlightEventId`, and `lastSequence` without mutating
+anything.
+
+## 7. Diagram-only mode
+
+`chatEnabled: false` still starts the same managed process and the same
+renderer. There is no child. You hold the conversation in the main harness,
+re-render by writing a new request when the user's question moves, and end the
+session with the same recovery sequence.
+
+## 8. End, failure, and recovery
+
+Normal End, a child crash, a server or compiler failure, a browser that stays
+away past its five-minute grace, a protocol mismatch, or your own cancellation
+all take one path. You are the parent and the source of authority; the child is
+disposable.
+
+```sh
+yarramate-visual recover <descriptor.json>              # structured handoff
+yarramate-visual recover <descriptor.json> --transcript # only if the summary is not enough
+yarramate-visual stop <descriptor.json>                 # shuts down, then deletes
+```
+
+1. `recover` first, always, before anything is torn down. It returns
+   `yarramate/visual-handoff/v1`: `summary`, `confirmedDecisions`,
+   `requestedChanges`, `unresolvedQuestions`, `finalViews`, `authority`,
+   `decision`, `terminationReason`, `lastSequence`, and `transcriptPath`. This
+   is the record of what happened; your recollection is not.
+2. Request `--transcript` only when the summary leaves a question open. It is
+   available until you stop the session.
+3. `stop` performs recoverable shutdown, terminates the server process tree,
+   and deletes the session directory itself. Do not delete `sessionRoot`, and
+   do not signal the process tree by hand — `stop` owns both. A repeated `stop`
+   reports the already-stopped state.
+4. Stop the managed process by its registered name.
+5. Resume the main conversation. Report the handoff, then treat
+   `requestedChanges` as proposals for the ordinary journeys — never as edits
+   already made.
+
+A session that never started delegates nothing: report the diagnostic and
+continue in the main harness. A hard-killed runtime leaves its directory
+behind; the next `start` prunes it once it is more than 24 hours old.
+
+## Report
+
+Add to the normal handoff: authority label and its source, whether chat or
+diagram-only ran and which capability decided it, the compiler that was used
+and whether the pinned runner was consented, confirmed selections and requested
+changes from the handoff, the termination reason, and confirmation that the
+session was stopped.

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -276,11 +276,16 @@ export const runVisualStart = async (
   signals.on('SIGTERM', interrupt)
   try {
     const closed = await handle.closed
-    return FAILED_TERMINATION[closed.reason] === true
+    // The recovered handoff is what the journal says happened; the reason the
+    // stop asked for is only what someone wanted. A session the reviewer ended
+    // is a success even when a cancelling agent is what closed the server, and
+    // a child that died before its handoff is a failure even when it did not.
+    const outcome = closed.handoff?.terminationReason ?? closed.reason
+    return FAILED_TERMINATION[outcome] === true
       ? refusalResult([
           visualClientDiagnostic(
             'YMVS409',
-            `Visual session ${handle.started.sessionId} ended with termination reason "${closed.reason}"`,
+            `Visual session ${handle.started.sessionId} ended with termination reason "${outcome}"`,
           ),
         ])
       : { exitCode: 0, stdout: '', stderr: '' }

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -269,8 +269,14 @@ export const runVisualStart = async (
 
   // One handler for both signals: `stop` converges on the first reason it is
   // given, so a repeated or second signal is absorbed rather than racing.
+  //
+  // A signal is not a caller, and nothing here awaits the teardown it starts:
+  // a stop that fails is observed rather than left to reach the runtime as an
+  // unhandled rejection and take the whole session down with it. What it could
+  // not tear down is still up, this command is still blocked on `closed`, and
+  // the next signal runs the teardown again.
   const interrupt = () => {
-    void handle.stop('main-cancelled')
+    void handle.stop('main-cancelled').catch(() => undefined)
   }
   signals.on('SIGINT', interrupt)
   signals.on('SIGTERM', interrupt)

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+import { join } from 'node:path'
+import { isMainModule, versionResult, type CliResult } from '../cli-support.js'
+import {
+  fetchVisualStatus,
+  readVisualJsonDocument,
+  readVisualSessionDescriptor,
+  recoverVisualSessionClient,
+  sendVisualResponse,
+  stopVisualSessionClient,
+  visualClientDiagnostic,
+  visualFailureDiagnostics,
+  waitForVisualEvent,
+} from './visual/client.js'
+import {
+  parseVisualResponse,
+  parseVisualSessionRequest,
+  type VisualDiagnostic,
+  type VisualTerminationReason,
+} from './visual/protocol.js'
+import { startVisualServer } from './visual/session-server.js'
+import { pruneStaleVisualSessions } from './visual/session-store.js'
+
+export const visualUsage =
+  'Usage:\n' +
+  '  yarramate-visual start <request.json>\n' +
+  '  yarramate-visual wait <descriptor.json> [--after <sequence>]\n' +
+  '  yarramate-visual respond <descriptor.json> <response.json>\n' +
+  '  yarramate-visual status <descriptor.json>\n' +
+  '  yarramate-visual recover <descriptor.json> [--transcript]\n' +
+  '  yarramate-visual stop <descriptor.json> [--transcript]\n' +
+  '  yarramate-visual --version\n'
+
+/**
+ * Where a repository keeps its live sessions, one directory per session. It sits
+ * under the ignored build directory because a session is runtime state: never
+ * canonical, never committed, and pruned by the next start.
+ */
+export const VISUAL_SESSION_DIRECTORY = join('.yarramate-out', 'visual')
+
+/** Terminations that mean the session did not end the way it was asked to. */
+const FAILED_TERMINATION: Readonly<
+  Partial<Record<VisualTerminationReason, true>>
+> = {
+  'child-failed': true,
+  'server-failed': true,
+  'compiler-failed': true,
+}
+
+const usageResult: CliResult = {
+  exitCode: 2,
+  stdout: '',
+  stderr: visualUsage,
+}
+
+/**
+ * One document per line: every command an agent drives writes at most one
+ * versioned document, so a caller reads exactly one line per invocation.
+ */
+const documentLine = (value: unknown) => `${JSON.stringify(value)}\n`
+
+/**
+ * Stdout carries the document that was asked for and nothing else, so a refusal
+ * goes to stderr where it cannot be mistaken for an answer.
+ */
+const refusalResult = (
+  diagnostics: readonly VisualDiagnostic[],
+): CliResult => ({
+  exitCode: 1,
+  stdout: '',
+  stderr: documentLine({
+    format: 'yarramate/visual-diagnostic-result/v1',
+    diagnostics,
+  }),
+})
+
+/** Sequences are counted, so only a plain non-negative integer is one. */
+const sequenceFlag = (rest: readonly string[]): number | undefined => {
+  if (rest.length === 0) return 0
+  const [flag, value] = rest
+  if (flag !== '--after' || value === undefined || rest.length !== 2) {
+    return undefined
+  }
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) return undefined
+  const sequence = Number(value)
+  return Number.isSafeInteger(sequence) ? sequence : undefined
+}
+
+const transcriptFlag = (rest: readonly string[]): boolean | undefined =>
+  rest.length === 0
+    ? false
+    : rest.length === 1 && rest[0] === '--transcript'
+      ? true
+      : undefined
+
+const waitCliCommand = async (
+  descriptorPath: string,
+  rest: readonly string[],
+  cwd: string,
+): Promise<CliResult> => {
+  const after = sequenceFlag(rest)
+  if (after === undefined) return usageResult
+  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  const delivery = await waitForVisualEvent(descriptor.value, after)
+  if (!delivery.ok) return refusalResult(delivery.diagnostics)
+  return {
+    exitCode: 0,
+    // An idle window is not a failure and has no document: the caller polls
+    // again from the sequence it already knows.
+    stdout: delivery.value.waiting ? '' : documentLine(delivery.value.event),
+    stderr: '',
+  }
+}
+
+const respondCliCommand = async (
+  descriptorPath: string,
+  rest: readonly string[],
+  cwd: string,
+): Promise<CliResult> => {
+  const [responsePath, ...trailing] = rest
+  if (responsePath === undefined || trailing.length > 0) return usageResult
+  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  const document = await readVisualJsonDocument(responsePath, cwd)
+  if (!document.ok) return refusalResult(document.diagnostics)
+  // Validated here as well as by the runtime, so an invalid response never
+  // reaches the session at all.
+  const response = parseVisualResponse(document.value)
+  if (!response.ok) return refusalResult(response.diagnostics)
+  const accepted = await sendVisualResponse(descriptor.value, response.value)
+  if (!accepted.ok) return refusalResult(accepted.diagnostics)
+  return { exitCode: 0, stdout: documentLine(accepted.value), stderr: '' }
+}
+
+const statusCliCommand = async (
+  descriptorPath: string,
+  rest: readonly string[],
+  cwd: string,
+): Promise<CliResult> => {
+  if (rest.length > 0) return usageResult
+  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  const status = await fetchVisualStatus(descriptor.value)
+  if (!status.ok) return refusalResult(status.diagnostics)
+  return { exitCode: 0, stdout: documentLine(status.value), stderr: '' }
+}
+
+const recoverCliCommand = async (
+  descriptorPath: string,
+  rest: readonly string[],
+  cwd: string,
+): Promise<CliResult> => {
+  const includeTranscript = transcriptFlag(rest)
+  if (includeTranscript === undefined) return usageResult
+  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  const handoff = await recoverVisualSessionClient(
+    descriptor.value,
+    includeTranscript,
+  )
+  if (!handoff.ok) return refusalResult(handoff.diagnostics)
+  return { exitCode: 0, stdout: documentLine(handoff.value), stderr: '' }
+}
+
+const stopCliCommand = async (
+  descriptorPath: string,
+  rest: readonly string[],
+  cwd: string,
+): Promise<CliResult> => {
+  const includeTranscript = transcriptFlag(rest)
+  if (includeTranscript === undefined) return usageResult
+  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  const stopped = await stopVisualSessionClient(
+    descriptor.value,
+    includeTranscript,
+  )
+  if (!stopped.ok) return refusalResult(stopped.diagnostics)
+  return {
+    exitCode: 0,
+    // A session that was already gone has no handoff left to publish.
+    stdout: stopped.value === undefined ? '' : documentLine(stopped.value),
+    stderr: '',
+  }
+}
+
+/**
+ * Every command an agent can run to completion. `start` is not one of them: it
+ * blocks for the life of the session and is dispatched by `runVisualCli`.
+ */
+export async function runVisualClientCli(
+  args: readonly string[],
+  cwd: string = process.cwd(),
+): Promise<CliResult> {
+  const [command, descriptor, ...rest] = args
+  if (command === '--version') return versionResult('yarramate-visual')
+  if (descriptor === undefined) return usageResult
+  switch (command) {
+    case 'wait':
+      return waitCliCommand(descriptor, rest, cwd)
+    case 'respond':
+      return respondCliCommand(descriptor, rest, cwd)
+    case 'status':
+      return statusCliCommand(descriptor, rest, cwd)
+    case 'recover':
+      return recoverCliCommand(descriptor, rest, cwd)
+    case 'stop':
+      return stopCliCommand(descriptor, rest, cwd)
+    default:
+      return usageResult
+  }
+}
+
+/** Where a foreground session publishes, and where it observes its signals. */
+export interface VisualSignalSource {
+  on(signal: 'SIGINT' | 'SIGTERM', listener: () => void): unknown
+  off(signal: 'SIGINT' | 'SIGTERM', listener: () => void): unknown
+}
+
+export interface VisualStartIo {
+  readonly stdout: (chunk: string) => void
+  readonly stderr: (chunk: string) => void
+  /** Defaults to the process itself. */
+  readonly signals?: VisualSignalSource
+}
+
+const processIo: VisualStartIo = {
+  stdout: (chunk) => void process.stdout.write(chunk),
+  stderr: (chunk) => void process.stderr.write(chunk),
+}
+
+/**
+ * Serves one visual session in the foreground.
+ *
+ * The request is validated before any filesystem or network effect, so a bad
+ * document costs nothing. Exactly one public `visual-session-started/v1` line is
+ * published before the command blocks — it names the private descriptor but
+ * never carries the agent capability, which lives only in that mode 0600 file.
+ * The command then holds the session open until the runtime closes it, whether
+ * that is a signal, an agent stop, or a runtime failure; the runtime recovers
+ * the handoff before it removes the session in every one of those cases.
+ */
+export const runVisualStart = async (
+  requestPath: string,
+  cwd: string = process.cwd(),
+  io: VisualStartIo = processIo,
+): Promise<CliResult> => {
+  const document = await readVisualJsonDocument(requestPath, cwd)
+  if (!document.ok) return refusalResult(document.diagnostics)
+  const request = parseVisualSessionRequest(document.value)
+  if (!request.ok) return refusalResult(request.diagnostics)
+
+  const baseDir = join(cwd, VISUAL_SESSION_DIRECTORY)
+  const signals = io.signals ?? process
+  let handle
+  try {
+    // A previous runtime's orphans are collected on the critical path of a new
+    // session, bounded per pass so a full directory cannot stall this one.
+    await pruneStaleVisualSessions(baseDir, new Date())
+    handle = await startVisualServer({ request: request.value, baseDir })
+  } catch (cause) {
+    // A failed start has already recovered and removed whatever it created.
+    return refusalResult(visualFailureDiagnostics(cause))
+  }
+
+  io.stdout(documentLine(handle.started))
+
+  // One handler for both signals: `stop` converges on the first reason it is
+  // given, so a repeated or second signal is absorbed rather than racing.
+  const interrupt = () => {
+    void handle.stop('main-cancelled')
+  }
+  signals.on('SIGINT', interrupt)
+  signals.on('SIGTERM', interrupt)
+  try {
+    const closed = await handle.closed
+    return FAILED_TERMINATION[closed.reason] === true
+      ? refusalResult([
+          visualClientDiagnostic(
+            'YMVS409',
+            `Visual session ${handle.started.sessionId} ended with termination reason "${closed.reason}"`,
+          ),
+        ])
+      : { exitCode: 0, stdout: '', stderr: '' }
+  } finally {
+    signals.off('SIGINT', interrupt)
+    signals.off('SIGTERM', interrupt)
+  }
+}
+
+/**
+ * The whole binary: `start` blocks and streams its one document through `io`,
+ * every other command runs to completion and returns its document.
+ */
+export const runVisualCli = async (
+  args: readonly string[],
+  cwd: string = process.cwd(),
+  io: VisualStartIo = processIo,
+): Promise<CliResult> => {
+  if (args[0] !== 'start') return runVisualClientCli(args, cwd)
+  const requestPath = args[1]
+  if (requestPath === undefined || args.length !== 2) return usageResult
+  return runVisualStart(requestPath, cwd, io)
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  void runVisualCli(process.argv.slice(2)).then((result) => {
+    process.stdout.write(result.stdout)
+    process.stderr.write(result.stderr)
+    process.exitCode = result.exitCode
+  })
+}

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -45,6 +45,7 @@ const FAILED_TERMINATION: Readonly<
   Partial<Record<VisualTerminationReason, true>>
 > = {
   'child-failed': true,
+  'browser-timeout': true,
   'server-failed': true,
   'compiler-failed': true,
 }

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -11,6 +11,7 @@ import {
   stopVisualSessionClient,
   visualClientDiagnostic,
   visualFailureDiagnostics,
+  visualSessionAlreadyStopped,
   waitForVisualEvent,
 } from './visual/client.js'
 import {
@@ -164,6 +165,20 @@ const recoverCliCommand = async (
   return { exitCode: 0, stdout: documentLine(handoff.value), stderr: '' }
 }
 
+/**
+ * Converges the session on stopped, and says so however many times it is asked.
+ * The design's failure table requires a repeated stop to report the
+ * already-stopped state, and the first stop takes the descriptor with the
+ * session root, so the second invocation has nothing left to read. That one
+ * shape — descriptor and session root both gone — reports the same benign
+ * already-stopped result the client returns for a retained descriptor: exit 0,
+ * no handoff document, because there is no session left to hand off.
+ *
+ * Every other unreadable descriptor still refuses. Nothing weakens: no
+ * credential is retained, no directory is removed on the strength of a
+ * descriptor that did not parse, and a corrupt, redirected, or foreign
+ * descriptor fails exactly as before.
+ */
 const stopCliCommand = async (
   descriptorPath: string,
   rest: readonly string[],
@@ -172,7 +187,11 @@ const stopCliCommand = async (
   const includeTranscript = transcriptFlag(rest)
   if (includeTranscript === undefined) return usageResult
   const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
-  if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  if (!descriptor.ok) {
+    return (await visualSessionAlreadyStopped(descriptorPath, cwd))
+      ? { exitCode: 0, stdout: '', stderr: '' }
+      : refusalResult(descriptor.diagnostics)
+  }
   const stopped = await stopVisualSessionClient(
     descriptor.value,
     includeTranscript,

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -1,5 +1,6 @@
-import { lstat, readFile, stat } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { constants } from 'node:fs'
+import { lstat, open, readFile, stat } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
 import {
   VISUAL_PROTOCOL_VERSION,
   parseVisualDiagnosticResult,
@@ -115,6 +116,26 @@ const exists = (path: string) =>
   )
 
 /**
+ * Whether a descriptor path is unreadable *because the session it lived in is
+ * already stopped*. A completed stop removes the descriptor with the session
+ * root that contained it, so the absence of both is the signature that stop
+ * leaves behind, and the only unreadable descriptor a repeated stop may treat
+ * as benign.
+ *
+ * Anything else stays fail-closed: a descriptor missing from a directory that
+ * still exists is an anomaly rather than a stop, a dangling symlink is a
+ * present entry `lstat` sees, and a path in a directory that never held a
+ * session reports the ordinary refusal.
+ */
+export const visualSessionAlreadyStopped = async (
+  path: string,
+  cwd: string = process.cwd(),
+): Promise<boolean> => {
+  const target = resolve(cwd, path)
+  return !(await exists(target)) && !(await exists(dirname(target)))
+}
+
+/**
  * The agent's entry point into one live session, read the way a hostile file
  * has to be read. The descriptor is the only file carrying the agent
  * capability, so a redirected or planted one must never be spent.
@@ -125,9 +146,25 @@ export const readVisualSessionDescriptor = async (
 ): Promise<ParseResult<VisualSessionDescriptor>> => {
   const target = resolve(cwd, path)
   let raw: string
+  // One handle, opened once: the descriptor is the only file carrying the agent
+  // capability, so the thing that is checked has to be the thing that is read.
+  // `O_NOFOLLOW` refuses a symlinked capability in the open itself, and the
+  // file kind is taken from the open handle, leaving no window between the
+  // check and the read for the path to be swapped.
+  const handle = await open(
+    target,
+    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+  ).catch(() => undefined)
+  if (handle === undefined) {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS401',
+        `Session descriptor "${target}" cannot be read`,
+      ),
+    ])
+  }
   try {
-    // lstat, never stat: a symlinked descriptor is a redirected capability.
-    const entry = await lstat(target)
+    const entry = await handle.stat()
     if (!entry.isFile()) {
       return refused([
         visualClientDiagnostic(
@@ -136,7 +173,7 @@ export const readVisualSessionDescriptor = async (
         ),
       ])
     }
-    raw = await readFile(target, 'utf8')
+    raw = await handle.readFile('utf8')
   } catch {
     return refused([
       visualClientDiagnostic(
@@ -144,6 +181,8 @@ export const readVisualSessionDescriptor = async (
         `Session descriptor "${target}" cannot be read`,
       ),
     ])
+  } finally {
+    await handle.close()
   }
   let document: unknown
   try {

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -148,12 +148,15 @@ export const readVisualSessionDescriptor = async (
   let raw: string
   // One handle, opened once: the descriptor is the only file carrying the agent
   // capability, so the thing that is checked has to be the thing that is read.
-  // `O_NOFOLLOW` refuses a symlinked capability in the open itself, and the
-  // file kind is taken from the open handle, leaving no window between the
-  // check and the read for the path to be swapped.
+  // `O_NOFOLLOW` refuses a symlinked capability in the open itself,
+  // `O_NONBLOCK` prevents a planted FIFO from hanging the open, and the file
+  // kind is taken from the open handle, leaving no window between the check
+  // and the read for the path to be swapped.
   const handle = await open(
     target,
-    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    constants.O_RDONLY |
+      constants.O_NONBLOCK |
+      (constants.O_NOFOLLOW ?? 0),
   ).catch(() => undefined)
   if (handle === undefined) {
     return refused([

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -1,6 +1,6 @@
 import { constants } from 'node:fs'
 import { lstat, open, readFile, stat } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import {
   VISUAL_PROTOCOL_VERSION,
   parseVisualDiagnosticResult,
@@ -115,24 +115,79 @@ const exists = (path: string) =>
     () => false,
   )
 
+
+const writeStoppedMarker = async (
+  sessionRoot: string,
+  sessionId: string,
+): Promise<void> => {
+  const handle = await open(
+    join(dirname(sessionRoot), `.stopped-${basename(sessionRoot)}.json`),
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_TRUNC |
+      (constants.O_NOFOLLOW ?? 0),
+    0o600,
+  )
+  try {
+    await handle.writeFile(
+      JSON.stringify({
+        format: 'yarramate/visual-session-stopped/v1',
+        sessionId,
+      }),
+      'utf8',
+    )
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+const readsStoppedMarker = async (
+  sessionRoot: string,
+  sessionId: string,
+): Promise<boolean> => {
+  const handle = await open(
+    join(dirname(sessionRoot), `.stopped-${basename(sessionRoot)}.json`),
+    constants.O_RDONLY |
+      constants.O_NONBLOCK |
+      (constants.O_NOFOLLOW ?? 0),
+  ).catch(() => undefined)
+  if (handle === undefined) return false
+  try {
+    const entry = await handle.stat()
+    if (!entry.isFile()) return false
+    const document = documentFields(
+      JSON.parse(await handle.readFile('utf8')) as unknown,
+    )
+    return (
+      document.format === 'yarramate/visual-session-stopped/v1' &&
+      document.sessionId === sessionId
+    )
+  } catch {
+    return false
+  } finally {
+    await handle.close()
+  }
+}
+
 /**
- * Whether a descriptor path is unreadable *because the session it lived in is
- * already stopped*. A completed stop removes the descriptor with the session
- * root that contained it, so the absence of both is the signature that stop
- * leaves behind, and the only unreadable descriptor a repeated stop may treat
- * as benign.
- *
- * Anything else stays fail-closed: a descriptor missing from a directory that
- * still exists is an anomaly rather than a stop, a dangling symlink is a
- * present entry `lstat` sees, and a path in a directory that never held a
- * session reports the ordinary refusal.
+ * Whether an unreadable descriptor belongs to a session this client already
+ * removed. Absence alone is not evidence: the stopped marker is written before
+ * teardown and names the vanished session directory.
  */
 export const visualSessionAlreadyStopped = async (
   path: string,
   cwd: string = process.cwd(),
 ): Promise<boolean> => {
   const target = resolve(cwd, path)
-  return !(await exists(target)) && !(await exists(dirname(target)))
+  const sessionRoot = dirname(target)
+  const sessionId = basename(sessionRoot)
+  return (
+    basename(target) === 'descriptor.json' &&
+    !(await exists(target)) &&
+    !(await exists(sessionRoot)) &&
+    (await readsStoppedMarker(sessionRoot, sessionId))
+  )
 }
 
 /**
@@ -541,6 +596,7 @@ export const stopVisualSessionClient = async (
   }
   const terminal = answered.ok ? closedHandoff(answered.value) : undefined
   try {
+    await writeStoppedMarker(paths.root, descriptor.sessionId)
     await removeVisualSession(paths, includeTranscript)
   } catch (cause) {
     return refused(visualFailureDiagnostics(cause))

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -4,6 +4,7 @@ import {
   VISUAL_PROTOCOL_VERSION,
   parseVisualDiagnosticResult,
   parseVisualEvent,
+  parseVisualHandoff,
   parseVisualSessionDescriptor,
   parseVisualStatus,
   type ParseResult,
@@ -450,10 +451,28 @@ export const recoverVisualSessionClient = async (
 }
 
 /**
+ * The handoff a runtime answered its own stop with. It is the terminal one —
+ * journaled terminal event and all — so it supersedes what this client read
+ * on the way in. Anything that is not a conforming handoff is dropped rather
+ * than repaired: the pre-stop recovery is already a sound answer.
+ */
+const closedHandoff = (answer: AgentAnswer): VisualHandoff | undefined => {
+  let document: unknown
+  try {
+    document = JSON.parse(answer.body)
+  } catch {
+    return undefined
+  }
+  const handoff = parseVisualHandoff(documentFields(document).handoff)
+  return handoff.ok ? handoff.value : undefined
+}
+
+/**
  * Converges one session on stopped, whatever is left of it. Recovery runs
  * first, so no later step can be the one that loses confirmed state; the stop
- * request only returns once the runtime has drained and removed the session it
- * owns; and the local removal converges the case where nothing was listening.
+ * request only returns once the runtime has journaled its terminal event,
+ * drained, and removed the session it owns; and the local removal converges
+ * the case where nothing was listening.
  *
  * `undefined` means the session was already gone, which is what makes a
  * repeated stop idempotent.
@@ -472,16 +491,17 @@ export const stopVisualSessionClient = async (
   const answered = await agentRequest(
     descriptor,
     AGENT_STOP,
-    JSON.stringify({ reason: STOP_REASON }),
+    JSON.stringify({ reason: STOP_REASON, includeTranscript }),
   )
   // A server that answered and refused is not this caller's to tear down.
   if (answered.ok && answered.value.status !== 200) {
     return refused(refusalDiagnostics(answered.value, AGENT_STOP))
   }
+  const terminal = answered.ok ? closedHandoff(answered.value) : undefined
   try {
     await removeVisualSession(paths, includeTranscript)
   } catch (cause) {
     return refused(visualFailureDiagnostics(cause))
   }
-  return recovered
+  return { ok: true, value: terminal ?? recovered.value }
 }

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -1,0 +1,487 @@
+import { lstat, readFile, stat } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import {
+  VISUAL_PROTOCOL_VERSION,
+  parseVisualDiagnosticResult,
+  parseVisualEvent,
+  parseVisualSessionDescriptor,
+  parseVisualStatus,
+  type ParseResult,
+  type VisualDiagnostic,
+  type VisualHandoff,
+  type VisualResponse,
+  type VisualSessionDescriptor,
+  type VisualStatus,
+} from './protocol.js'
+import {
+  VISUAL_SERVER_LIMITS,
+  type VisualEventDelivery,
+  type VisualResponseAcceptance,
+} from './session-server.js'
+import {
+  recoverVisualSession,
+  removeVisualSession,
+  visualSessionPaths,
+} from './session-store.js'
+
+/**
+ * Document name reported by diagnostics the client itself raises — an
+ * unreadable descriptor, an unreachable session server, or an answer that is
+ * not the document the route promises.
+ */
+export const VISUAL_CLIENT_DOCUMENT = 'visual-session-client'
+
+export const VISUAL_CLIENT_LIMITS = {
+  /**
+   * Ceiling on one agent request. It has to outlast the server's long poll,
+   * which answers "still idle" only once its own window closes, or every idle
+   * wait would be reported as a transport failure.
+   */
+  requestTimeoutMs: VISUAL_SERVER_LIMITS.agentPollMs + 5_000,
+  /** How much of a refusal the diagnostic explaining it quotes back. */
+  refusalBytes: 512,
+} as const
+
+/** Termination reason a one-shot `stop` asks the runtime to close under. */
+const STOP_REASON = 'main-cancelled'
+
+const AGENT_EVENTS = '/api/agent/events'
+const AGENT_STATUS = '/api/agent/status'
+const AGENT_RESPONSES = '/api/agent/responses'
+const AGENT_STOP = '/api/agent/stop'
+
+/**
+ * Session store failures already carry the protocol code that explains them, so
+ * they are surfaced under that code rather than flattened into one client code.
+ */
+const STORE_FAILURE = /^(YMVS[0-9]{3}): ([\s\S]+)$/
+
+/**
+ * `pointer` is an RFC 6901 pointer into the document being refused; a refusal
+ * the client raised about the transport itself is rooted at `/`.
+ */
+export const visualClientDiagnostic = (
+  code: string,
+  message: string,
+  pointer = '/',
+): VisualDiagnostic => ({
+  severity: 'error',
+  code,
+  message,
+  path: VISUAL_CLIENT_DOCUMENT,
+  pointer,
+  line: 1,
+  column: 1,
+})
+
+const refused = <T>(
+  diagnostics: readonly VisualDiagnostic[],
+): ParseResult<T> => ({ ok: false, diagnostics })
+
+export const visualFailureDiagnostics = (
+  cause: unknown,
+): readonly VisualDiagnostic[] => {
+  const message = cause instanceof Error ? cause.message : String(cause)
+  const named = STORE_FAILURE.exec(message)
+  const code = named?.[1]
+  const detail = named?.[2]
+  return code === undefined || detail === undefined
+    ? [visualClientDiagnostic('YMVS408', message)]
+    : [visualClientDiagnostic(code, detail)]
+}
+
+const summarise = (value: unknown) => {
+  const text = value instanceof Error ? value.message : String(value)
+  const trimmed = text.trim().split('\n')[0] ?? ''
+  return trimmed.length > VISUAL_CLIENT_LIMITS.refusalBytes
+    ? `${trimmed.slice(0, VISUAL_CLIENT_LIMITS.refusalBytes)}…`
+    : trimmed
+}
+
+/**
+ * Reads an untrusted answer's own fields. Anything that is not a plain object
+ * simply has no fields, so the field checks report the violation.
+ */
+const documentFields = (value: unknown): Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : {}
+
+const exists = (path: string) =>
+  lstat(path).then(
+    () => true,
+    () => false,
+  )
+
+/**
+ * The agent's entry point into one live session, read the way a hostile file
+ * has to be read. The descriptor is the only file carrying the agent
+ * capability, so a redirected or planted one must never be spent.
+ */
+export const readVisualSessionDescriptor = async (
+  path: string,
+  cwd: string = process.cwd(),
+): Promise<ParseResult<VisualSessionDescriptor>> => {
+  const target = resolve(cwd, path)
+  let raw: string
+  try {
+    // lstat, never stat: a symlinked descriptor is a redirected capability.
+    const entry = await lstat(target)
+    if (!entry.isFile()) {
+      return refused([
+        visualClientDiagnostic(
+          'YMVS401',
+          `Session descriptor "${target}" is not a regular file`,
+        ),
+      ])
+    }
+    raw = await readFile(target, 'utf8')
+  } catch {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS401',
+        `Session descriptor "${target}" cannot be read`,
+      ),
+    ])
+  }
+  let document: unknown
+  try {
+    document = JSON.parse(raw)
+  } catch {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS402',
+        `Session descriptor "${target}" is not JSON`,
+      ),
+    ])
+  }
+  const parsed = parseVisualSessionDescriptor(document)
+  if (!parsed.ok) return parsed
+  const paths = visualSessionPaths(parsed.value.sessionRoot)
+  // A descriptor authorises work on the session it lives in and no other: this
+  // is the same invariant the runtime enforced when it published the file, so a
+  // copied or planted descriptor cannot direct a stop at another directory.
+  if (paths.descriptor !== target || paths.journal !== parsed.value.journalPath) {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS403',
+        `Session descriptor "${target}" names session artefacts outside its own directory`,
+      ),
+    ])
+  }
+  return parsed
+}
+
+/** One JSON document the agent hands to a command, read from the filesystem. */
+export const readVisualJsonDocument = async (
+  path: string,
+  cwd: string = process.cwd(),
+): Promise<ParseResult<unknown>> => {
+  const target = resolve(cwd, path)
+  try {
+    return { ok: true, value: JSON.parse(await readFile(target, 'utf8')) }
+  } catch {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS407',
+        `Document "${target}" is not a readable JSON document`,
+      ),
+    ])
+  }
+}
+
+interface AgentAnswer {
+  readonly status: number
+  readonly contentType: string
+  readonly body: string
+}
+
+/**
+ * One bearer request to the loopback origin the descriptor names. The
+ * descriptor schema confines that origin to 127.0.0.1, so the capability never
+ * travels off the host that minted it.
+ */
+const agentRequest = async (
+  descriptor: VisualSessionDescriptor,
+  route: string,
+  body?: string,
+): Promise<ParseResult<AgentAnswer>> => {
+  try {
+    const response = await fetch(`${descriptor.origin}${route}`, {
+      method: body === undefined ? 'GET' : 'POST',
+      headers: {
+        Authorization: `Bearer ${descriptor.agentCapability}`,
+        ...(body === undefined
+          ? {}
+          : { 'Content-Type': 'application/json; charset=utf-8' }),
+      },
+      body,
+      signal: AbortSignal.timeout(VISUAL_CLIENT_LIMITS.requestTimeoutMs),
+    })
+    return {
+      ok: true,
+      value: {
+        status: response.status,
+        contentType: response.headers.get('content-type') ?? '',
+        body: await response.text(),
+      },
+    }
+  } catch (cause) {
+    return refused([
+      visualClientDiagnostic(
+        'YMVS404',
+        `Session server at ${descriptor.origin} did not answer ${route}: ${summarise(cause)}`,
+      ),
+    ])
+  }
+}
+
+/**
+ * Diagnostics a refusal carried as one of the server's own JSON documents. They
+ * explain the refusal better than its status line ever could, but they arrive
+ * over a trust boundary: anything that is not already a conforming
+ * `visual-diagnostic-result/v1` payload is dropped rather than repaired, so a
+ * protocol violation upstream is reported as the transport failure it is
+ * instead of being laundered into this client's own output.
+ */
+const carriedDiagnostics = (
+  answer: AgentAnswer,
+): readonly VisualDiagnostic[] | undefined => {
+  if (!answer.contentType.startsWith('application/json')) return undefined
+  let document: unknown
+  try {
+    document = JSON.parse(answer.body)
+  } catch {
+    return undefined
+  }
+  const parsed = parseVisualDiagnosticResult({
+    format: 'yarramate/visual-diagnostic-result/v1',
+    diagnostics: documentFields(document).diagnostics,
+  })
+  return parsed.ok && parsed.value.diagnostics.length > 0
+    ? parsed.value.diagnostics
+    : undefined
+}
+
+const refusalDiagnostics = (
+  answer: AgentAnswer,
+  route: string,
+): readonly VisualDiagnostic[] =>
+  carriedDiagnostics(answer) ?? [
+    visualClientDiagnostic(
+      'YMVS405',
+      `Session server refused ${route} with status ${answer.status}: ${summarise(answer.body)}`,
+    ),
+  ]
+
+const malformed = <T>(route: string, detail: string): ParseResult<T> =>
+  refused([
+    visualClientDiagnostic(
+      'YMVS406',
+      `Session server answered ${route} with ${detail}`,
+    ),
+  ])
+
+/** The 200 body of an agent route, decoded; any other status is a refusal. */
+const decoded = (
+  answer: AgentAnswer,
+  route: string,
+): ParseResult<unknown> => {
+  if (answer.status !== 200) return refused(refusalDiagnostics(answer, route))
+  try {
+    return { ok: true, value: JSON.parse(answer.body) }
+  } catch {
+    return malformed(route, 'a body that is not JSON')
+  }
+}
+
+/**
+ * Long-polls for the next actionable event past `after`. The server holds the
+ * request for its whole poll window before answering that the session is still
+ * idle, which is why this is the client's longest-running call.
+ */
+export const waitForVisualEvent = async (
+  descriptor: VisualSessionDescriptor,
+  after: number,
+): Promise<ParseResult<VisualEventDelivery>> => {
+  const answered = await agentRequest(
+    descriptor,
+    `${AGENT_EVENTS}?after=${after}`,
+  )
+  if (!answered.ok) return answered
+  const body = decoded(answered.value, AGENT_EVENTS)
+  if (!body.ok) return body
+  const fields = documentFields(body.value)
+  const { lastSequence, pendingEvents } = fields
+  if (typeof lastSequence !== 'number' || typeof pendingEvents !== 'number') {
+    return malformed(AGENT_EVENTS, 'a document that is not an event delivery')
+  }
+  if (fields.waiting === true) {
+    return { ok: true, value: { waiting: true, lastSequence, pendingEvents } }
+  }
+  if (fields.waiting !== false) {
+    return malformed(AGENT_EVENTS, 'a document that is not an event delivery')
+  }
+  const event = parseVisualEvent(fields.event)
+  if (!event.ok) return event
+  return {
+    ok: true,
+    value: { waiting: false, event: event.value, lastSequence, pendingEvents },
+  }
+}
+
+/**
+ * Delivers one agent response. A response the runtime already journaled is
+ * accepted again as a duplicate, so a retried delivery is never a second turn.
+ */
+export const sendVisualResponse = async (
+  descriptor: VisualSessionDescriptor,
+  response: VisualResponse,
+): Promise<ParseResult<Extract<VisualResponseAcceptance, { accepted: true }>>> => {
+  const answered = await agentRequest(
+    descriptor,
+    AGENT_RESPONSES,
+    JSON.stringify(response),
+  )
+  if (!answered.ok) return answered
+  const body = decoded(answered.value, AGENT_RESPONSES)
+  if (!body.ok) return body
+  const fields = documentFields(body.value)
+  if (
+    fields.accepted !== true ||
+    typeof fields.duplicate !== 'boolean' ||
+    typeof fields.lastSequence !== 'number' ||
+    !Array.isArray(fields.diagnostics)
+  ) {
+    return malformed(
+      AGENT_RESPONSES,
+      'a document that is not a response acceptance',
+    )
+  }
+  // Every discriminating field is checked above; `model` and `diagnostics` are
+  // carried through unread from the runtime's own acceptance document.
+  const acceptance = body.value as Extract<
+    VisualResponseAcceptance,
+    { accepted: true }
+  >
+  return { ok: true, value: acceptance }
+}
+
+/**
+ * The status of a session whose runtime is gone: stopped, and reporting the
+ * journal that outlived it. A marker that is absent went with the runtime; a
+ * marker that is present and unusable is a fault the caller has to see.
+ */
+const localVisualStatus = async (
+  descriptor: VisualSessionDescriptor,
+): Promise<ParseResult<VisualStatus>> => {
+  const paths = visualSessionPaths(descriptor.sessionRoot)
+  let lastSequence = 0
+  let transcriptBytes = 0
+  try {
+    lastSequence = (await recoverVisualSession(paths)).lastSequence
+    transcriptBytes = (await stat(paths.journal)).size
+  } catch (cause) {
+    if (await exists(paths.marker)) {
+      return refused(visualFailureDiagnostics(cause))
+    }
+  }
+  return {
+    ok: true,
+    value: {
+      format: 'yarramate/visual-status/v1',
+      protocolVersion: VISUAL_PROTOCOL_VERSION,
+      sessionId: descriptor.sessionId,
+      lifecycle: 'stopped',
+      alreadyStopped: true,
+      server: { listening: false, origin: descriptor.origin },
+      browser: { connected: false, connections: 0 },
+      agent: { attached: false, inFlightEventId: null },
+      queue: { pendingEvents: 0, lastSequence, frozen: false },
+      // Every capability is the runtime's, and the runtime is gone.
+      capabilities: {
+        chat: false,
+        choices: false,
+        navigation: false,
+        modelReplacement: false,
+        transcript: false,
+      },
+      transcriptBytes,
+      updatedAt: new Date().toISOString(),
+    },
+  }
+}
+
+/**
+ * Asks the runtime for its status, falling back to the local one when nothing
+ * is listening: a session whose server died still has a status, and it is
+ * stopped. A server that answers and refuses does not fall back — that is a
+ * capability fault, not a dead session.
+ */
+export const fetchVisualStatus = async (
+  descriptor: VisualSessionDescriptor,
+): Promise<ParseResult<VisualStatus>> => {
+  const answered = await agentRequest(descriptor, AGENT_STATUS)
+  if (!answered.ok) return localVisualStatus(descriptor)
+  const body = decoded(answered.value, AGENT_STATUS)
+  if (!body.ok) return body
+  return parseVisualStatus(body.value)
+}
+
+/**
+ * Recovers the handoff from the journal. Recovery never asks the server: the
+ * journal is the record, and it is written to outlive the runtime that kept it.
+ */
+export const recoverVisualSessionClient = async (
+  descriptor: VisualSessionDescriptor,
+  includeTranscript = false,
+): Promise<ParseResult<VisualHandoff>> => {
+  try {
+    return {
+      ok: true,
+      value: await recoverVisualSession(
+        visualSessionPaths(descriptor.sessionRoot),
+        includeTranscript,
+      ),
+    }
+  } catch (cause) {
+    return refused(visualFailureDiagnostics(cause))
+  }
+}
+
+/**
+ * Converges one session on stopped, whatever is left of it. Recovery runs
+ * first, so no later step can be the one that loses confirmed state; the stop
+ * request only returns once the runtime has drained and removed the session it
+ * owns; and the local removal converges the case where nothing was listening.
+ *
+ * `undefined` means the session was already gone, which is what makes a
+ * repeated stop idempotent.
+ */
+export const stopVisualSessionClient = async (
+  descriptor: VisualSessionDescriptor,
+  includeTranscript = false,
+): Promise<ParseResult<VisualHandoff | undefined>> => {
+  const paths = visualSessionPaths(descriptor.sessionRoot)
+  if (!(await exists(paths.root))) return { ok: true, value: undefined }
+  const recovered = await recoverVisualSessionClient(
+    descriptor,
+    includeTranscript,
+  )
+  if (!recovered.ok) return recovered
+  const answered = await agentRequest(
+    descriptor,
+    AGENT_STOP,
+    JSON.stringify({ reason: STOP_REASON }),
+  )
+  // A server that answered and refused is not this caller's to tear down.
+  if (answered.ok && answered.value.status !== 200) {
+    return refused(refusalDiagnostics(answered.value, AGENT_STOP))
+  }
+  try {
+    await removeVisualSession(paths, includeTranscript)
+  } catch (cause) {
+    return refused(visualFailureDiagnostics(cause))
+  }
+  return recovered
+}

--- a/src/adapters/visual/likec4-compiler.ts
+++ b/src/adapters/visual/likec4-compiler.ts
@@ -319,16 +319,16 @@ const projectDocument = (
   if (projects.length === 1 && only !== undefined) {
     return { ok: true, document: only }
   }
-  const defining = projects.filter(
-    (document) => initialView in plainFields(plainFields(document).views),
+  const defining = projects.filter((document) =>
+    Object.hasOwn(plainFields(plainFields(document).views), initialView),
   )
   const named =
     declared === undefined
       ? []
-      : defining.filter(
+      : projects.filter(
           (document) => plainFields(document).projectId === declared,
         )
-  const resolved = named.length === 1 ? named : defining
+  const resolved = declared === undefined ? defining : named
   const match = resolved[0]
   return resolved.length === 1 && match !== undefined
     ? { ok: true, document: match }
@@ -543,7 +543,18 @@ const exportViews = async (
   // read above imposed; a create-time mode would not apply to a file that the
   // compiler already wrote.
   if (sole.document !== exported) {
-    await writeFile(exportPath, JSON.stringify(sole.document, null, 2))
+    try {
+      await writeFile(exportPath, JSON.stringify(sole.document, null, 2))
+    } catch {
+      return {
+        diagnostics: [
+          compilerDiagnostic(
+            'YMVS207',
+            `LikeC4 export "${VISUAL_COMPILER_EXPORT_FILE}" could not be narrowed`,
+          ),
+        ],
+      }
+    }
   }
   const views = plainFields(sole.document).views
   if (!isPlainObject(views)) {

--- a/src/adapters/visual/likec4-compiler.ts
+++ b/src/adapters/visual/likec4-compiler.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { Readable } from 'node:stream'
 import type {
@@ -93,10 +93,13 @@ interface ProcessOutcome {
  * Reads a trusted compiler document's own fields. Anything that is not a plain
  * object simply has no fields, so the caller's field checks report the fault.
  */
-const plainFields = (value: unknown): Readonly<Record<string, unknown>> =>
+const isPlainObject = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? (value as Readonly<Record<string, unknown>>)
-    : {}
+
+const plainFields = (value: unknown): Readonly<Record<string, unknown>> =>
+  isPlainObject(value) ? value : {}
 
 const pointerSegment = (segment: string) =>
   segment.replace(/~/g, '~0').replace(/\//g, '~1')
@@ -272,6 +275,67 @@ const exitDiagnostic = (stage: CompilerStage, outcome: ProcessOutcome) =>
   )
 
 /**
+ * Project the staged configuration declares, if it declares one.
+ */
+const declaredProject = (model: VisualModel): string | undefined => {
+  const config = model.files['likec4.config.json']
+  if (config === undefined) return undefined
+  try {
+    const name = plainFields(JSON.parse(config)).name
+    return typeof name === 'string' && name.length > 0 ? name : undefined
+  } catch {
+    // An unreadable configuration is the CLI's to report, not this adapter's.
+    return undefined
+  }
+}
+
+/**
+ * The one exported project this rendering comes from.
+ *
+ * `likec4 export json` writes a bare project document for exactly one project
+ * and a bare array otherwise, and a workspace that stages a configuration
+ * resolves the named project beside an implicit default over the same sources.
+ * The named project is asked for on the command line; this is the reader that
+ * still resolves whatever arrives: one project, else the only project defining
+ * the requested view, else the one the configuration named. Anything still
+ * ambiguous is refused rather than picked from.
+ */
+const projectDocument = (
+  exported: unknown,
+  initialView: string,
+  declared: string | undefined,
+):
+  | { readonly ok: true; readonly document: unknown }
+  | {
+      readonly ok: false
+      readonly projects: number
+      readonly matches: number
+    } => {
+  const documents = Array.isArray(exported) ? exported : [exported]
+  const projects = documents.filter((document) =>
+    isPlainObject(plainFields(document).views),
+  )
+  const only = projects[0]
+  if (projects.length === 1 && only !== undefined) {
+    return { ok: true, document: only }
+  }
+  const defining = projects.filter(
+    (document) => initialView in plainFields(plainFields(document).views),
+  )
+  const named =
+    declared === undefined
+      ? []
+      : defining.filter(
+          (document) => plainFields(document).projectId === declared,
+        )
+  const resolved = named.length === 1 ? named : defining
+  const match = resolved[0]
+  return resolved.length === 1 && match !== undefined
+    ? { ok: true, document: match }
+    : { ok: false, projects: projects.length, matches: defining.length }
+}
+
+/**
  * Candidate-relative POSIX path for a source location the compiler reported,
  * or `undefined` when the location is not a file staged under this candidate.
  */
@@ -393,6 +457,7 @@ const exportViews = async (
   readonly views?: readonly string[]
   readonly diagnostics: readonly VisualDiagnostic[]
 }> => {
+  const declared = declaredProject(model)
   const outcome = await runCompiler(
     command,
     [
@@ -400,6 +465,9 @@ const exportViews = async (
       'export',
       'json',
       '--pretty',
+      // Without a project the CLI writes every project it resolved, and a
+      // staged configuration always resolves at least two.
+      ...(declared === undefined ? [] : ['--project', declared]),
       '-o',
       exportPath,
       candidateDir,
@@ -446,8 +514,28 @@ const exportViews = async (
       ],
     }
   }
-  const views = plainFields(exported).views
-  if (typeof views !== 'object' || views === null || Array.isArray(views)) {
+  const sole = projectDocument(exported, model.initialView, declared)
+  if (!sole.ok) {
+    return {
+      diagnostics: [
+        compilerDiagnostic(
+          sole.projects === 0 ? 'YMVS207' : 'YMVS210',
+          sole.projects === 0
+            ? 'LikeC4 export document does not carry a view collection'
+            : `LikeC4 export carries ${sole.projects} projects and ${sole.matches} of them define "${model.initialView}", so no single rendering can be promoted`,
+        ),
+      ],
+    }
+  }
+  // The promoted artefact is always one project document, because that is what
+  // the browser's model factory reads.
+  if (sole.document !== exported) {
+    await writeFile(exportPath, JSON.stringify(sole.document, null, 2), {
+      mode: 0o600,
+    })
+  }
+  const views = plainFields(sole.document).views
+  if (!isPlainObject(views)) {
     return {
       diagnostics: [
         compilerDiagnostic(

--- a/src/adapters/visual/likec4-compiler.ts
+++ b/src/adapters/visual/likec4-compiler.ts
@@ -135,6 +135,14 @@ const runCompiler = (
   budget: CompilerBudget,
 ): Promise<ProcessOutcome> =>
   new Promise((settle) => {
+    // An abort that already landed raises no further event, so a signal
+    // cancelled before this call — including in the window between one stage
+    // settling and the next registering its listener — must be read directly.
+    if (budget.signal?.aborted === true) {
+      settle({ status: 'cancelled', code: null, failure: '', stdout: '', stderr: '' })
+      return
+    }
+
     const controller = new AbortController()
     let timedOut = false
     const deadline = setTimeout(() => {
@@ -490,6 +498,19 @@ export const compileVisualModel = async (
         compilerDiagnostic(
           'YMVS202',
           `LikeC4 compiler command "${command.command}" must be an absolute executable path`,
+        ),
+      ],
+    }
+  }
+  // Staging a candidate for a request the caller already withdrew would leave
+  // a directory behind for work that can never be promoted.
+  if (options.signal?.aborted === true) {
+    return {
+      ok: false,
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS204',
+          'LikeC4 compilation was cancelled before it started',
         ),
       ],
     }

--- a/src/adapters/visual/likec4-compiler.ts
+++ b/src/adapters/visual/likec4-compiler.ts
@@ -1,0 +1,540 @@
+import { spawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import type { Readable } from 'node:stream'
+import type {
+  VisualAuthority,
+  VisualCompilerCommand,
+  VisualDiagnostic,
+  VisualModel,
+} from './protocol.js'
+import {
+  promoteCompiledModel,
+  type VisualSessionPaths,
+} from './session-store.js'
+
+/**
+ * Document name reported by diagnostics that no staged source file owns — a
+ * compiler that could not be executed, ran past its budget, or answered with
+ * something other than the report its command promised.
+ */
+export const VISUAL_COMPILER_DOCUMENT = 'likec4-compiler'
+
+/**
+ * Name of the exported document inside the candidate root. The leading dot
+ * cannot collide with a staged model file, because model paths reject
+ * dot-prefixed segments.
+ */
+export const VISUAL_COMPILER_EXPORT_FILE = '.likec4-export.json'
+
+export const VISUAL_COMPILER_LIMITS = {
+  timeoutMs: 30_000,
+  outputBytes: 1024 * 1024,
+  exportBytes: 16 * 1024 * 1024,
+  /** Grace between the abort's SIGTERM and an unconditional SIGKILL. */
+  killGraceMs: 2_000,
+} as const
+
+const MODEL_SOURCE_EXTENSIONS = ['.c4', '.likec4'] as const
+
+export interface CompileVisualModelOptions {
+  readonly model: VisualModel
+  /** Trusted preflight vector. Never assembled from browser input. */
+  readonly command: VisualCompilerCommand
+  readonly paths: VisualSessionPaths
+  readonly now?: () => Date
+  readonly signal?: AbortSignal
+  readonly timeoutMs?: number
+  readonly maxOutputBytes?: number
+  readonly maxExportBytes?: number
+}
+
+export interface CompiledVisualModel {
+  readonly candidate: string
+  readonly candidateDir: string
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly views: readonly string[]
+  readonly exportPath: string
+}
+
+export type LikeC4CompilationResult =
+  | {
+      readonly ok: true
+      readonly compiled: CompiledVisualModel
+      readonly diagnostics: readonly VisualDiagnostic[]
+    }
+  | {
+      readonly ok: false
+      readonly diagnostics: readonly VisualDiagnostic[]
+    }
+
+interface CompilerBudget {
+  readonly timeoutMs: number
+  readonly outputBytes: number
+  readonly exportBytes: number
+  readonly signal: AbortSignal | undefined
+}
+
+type CompilerStage = 'validate' | 'export'
+
+type ProcessStatus = 'exited' | 'timeout' | 'cancelled' | 'overflow' | 'failed'
+
+interface ProcessOutcome {
+  readonly status: ProcessStatus
+  readonly code: number | null
+  readonly stdout: string
+  readonly stderr: string
+  /** Spawn or abort error message; empty when the child ran. */
+  readonly failure: string
+}
+
+/**
+ * Reads a trusted compiler document's own fields. Anything that is not a plain
+ * object simply has no fields, so the caller's field checks report the fault.
+ */
+const plainFields = (value: unknown): Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : {}
+
+const pointerSegment = (segment: string) =>
+  segment.replace(/~/g, '~0').replace(/\//g, '~1')
+
+const compilerDiagnostic = (
+  code: string,
+  message: string,
+  path: string = VISUAL_COMPILER_DOCUMENT,
+  pointer = '/files',
+  line = 1,
+  column = 1,
+): VisualDiagnostic => ({
+  severity: 'error',
+  code,
+  message,
+  path,
+  pointer,
+  line,
+  column,
+})
+
+/** Keeps a compiler's own prose from entering the diagnostic stream unbounded. */
+const summarise = (text: string) => {
+  const line = text
+    .split('\n')
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.length > 0)
+  if (line === undefined) return 'no diagnostic output'
+  return line.length > 500 ? `${line.slice(0, 500)}…` : line
+}
+
+const runCompiler = (
+  command: VisualCompilerCommand,
+  args: readonly string[],
+  cwd: string,
+  budget: CompilerBudget,
+): Promise<ProcessOutcome> =>
+  new Promise((settle) => {
+    const controller = new AbortController()
+    let timedOut = false
+    const deadline = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, budget.timeoutMs)
+    const cancel = () => controller.abort()
+    budget.signal?.addEventListener('abort', cancel, { once: true })
+
+    const child = spawn(command.command, [...args], {
+      shell: false,
+      signal: controller.signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd,
+    })
+
+    // Aborting the spawn only sends SIGTERM; a child that declines to honour it
+    // must still not outlive its budget.
+    let grace: NodeJS.Timeout | undefined
+    controller.signal.addEventListener(
+      'abort',
+      () => {
+        grace = setTimeout(
+          () => child.kill('SIGKILL'),
+          VISUAL_COMPILER_LIMITS.killGraceMs,
+        )
+        grace.unref()
+      },
+      { once: true },
+    )
+
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let bytes = 0
+    let overflowed = false
+    const bound = (stream: Readable | null, sink: Buffer[]) => {
+      stream?.on('data', (chunk: Buffer) => {
+        bytes += chunk.byteLength
+        if (bytes > budget.outputBytes) {
+          overflowed = true
+          child.kill('SIGKILL')
+          return
+        }
+        sink.push(chunk)
+      })
+    }
+    bound(child.stdout, stdout)
+    bound(child.stderr, stderr)
+
+    let failure = ''
+    let settled = false
+    const finish = (status: ProcessStatus, code: number | null) => {
+      if (settled) return
+      settled = true
+      clearTimeout(deadline)
+      if (grace !== undefined) clearTimeout(grace)
+      budget.signal?.removeEventListener('abort', cancel)
+      settle({
+        status,
+        code,
+        failure,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+      })
+    }
+
+    child.on('error', (error: Error) => {
+      failure = error.message
+      // A child that never started owns no stdio to close, so a spawn failure
+      // settles here rather than waiting for a 'close' that may not arrive.
+      if (child.pid === undefined) finish('failed', null)
+    })
+    child.on('close', (code) => {
+      if (overflowed) finish('overflow', code)
+      else if (timedOut) finish('timeout', code)
+      else if (controller.signal.aborted) finish('cancelled', code)
+      else if (failure !== '') finish('failed', code)
+      else finish('exited', code)
+    })
+  })
+
+const processDiagnostics = (
+  stage: CompilerStage,
+  outcome: ProcessOutcome,
+  budget: CompilerBudget,
+): readonly VisualDiagnostic[] => {
+  switch (outcome.status) {
+    case 'timeout':
+      return [
+        compilerDiagnostic(
+          'YMVS204',
+          `LikeC4 ${stage} exceeded its ${budget.timeoutMs}ms budget`,
+        ),
+      ]
+    case 'cancelled':
+      return [
+        compilerDiagnostic(
+          'YMVS204',
+          `LikeC4 ${stage} was cancelled before it finished`,
+        ),
+      ]
+    case 'overflow':
+      return [
+        compilerDiagnostic(
+          'YMVS205',
+          `LikeC4 ${stage} exceeded its ${budget.outputBytes} byte output budget`,
+        ),
+      ]
+    case 'failed':
+      return [
+        compilerDiagnostic(
+          'YMVS203',
+          `LikeC4 ${stage} could not be executed: ${summarise(outcome.failure)}`,
+        ),
+      ]
+    default:
+      return []
+  }
+}
+
+const exitDiagnostic = (stage: CompilerStage, outcome: ProcessOutcome) =>
+  compilerDiagnostic(
+    'YMVS203',
+    `LikeC4 ${stage} exited with status ${outcome.code}: ${summarise(
+      outcome.stderr,
+    )}`,
+  )
+
+/**
+ * Candidate-relative POSIX path for a source location the compiler reported,
+ * or `undefined` when the location is not a file staged under this candidate.
+ */
+const stagedSource = (raw: unknown, candidateDir: string) => {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined
+  const within = relative(candidateDir, resolve(candidateDir, raw))
+  if (within === '' || within.startsWith('..') || isAbsolute(within)) {
+    return undefined
+  }
+  return within.split(sep).join('/')
+}
+
+const reportedLocation = (entry: Readonly<Record<string, unknown>>) => {
+  // LikeC4 reports LSP ranges, which count lines and characters from zero.
+  const start = plainFields(plainFields(entry.range).start)
+  const oneBased = (value: unknown) =>
+    typeof value === 'number' && Number.isInteger(value) && value >= 0
+      ? value + 1
+      : 1
+  return { line: oneBased(start.line), column: oneBased(start.character) }
+}
+
+const validationDiagnostics = (
+  entries: readonly unknown[],
+  candidateDir: string,
+): readonly VisualDiagnostic[] =>
+  entries.flatMap((entry) => {
+    const fields = plainFields(entry)
+    // LikeC4 reports warnings and hints beside errors and still exits clean;
+    // only an error may block a candidate.
+    const severity = fields.severity
+    if (severity !== undefined && severity !== 1 && severity !== 'error') {
+      return []
+    }
+    const message =
+      typeof fields.message === 'string' && fields.message.length > 0
+        ? fields.message
+        : 'LikeC4 reported an unlabelled validation error'
+    const source = stagedSource(fields.sourceFsPath, candidateDir)
+    if (source === undefined) return [compilerDiagnostic('YMVS201', message)]
+    const { line, column } = reportedLocation(fields)
+    return [
+      compilerDiagnostic(
+        'YMVS201',
+        message,
+        source,
+        `/files/${pointerSegment(source)}`,
+        line,
+        column,
+      ),
+    ]
+  })
+
+const validate = async (
+  command: VisualCompilerCommand,
+  model: VisualModel,
+  candidateDir: string,
+  budget: CompilerBudget,
+): Promise<readonly VisualDiagnostic[]> => {
+  const sources = Object.keys(model.files)
+    .filter((file) =>
+      MODEL_SOURCE_EXTENSIONS.some((allowed) => allowed === extname(file)),
+    )
+    .sort()
+  const outcome = await runCompiler(
+    command,
+    [
+      ...command.args,
+      'validate',
+      '--json',
+      '--no-layout',
+      ...sources.flatMap((file) => ['--file', file]),
+      candidateDir,
+    ],
+    candidateDir,
+    budget,
+  )
+  const bounded = processDiagnostics('validate', outcome, budget)
+  if (bounded.length > 0) return bounded
+
+  // No report at all is a process failure; a report that is not the promised
+  // JSON is a broken compiler contract.
+  if (outcome.stdout.trim() === '') {
+    return outcome.code === 0 ? [] : [exitDiagnostic('validate', outcome)]
+  }
+  let report: unknown
+  try {
+    report = JSON.parse(outcome.stdout)
+  } catch {
+    return [
+      compilerDiagnostic(
+        'YMVS206',
+        `LikeC4 validate did not emit a JSON report: ${summarise(outcome.stdout)}`,
+      ),
+    ]
+  }
+  const entries = plainFields(report).diagnostics
+  if (entries !== undefined && !Array.isArray(entries)) {
+    return [
+      compilerDiagnostic(
+        'YMVS206',
+        'LikeC4 validate reported diagnostics that are not a list',
+      ),
+    ]
+  }
+  const reported = validationDiagnostics(entries ?? [], candidateDir)
+  if (reported.length > 0) return reported
+  // A compiler that fails without naming a cause must still fail the candidate.
+  return outcome.code === 0 ? [] : [exitDiagnostic('validate', outcome)]
+}
+
+const exportViews = async (
+  command: VisualCompilerCommand,
+  model: VisualModel,
+  candidateDir: string,
+  exportPath: string,
+  budget: CompilerBudget,
+): Promise<{
+  readonly views?: readonly string[]
+  readonly diagnostics: readonly VisualDiagnostic[]
+}> => {
+  const outcome = await runCompiler(
+    command,
+    [
+      ...command.args,
+      'export',
+      'json',
+      '--pretty',
+      '-o',
+      exportPath,
+      candidateDir,
+    ],
+    candidateDir,
+    budget,
+  )
+  const bounded = processDiagnostics('export', outcome, budget)
+  if (bounded.length > 0) return { diagnostics: bounded }
+  if (outcome.code !== 0) {
+    return { diagnostics: [exitDiagnostic('export', outcome)] }
+  }
+
+  let raw: Buffer
+  try {
+    raw = await readFile(exportPath)
+  } catch {
+    return {
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS207',
+          `LikeC4 export did not write "${VISUAL_COMPILER_EXPORT_FILE}"`,
+        ),
+      ],
+    }
+  }
+  if (raw.byteLength > budget.exportBytes) {
+    return {
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS205',
+          `LikeC4 export exceeded its ${budget.exportBytes} byte output budget`,
+        ),
+      ],
+    }
+  }
+  let exported: unknown
+  try {
+    exported = JSON.parse(raw.toString('utf8'))
+  } catch {
+    return {
+      diagnostics: [
+        compilerDiagnostic('YMVS207', 'LikeC4 export document is not JSON'),
+      ],
+    }
+  }
+  const views = plainFields(exported).views
+  if (typeof views !== 'object' || views === null || Array.isArray(views)) {
+    return {
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS207',
+          'LikeC4 export document does not carry a view collection',
+        ),
+      ],
+    }
+  }
+  const ids = Object.keys(views).sort()
+  if (ids.length === 0) {
+    return {
+      diagnostics: [
+        compilerDiagnostic('YMVS208', 'LikeC4 export contains no views'),
+      ],
+    }
+  }
+  if (!ids.includes(model.initialView)) {
+    return {
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS209',
+          `LikeC4 export does not contain the requested initial view "${model.initialView}"`,
+        ),
+      ],
+    }
+  }
+  return { views: ids, diagnostics: [] }
+}
+
+/**
+ * Validates and exports one candidate model with the trusted LikeC4 command,
+ * promoting it only once a complete export naming the requested initial view
+ * has been parsed. Every process, parse, and diagnostic failure becomes a
+ * `VisualDiagnostic` and leaves the last good rendering in place.
+ */
+export const compileVisualModel = async (
+  options: CompileVisualModelOptions,
+): Promise<LikeC4CompilationResult> => {
+  const { command, model, paths } = options
+  // The command vector is trusted preflight input, so a relative executable is
+  // a caller defect: resolving it against PATH or the cwd is exactly the
+  // ambiguity a session must not carry into a spawned process.
+  if (!isAbsolute(command.command)) {
+    return {
+      ok: false,
+      diagnostics: [
+        compilerDiagnostic(
+          'YMVS202',
+          `LikeC4 compiler command "${command.command}" must be an absolute executable path`,
+        ),
+      ],
+    }
+  }
+  const budget: CompilerBudget = {
+    timeoutMs: options.timeoutMs ?? VISUAL_COMPILER_LIMITS.timeoutMs,
+    outputBytes: options.maxOutputBytes ?? VISUAL_COMPILER_LIMITS.outputBytes,
+    exportBytes: options.maxExportBytes ?? VISUAL_COMPILER_LIMITS.exportBytes,
+    signal: options.signal,
+  }
+
+  let views: readonly string[] | undefined
+  let exportPath = ''
+  const promotion = await promoteCompiledModel(paths, {
+    model,
+    now: options.now ?? (() => new Date()),
+    compile: async (candidateDir) => {
+      const invalid = await validate(command, model, candidateDir, budget)
+      if (invalid.length > 0) return invalid
+      exportPath = join(candidateDir, VISUAL_COMPILER_EXPORT_FILE)
+      const exported = await exportViews(
+        command,
+        model,
+        candidateDir,
+        exportPath,
+        budget,
+      )
+      views = exported.views
+      return exported.diagnostics
+    },
+  })
+
+  if (!promotion.promoted || views === undefined) {
+    return { ok: false, diagnostics: promotion.diagnostics }
+  }
+  return {
+    ok: true,
+    diagnostics: [],
+    compiled: {
+      candidate: promotion.candidate,
+      candidateDir: promotion.candidateDir,
+      authority: model.authority,
+      initialView: model.initialView,
+      views,
+      exportPath,
+    },
+  }
+}

--- a/src/adapters/visual/likec4-compiler.ts
+++ b/src/adapters/visual/likec4-compiler.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { readFile, writeFile } from 'node:fs/promises'
+import { open, writeFile } from 'node:fs/promises'
 import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { Readable } from 'node:stream'
 import type {
@@ -483,7 +483,18 @@ const exportViews = async (
 
   let raw: Buffer
   try {
-    raw = await readFile(exportPath)
+    // The compiler is a separate process, so it creates the export with its
+    // own umask and typically leaves it group- and world-readable. The
+    // document is narrowed through the descriptor it is read from, so no
+    // widely readable rendering exists at any point between the export and
+    // the promotion, and no path is resolved twice in between.
+    const handle = await open(exportPath, 'r')
+    try {
+      await handle.chmod(0o600)
+      raw = await handle.readFile()
+    } finally {
+      await handle.close()
+    }
   } catch {
     return {
       diagnostics: [
@@ -528,11 +539,11 @@ const exportViews = async (
     }
   }
   // The promoted artefact is always one project document, because that is what
-  // the browser's model factory reads.
+  // the browser's model factory reads. Truncating in place keeps the 0600 the
+  // read above imposed; a create-time mode would not apply to a file that the
+  // compiler already wrote.
   if (sole.document !== exported) {
-    await writeFile(exportPath, JSON.stringify(sole.document, null, 2), {
-      mode: 0o600,
-    })
+    await writeFile(exportPath, JSON.stringify(sole.document, null, 2))
   }
   const views = plainFields(sole.document).views
   if (!isPlainObject(views)) {

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -108,8 +108,18 @@ export interface VisualViewNavigatePayload {
   readonly requiresAttention: boolean
 }
 
+/**
+ * Terminal event payload. Every reason is the runtime's to choose: only it
+ * knows whether a session ended by request, by a failing child, by a browser
+ * that never came back, or by its own cancellation.
+ */
 export interface VisualSessionEndPayload {
-  readonly reason: 'user-ended' | 'browser-timeout'
+  readonly reason: VisualTerminationReason
+}
+
+/** End as an untrusted browser may ask for it, and nothing more. */
+export interface VisualBrowserSessionEndPayload {
+  readonly reason: 'user-ended'
 }
 
 export interface VisualBrowserConnectedPayload {
@@ -151,7 +161,7 @@ export type VisualBrowserInput =
   | {
       readonly type: 'session.end'
       readonly lastAcknowledgedSequence: number
-      readonly payload: VisualSessionEndPayload
+      readonly payload: VisualBrowserSessionEndPayload
     }
 
 interface VisualEventEnvelope<Type extends string, Payload> {

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -1,0 +1,298 @@
+/**
+ * Every visual protocol declaration, and the limits they are measured against,
+ * with no runtime dependency of any kind.
+ *
+ * The validators that police these documents live in `./protocol.js`, which
+ * re-exports this module so a Node consumer still has one import for the whole
+ * protocol. The split exists because the browser application ships the same
+ * contract: it can import these declarations and limits without pulling Ajv,
+ * `node:path`, or the schema documents into its bundle.
+ */
+export const VISUAL_PROTOCOL_VERSION = 'yarramate/visual-protocol/v1' as const
+
+export const VISUAL_LIMITS = {
+  messageBytes: 64 * 1024,
+  modelBytes: 5 * 1024 * 1024,
+  transcriptBytes: 5 * 1024 * 1024,
+  pendingEvents: 32,
+  reconnectMs: 5 * 60 * 1000,
+  staleSessionMs: 24 * 60 * 60 * 1000,
+} as const
+
+export type VisualAuthority = 'canonical' | 'ad-hoc'
+
+export interface VisualDiagnostic {
+  readonly severity: 'error'
+  readonly code: string
+  readonly message: string
+  readonly path: string
+  readonly pointer: string
+  readonly line: number
+  readonly column: number
+}
+
+export interface VisualDiagnosticResult {
+  readonly format: 'yarramate/visual-diagnostic-result/v1'
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+export interface VisualCapabilities {
+  readonly chat: boolean
+  readonly choices: boolean
+  readonly navigation: boolean
+  readonly modelReplacement: boolean
+  readonly transcript: boolean
+}
+
+export interface VisualModel {
+  readonly format: 'yarramate/visual-model/v1'
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly sourceDigests: Readonly<Record<string, string>>
+  readonly files: Readonly<Record<string, string>>
+}
+
+export interface VisualCompilerCommand {
+  readonly command: string
+  readonly args: readonly string[]
+}
+
+export interface VisualSessionRequest {
+  readonly format: 'yarramate/visual-session-request/v1'
+  readonly authority: VisualModel['authority']
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly compiler: VisualCompilerCommand
+  readonly initialModel: VisualModel
+}
+
+export interface VisualSessionStarted {
+  readonly format: 'yarramate/visual-session-started/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly chatEnabled: boolean
+  readonly browserUrl: string
+  readonly webSocketUrl: string
+  readonly origin: string
+  readonly descriptorPath: string
+  readonly sessionRoot: string
+  readonly capabilities: VisualCapabilities
+  readonly startedAt: string
+}
+
+export interface VisualSessionDescriptor {
+  readonly format: 'yarramate/visual-session-descriptor/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly origin: string
+  readonly agentCapability: string
+  readonly sessionRoot: string
+  readonly journalPath: string
+  readonly createdAt: string
+}
+
+export interface VisualChatMessagePayload {
+  readonly text: string
+}
+
+export interface VisualChoiceSelectedPayload {
+  readonly choiceId: string
+  readonly optionId: string
+}
+
+export interface VisualViewNavigatePayload {
+  readonly viewId: string
+  readonly requiresAttention: boolean
+}
+
+export interface VisualSessionEndPayload {
+  readonly reason: 'user-ended' | 'browser-timeout'
+}
+
+export interface VisualBrowserConnectedPayload {
+  readonly connectionId: string
+}
+
+export interface VisualBrowserDisconnectedPayload {
+  readonly connectionId: string
+  readonly code: number
+}
+
+/**
+ * Untrusted browser message. The runtime owns session identifiers, sequence
+ * numbers, event identifiers, and timestamps, so the browser may send only a
+ * discriminant, the last sequence it saw acknowledged, and its payload.
+ *
+ * `lastAcknowledgedSequence` is the browser's own view of the journal, carried
+ * on every frame so a session that reconnected mid-turn can be told it is
+ * ahead of the journal it claims to have read. It is 0 before the first
+ * acknowledgement, and never authorises anything: admission still assigns the
+ * sequence and event identifier.
+ */
+export type VisualBrowserInput =
+  | {
+      readonly type: 'chat.message'
+      readonly lastAcknowledgedSequence: number
+      readonly payload: VisualChatMessagePayload
+    }
+  | {
+      readonly type: 'choice.selected'
+      readonly lastAcknowledgedSequence: number
+      readonly payload: VisualChoiceSelectedPayload
+    }
+  | {
+      readonly type: 'view.navigate'
+      readonly lastAcknowledgedSequence: number
+      readonly payload: VisualViewNavigatePayload
+    }
+  | {
+      readonly type: 'session.end'
+      readonly lastAcknowledgedSequence: number
+      readonly payload: VisualSessionEndPayload
+    }
+
+interface VisualEventEnvelope<Type extends string, Payload> {
+  readonly format: 'yarramate/visual-event/v1'
+  readonly sessionId: string
+  readonly sequence: number
+  readonly eventId: string
+  readonly type: Type
+  readonly timestamp: string
+  readonly payload: Payload
+}
+
+export type VisualEvent =
+  | VisualEventEnvelope<'chat.message', VisualChatMessagePayload>
+  | VisualEventEnvelope<'choice.selected', VisualChoiceSelectedPayload>
+  | VisualEventEnvelope<'view.navigate', VisualViewNavigatePayload>
+  | VisualEventEnvelope<'session.end', VisualSessionEndPayload>
+  | VisualEventEnvelope<'browser.connected', VisualBrowserConnectedPayload>
+  | VisualEventEnvelope<
+      'browser.disconnected',
+      VisualBrowserDisconnectedPayload
+    >
+
+export interface VisualChatResponsePayload {
+  readonly text: string
+}
+
+export interface VisualAgentStatusPayload {
+  readonly state: 'thinking' | 'compiling' | 'waiting' | 'idle'
+  readonly detail?: string
+}
+
+export interface VisualChoiceOption {
+  readonly id: string
+  readonly label: string
+  readonly description?: string
+}
+
+export interface VisualChoicePresentPayload {
+  readonly choiceId: string
+  readonly question: string
+  readonly options: readonly VisualChoiceOption[]
+}
+
+export interface VisualModelReplacePayload {
+  readonly model: VisualModel
+}
+
+export interface VisualHandoffSummary {
+  readonly summary: string
+  readonly confirmedDecisions: readonly string[]
+  readonly requestedChanges: readonly string[]
+  readonly unresolvedQuestions: readonly string[]
+  readonly finalViews: readonly string[]
+}
+
+export interface VisualDiagnosticPayload {
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+interface VisualResponseEnvelope<Type extends string, Payload> {
+  readonly format: 'yarramate/visual-response/v1'
+  readonly sessionId: string
+  readonly responseId: string
+  readonly eventId: string
+  readonly type: Type
+  readonly timestamp: string
+  readonly payload: Payload
+}
+
+export type VisualResponse =
+  | VisualResponseEnvelope<'chat.response', VisualChatResponsePayload>
+  | VisualResponseEnvelope<'agent.status', VisualAgentStatusPayload>
+  | VisualResponseEnvelope<'choice.present', VisualChoicePresentPayload>
+  | VisualResponseEnvelope<'model.replace', VisualModelReplacePayload>
+  | VisualResponseEnvelope<'handoff.complete', VisualHandoffSummary>
+  | VisualResponseEnvelope<'diagnostic', VisualDiagnosticPayload>
+
+export type VisualHandoffDecision = 'completed' | 'cancelled' | 'failed'
+
+export type VisualTerminationReason =
+  | 'user-ended'
+  | 'child-failed'
+  | 'browser-timeout'
+  | 'main-cancelled'
+  | 'server-failed'
+  | 'compiler-failed'
+
+export interface VisualHandoff extends VisualHandoffSummary {
+  readonly format: 'yarramate/visual-handoff/v1'
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly decision: VisualHandoffDecision
+  readonly terminationReason: VisualTerminationReason
+  readonly lastSequence: number
+  readonly transcriptPath: string
+  readonly transcript?: readonly (VisualEvent | VisualResponse)[]
+  readonly completedAt: string
+}
+
+export type VisualLifecycle = 'starting' | 'running' | 'draining' | 'stopped'
+
+export type VisualFreezeReason =
+  | 'message-bytes'
+  | 'model-bytes'
+  | 'transcript-bytes'
+  | 'pending-events'
+  | 'browser-disconnected'
+  | 'terminal-event'
+
+export interface VisualStatus {
+  readonly format: 'yarramate/visual-status/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly lifecycle: VisualLifecycle
+  readonly alreadyStopped: boolean
+  readonly server: {
+    readonly listening: boolean
+    readonly origin: string
+  }
+  readonly browser: {
+    readonly connected: boolean
+    readonly connections: number
+    readonly lastSeenAt?: string
+    readonly graceExpiresAt?: string
+  }
+  readonly agent: {
+    readonly attached: boolean
+    readonly inFlightEventId: string | null
+  }
+  readonly queue: {
+    readonly pendingEvents: number
+    readonly lastSequence: number
+    readonly frozen: boolean
+    readonly frozenReason?: VisualFreezeReason
+  }
+  readonly capabilities: VisualCapabilities
+  readonly transcriptBytes: number
+  readonly updatedAt: string
+}
+
+export type ParseResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] }

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -327,25 +327,45 @@ const responseSemantics = (
   return []
 }
 
+/**
+ * A handoff is one session's record. The schema validates each transcript entry
+ * as a well-formed event or response but cannot relate it to the document that
+ * carries it, so the one cross-session check the nine documents would otherwise
+ * be missing is made here: every entry names the session the handoff does.
+ */
 const handoffSemantics = (
   input: unknown,
   path: string,
 ): readonly VisualDiagnostic[] => {
-  const transcript = documentFields(input).transcript
-  if (
-    transcript === undefined ||
-    jsonBytes(transcript) <= VISUAL_LIMITS.transcriptBytes
-  ) {
-    return []
+  const fields = documentFields(input)
+  const transcript = fields.transcript
+  if (transcript === undefined) return []
+  const diagnostics: VisualDiagnostic[] = []
+  if (jsonBytes(transcript) > VISUAL_LIMITS.transcriptBytes) {
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS115',
+        `A raw transcript must not exceed ${VISUAL_LIMITS.transcriptBytes} bytes`,
+        path,
+        '/transcript',
+      ),
+    )
   }
-  return [
-    visualDiagnostic(
-      'YMVS115',
-      `A raw transcript must not exceed ${VISUAL_LIMITS.transcriptBytes} bytes`,
-      path,
-      '/transcript',
-    ),
-  ]
+  if (Array.isArray(transcript)) {
+    for (const [index, entry] of transcript.entries()) {
+      const owner = documentFields(entry).sessionId
+      if (owner === fields.sessionId) continue
+      diagnostics.push(
+        visualDiagnostic(
+          'YMVS116',
+          `Transcript entry ${index} belongs to session "${String(owner)}", not "${String(fields.sessionId)}"`,
+          path,
+          `/transcript/${index}/sessionId`,
+        ),
+      )
+    }
+  }
+  return diagnostics
 }
 
 type DocumentSemantics = (

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -1,0 +1,706 @@
+import { posix } from 'node:path'
+import type { ErrorObject, ValidateFunction } from 'ajv'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describeSchemaViolation } from '../../source-document.js'
+import visualDiagnosticResultSchema from '../../../schema/yarramate-visual-diagnostic-result.schema.json' with {
+  type: 'json',
+}
+import visualEventSchema from '../../../schema/yarramate-visual-event.schema.json' with {
+  type: 'json',
+}
+import visualHandoffSchema from '../../../schema/yarramate-visual-handoff.schema.json' with {
+  type: 'json',
+}
+import visualModelSchema from '../../../schema/yarramate-visual-model.schema.json' with {
+  type: 'json',
+}
+import visualResponseSchema from '../../../schema/yarramate-visual-response.schema.json' with {
+  type: 'json',
+}
+import visualSessionDescriptorSchema from '../../../schema/yarramate-visual-session-descriptor.schema.json' with {
+  type: 'json',
+}
+import visualSessionRequestSchema from '../../../schema/yarramate-visual-session-request.schema.json' with {
+  type: 'json',
+}
+import visualSessionStartedSchema from '../../../schema/yarramate-visual-session-started.schema.json' with {
+  type: 'json',
+}
+import visualStatusSchema from '../../../schema/yarramate-visual-status.schema.json' with {
+  type: 'json',
+}
+
+export const VISUAL_PROTOCOL_VERSION = 'yarramate/visual-protocol/v1' as const
+
+export const VISUAL_LIMITS = {
+  messageBytes: 64 * 1024,
+  modelBytes: 5 * 1024 * 1024,
+  transcriptBytes: 5 * 1024 * 1024,
+  pendingEvents: 32,
+  reconnectMs: 5 * 60 * 1000,
+  staleSessionMs: 24 * 60 * 60 * 1000,
+} as const
+
+export type VisualAuthority = 'canonical' | 'ad-hoc'
+
+export interface VisualDiagnostic {
+  readonly severity: 'error'
+  readonly code: string
+  readonly message: string
+  readonly path: string
+  readonly pointer: string
+  readonly line: number
+  readonly column: number
+}
+
+export interface VisualDiagnosticResult {
+  readonly format: 'yarramate/visual-diagnostic-result/v1'
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+export interface VisualCapabilities {
+  readonly chat: boolean
+  readonly choices: boolean
+  readonly navigation: boolean
+  readonly modelReplacement: boolean
+  readonly transcript: boolean
+}
+
+export interface VisualModel {
+  readonly format: 'yarramate/visual-model/v1'
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly sourceDigests: Readonly<Record<string, string>>
+  readonly files: Readonly<Record<string, string>>
+}
+
+export interface VisualCompilerCommand {
+  readonly command: string
+  readonly args: readonly string[]
+}
+
+export interface VisualSessionRequest {
+  readonly format: 'yarramate/visual-session-request/v1'
+  readonly authority: VisualModel['authority']
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly compiler: VisualCompilerCommand
+  readonly initialModel: VisualModel
+}
+
+export interface VisualSessionStarted {
+  readonly format: 'yarramate/visual-session-started/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly chatEnabled: boolean
+  readonly browserUrl: string
+  readonly webSocketUrl: string
+  readonly origin: string
+  readonly descriptorPath: string
+  readonly sessionRoot: string
+  readonly capabilities: VisualCapabilities
+  readonly startedAt: string
+}
+
+export interface VisualSessionDescriptor {
+  readonly format: 'yarramate/visual-session-descriptor/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly origin: string
+  readonly agentCapability: string
+  readonly sessionRoot: string
+  readonly journalPath: string
+  readonly createdAt: string
+}
+
+export interface VisualChatMessagePayload {
+  readonly text: string
+}
+
+export interface VisualChoiceSelectedPayload {
+  readonly choiceId: string
+  readonly optionId: string
+}
+
+export interface VisualViewNavigatePayload {
+  readonly viewId: string
+  readonly requiresAttention: boolean
+}
+
+export interface VisualSessionEndPayload {
+  readonly reason: 'user-ended' | 'browser-timeout'
+}
+
+export interface VisualBrowserConnectedPayload {
+  readonly connectionId: string
+}
+
+export interface VisualBrowserDisconnectedPayload {
+  readonly connectionId: string
+  readonly code: number
+}
+
+/**
+ * Untrusted browser message. The runtime owns session identifiers, sequence
+ * numbers, event identifiers, and timestamps, so the browser may send only a
+ * discriminant and its payload.
+ */
+export type VisualBrowserInput =
+  | {
+      readonly type: 'chat.message'
+      readonly payload: VisualChatMessagePayload
+    }
+  | {
+      readonly type: 'choice.selected'
+      readonly payload: VisualChoiceSelectedPayload
+    }
+  | {
+      readonly type: 'view.navigate'
+      readonly payload: VisualViewNavigatePayload
+    }
+  | { readonly type: 'session.end'; readonly payload: VisualSessionEndPayload }
+
+interface VisualEventEnvelope<Type extends string, Payload> {
+  readonly format: 'yarramate/visual-event/v1'
+  readonly sessionId: string
+  readonly sequence: number
+  readonly eventId: string
+  readonly type: Type
+  readonly timestamp: string
+  readonly payload: Payload
+}
+
+export type VisualEvent =
+  | VisualEventEnvelope<'chat.message', VisualChatMessagePayload>
+  | VisualEventEnvelope<'choice.selected', VisualChoiceSelectedPayload>
+  | VisualEventEnvelope<'view.navigate', VisualViewNavigatePayload>
+  | VisualEventEnvelope<'session.end', VisualSessionEndPayload>
+  | VisualEventEnvelope<'browser.connected', VisualBrowserConnectedPayload>
+  | VisualEventEnvelope<
+      'browser.disconnected',
+      VisualBrowserDisconnectedPayload
+    >
+
+export interface VisualChatResponsePayload {
+  readonly text: string
+}
+
+export interface VisualAgentStatusPayload {
+  readonly state: 'thinking' | 'compiling' | 'waiting' | 'idle'
+  readonly detail?: string
+}
+
+export interface VisualChoiceOption {
+  readonly id: string
+  readonly label: string
+  readonly description?: string
+}
+
+export interface VisualChoicePresentPayload {
+  readonly choiceId: string
+  readonly question: string
+  readonly options: readonly VisualChoiceOption[]
+}
+
+export interface VisualModelReplacePayload {
+  readonly model: VisualModel
+}
+
+export interface VisualHandoffSummary {
+  readonly summary: string
+  readonly confirmedDecisions: readonly string[]
+  readonly requestedChanges: readonly string[]
+  readonly unresolvedQuestions: readonly string[]
+  readonly finalViews: readonly string[]
+}
+
+export interface VisualDiagnosticPayload {
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+interface VisualResponseEnvelope<Type extends string, Payload> {
+  readonly format: 'yarramate/visual-response/v1'
+  readonly sessionId: string
+  readonly responseId: string
+  readonly eventId: string
+  readonly type: Type
+  readonly timestamp: string
+  readonly payload: Payload
+}
+
+export type VisualResponse =
+  | VisualResponseEnvelope<'chat.response', VisualChatResponsePayload>
+  | VisualResponseEnvelope<'agent.status', VisualAgentStatusPayload>
+  | VisualResponseEnvelope<'choice.present', VisualChoicePresentPayload>
+  | VisualResponseEnvelope<'model.replace', VisualModelReplacePayload>
+  | VisualResponseEnvelope<'handoff.complete', VisualHandoffSummary>
+  | VisualResponseEnvelope<'diagnostic', VisualDiagnosticPayload>
+
+export type VisualHandoffDecision = 'completed' | 'cancelled' | 'failed'
+
+export type VisualTerminationReason =
+  | 'user-ended'
+  | 'child-failed'
+  | 'browser-timeout'
+  | 'main-cancelled'
+  | 'server-failed'
+  | 'compiler-failed'
+
+export interface VisualHandoff extends VisualHandoffSummary {
+  readonly format: 'yarramate/visual-handoff/v1'
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly decision: VisualHandoffDecision
+  readonly terminationReason: VisualTerminationReason
+  readonly lastSequence: number
+  readonly transcriptPath: string
+  readonly transcript?: readonly (VisualEvent | VisualResponse)[]
+  readonly completedAt: string
+}
+
+export type VisualLifecycle = 'starting' | 'running' | 'draining' | 'stopped'
+
+export type VisualFreezeReason =
+  | 'message-bytes'
+  | 'model-bytes'
+  | 'transcript-bytes'
+  | 'pending-events'
+  | 'browser-disconnected'
+  | 'terminal-event'
+
+export interface VisualStatus {
+  readonly format: 'yarramate/visual-status/v1'
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly lifecycle: VisualLifecycle
+  readonly alreadyStopped: boolean
+  readonly server: {
+    readonly listening: boolean
+    readonly origin: string
+  }
+  readonly browser: {
+    readonly connected: boolean
+    readonly connections: number
+    readonly lastSeenAt?: string
+    readonly graceExpiresAt?: string
+  }
+  readonly agent: {
+    readonly attached: boolean
+    readonly inFlightEventId: string | null
+  }
+  readonly queue: {
+    readonly pendingEvents: number
+    readonly lastSequence: number
+    readonly frozen: boolean
+    readonly frozenReason?: VisualFreezeReason
+  }
+  readonly capabilities: VisualCapabilities
+  readonly transcriptBytes: number
+  readonly updatedAt: string
+}
+
+export type ParseResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] }
+
+const Ajv2020 = Ajv2020Module.default
+const ajv = new Ajv2020({ allErrors: true })
+ajv.addSchema([
+  visualDiagnosticResultSchema,
+  visualModelSchema,
+  visualEventSchema,
+  visualResponseSchema,
+  visualSessionRequestSchema,
+  visualSessionStartedSchema,
+  visualSessionDescriptorSchema,
+  visualHandoffSchema,
+  visualStatusSchema,
+])
+
+// Diagnostics report the document they came from rather than a source file,
+// because visual protocol documents arrive as parsed JSON over the wire.
+const documentPaths = new WeakMap<ValidateFunction, string>()
+
+const visualValidator = (
+  document: string,
+  reference = `https://yarramate.org/schema/${document}`,
+) => {
+  const compiled = ajv.getSchema(reference)
+  if (!compiled) throw new Error(`Unknown visual schema reference: ${reference}`)
+  documentPaths.set(compiled, document)
+  return compiled
+}
+
+const validateVisualModel = visualValidator('visual-model/v1')
+const validateVisualSessionRequest = visualValidator(
+  'visual-session-request/v1',
+)
+const validateVisualSessionStarted = visualValidator(
+  'visual-session-started/v1',
+)
+const validateVisualSessionDescriptor = visualValidator(
+  'visual-session-descriptor/v1',
+)
+const validateVisualBrowserInput = visualValidator(
+  'visual-browser-input/v1',
+  'https://yarramate.org/schema/visual-event/v1#/$defs/browserInput',
+)
+const validateVisualEvent = visualValidator('visual-event/v1')
+const validateVisualResponse = visualValidator('visual-response/v1')
+const validateVisualHandoff = visualValidator('visual-handoff/v1')
+const validateVisualStatus = visualValidator('visual-status/v1')
+const validateVisualDiagnosticResult = visualValidator(
+  'visual-diagnostic-result/v1',
+)
+
+/**
+ * Reads an untrusted document's own fields. Semantic checks run beside schema
+ * validation on raw input, so anything that is not a plain object simply has
+ * no fields to inspect and the schema reports the type violation.
+ */
+const documentFields = (value: unknown): Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : {}
+
+const pointerSegment = (segment: string) =>
+  segment.replace(/~/g, '~0').replace(/\//g, '~1')
+
+const visualDiagnostic = (
+  code: string,
+  message: string,
+  path: string,
+  pointer: string,
+): VisualDiagnostic => ({
+  severity: 'error',
+  code,
+  message,
+  path,
+  pointer,
+  line: 1,
+  column: 1,
+})
+
+const visualDiagnosticOrder = (
+  left: VisualDiagnostic,
+  right: VisualDiagnostic,
+) =>
+  left.pointer.localeCompare(right.pointer) ||
+  left.code.localeCompare(right.code) ||
+  left.message.localeCompare(right.message)
+
+const jsonBytes = (value: unknown): number => {
+  const encoded = JSON.stringify(value)
+  if (encoded === undefined) return 0
+  return Buffer.byteLength(encoded, 'utf8')
+}
+
+const MODEL_ROOT_CONFIG = 'likec4.config.json'
+const MODEL_SOURCE_EXTENSIONS = ['.c4', '.likec4'] as const
+
+/**
+ * Relative POSIX path confined to the candidate root. Absolute paths, parent
+ * traversal, empty segments, dot-prefixed segments (how a staged symlink or
+ * metadata entry would be smuggled in), Windows separators, and NUL bytes are
+ * all rejected.
+ */
+const isConfinedRelativePath = (candidate: string): boolean => {
+  if (candidate.length === 0 || candidate.length > 1024) return false
+  if (candidate.includes('\\') || candidate.includes('\u0000')) return false
+  if (posix.isAbsolute(candidate)) return false
+  if (posix.normalize(candidate) !== candidate) return false
+  return candidate
+    .split('/')
+    .every((segment) => segment.length > 0 && !segment.startsWith('.'))
+}
+
+export const isSafeVisualModelPath = (candidate: string): boolean => {
+  if (!isConfinedRelativePath(candidate)) return false
+  if (candidate === MODEL_ROOT_CONFIG) return true
+  const extension = posix.extname(candidate)
+  return MODEL_SOURCE_EXTENSIONS.some((allowed) => allowed === extension)
+}
+
+const modelSemantics = (
+  input: unknown,
+  path: string,
+  prefix: string,
+): readonly VisualDiagnostic[] => {
+  const fields = documentFields(input)
+  const diagnostics: VisualDiagnostic[] = []
+
+  const files = documentFields(fields.files)
+  const fileKeys = Object.keys(files)
+  if (fileKeys.length > 0) {
+    let sources = 0
+    for (const key of fileKeys) {
+      if (!isSafeVisualModelPath(key)) {
+        diagnostics.push(
+          visualDiagnostic(
+            'YMVS113',
+            `Model file "${key}" escapes the candidate root or is not a LikeC4 source`,
+            path,
+            `${prefix}/files/${pointerSegment(key)}`,
+          ),
+        )
+        continue
+      }
+      if (key !== MODEL_ROOT_CONFIG) sources += 1
+    }
+    if (sources === 0) {
+      diagnostics.push(
+        visualDiagnostic(
+          'YMVS114',
+          'A visual model requires at least one .c4 or .likec4 source file',
+          path,
+          `${prefix}/files`,
+        ),
+      )
+    }
+  }
+
+  const digestKeys = Object.keys(documentFields(fields.sourceDigests))
+  for (const key of digestKeys) {
+    if (isConfinedRelativePath(key)) continue
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS113',
+        `Source digest "${key}" escapes the candidate root`,
+        path,
+        `${prefix}/sourceDigests/${pointerSegment(key)}`,
+      ),
+    )
+  }
+  if (fields.authority === 'canonical' && digestKeys.length === 0) {
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS112',
+        'A canonical visual model must record the source digests it was derived from',
+        path,
+        `${prefix}/sourceDigests`,
+      ),
+    )
+  }
+  if (fields.authority === 'ad-hoc' && digestKeys.length > 0) {
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS112',
+        'An ad-hoc visual model must not claim canonical source digests',
+        path,
+        `${prefix}/sourceDigests`,
+      ),
+    )
+  }
+
+  if (jsonBytes(input) > VISUAL_LIMITS.modelBytes) {
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS115',
+        `A visual model must not exceed ${VISUAL_LIMITS.modelBytes} bytes`,
+        path,
+        prefix === '' ? '/' : prefix,
+      ),
+    )
+  }
+
+  return diagnostics
+}
+
+const chatTextSemantics = (
+  payload: unknown,
+  path: string,
+  prefix: string,
+): readonly VisualDiagnostic[] => {
+  const text = documentFields(payload).text
+  if (
+    typeof text !== 'string' ||
+    Buffer.byteLength(text, 'utf8') <= VISUAL_LIMITS.messageBytes
+  ) {
+    return []
+  }
+  return [
+    visualDiagnostic(
+      'YMVS115',
+      `A chat message must not exceed ${VISUAL_LIMITS.messageBytes} bytes`,
+      path,
+      `${prefix}/text`,
+    ),
+  ]
+}
+
+const sessionRequestSemantics = (
+  input: unknown,
+  path: string,
+): readonly VisualDiagnostic[] => {
+  const fields = documentFields(input)
+  const modelAuthority = documentFields(fields.initialModel).authority
+  const diagnostics = [
+    ...modelSemantics(fields.initialModel, path, '/initialModel'),
+  ]
+  if (
+    typeof fields.authority === 'string' &&
+    typeof modelAuthority === 'string' &&
+    fields.authority !== modelAuthority
+  ) {
+    diagnostics.push(
+      visualDiagnostic(
+        'YMVS111',
+        `Session authority "${fields.authority}" does not match the initial model authority "${modelAuthority}"`,
+        path,
+        '/initialModel/authority',
+      ),
+    )
+  }
+  return diagnostics
+}
+
+const chatCarryingSemantics = (
+  input: unknown,
+  path: string,
+): readonly VisualDiagnostic[] => {
+  const fields = documentFields(input)
+  if (fields.type !== 'chat.message') return []
+  return chatTextSemantics(fields.payload, path, '/payload')
+}
+
+const responseSemantics = (
+  input: unknown,
+  path: string,
+): readonly VisualDiagnostic[] => {
+  const fields = documentFields(input)
+  if (fields.type === 'chat.response') {
+    return chatTextSemantics(fields.payload, path, '/payload')
+  }
+  if (fields.type === 'model.replace') {
+    return modelSemantics(
+      documentFields(fields.payload).model,
+      path,
+      '/payload/model',
+    )
+  }
+  return []
+}
+
+const handoffSemantics = (
+  input: unknown,
+  path: string,
+): readonly VisualDiagnostic[] => {
+  const transcript = documentFields(input).transcript
+  if (
+    transcript === undefined ||
+    jsonBytes(transcript) <= VISUAL_LIMITS.transcriptBytes
+  ) {
+    return []
+  }
+  return [
+    visualDiagnostic(
+      'YMVS115',
+      `A raw transcript must not exceed ${VISUAL_LIMITS.transcriptBytes} bytes`,
+      path,
+      '/transcript',
+    ),
+  ]
+}
+
+type DocumentSemantics = (
+  input: unknown,
+  path: string,
+) => readonly VisualDiagnostic[]
+
+// Byte limits and path confinement are enforced here as well as in the schemas
+// so a schema regression cannot silently widen the untrusted input surface.
+const semanticsByDocument: Readonly<Record<string, DocumentSemantics>> = {
+  'visual-model/v1': (input, path) => modelSemantics(input, path, ''),
+  'visual-session-request/v1': sessionRequestSemantics,
+  'visual-browser-input/v1': chatCarryingSemantics,
+  'visual-event/v1': chatCarryingSemantics,
+  'visual-response/v1': responseSemantics,
+  'visual-handoff/v1': handoffSemantics,
+}
+
+const schemaDiagnostics = (
+  errors: readonly ErrorObject[],
+  code: string,
+  path: string,
+): readonly VisualDiagnostic[] =>
+  errors.map((error) => {
+    const property =
+      error.keyword === 'additionalProperties'
+        ? String(error.params.additionalProperty)
+        : undefined
+    const pointer = property
+      ? `${error.instancePath}/${pointerSegment(property)}`
+      : error.instancePath || '/'
+    return visualDiagnostic(
+      code,
+      property
+        ? `Property "${property}" is not allowed`
+        : `${path} schema violation: ${describeSchemaViolation(error)}`,
+      path,
+      pointer,
+    )
+  })
+
+const parseWith = <T>(
+  validate: ValidateFunction,
+  input: unknown,
+  code: string,
+): ParseResult<T> => {
+  const path = documentPaths.get(validate) ?? 'visual-document'
+  const semantics = semanticsByDocument[path]
+  const diagnostics = [
+    ...(validate(input)
+      ? []
+      : schemaDiagnostics(validate.errors ?? [], code, path)),
+    ...(semantics ? semantics(input, path) : []),
+  ].sort(visualDiagnosticOrder)
+  if (diagnostics.length > 0) return { ok: false, diagnostics }
+  return { ok: true, value: input as T }
+}
+
+export const parseVisualModel = (input: unknown): ParseResult<VisualModel> =>
+  parseWith(validateVisualModel, input, 'YMVS106')
+
+export const parseVisualSessionRequest = (
+  input: unknown,
+): ParseResult<VisualSessionRequest> =>
+  parseWith(validateVisualSessionRequest, input, 'YMVS101')
+
+export const parseVisualSessionStarted = (
+  input: unknown,
+): ParseResult<VisualSessionStarted> =>
+  parseWith(validateVisualSessionStarted, input, 'YMVS102')
+
+export const parseVisualSessionDescriptor = (
+  input: unknown,
+): ParseResult<VisualSessionDescriptor> =>
+  parseWith(validateVisualSessionDescriptor, input, 'YMVS103')
+
+export const parseVisualBrowserInput = (
+  input: unknown,
+): ParseResult<VisualBrowserInput> =>
+  parseWith(validateVisualBrowserInput, input, 'YMVS109')
+
+export const parseVisualEvent = (input: unknown): ParseResult<VisualEvent> =>
+  parseWith(validateVisualEvent, input, 'YMVS104')
+
+export const parseVisualResponse = (
+  input: unknown,
+): ParseResult<VisualResponse> =>
+  parseWith(validateVisualResponse, input, 'YMVS105')
+
+export const parseVisualHandoff = (
+  input: unknown,
+): ParseResult<VisualHandoff> =>
+  parseWith(validateVisualHandoff, input, 'YMVS107')
+
+export const parseVisualStatus = (input: unknown): ParseResult<VisualStatus> =>
+  parseWith(validateVisualStatus, input, 'YMVS108')
+
+export const parseVisualDiagnosticResult = (
+  input: unknown,
+): ParseResult<VisualDiagnosticResult> =>
+  parseWith(validateVisualDiagnosticResult, input, 'YMVS110')

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -29,282 +29,25 @@ import visualSessionStartedSchema from '../../../schema/yarramate-visual-session
 import visualStatusSchema from '../../../schema/yarramate-visual-status.schema.json' with {
   type: 'json',
 }
+import {
+  VISUAL_LIMITS,
+  type ParseResult,
+  type VisualBrowserInput,
+  type VisualDiagnostic,
+  type VisualDiagnosticResult,
+  type VisualEvent,
+  type VisualHandoff,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionDescriptor,
+  type VisualSessionRequest,
+  type VisualSessionStarted,
+  type VisualStatus,
+} from './protocol-contract.js'
 
-export const VISUAL_PROTOCOL_VERSION = 'yarramate/visual-protocol/v1' as const
-
-export const VISUAL_LIMITS = {
-  messageBytes: 64 * 1024,
-  modelBytes: 5 * 1024 * 1024,
-  transcriptBytes: 5 * 1024 * 1024,
-  pendingEvents: 32,
-  reconnectMs: 5 * 60 * 1000,
-  staleSessionMs: 24 * 60 * 60 * 1000,
-} as const
-
-export type VisualAuthority = 'canonical' | 'ad-hoc'
-
-export interface VisualDiagnostic {
-  readonly severity: 'error'
-  readonly code: string
-  readonly message: string
-  readonly path: string
-  readonly pointer: string
-  readonly line: number
-  readonly column: number
-}
-
-export interface VisualDiagnosticResult {
-  readonly format: 'yarramate/visual-diagnostic-result/v1'
-  readonly diagnostics: readonly VisualDiagnostic[]
-}
-
-export interface VisualCapabilities {
-  readonly chat: boolean
-  readonly choices: boolean
-  readonly navigation: boolean
-  readonly modelReplacement: boolean
-  readonly transcript: boolean
-}
-
-export interface VisualModel {
-  readonly format: 'yarramate/visual-model/v1'
-  readonly authority: VisualAuthority
-  readonly initialView: string
-  readonly sourceDigests: Readonly<Record<string, string>>
-  readonly files: Readonly<Record<string, string>>
-}
-
-export interface VisualCompilerCommand {
-  readonly command: string
-  readonly args: readonly string[]
-}
-
-export interface VisualSessionRequest {
-  readonly format: 'yarramate/visual-session-request/v1'
-  readonly authority: VisualModel['authority']
-  readonly title: string
-  readonly description: string
-  readonly chatEnabled: boolean
-  readonly compiler: VisualCompilerCommand
-  readonly initialModel: VisualModel
-}
-
-export interface VisualSessionStarted {
-  readonly format: 'yarramate/visual-session-started/v1'
-  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
-  readonly sessionId: string
-  readonly authority: VisualAuthority
-  readonly title: string
-  readonly chatEnabled: boolean
-  readonly browserUrl: string
-  readonly webSocketUrl: string
-  readonly origin: string
-  readonly descriptorPath: string
-  readonly sessionRoot: string
-  readonly capabilities: VisualCapabilities
-  readonly startedAt: string
-}
-
-export interface VisualSessionDescriptor {
-  readonly format: 'yarramate/visual-session-descriptor/v1'
-  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
-  readonly sessionId: string
-  readonly origin: string
-  readonly agentCapability: string
-  readonly sessionRoot: string
-  readonly journalPath: string
-  readonly createdAt: string
-}
-
-export interface VisualChatMessagePayload {
-  readonly text: string
-}
-
-export interface VisualChoiceSelectedPayload {
-  readonly choiceId: string
-  readonly optionId: string
-}
-
-export interface VisualViewNavigatePayload {
-  readonly viewId: string
-  readonly requiresAttention: boolean
-}
-
-export interface VisualSessionEndPayload {
-  readonly reason: 'user-ended' | 'browser-timeout'
-}
-
-export interface VisualBrowserConnectedPayload {
-  readonly connectionId: string
-}
-
-export interface VisualBrowserDisconnectedPayload {
-  readonly connectionId: string
-  readonly code: number
-}
-
-/**
- * Untrusted browser message. The runtime owns session identifiers, sequence
- * numbers, event identifiers, and timestamps, so the browser may send only a
- * discriminant and its payload.
- */
-export type VisualBrowserInput =
-  | {
-      readonly type: 'chat.message'
-      readonly payload: VisualChatMessagePayload
-    }
-  | {
-      readonly type: 'choice.selected'
-      readonly payload: VisualChoiceSelectedPayload
-    }
-  | {
-      readonly type: 'view.navigate'
-      readonly payload: VisualViewNavigatePayload
-    }
-  | { readonly type: 'session.end'; readonly payload: VisualSessionEndPayload }
-
-interface VisualEventEnvelope<Type extends string, Payload> {
-  readonly format: 'yarramate/visual-event/v1'
-  readonly sessionId: string
-  readonly sequence: number
-  readonly eventId: string
-  readonly type: Type
-  readonly timestamp: string
-  readonly payload: Payload
-}
-
-export type VisualEvent =
-  | VisualEventEnvelope<'chat.message', VisualChatMessagePayload>
-  | VisualEventEnvelope<'choice.selected', VisualChoiceSelectedPayload>
-  | VisualEventEnvelope<'view.navigate', VisualViewNavigatePayload>
-  | VisualEventEnvelope<'session.end', VisualSessionEndPayload>
-  | VisualEventEnvelope<'browser.connected', VisualBrowserConnectedPayload>
-  | VisualEventEnvelope<
-      'browser.disconnected',
-      VisualBrowserDisconnectedPayload
-    >
-
-export interface VisualChatResponsePayload {
-  readonly text: string
-}
-
-export interface VisualAgentStatusPayload {
-  readonly state: 'thinking' | 'compiling' | 'waiting' | 'idle'
-  readonly detail?: string
-}
-
-export interface VisualChoiceOption {
-  readonly id: string
-  readonly label: string
-  readonly description?: string
-}
-
-export interface VisualChoicePresentPayload {
-  readonly choiceId: string
-  readonly question: string
-  readonly options: readonly VisualChoiceOption[]
-}
-
-export interface VisualModelReplacePayload {
-  readonly model: VisualModel
-}
-
-export interface VisualHandoffSummary {
-  readonly summary: string
-  readonly confirmedDecisions: readonly string[]
-  readonly requestedChanges: readonly string[]
-  readonly unresolvedQuestions: readonly string[]
-  readonly finalViews: readonly string[]
-}
-
-export interface VisualDiagnosticPayload {
-  readonly diagnostics: readonly VisualDiagnostic[]
-}
-
-interface VisualResponseEnvelope<Type extends string, Payload> {
-  readonly format: 'yarramate/visual-response/v1'
-  readonly sessionId: string
-  readonly responseId: string
-  readonly eventId: string
-  readonly type: Type
-  readonly timestamp: string
-  readonly payload: Payload
-}
-
-export type VisualResponse =
-  | VisualResponseEnvelope<'chat.response', VisualChatResponsePayload>
-  | VisualResponseEnvelope<'agent.status', VisualAgentStatusPayload>
-  | VisualResponseEnvelope<'choice.present', VisualChoicePresentPayload>
-  | VisualResponseEnvelope<'model.replace', VisualModelReplacePayload>
-  | VisualResponseEnvelope<'handoff.complete', VisualHandoffSummary>
-  | VisualResponseEnvelope<'diagnostic', VisualDiagnosticPayload>
-
-export type VisualHandoffDecision = 'completed' | 'cancelled' | 'failed'
-
-export type VisualTerminationReason =
-  | 'user-ended'
-  | 'child-failed'
-  | 'browser-timeout'
-  | 'main-cancelled'
-  | 'server-failed'
-  | 'compiler-failed'
-
-export interface VisualHandoff extends VisualHandoffSummary {
-  readonly format: 'yarramate/visual-handoff/v1'
-  readonly sessionId: string
-  readonly authority: VisualAuthority
-  readonly decision: VisualHandoffDecision
-  readonly terminationReason: VisualTerminationReason
-  readonly lastSequence: number
-  readonly transcriptPath: string
-  readonly transcript?: readonly (VisualEvent | VisualResponse)[]
-  readonly completedAt: string
-}
-
-export type VisualLifecycle = 'starting' | 'running' | 'draining' | 'stopped'
-
-export type VisualFreezeReason =
-  | 'message-bytes'
-  | 'model-bytes'
-  | 'transcript-bytes'
-  | 'pending-events'
-  | 'browser-disconnected'
-  | 'terminal-event'
-
-export interface VisualStatus {
-  readonly format: 'yarramate/visual-status/v1'
-  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
-  readonly sessionId: string
-  readonly lifecycle: VisualLifecycle
-  readonly alreadyStopped: boolean
-  readonly server: {
-    readonly listening: boolean
-    readonly origin: string
-  }
-  readonly browser: {
-    readonly connected: boolean
-    readonly connections: number
-    readonly lastSeenAt?: string
-    readonly graceExpiresAt?: string
-  }
-  readonly agent: {
-    readonly attached: boolean
-    readonly inFlightEventId: string | null
-  }
-  readonly queue: {
-    readonly pendingEvents: number
-    readonly lastSequence: number
-    readonly frozen: boolean
-    readonly frozenReason?: VisualFreezeReason
-  }
-  readonly capabilities: VisualCapabilities
-  readonly transcriptBytes: number
-  readonly updatedAt: string
-}
-
-export type ParseResult<T> =
-  | { readonly ok: true; readonly value: T }
-  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] }
+// One import site for the whole protocol: the declarations this module
+// validates travel with the validators.
+export * from './protocol-contract.js'
 
 const Ajv2020 = Ajv2020Module.default
 const ajv = new Ajv2020({ allErrors: true })
@@ -704,3 +447,4 @@ export const parseVisualDiagnosticResult = (
   input: unknown,
 ): ParseResult<VisualDiagnosticResult> =>
   parseWith(validateVisualDiagnosticResult, input, 'YMVS110')
+

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -235,10 +235,15 @@ type BodyResult =
 const serverError = (code: string, message: string) =>
   new Error(`${code}: ${message}`)
 
+/**
+ * `pointer` is an RFC 6901 pointer into the document being refused, rooted at
+ * `/`, because these diagnostics are published in `visual-diagnostic-result/v1`
+ * documents and read back by the one-shot agent clients.
+ */
 const serverDiagnostic = (
   code: string,
   message: string,
-  pointer = '#',
+  pointer = '/',
 ): VisualDiagnostic => ({
   severity: 'error',
   code,
@@ -715,7 +720,7 @@ export const startVisualServer = async (
             serverDiagnostic(
               'YMVS305',
               `Queue already holds the ${VISUAL_LIMITS.pendingEvents} event maximum`,
-              '#/sequence',
+              '/sequence',
             ),
           ],
         })
@@ -893,7 +898,7 @@ export const startVisualServer = async (
           serverDiagnostic(
             'YMVS126',
             `Response belongs to session "${response.sessionId}", not "${sessionId}"`,
-            '#/sessionId',
+            '/sessionId',
           ),
         ],
       } satisfies VisualResponseAcceptance)

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -665,7 +665,7 @@ export const startVisualServer = async (
     cancelGrace = schedule(async () => {
       cancelGrace = undefined
       if (connections.size > 0 || active.lifecycle !== 'running') return
-      await terminateVisualSession(active, 'browser-timeout')
+      await stop('browser-timeout')
     }, VISUAL_LIMITS.reconnectMs)
   }
   const disarmGrace = () => {
@@ -1082,9 +1082,10 @@ export const startVisualServer = async (
   const journalConnection = (
     connectionId: string,
     closedWith?: number,
-  ): Promise<void> =>
+    onJournaled?: () => void,
+  ): Promise<boolean> =>
     admit(async () => {
-      if (active.lifecycle !== 'running' || frozen !== undefined) return
+      if (active.lifecycle !== 'running' || frozen !== undefined) return false
       const envelope = {
         format: 'yarramate/visual-event/v1',
         sessionId,
@@ -1103,18 +1104,17 @@ export const startVisualServer = async (
       const appended = await appendVisualEvent(paths, event)
       if (!appended.ok) {
         if (appended.freeze !== undefined) freeze(appended.freeze)
-        return
+        return false
       }
       lastSequence = appended.lastSequence
       transcriptBytes = appended.transcriptBytes
-    }).catch(() => undefined)
+      onJournaled?.()
+      return true
+    }).catch(() => false)
 
   const attachBrowser = (socket: WebSocket) => {
     const connectionId = drawHex(16)
-    // The reviewer is back inside the window, so the session it was holding
-    // open for them is not going to end.
-    disarmGrace()
-    connections.set(connectionId, socket)
+    let registered = false
     lastSeenAt = stamp()
     socket.on('message', (raw, binary) => {
       // Nothing awaits this handler, so a rejection here would reach the
@@ -1150,6 +1150,7 @@ export const startVisualServer = async (
       }
     })
     socket.on('close', (code: number) => {
+      if (!registered) return
       connections.delete(connectionId)
       lastSeenAt = stamp()
       // The code the transport reported, held inside the range the journal
@@ -1161,12 +1162,19 @@ export const startVisualServer = async (
       )
       if (connections.size === 0) armGrace()
     })
-    // The arrival is journaled before the snapshot is handed over, so the
-    // sequence the browser starts from already counts it, and a reload cannot
-    // be told it acknowledged a sequence the journal never reached.
-    void journalConnection(connectionId)
-      .then(() => sendFrame(socket, { kind: 'ready', snapshot: snapshot() }))
-      .catch(() => socket.close(1011))
+    // Admission is one serialized operation: the connection is visible only
+    // after its event is durable, so no frame can be accepted against a
+    void journalConnection(connectionId, undefined, () => {
+      registered = true
+      connections.set(connectionId, socket)
+      disarmGrace()
+    }).then((journaled) => {
+      if (!journaled || socket.readyState !== socket.OPEN) {
+        socket.close(1011)
+        return
+      }
+      sendFrame(socket, { kind: 'ready', snapshot: snapshot() })
+    })
   }
 
   // ------------------------------------------------------------- agent routes

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -568,8 +568,11 @@ export const startVisualServer = async (
    */
   let choicesClosed = false
   const connections = new Map<string, WebSocket>()
+  let browserConnectionReservations = 0
   const polls = new Set<PendingPoll>()
   const httpSockets = new Set<Socket>()
+  const unclassifiedHttpSockets = new Set<Socket>()
+  const stopResponseSockets = new Set<Socket>()
 
   /** Every sequence assignment and queue mutation runs in call order. */
   let admission: Promise<unknown> = Promise.resolve()
@@ -851,7 +854,12 @@ export const startVisualServer = async (
   const httpServer = createServer()
   httpServer.on('connection', (socket) => {
     httpSockets.add(socket)
-    socket.on('close', () => httpSockets.delete(socket))
+    unclassifiedHttpSockets.add(socket)
+    socket.on('close', () => {
+      httpSockets.delete(socket)
+      unclassifiedHttpSockets.delete(socket)
+      stopResponseSockets.delete(socket)
+    })
   })
   httpServer.on('clientError', (_error, socket) => socket.destroy())
 
@@ -1112,7 +1120,10 @@ export const startVisualServer = async (
       return true
     }).catch(() => false)
 
-  const attachBrowser = (socket: WebSocket) => {
+  const attachBrowser = (
+    socket: WebSocket,
+    releaseReservation: () => void,
+  ) => {
     const connectionId = drawHex(16)
     let registered = false
     lastSeenAt = stamp()
@@ -1169,6 +1180,7 @@ export const startVisualServer = async (
       connections.set(connectionId, socket)
       disarmGrace()
     }).then((journaled) => {
+      releaseReservation()
       if (!journaled || socket.readyState !== socket.OPEN) {
         socket.close(1011)
         return
@@ -1405,6 +1417,7 @@ export const startVisualServer = async (
     server: ServerResponse,
     incoming: IncomingMessage,
   ) => {
+    const responseSocket = incoming.socket
     const body = await readJsonBody(
       incoming,
       VISUAL_SERVER_LIMITS.agentControlBytes,
@@ -1429,14 +1442,14 @@ export const startVisualServer = async (
       refuse(server, 400, 'Stop takes a boolean "includeTranscript" or none')
       return
     }
-    // The socket answering the stop is the one connection shutdown may not end
-    // before it has been written to.
+    // Every stop response already in flight is protected from the shared
+    // teardown. The response that wins the stop does not get to close its
+    // concurrent callers before they can observe the same result.
     const closed = await stop(
       reason as VisualTerminationReason,
-      incoming.socket,
       asked.includeTranscript,
     )
-    server.on('finish', () => incoming.socket.end())
+    server.on('finish', () => responseSocket.end())
     respondJson(server, 200, closed)
   }
 
@@ -1575,6 +1588,16 @@ export const startVisualServer = async (
   }
 
   httpServer.on('request', (incoming, server) => {
+    const responseSocket = incoming.socket
+    unclassifiedHttpSockets.delete(responseSocket)
+    if ((incoming.url ?? '/').split('?')[0] === '/api/agent/stop') {
+      stopResponseSockets.add(responseSocket)
+      const releaseResponseSocket = () => {
+        stopResponseSockets.delete(responseSocket)
+      }
+      server.once('finish', releaseResponseSocket)
+      server.once('close', releaseResponseSocket)
+    }
     void (async () => {
       try {
         // Rebinding defence: a request that reached this port under any other
@@ -1629,10 +1652,23 @@ export const startVisualServer = async (
     ) {
       return deny(401, 'Unauthorized')
     }
-    if (connections.size >= VISUAL_SERVER_LIMITS.browserConnections) {
+    if (
+      connections.size + browserConnectionReservations >=
+      VISUAL_SERVER_LIMITS.browserConnections
+    ) {
       return deny(503, 'Service Unavailable')
     }
-    sockets.handleUpgrade(incoming, socket, head, attachBrowser)
+    browserConnectionReservations += 1
+    try {
+      sockets.handleUpgrade(incoming, socket, head, (browser) => {
+        attachBrowser(browser, () => {
+          browserConnectionReservations -= 1
+        })
+      })
+    } catch (cause) {
+      browserConnectionReservations -= 1
+      throw cause
+    }
   })
 
   // ----------------------------------------------------------------- shutdown
@@ -1643,7 +1679,6 @@ export const startVisualServer = async (
 
   const stop = async (
     reason: VisualTerminationReason,
-    exempt?: Socket,
     includeTranscript = options.includeTranscript ?? false,
   ): Promise<VisualServerClosed> => {
     if (stopping !== undefined) {
@@ -1655,7 +1690,6 @@ export const startVisualServer = async (
       active.lifecycle = 'draining'
       listening = false
       disarmGrace()
-      httpServer.close()
       // Waiting agents are answered before any socket is torn down, so a poll
       // in flight during a stop still receives its non-terminal idle result.
       settleAllPolls()
@@ -1669,10 +1703,19 @@ export const startVisualServer = async (
       // anything, so shutdown can never be the step that loses confirmed state.
       // A session that already ended answers with the handoff it ended with.
       const terminal = await terminateVisualSession(active, reason)
-      // Only now: an in-flight agent request has had its answer written, so
-      // ending its connection cannot swallow the refusal it was owed.
+      // Keep the listener alive while stop requests already reaching the port
+      // join the shared attempt. Closing it earlier resets accepted idle
+      // sockets before Node has emitted their request events.
+      httpServer.close()
+      // Stop requests already on the wire, including accepted sockets whose
+      // request event has not fired yet, must survive long enough to answer.
       for (const socket of httpSockets) {
-        if (socket !== exempt) socket.end()
+        if (
+          !stopResponseSockets.has(socket) &&
+          !unclassifiedHttpSockets.has(socket)
+        ) {
+          socket.end()
+        }
       }
       // The transcript is read once, here, and only if this stop asked for it;
       // the same read is what removes the marked root.

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -537,6 +537,13 @@ export const startVisualServer = async (
    * again after a reload if the session hands the question back.
    */
   let pendingChoice: VisualChoicePresentPayload | null = null
+  /**
+   * A journaled End is the last thing this session takes from the reviewer, so
+   * no later question can ever be answered. The lock outlives the clearing
+   * below: an agent response still in flight when the End landed must not hand
+   * a reloading browser buttons that lead nowhere.
+   */
+  let choicesClosed = false
   const connections = new Map<string, WebSocket>()
   const polls = new Set<PendingPoll>()
   const httpSockets = new Set<Socket>()
@@ -619,6 +626,7 @@ export const startVisualServer = async (
     if (event.type === 'chat.message' || event.type === 'session.end') {
       pendingChoice = null
     }
+    if (event.type === 'session.end') choicesClosed = true
     if (event.type === 'chat.message') {
       transcript.push({
         id: event.eventId,
@@ -644,7 +652,7 @@ export const startVisualServer = async (
   /** An accepted agent response, as the line the reviewer sees. */
   const recordResponse = (response: VisualResponse) => {
     if (response.type === 'choice.present') {
-      pendingChoice = response.payload
+      if (!choicesClosed) pendingChoice = response.payload
       choiceLabels.set(
         response.payload.choiceId,
         new Map(
@@ -1113,6 +1121,12 @@ export const startVisualServer = async (
     // limit, and the limit outlives this response.
     else if (appended.freeze !== undefined) freeze(appended.freeze)
     broadcast({ kind: 'response', response: diagnostic })
+    // The diagnostic is the answer to the event the replacement was answering,
+    // and it is the only one that event will get. It retires the turn exactly
+    // as an agent-posted diagnostic would, so the reviewer's next message is
+    // deliverable instead of waiting behind a turn nobody will ever close.
+    markAnswered(diagnostic)
+    completeTurn(diagnostic)
     return { diagnostics: compiled.diagnostics }
   }
 
@@ -1516,7 +1530,7 @@ export const startVisualServer = async (
     if (stopping !== undefined) {
       return { ...(await stopping), alreadyStopped: true }
     }
-    stopping = (async () => {
+    const attempt = (async () => {
       // Frozen before anything is torn down: a request already on the wire
       // must not be journaled behind the recovery this stop is about to read.
       active.lifecycle = 'draining'
@@ -1553,7 +1567,16 @@ export const startVisualServer = async (
       announceClosed(outcome)
       return outcome
     })()
-    return stopping
+    // Every step of a teardown is idempotent, and one that throws has left the
+    // session directory behind for someone to finish. Forgetting the failed
+    // attempt is what makes the next stop that fresh run rather than a replay
+    // of the same rejection; observing it here is what keeps the cached promise
+    // from being a rejection nothing ever handled.
+    stopping = attempt
+    attempt.catch(() => {
+      if (stopping === attempt) stopping = undefined
+    })
+    return attempt
   }
 
   // Everything from here is publication, and every way it can fail — a

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -28,6 +28,7 @@ import {
   type VisualAuthority,
   type VisualBrowserInput,
   type VisualCapabilities,
+  type VisualChoicePresentPayload,
   type VisualDiagnostic,
   type VisualEvent,
   type VisualFreezeReason,
@@ -530,6 +531,12 @@ export const startVisualServer = async (
   const transcript: VisualTranscriptRecord[] = []
   /** Option labels the agent presented, so a selection restores as its label. */
   const choiceLabels = new Map<string, Map<string, string>>()
+  /**
+   * The choice the agent presented and nobody has answered. It is session
+   * state, not transcript: the reviewer's browser can only render the buttons
+   * again after a reload if the session hands the question back.
+   */
+  let pendingChoice: VisualChoicePresentPayload | null = null
   const connections = new Map<string, WebSocket>()
   const polls = new Set<PendingPoll>()
   const httpSockets = new Set<Socket>()
@@ -607,6 +614,11 @@ export const startVisualServer = async (
 
   /** A journaled browser event, as the line the reviewer sees. */
   const recordEvent = (event: VisualEvent) => {
+    // A session on its way out waits on nobody, and asking past the question
+    // is how a reviewer declines to answer it.
+    if (event.type === 'chat.message' || event.type === 'session.end') {
+      pendingChoice = null
+    }
     if (event.type === 'chat.message') {
       transcript.push({
         id: event.eventId,
@@ -616,6 +628,7 @@ export const startVisualServer = async (
       return
     }
     if (event.type !== 'choice.selected') return
+    if (pendingChoice?.choiceId === event.payload.choiceId) pendingChoice = null
     // The reviewer chose a label, not an identifier, so that is what the
     // restored conversation says they chose.
     const label = choiceLabels
@@ -631,6 +644,7 @@ export const startVisualServer = async (
   /** An accepted agent response, as the line the reviewer sees. */
   const recordResponse = (response: VisualResponse) => {
     if (response.type === 'choice.present') {
+      pendingChoice = response.payload
       choiceLabels.set(
         response.payload.choiceId,
         new Map(
@@ -661,6 +675,7 @@ export const startVisualServer = async (
     model: rendered,
     transcript: [...transcript],
     agentTurnOpen: openTurn(),
+    pendingChoice,
     styleNonce,
     lastSequence,
     frozen: frozen !== undefined,

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -14,7 +14,10 @@ import { basename, extname, join, resolve, sep } from 'node:path'
 import type { Duplex } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { WebSocketServer, type RawData, type WebSocket } from 'ws'
-import { compileVisualModel } from './likec4-compiler.js'
+import {
+  compileVisualModel,
+  type CompiledVisualModel,
+} from './likec4-compiler.js'
 import {
   VISUAL_LIMITS,
   VISUAL_PROTOCOL_VERSION,
@@ -44,6 +47,16 @@ import {
   removeVisualSession,
   writeVisualSessionDescriptor,
 } from './session-store.js'
+import type {
+  VisualRenderedModel,
+  VisualServerFrame,
+  VisualSessionSnapshot,
+} from './wire.js'
+
+// The browser application imports these from `./wire.js`; the server keeps
+// publishing them so one import still covers the whole transport for an
+// agent-side consumer.
+export type { VisualRenderedModel, VisualServerFrame, VisualSessionSnapshot }
 
 /**
  * Document name reported by diagnostics the server itself raises — a refused
@@ -119,48 +132,20 @@ const DEFAULT_ASSET_ROOT = fileURLToPath(
   new URL('../../visual-app/', import.meta.url),
 )
 
-export interface VisualRenderedModel {
-  readonly candidate: string
-  readonly authority: VisualAuthority
-  readonly initialView: string
-  readonly views: readonly string[]
-}
-
-/** Everything the browser needs to render, and nothing that authenticates it. */
-export interface VisualSessionSnapshot {
-  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
-  readonly sessionId: string
-  readonly authority: VisualAuthority
-  readonly title: string
-  readonly description: string
-  readonly chatEnabled: boolean
-  readonly capabilities: VisualCapabilities
-  readonly webSocketUrl: string
-  readonly model: VisualRenderedModel
-  readonly lastSequence: number
-  readonly frozen: boolean
-}
-
 /**
- * Server-to-browser transport frame. These are not protocol documents: they
- * carry validated documents plus the transport's own acknowledgements, so they
- * are discriminated by `kind` rather than by a versioned `format`.
+ * One promoted candidate as the browser receives it. The export is read back
+ * from the candidate directory rather than re-derived, so what the browser
+ * draws is exactly the document the trusted compiler wrote.
  */
-export type VisualServerFrame =
-  | { readonly kind: 'ready'; readonly snapshot: VisualSessionSnapshot }
-  | {
-      readonly kind: 'accepted'
-      readonly sequence: number
-      readonly eventId: string
-    }
-  | {
-      readonly kind: 'rejected'
-      readonly diagnostics: readonly VisualDiagnostic[]
-      readonly frozen?: VisualFreezeReason
-    }
-  | { readonly kind: 'response'; readonly response: VisualResponse }
-  | { readonly kind: 'model'; readonly model: VisualRenderedModel }
-  | { readonly kind: 'closing'; readonly reason: VisualTerminationReason }
+const renderCompiled = async (
+  compiled: CompiledVisualModel,
+): Promise<VisualRenderedModel> => ({
+  candidate: compiled.candidate,
+  authority: compiled.authority,
+  initialView: compiled.initialView,
+  views: compiled.views,
+  compiled: JSON.parse(await readFile(compiled.exportPath, 'utf8')) as unknown,
+})
 
 export type VisualEventDelivery =
   | {
@@ -412,12 +397,9 @@ export const startVisualServer = async (
     )
   }
 
-  let rendered: VisualRenderedModel = {
-    candidate: compilation.compiled.candidate,
-    authority: compilation.compiled.authority,
-    initialView: compilation.compiled.initialView,
-    views: compilation.compiled.views,
-  }
+  let rendered: VisualRenderedModel = await renderCompiled(
+    compilation.compiled,
+  ).catch(abandon)
 
   const capabilities: VisualCapabilities = {
     chat: request.chatEnabled,
@@ -703,6 +685,24 @@ export const startVisualServer = async (
         })
         return
       }
+      // A browser cannot have seen an acknowledgement the journal never issued.
+      // A stale claim is ordinary — a reconnect mid-turn looks exactly like one
+      // — but a claim ahead of the journal means this frame was composed against
+      // a session state that does not exist, so it is refused rather than
+      // journaled behind a sequence its sender never read.
+      if (input.value.lastAcknowledgedSequence > lastSequence) {
+        sendFrame(socket, {
+          kind: 'rejected',
+          diagnostics: [
+            serverDiagnostic(
+              'YMVS308',
+              `Browser acknowledged sequence ${input.value.lastAcknowledgedSequence}, past the journal's ${lastSequence}`,
+              '/lastAcknowledgedSequence',
+            ),
+          ],
+        })
+        return
+      }
       const event = eventFrom(input.value, {
         format: 'yarramate/visual-event/v1',
         sessionId,
@@ -836,12 +836,7 @@ export const startVisualServer = async (
       now,
     })
     if (compiled.ok) {
-      rendered = {
-        candidate: compiled.compiled.candidate,
-        authority: compiled.compiled.authority,
-        initialView: compiled.compiled.initialView,
-        views: compiled.compiled.views,
-      }
+      rendered = await renderCompiled(compiled.compiled)
       broadcast({ kind: 'model', model: rendered })
       return { model: rendered, diagnostics: [] }
     }

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -1519,7 +1519,7 @@ export const startVisualServer = async (
     server.writeHead(303, {
       ...browserHeaders,
       Location: '/',
-      'Set-Cookie': `${COOKIE_NAME}=${cookieSecret}; HttpOnly; SameSite=Strict; Path=/`,
+      'Set-Cookie': `${COOKIE_NAME}=${cookieSecret}; HttpOnly; SameSite=Strict; Secure; Path=/`,
       'Content-Length': 0,
     })
     server.end()

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -447,6 +447,18 @@ export const startVisualServer = async (
     return next
   }
 
+  /**
+   * Waits until nothing is left on the admission chain. `admission` absorbs its
+   * own rejections, and work can still enqueue while draining (it refuses
+   * itself), so the tail is re-read until it stops moving.
+   */
+  const drainAdmission = async () => {
+    for (let tail = admission; ; tail = admission) {
+      await tail
+      if (tail === admission) return
+    }
+  }
+
   /** The first limit a session reaches is the one it reports for good. */
   const freeze = (reason: VisualFreezeReason) => {
     frozen ??= reason
@@ -576,16 +588,15 @@ export const startVisualServer = async (
   })
   httpServer.on('clientError', (_error, socket) => socket.destroy())
 
-  await new Promise<void>((settle, fail) => {
-    const onError = (error: Error) => fail(error)
-    httpServer.once('error', onError)
-    // Loopback only, on a kernel-assigned port: the session is never reachable
-    // from another host, and never collides with a well-known service.
-    httpServer.listen(0, '127.0.0.1', () => {
-      httpServer.removeListener('error', onError)
-      settle()
-    })
-  }).catch(abandon)
+  const bound = Promise.withResolvers<void>()
+  httpServer.once('error', bound.reject)
+  // Loopback only, on a kernel-assigned port: the session is never reachable
+  // from another host, and never collides with a well-known service.
+  httpServer.listen(0, '127.0.0.1', () => {
+    httpServer.removeListener('error', bound.reject)
+    bound.resolve()
+  })
+  await bound.promise.catch(abandon)
 
   const address = httpServer.address() as AddressInfo
   const origin = `http://127.0.0.1:${address.port}`
@@ -662,6 +673,21 @@ export const startVisualServer = async (
       return
     }
     await admit(async () => {
+      // A frame can already be on the chain when a stop begins. Recovery must
+      // see a journal nothing is still writing to, so anything that has not
+      // been journaled yet is refused rather than raced.
+      if (lifecycle !== 'running') {
+        sendFrame(socket, {
+          kind: 'rejected',
+          diagnostics: [
+            serverDiagnostic(
+              'YMVS306',
+              `Session is ${lifecycle} and no longer accepts input`,
+            ),
+          ],
+        })
+        return
+      }
       if (frozen !== undefined) {
         sendFrame(socket, {
           kind: 'rejected',
@@ -725,15 +751,35 @@ export const startVisualServer = async (
     connections.set(connectionId, socket)
     lastSeenAt = stamp()
     socket.on('message', (raw, binary) => {
-      void admitBrowserInput(socket, raw, binary)
+      // Nothing awaits this handler, so a rejection here would reach the
+      // process as an unhandled one and take the runtime down with it. The
+      // browser is told its frame failed; the session stays up.
+      admitBrowserInput(socket, raw, binary).catch((cause: unknown) => {
+        try {
+          sendFrame(socket, {
+            kind: 'rejected',
+            diagnostics: [
+              serverDiagnostic(
+                'YMVS307',
+                `Admitting the browser frame failed: ${
+                  cause instanceof Error ? cause.message : String(cause)
+                }`,
+              ),
+            ],
+          })
+        } catch {
+          socket.close(1011)
+        }
+      })
     })
     socket.on('error', (error) => {
       // ws refuses an oversized frame before buffering it, which is exactly the
       // byte ceiling the protocol calls a freeze.
-      if (
-        (error as { code?: string }).code ===
-        'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH'
-      ) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? error.code
+          : undefined
+      if (code === 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH') {
         freeze('message-bytes')
       }
     })
@@ -858,6 +904,22 @@ export const startVisualServer = async (
         readonly code: number
         readonly body: VisualResponseAcceptance
       }> => {
+        // Same race as a browser frame: a request already on the chain must not
+        // append to a session recovery has begun reading.
+        if (lifecycle !== 'running') {
+          return {
+            code: 503,
+            body: {
+              accepted: false,
+              diagnostics: [
+                serverDiagnostic(
+                  'YMVS306',
+                  `Session is ${lifecycle} and no longer accepts responses`,
+                ),
+              ],
+            },
+          }
+        }
         const appended = await appendVisualResponse(paths, response)
         if (!appended.ok) {
           if (appended.freeze !== undefined) freeze(appended.freeze)
@@ -913,7 +975,12 @@ export const startVisualServer = async (
       refuse(server, body.status, body.message)
       return
     }
-    const reason = (body.value as { readonly reason?: unknown }).reason
+    const reason =
+      typeof body.value === 'object' &&
+      body.value !== null &&
+      'reason' in body.value
+        ? body.value.reason
+        : undefined
     if (typeof reason !== 'string' || TERMINATION_REASONS[reason] !== true) {
       refuse(server, 400, 'Stop requires a known termination reason')
       return
@@ -1125,10 +1192,8 @@ export const startVisualServer = async (
 
   // ----------------------------------------------------------------- shutdown
 
-  let announceClosed!: (closed: VisualServerClosed) => void
-  const closed = new Promise<VisualServerClosed>((settle) => {
-    announceClosed = settle
-  })
+  const { promise: closed, resolve: announceClosed } =
+    Promise.withResolvers<VisualServerClosed>()
   let stopping: Promise<VisualServerClosed> | undefined
 
   const stop = async (
@@ -1150,6 +1215,13 @@ export const startVisualServer = async (
         socket.close(1001)
       }
       sockets.close()
+      // Work admitted before the drain began still has to finish: recovery must
+      // read a journal nothing is mid-append to, and a rejected append must be
+      // observed here rather than escaping as an unhandled rejection. Work that
+      // has not started refuses itself, which is what bounds this wait.
+      await drainAdmission()
+      // Only now: an in-flight agent request has had its answer written, so
+      // ending its connection cannot swallow the refusal it was owed.
       for (const socket of httpSockets) {
         if (socket !== exempt) socket.end()
       }

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -40,12 +40,16 @@ import {
   type VisualTerminationReason,
 } from './protocol.js'
 import {
+  appendTerminalEvent,
   appendVisualEvent,
   appendVisualResponse,
   createVisualSession,
   isActionableVisualEvent,
+  recoverVisualSession,
   removeVisualSession,
   writeVisualSessionDescriptor,
+  type TerminalEventDependencies,
+  type VisualSessionPaths,
 } from './session-store.js'
 import type {
   VisualRenderedModel,
@@ -204,6 +208,12 @@ export interface VisualServerOptions {
   readonly agentPollMs?: number
   /** Whether the handoff a stop returns carries the raw transcript. */
   readonly includeTranscript?: boolean
+  /**
+   * Arms the browser reconnect grace, and answers with the cancellation of the
+   * window it armed. Injected so the exact window a session waits is
+   * observable, and so it can elapse without waiting out five real minutes.
+   */
+  readonly schedule?: (task: () => Promise<void>, ms: number) => () => void
 }
 
 export interface VisualServerHandle {
@@ -211,6 +221,71 @@ export interface VisualServerHandle {
   readonly closed: Promise<VisualServerClosed>
   status(): VisualStatus
   stop(reason: VisualTerminationReason): Promise<VisualServerClosed>
+}
+
+/**
+ * The runtime half of one live session: everything the terminal transition
+ * mutates, and the hooks it needs to quiet the rest down first.
+ *
+ * `lifecycle` is the whole admission gate — only a `running` session takes a
+ * browser frame or an agent response — so freezing input is one assignment
+ * rather than a second flag that could disagree with it.
+ */
+export interface ActiveVisualSession {
+  readonly paths: VisualSessionPaths
+  lifecycle: VisualLifecycle
+  /** Cancels whatever the trusted compiler is doing for this session. */
+  readonly compilerAbort: AbortController
+  /** Records why the browser stopped being able to speak. */
+  readonly freeze: (reason: VisualFreezeReason) => void
+  /** Settles work already admitted, so recovery reads a quiet journal. */
+  readonly quiesce: () => Promise<void>
+  readonly terminalEvent: TerminalEventDependencies
+  /** The transition in flight, so concurrent causes converge on one run. */
+  terminating: Promise<VisualHandoff> | undefined
+  /** What this session ended with, once it has ended. */
+  handoff: VisualHandoff | undefined
+}
+
+/**
+ * Takes one session terminal, whatever caused it: a reviewer's End, a child
+ * that failed, a browser that never came back, a cancelling main agent, or a
+ * runtime shutting itself down.
+ *
+ * The order is the invariant. Input freezes before anything is read; the
+ * compiler is cancelled rather than waited out; work already admitted is still
+ * allowed to finish; exactly one terminal event is journaled; and the handoff
+ * is recovered without deleting anything, so `stop` — and only `stop` — is what
+ * removes the session directory.
+ */
+export const terminateVisualSession = (
+  session: ActiveVisualSession,
+  reason: VisualTerminationReason,
+): Promise<VisualHandoff> => {
+  session.terminating ??= (async () => {
+    if (session.lifecycle !== 'stopped') session.lifecycle = 'draining'
+    session.freeze('terminal-event')
+    session.compilerAbort.abort()
+    await session.quiesce()
+    // A terminal event that cannot be journaled must not be why a session
+    // stays up: `runVisualStart` waits on this to return, so a transition that
+    // refuses to settle hangs the command and strands the directory. The
+    // journal is then a runtime that died without saying why, and recovery
+    // reports precisely that.
+    await appendTerminalEvent(
+      session.paths,
+      reason,
+      session.terminalEvent,
+    ).catch(() => undefined)
+    session.handoff = await recoverVisualSession(session.paths, false)
+    return session.handoff
+  })().catch((cause: unknown) => {
+    // A transition that failed is not this session's outcome: the next
+    // terminal cause has to be able to try it again.
+    session.terminating = undefined
+    throw cause
+  })
+  return session.terminating
 }
 
 interface VisualEventEnvelope {
@@ -392,9 +467,17 @@ export const startVisualServer = async (
     'Content-Security-Policy': visualContentSecurityPolicy(styleNonce),
   }
 
+  /** Cancels every compile this session runs, including one in flight. */
+  const compilerAbort = new AbortController()
+  /** Set once the loopback listener exists; a failed start has to close it. */
+  let closeListener: (() => Promise<void>) | undefined
+
   // Past this point a session directory exists on disk; a failed start must not
-  // leave one behind for the next run to prune.
+  // leave one behind for the next run to prune, nor a listener for the process
+  // to outlive.
   const abandon = async (cause: unknown): Promise<never> => {
+    compilerAbort.abort()
+    await closeListener?.().catch(() => undefined)
     await removeVisualSession(paths).catch(() => undefined)
     throw cause
   }
@@ -404,6 +487,7 @@ export const startVisualServer = async (
     command: request.compiler,
     paths,
     now,
+    signal: compilerAbort.signal,
   }).catch(abandon)
   if (!compilation.ok) {
     const first = compilation.diagnostics[0]
@@ -429,7 +513,6 @@ export const startVisualServer = async (
     transcript: true,
   }
 
-  let lifecycle: VisualLifecycle = 'starting'
   let listening = false
   let bootstrapSpent = false
   let agentAttached = false
@@ -477,6 +560,49 @@ export const startVisualServer = async (
   /** The first limit a session reaches is the one it reports for good. */
   const freeze = (reason: VisualFreezeReason) => {
     frozen ??= reason
+  }
+
+  /**
+   * Everything a terminal cause touches, in one place. The transition below is
+   * the only thing that moves a live session off `running`.
+   */
+  const active: ActiveVisualSession = {
+    paths,
+    lifecycle: 'starting',
+    compilerAbort,
+    freeze,
+    quiesce: drainAdmission,
+    terminalEvent: { now, randomBytes },
+    terminating: undefined,
+    handoff: undefined,
+  }
+
+  const schedule =
+    options.schedule ??
+    ((task, ms) => {
+      const timer = setTimeout(() => void task().catch(() => undefined), ms)
+      // A grace nobody is waiting on must never be why a process stays alive.
+      timer.unref()
+      return () => clearTimeout(timer)
+    })
+
+  /**
+   * The reviewer's browser is gone and the session is holding the conversation
+   * open for it. Reconnecting inside the window resumes exactly where it left
+   * off; reaching the end of it is a terminal cause like any other.
+   */
+  let cancelGrace: (() => void) | undefined
+  const armGrace = () => {
+    if (cancelGrace !== undefined || active.lifecycle !== 'running') return
+    cancelGrace = schedule(async () => {
+      cancelGrace = undefined
+      if (connections.size > 0 || active.lifecycle !== 'running') return
+      await terminateVisualSession(active, 'browser-timeout')
+    }, VISUAL_LIMITS.reconnectMs)
+  }
+  const disarmGrace = () => {
+    cancelGrace?.()
+    cancelGrace = undefined
   }
 
   /** A journaled browser event, as the line the reviewer sees. */
@@ -545,14 +671,16 @@ export const startVisualServer = async (
       format: 'yarramate/visual-status/v1',
       protocolVersion: VISUAL_PROTOCOL_VERSION,
       sessionId,
-      lifecycle,
-      alreadyStopped: lifecycle === 'stopped',
+      lifecycle: active.lifecycle,
+      alreadyStopped: active.lifecycle === 'stopped',
       server: { listening, origin },
       browser: {
         connected: connections.size > 0,
         connections: connections.size,
         ...(lastSeenAt === undefined ? {} : { lastSeenAt }),
-        ...(connections.size === 0 && lastSeenAt !== undefined
+        // Only while one is actually armed: a session whose window already
+        // elapsed is not still waiting for that browser, and must not say so.
+        ...(cancelGrace !== undefined && lastSeenAt !== undefined
           ? {
               graceExpiresAt: new Date(
                 Date.parse(lastSeenAt) + VISUAL_LIMITS.reconnectMs,
@@ -671,6 +799,17 @@ export const startVisualServer = async (
     maxPayload: VISUAL_SERVER_LIMITS.browserFrameBytes,
   })
 
+  // A start that fails after the port is bound has to give it back; nothing
+  // has published this origin yet, so there is nothing to drain first.
+  closeListener = async () => {
+    listening = false
+    sockets.close()
+    for (const socket of httpSockets) socket.destroy()
+    const shut = Promise.withResolvers<void>()
+    httpServer.close(() => shut.resolve())
+    await shut.promise
+  }
+
   // ---------------------------------------------------------------- responses
 
   const respond = (
@@ -685,7 +824,7 @@ export const startVisualServer = async (
       'Content-Length': Buffer.byteLength(body),
       // A draining session must not leave a pooled connection behind that
       // outlives its listener.
-      ...(lifecycle === 'running' ? {} : { Connection: 'close' }),
+      ...(active.lifecycle === 'running' ? {} : { Connection: 'close' }),
     })
     server.end(body)
   }
@@ -738,13 +877,13 @@ export const startVisualServer = async (
       // A frame can already be on the chain when a stop begins. Recovery must
       // see a journal nothing is still writing to, so anything that has not
       // been journaled yet is refused rather than raced.
-      if (lifecycle !== 'running') {
+      if (active.lifecycle !== 'running') {
         sendFrame(socket, {
           kind: 'rejected',
           diagnostics: [
             serverDiagnostic(
               'YMVS306',
-              `Session is ${lifecycle} and no longer accepts input`,
+              `Session is ${active.lifecycle} and no longer accepts input`,
             ),
           ],
         })
@@ -756,6 +895,27 @@ export const startVisualServer = async (
           frozen,
           diagnostics: [
             serverDiagnostic('YMVS304', `Session input is frozen: ${frozen}`),
+          ],
+        })
+        return
+      }
+      // A session that was started without a conversation has no chat and no
+      // choices to make; the diagram, and moving around it, is all it granted.
+      const granted =
+        input.value.type === 'chat.message'
+          ? capabilities.chat
+          : input.value.type === 'choice.selected'
+            ? capabilities.choices
+            : true
+      if (!granted) {
+        sendFrame(socket, {
+          kind: 'rejected',
+          diagnostics: [
+            serverDiagnostic(
+              'YMVS309',
+              `Session did not grant the capability "${input.value.type}" needs`,
+              '/type',
+            ),
           ],
         })
         return
@@ -829,6 +989,9 @@ export const startVisualServer = async (
 
   const attachBrowser = (socket: WebSocket) => {
     const connectionId = drawHex(16)
+    // The reviewer is back inside the window, so the session it was holding
+    // open for them is not going to end.
+    disarmGrace()
     connections.set(connectionId, socket)
     lastSeenAt = stamp()
     socket.on('message', (raw, binary) => {
@@ -867,6 +1030,7 @@ export const startVisualServer = async (
     socket.on('close', () => {
       connections.delete(connectionId)
       lastSeenAt = stamp()
+      if (connections.size === 0) armGrace()
     })
     sendFrame(socket, { kind: 'ready', snapshot: snapshot() })
   }
@@ -881,7 +1045,7 @@ export const startVisualServer = async (
       return
     }
     const immediate = takeDelivery(after)
-    if (!immediate.waiting || lifecycle !== 'running') {
+    if (!immediate.waiting || active.lifecycle !== 'running') {
       respondJson(server, 200, immediate)
       return
     }
@@ -910,6 +1074,7 @@ export const startVisualServer = async (
       command: request.compiler,
       paths,
       now,
+      signal: compilerAbort.signal,
     })
     if (compiled.ok) {
       rendered = await renderCompiled(compiled.compiled)
@@ -929,6 +1094,9 @@ export const startVisualServer = async (
     }
     const appended = await appendVisualResponse(paths, diagnostic)
     if (appended.ok) transcriptBytes = appended.transcriptBytes
+    // A journal that refused the explanation is still a journal that reached a
+    // limit, and the limit outlives this response.
+    else if (appended.freeze !== undefined) freeze(appended.freeze)
     broadcast({ kind: 'response', response: diagnostic })
     return { diagnostics: compiled.diagnostics }
   }
@@ -1001,6 +1169,24 @@ export const startVisualServer = async (
       } satisfies VisualResponseAcceptance)
       return
     }
+    // The agent cannot hold a conversation a diagram-only session never
+    // offered; the browser has nowhere to show one.
+    if (
+      !capabilities.chat &&
+      (response.type === 'chat.response' || response.type === 'choice.present')
+    ) {
+      respondJson(server, 409, {
+        accepted: false,
+        diagnostics: [
+          serverDiagnostic(
+            'YMVS309',
+            `Session did not grant the capability "${response.type}" needs`,
+            '/type',
+          ),
+        ],
+      } satisfies VisualResponseAcceptance)
+      return
+    }
     const result = await admit(
       async (): Promise<{
         readonly code: number
@@ -1008,7 +1194,7 @@ export const startVisualServer = async (
       }> => {
         // Same race as a browser frame: a request already on the chain must not
         // append to a session recovery has begun reading.
-        if (lifecycle !== 'running') {
+        if (active.lifecycle !== 'running') {
           return {
             code: 503,
             body: {
@@ -1016,7 +1202,7 @@ export const startVisualServer = async (
               diagnostics: [
                 serverDiagnostic(
                   'YMVS306',
-                  `Session is ${lifecycle} and no longer accepts responses`,
+                  `Session is ${active.lifecycle} and no longer accepts responses`,
                 ),
               ],
             },
@@ -1079,14 +1265,20 @@ export const startVisualServer = async (
       refuse(server, body.status, body.message)
       return
     }
-    const reason =
-      typeof body.value === 'object' &&
-      body.value !== null &&
-      'reason' in body.value
-        ? body.value.reason
-        : undefined
+    const asked =
+      typeof body.value === 'object' && body.value !== null
+        ? (body.value as Readonly<Record<string, unknown>>)
+        : {}
+    const reason = asked.reason
     if (typeof reason !== 'string' || TERMINATION_REASONS[reason] !== true) {
       refuse(server, 400, 'Stop requires a known termination reason')
+      return
+    }
+    if (
+      asked.includeTranscript !== undefined &&
+      typeof asked.includeTranscript !== 'boolean'
+    ) {
+      refuse(server, 400, 'Stop takes a boolean "includeTranscript" or none')
       return
     }
     // The socket answering the stop is the one connection shutdown may not end
@@ -1094,6 +1286,7 @@ export const startVisualServer = async (
     const closed = await stop(
       reason as VisualTerminationReason,
       incoming.socket,
+      asked.includeTranscript,
     )
     server.on('finish', () => incoming.socket.end())
     respondJson(server, 200, closed)
@@ -1274,7 +1467,7 @@ export const startVisualServer = async (
       )
       socket.destroy()
     }
-    if (lifecycle !== 'running') return deny(503, 'Service Unavailable')
+    if (active.lifecycle !== 'running') return deny(503, 'Service Unavailable')
     if (incoming.headers.host !== authority) return deny(403, 'Forbidden')
     // An upgrade always carries an Origin, so it is checked without exception.
     if (incoming.headers.origin !== origin) return deny(403, 'Forbidden')
@@ -1303,13 +1496,17 @@ export const startVisualServer = async (
   const stop = async (
     reason: VisualTerminationReason,
     exempt?: Socket,
+    includeTranscript = options.includeTranscript ?? false,
   ): Promise<VisualServerClosed> => {
     if (stopping !== undefined) {
       return { ...(await stopping), alreadyStopped: true }
     }
     stopping = (async () => {
-      lifecycle = 'draining'
+      // Frozen before anything is torn down: a request already on the wire
+      // must not be journaled behind the recovery this stop is about to read.
+      active.lifecycle = 'draining'
       listening = false
+      disarmGrace()
       httpServer.close()
       // Waiting agents are answered before any socket is torn down, so a poll
       // in flight during a stop still receives its non-terminal idle result.
@@ -1319,27 +1516,24 @@ export const startVisualServer = async (
         socket.close(1001)
       }
       sockets.close()
-      // Work admitted before the drain began still has to finish: recovery must
-      // read a journal nothing is mid-append to, and a rejected append must be
-      // observed here rather than escaping as an unhandled rejection. Work that
-      // has not started refuses itself, which is what bounds this wait.
-      await drainAdmission()
+      // The one transition: freeze, cancel the compiler, let admitted work
+      // finish, journal the terminal event, and recover — all without deleting
+      // anything, so shutdown can never be the step that loses confirmed state.
+      // A session that already ended answers with the handoff it ended with.
+      const terminal = await terminateVisualSession(active, reason)
       // Only now: an in-flight agent request has had its answer written, so
       // ending its connection cannot swallow the refusal it was owed.
       for (const socket of httpSockets) {
         if (socket !== exempt) socket.end()
       }
-      // Recovery runs before the delete, so shutdown can never be the step that
-      // loses confirmed state.
-      const handoff = await removeVisualSession(
-        paths,
-        options.includeTranscript ?? false,
-      )
-      lifecycle = 'stopped'
+      // The transcript is read once, here, and only if this stop asked for it;
+      // the same read is what removes the marked root.
+      const removed = await removeVisualSession(paths, includeTranscript)
+      active.lifecycle = 'stopped'
       const outcome: VisualServerClosed = {
         reason,
         alreadyStopped: false,
-        handoff,
+        handoff: removed ?? terminal,
       }
       announceClosed(outcome)
       return outcome
@@ -1347,44 +1541,50 @@ export const startVisualServer = async (
     return stopping
   }
 
-  await writeVisualSessionDescriptor(paths, {
-    format: 'yarramate/visual-session-descriptor/v1',
-    protocolVersion: VISUAL_PROTOCOL_VERSION,
-    sessionId,
-    origin,
-    agentCapability: session.agentToken,
-    sessionRoot: paths.root,
-    journalPath: paths.journal,
-    createdAt: stamp(),
-  }).catch(abandon)
-
-  const started: VisualSessionStarted = {
-    format: 'yarramate/visual-session-started/v1',
-    protocolVersion: VISUAL_PROTOCOL_VERSION,
-    sessionId,
-    authority: request.authority,
-    title: request.title,
-    chatEnabled: request.chatEnabled,
-    browserUrl: `${origin}/bootstrap?key=${session.browserToken}`,
-    webSocketUrl,
-    origin,
-    descriptorPath: paths.descriptor,
-    sessionRoot: paths.root,
-    capabilities,
-    startedAt: stamp(),
-  }
-  const validated = parseVisualSessionStarted(started)
-  if (!validated.ok) {
-    return abandon(
-      serverError(
+  // Everything from here is publication, and every way it can fail — a
+  // descriptor that will not write, a document that does not validate, a clock
+  // that answers with nonsense — leaves a bound port and a session directory
+  // behind unless it goes through `abandon`.
+  let started: VisualSessionStarted
+  try {
+    await writeVisualSessionDescriptor(paths, {
+      format: 'yarramate/visual-session-descriptor/v1',
+      protocolVersion: VISUAL_PROTOCOL_VERSION,
+      sessionId,
+      origin,
+      agentCapability: session.agentToken,
+      sessionRoot: paths.root,
+      journalPath: paths.journal,
+      createdAt: stamp(),
+    })
+    started = {
+      format: 'yarramate/visual-session-started/v1',
+      protocolVersion: VISUAL_PROTOCOL_VERSION,
+      sessionId,
+      authority: request.authority,
+      title: request.title,
+      chatEnabled: request.chatEnabled,
+      browserUrl: `${origin}/bootstrap?key=${session.browserToken}`,
+      webSocketUrl,
+      origin,
+      descriptorPath: paths.descriptor,
+      sessionRoot: paths.root,
+      capabilities,
+      startedAt: stamp(),
+    }
+    const validated = parseVisualSessionStarted(started)
+    if (!validated.ok) {
+      throw serverError(
         validated.diagnostics[0]?.code ?? 'YMVS102',
         `Started session is invalid: ${
           validated.diagnostics[0]?.message ?? 'unknown violation'
         }`,
-      ),
-    )
+      )
+    }
+  } catch (cause) {
+    return abandon(cause)
   }
-  lifecycle = 'running'
+  active.lifecycle = 'running'
 
   return { started, closed, status, stop: (reason) => stop(reason) }
 }

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -146,6 +146,23 @@ const TERMINATION_REASONS: Readonly<Record<string, true>> = {
   'compiler-failed': true,
 }
 
+/**
+ * Which freezes are a runtime failing rather than a session closing.
+ *
+ * A ceiling the runtime enforced for itself means nothing more can be
+ * journaled, so the conversation is over whether or not anyone asks it to
+ * stop. `terminal-event` is already that ending, and a disconnected browser is
+ * the reconnect grace's business, so neither ends a session a second time.
+ */
+const LIMIT_FREEZE: Readonly<Record<VisualFreezeReason, boolean>> = {
+  'message-bytes': true,
+  'model-bytes': true,
+  'transcript-bytes': true,
+  'pending-events': true,
+  'browser-disconnected': false,
+  'terminal-event': false,
+}
+
 /** Built browser application, beside the compiled adapter in `dist`. */
 const DEFAULT_ASSET_ROOT = fileURLToPath(
   new URL('../../visual-app/', import.meta.url),
@@ -571,9 +588,40 @@ export const startVisualServer = async (
     }
   }
 
-  /** The first limit a session reaches is the one it reports for good. */
+  /**
+   * Ends a session that reached one of its own ceilings, exactly once.
+   *
+   * `freeze` is reached from inside the admission chain and the transition
+   * drains that same chain, so the entry that detected the limit is allowed to
+   * answer its sender first: starting the transition inline would be a session
+   * waiting on itself. Nothing is truncated — every record already accepted
+   * stands, and only the closing one is added.
+   */
+  let limitFailure: Promise<void> | undefined
+  const failOnLimit = () => {
+    limitFailure ??= (async () => {
+      await drainAdmission()
+      try {
+        // `server-failed` is the truth of it: not the reviewer, not the child,
+        // but the runtime is why the conversation stopped. Recovery reads that
+        // back as a failed handoff carrying everything the session did accept.
+        await terminateVisualSession(active, 'server-failed')
+      } finally {
+        // Whatever the journal managed, the child must not be left holding a
+        // turn on a session that has stopped answering.
+        settleAllPolls()
+      }
+    })().catch(() => undefined)
+  }
+
+  /**
+   * The first limit a session reaches is the one it reports for good, and a
+   * limit the runtime detected for itself also ends it.
+   */
   const freeze = (reason: VisualFreezeReason) => {
-    frozen ??= reason
+    if (frozen !== undefined) return
+    frozen = reason
+    if (LIMIT_FREEZE[reason]) failOnLimit()
   }
 
   /**
@@ -1010,6 +1058,51 @@ export const startVisualServer = async (
     })
   }
 
+  /**
+   * Journals one transport record the runtime owns outright: a browser was
+   * admitted, or the socket it was admitted on went away. `closedWith` is the
+   * close code for the second and absent for the first.
+   *
+   * The browser neither sends these nor waits on them. They are non-actionable,
+   * so they open no agent turn and never join the pending queue; they take
+   * their sequence, identifier, and timestamp from the same admission chain
+   * every other record does, so a connection is always journaled ahead of the
+   * frames it goes on to send. A session that is no longer taking input skips
+   * them, because a shutdown closing its own sockets is not the reviewer
+   * leaving. The append is deliberately answered to nobody: a socket callback
+   * awaits nothing, so a failure here becomes a freeze rather than a rejection
+   * the process never handles.
+   */
+  const journalConnection = (
+    connectionId: string,
+    closedWith?: number,
+  ): Promise<void> =>
+    admit(async () => {
+      if (active.lifecycle !== 'running' || frozen !== undefined) return
+      const envelope = {
+        format: 'yarramate/visual-event/v1',
+        sessionId,
+        sequence: lastSequence + 1,
+        eventId: drawHex(16),
+        timestamp: stamp(),
+      } as const
+      const event: VisualEvent =
+        closedWith === undefined
+          ? { ...envelope, type: 'browser.connected', payload: { connectionId } }
+          : {
+              ...envelope,
+              type: 'browser.disconnected',
+              payload: { connectionId, code: closedWith },
+            }
+      const appended = await appendVisualEvent(paths, event)
+      if (!appended.ok) {
+        if (appended.freeze !== undefined) freeze(appended.freeze)
+        return
+      }
+      lastSequence = appended.lastSequence
+      transcriptBytes = appended.transcriptBytes
+    }).catch(() => undefined)
+
   const attachBrowser = (socket: WebSocket) => {
     const connectionId = drawHex(16)
     // The reviewer is back inside the window, so the session it was holding
@@ -1050,12 +1143,24 @@ export const startVisualServer = async (
         freeze('message-bytes')
       }
     })
-    socket.on('close', () => {
+    socket.on('close', (code: number) => {
       connections.delete(connectionId)
       lastSeenAt = stamp()
+      // The code the transport reported, held inside the range the journal
+      // accepts: a socket that died without one still has to be recorded as
+      // having gone, and 1006 is what that abnormal closure is called.
+      void journalConnection(
+        connectionId,
+        Number.isInteger(code) && code >= 1000 && code <= 4999 ? code : 1006,
+      )
       if (connections.size === 0) armGrace()
     })
-    sendFrame(socket, { kind: 'ready', snapshot: snapshot() })
+    // The arrival is journaled before the snapshot is handed over, so the
+    // sequence the browser starts from already counts it, and a reload cannot
+    // be told it acknowledged a sequence the journal never reached.
+    void journalConnection(connectionId)
+      .then(() => sendFrame(socket, { kind: 'ready', snapshot: snapshot() }))
+      .catch(() => socket.close(1011))
   }
 
   // ------------------------------------------------------------- agent routes

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -51,12 +51,18 @@ import type {
   VisualRenderedModel,
   VisualServerFrame,
   VisualSessionSnapshot,
+  VisualTranscriptRecord,
 } from './wire.js'
 
 // The browser application imports these from `./wire.js`; the server keeps
 // publishing them so one import still covers the whole transport for an
 // agent-side consumer.
-export type { VisualRenderedModel, VisualServerFrame, VisualSessionSnapshot }
+export type {
+  VisualRenderedModel,
+  VisualServerFrame,
+  VisualSessionSnapshot,
+  VisualTranscriptRecord,
+}
 
 /**
  * Document name reported by diagnostics the server itself raises — a refused
@@ -71,11 +77,19 @@ export const VISUAL_SERVER_DOCUMENT = 'visual-session-server'
  * and the page can be neither framed nor used as a base for relative fetches.
  */
 export const VISUAL_BROWSER_HEADERS = {
-  'Content-Security-Policy': `default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'`,
   'Referrer-Policy': 'no-referrer',
   'X-Content-Type-Options': 'nosniff',
   'Cache-Control': 'no-store',
 } as const
+
+/**
+ * This session's content policy. Every source stays `'self'`; the one addition
+ * is a per-session nonce for inline style, because the diagram renderer injects
+ * its own stylesheets at runtime. A nonce admits exactly the styles this
+ * application emits, where `'unsafe-inline'` would admit anyone's.
+ */
+export const visualContentSecurityPolicy = (styleNonce: string) =>
+  `default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'nonce-${styleNonce}'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'`
 
 export const VISUAL_SERVER_LIMITS = {
   /** WebSocket frame ceiling: one 64 KiB chat message plus its envelope. */
@@ -371,6 +385,12 @@ export const startVisualServer = async (
   const paths = session.paths
   const sessionId = basename(paths.root)
   const cookieSecret = drawHex(32)
+  // Not a credential: it authorises inline style for this page, nothing else.
+  const styleNonce = drawHex(16)
+  const browserHeaders = {
+    ...VISUAL_BROWSER_HEADERS,
+    'Content-Security-Policy': visualContentSecurityPolicy(styleNonce),
+  }
 
   // Past this point a session directory exists on disk; a failed start must not
   // leave one behind for the next run to prune.
@@ -419,6 +439,14 @@ export const startVisualServer = async (
   let inFlight: VisualEvent | undefined
   let lastSeenAt: string | undefined
   let pending: VisualEvent[] = []
+  /**
+   * What the browser has seen said, in order. It is derived from the same
+   * events and responses the journal takes, so a browser that reloads inside
+   * the grace is handed back the conversation it left rather than a blank one.
+   */
+  const transcript: VisualTranscriptRecord[] = []
+  /** Option labels the agent presented, so a selection restores as its label. */
+  const choiceLabels = new Map<string, Map<string, string>>()
   const connections = new Map<string, WebSocket>()
   const polls = new Set<PendingPoll>()
   const httpSockets = new Set<Socket>()
@@ -451,6 +479,50 @@ export const startVisualServer = async (
     frozen ??= reason
   }
 
+  /** A journaled browser event, as the line the reviewer sees. */
+  const recordEvent = (event: VisualEvent) => {
+    if (event.type === 'chat.message') {
+      transcript.push({
+        id: event.eventId,
+        speaker: 'reviewer',
+        text: event.payload.text,
+      })
+      return
+    }
+    if (event.type !== 'choice.selected') return
+    // The reviewer chose a label, not an identifier, so that is what the
+    // restored conversation says they chose.
+    const label = choiceLabels
+      .get(event.payload.choiceId)
+      ?.get(event.payload.optionId)
+    transcript.push({
+      id: event.eventId,
+      speaker: 'reviewer',
+      text: label ?? event.payload.optionId,
+    })
+  }
+
+  /** An accepted agent response, as the line the reviewer sees. */
+  const recordResponse = (response: VisualResponse) => {
+    if (response.type === 'choice.present') {
+      choiceLabels.set(
+        response.payload.choiceId,
+        new Map(
+          response.payload.options.map((option) => [option.id, option.label]),
+        ),
+      )
+      return
+    }
+    const text =
+      response.type === 'chat.response'
+        ? response.payload.text
+        : response.type === 'handoff.complete'
+          ? response.payload.summary
+          : undefined
+    if (text === undefined) return
+    transcript.push({ id: response.responseId, speaker: 'agent', text })
+  }
+
   const snapshot = (): VisualSessionSnapshot => ({
     protocolVersion: VISUAL_PROTOCOL_VERSION,
     sessionId,
@@ -461,6 +533,8 @@ export const startVisualServer = async (
     capabilities,
     webSocketUrl,
     model: rendered,
+    transcript: [...transcript],
+    styleNonce,
     lastSequence,
     frozen: frozen !== undefined,
   })
@@ -605,7 +679,7 @@ export const startVisualServer = async (
     contentType: string,
   ) => {
     server.writeHead(code, {
-      ...VISUAL_BROWSER_HEADERS,
+      ...browserHeaders,
       'Content-Type': contentType,
       'Content-Length': Buffer.byteLength(body),
       // A draining session must not leave a pooled connection behind that
@@ -738,6 +812,7 @@ export const startVisualServer = async (
       }
       lastSequence = appended.lastSequence
       transcriptBytes = appended.transcriptBytes
+      recordEvent(event)
       if (actionable) pending.push(event)
       // A journaled end is the last input this session takes. The agent still
       // has to see it, so the queue freezes rather than the socket closing.
@@ -942,6 +1017,7 @@ export const startVisualServer = async (
             },
           }
         }
+        recordResponse(response)
         broadcast({ kind: 'response', response })
         const replaced =
           response.type === 'model.replace'
@@ -1086,7 +1162,7 @@ export const startVisualServer = async (
     // and a leaked cookie cannot be pasted into an address bar.
     bootstrapSpent = true
     server.writeHead(303, {
-      ...VISUAL_BROWSER_HEADERS,
+      ...browserHeaders,
       Location: '/',
       'Set-Cookie': `${COOKIE_NAME}=${cookieSecret}; HttpOnly; SameSite=Strict; Path=/`,
       'Content-Length': 0,

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -534,6 +534,7 @@ export const startVisualServer = async (
     webSocketUrl,
     model: rendered,
     transcript: [...transcript],
+    agentTurnOpen: openTurn(),
     styleNonce,
     lastSequence,
     frozen: frozen !== undefined,
@@ -932,6 +933,32 @@ export const startVisualServer = async (
     return { diagnostics: compiled.diagnostics }
   }
 
+  /**
+   * Events a turn-completing response has already answered.
+   *
+   * `completeTurn` only retires an event the agent actually polled for, so an
+   * answer that arrives before the poll leaves the event queued. The browser
+   * still has to be told its turn is over, and it is pruned back to the queue
+   * it describes so it cannot outgrow it.
+   */
+  const answered = new Set<string>()
+
+  const openTurn = () =>
+    (inFlight === undefined ? pending : [inFlight, ...pending]).some(
+      (event) => !answered.has(event.eventId),
+    )
+
+  const markAnswered = (response: VisualResponse) => {
+    if (TURN_COMPLETING[response.type] !== true) return
+    answered.add(response.eventId)
+    for (const eventId of answered) {
+      const queued =
+        inFlight?.eventId === eventId ||
+        pending.some((event) => event.eventId === eventId)
+      if (!queued) answered.delete(eventId)
+    }
+  }
+
   const completeTurn = (response: VisualResponse) => {
     if (TURN_COMPLETING[response.type] !== true) return
     if (inFlight?.eventId !== response.eventId) return
@@ -1018,6 +1045,7 @@ export const startVisualServer = async (
           }
         }
         recordResponse(response)
+        markAnswered(response)
         broadcast({ kind: 'response', response })
         const replaced =
           response.type === 'model.replace'

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -1,0 +1,1214 @@
+import {
+  createHash,
+  randomBytes as randomSource,
+  timingSafeEqual,
+} from 'node:crypto'
+import { lstat, readFile } from 'node:fs/promises'
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http'
+import type { AddressInfo, Socket } from 'node:net'
+import { basename, extname, join, resolve, sep } from 'node:path'
+import type { Duplex } from 'node:stream'
+import { fileURLToPath } from 'node:url'
+import { WebSocketServer, type RawData, type WebSocket } from 'ws'
+import { compileVisualModel } from './likec4-compiler.js'
+import {
+  VISUAL_LIMITS,
+  VISUAL_PROTOCOL_VERSION,
+  parseVisualBrowserInput,
+  parseVisualResponse,
+  parseVisualSessionStarted,
+  parseVisualStatus,
+  type VisualAuthority,
+  type VisualBrowserInput,
+  type VisualCapabilities,
+  type VisualDiagnostic,
+  type VisualEvent,
+  type VisualFreezeReason,
+  type VisualHandoff,
+  type VisualLifecycle,
+  type VisualResponse,
+  type VisualSessionRequest,
+  type VisualSessionStarted,
+  type VisualStatus,
+  type VisualTerminationReason,
+} from './protocol.js'
+import {
+  appendVisualEvent,
+  appendVisualResponse,
+  createVisualSession,
+  isActionableVisualEvent,
+  removeVisualSession,
+  writeVisualSessionDescriptor,
+} from './session-store.js'
+
+/**
+ * Document name reported by diagnostics the server itself raises — a refused
+ * frame, a frozen queue, or a transport violation that no protocol document
+ * owns.
+ */
+export const VISUAL_SERVER_DOCUMENT = 'visual-session-server'
+
+/**
+ * Returned on every response. The policy admits no external origin at all, so
+ * neither a compromised model nor a hostile chat message can reach the network,
+ * and the page can be neither framed nor used as a base for relative fetches.
+ */
+export const VISUAL_BROWSER_HEADERS = {
+  'Content-Security-Policy': `default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'`,
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'no-store',
+} as const
+
+export const VISUAL_SERVER_LIMITS = {
+  /** WebSocket frame ceiling: one 64 KiB chat message plus its envelope. */
+  browserFrameBytes: VISUAL_LIMITS.messageBytes + 1024,
+  /** Agent request body ceiling: one 5 MiB candidate model plus its envelope. */
+  agentBodyBytes: VISUAL_LIMITS.modelBytes + 64 * 1024,
+  /** Agent stop requests carry a termination reason and nothing else. */
+  agentControlBytes: 4096,
+  /** How long one agent long poll waits before answering "still idle". */
+  agentPollMs: 30_000,
+  /** Browser sockets one session serves at once. */
+  browserConnections: 8,
+} as const
+
+export const VISUAL_SOCKET_PATH = '/socket'
+
+const COOKIE_NAME = 'ym_visual'
+
+/**
+ * Assets are addressed by a single flat, hashed file name. Rejecting every
+ * separator here means a traversal never reaches path resolution at all.
+ */
+const ASSET_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+}
+
+/** Response types that finish the agent turn an event opened. */
+const TURN_COMPLETING: Readonly<Record<string, true>> = {
+  'chat.response': true,
+  'choice.present': true,
+  'handoff.complete': true,
+  diagnostic: true,
+}
+
+const TERMINATION_REASONS: Readonly<Record<string, true>> = {
+  'user-ended': true,
+  'child-failed': true,
+  'browser-timeout': true,
+  'main-cancelled': true,
+  'server-failed': true,
+  'compiler-failed': true,
+}
+
+/** Built browser application, beside the compiled adapter in `dist`. */
+const DEFAULT_ASSET_ROOT = fileURLToPath(
+  new URL('../../visual-app/', import.meta.url),
+)
+
+export interface VisualRenderedModel {
+  readonly candidate: string
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly views: readonly string[]
+}
+
+/** Everything the browser needs to render, and nothing that authenticates it. */
+export interface VisualSessionSnapshot {
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly capabilities: VisualCapabilities
+  readonly webSocketUrl: string
+  readonly model: VisualRenderedModel
+  readonly lastSequence: number
+  readonly frozen: boolean
+}
+
+/**
+ * Server-to-browser transport frame. These are not protocol documents: they
+ * carry validated documents plus the transport's own acknowledgements, so they
+ * are discriminated by `kind` rather than by a versioned `format`.
+ */
+export type VisualServerFrame =
+  | { readonly kind: 'ready'; readonly snapshot: VisualSessionSnapshot }
+  | {
+      readonly kind: 'accepted'
+      readonly sequence: number
+      readonly eventId: string
+    }
+  | {
+      readonly kind: 'rejected'
+      readonly diagnostics: readonly VisualDiagnostic[]
+      readonly frozen?: VisualFreezeReason
+    }
+  | { readonly kind: 'response'; readonly response: VisualResponse }
+  | { readonly kind: 'model'; readonly model: VisualRenderedModel }
+  | { readonly kind: 'closing'; readonly reason: VisualTerminationReason }
+
+export type VisualEventDelivery =
+  | {
+      readonly waiting: false
+      readonly event: VisualEvent
+      readonly lastSequence: number
+      readonly pendingEvents: number
+    }
+  | {
+      readonly waiting: true
+      readonly lastSequence: number
+      readonly pendingEvents: number
+    }
+
+export type VisualResponseAcceptance =
+  | {
+      readonly accepted: true
+      readonly duplicate: boolean
+      readonly lastSequence: number
+      readonly model?: VisualRenderedModel
+      readonly diagnostics: readonly VisualDiagnostic[]
+    }
+  | {
+      readonly accepted: false
+      readonly diagnostics: readonly VisualDiagnostic[]
+    }
+
+export interface VisualServerClosed {
+  readonly reason: VisualTerminationReason
+  readonly alreadyStopped: boolean
+  readonly handoff: VisualHandoff | undefined
+}
+
+export interface VisualServerOptions {
+  readonly request: VisualSessionRequest
+  /** Directory that holds one directory per live session. */
+  readonly baseDir: string
+  /** Root of the self-contained browser application. */
+  readonly assetRoot?: string
+  readonly now?: () => Date
+  readonly randomBytes?: (size: number) => Buffer
+  readonly agentPollMs?: number
+  /** Whether the handoff a stop returns carries the raw transcript. */
+  readonly includeTranscript?: boolean
+}
+
+export interface VisualServerHandle {
+  readonly started: VisualSessionStarted
+  readonly closed: Promise<VisualServerClosed>
+  status(): VisualStatus
+  stop(reason: VisualTerminationReason): Promise<VisualServerClosed>
+}
+
+interface VisualEventEnvelope {
+  readonly format: 'yarramate/visual-event/v1'
+  readonly sessionId: string
+  readonly sequence: number
+  readonly eventId: string
+  readonly timestamp: string
+}
+
+interface PendingPoll {
+  readonly after: number
+  readonly settle: (delivery: VisualEventDelivery) => void
+  readonly timer: NodeJS.Timeout
+}
+
+type BodyResult =
+  | { readonly ok: true; readonly value: unknown }
+  | { readonly ok: false; readonly status: number; readonly message: string }
+
+const serverError = (code: string, message: string) =>
+  new Error(`${code}: ${message}`)
+
+const serverDiagnostic = (
+  code: string,
+  message: string,
+  pointer = '#',
+): VisualDiagnostic => ({
+  severity: 'error',
+  code,
+  message,
+  path: VISUAL_SERVER_DOCUMENT,
+  pointer,
+  line: 1,
+  column: 1,
+})
+
+/**
+ * Compares two capabilities without leaking where they differ, or how long the
+ * presented one is: both sides are reduced to a fixed-width digest first, so
+ * the comparison is over equal-length buffers by construction.
+ */
+const secretEquals = (expected: string, presented: string | undefined) => {
+  if (presented === undefined) return false
+  const digest = (value: string) =>
+    createHash('sha256').update(value, 'utf8').digest()
+  return timingSafeEqual(digest(expected), digest(presented))
+}
+
+const cookieValue = (header: string | undefined, name: string) => {
+  if (header === undefined) return undefined
+  for (const part of header.split(';')) {
+    const split = part.indexOf('=')
+    if (split < 0) continue
+    if (part.slice(0, split).trim() === name) {
+      return part.slice(split + 1).trim()
+    }
+  }
+  return undefined
+}
+
+const bearerToken = (header: string | undefined) =>
+  header === undefined
+    ? undefined
+    : /^Bearer +([\x21-\x7e]+)$/.exec(header)?.[1]
+
+const isJsonContent = (header: string | undefined) =>
+  header !== undefined && /^application\/json\s*(;.*)?$/i.test(header.trim())
+
+/**
+ * Buffers at most `limit` bytes while always draining the request, so an
+ * oversized body costs bounded memory and still gets a clean HTTP answer
+ * instead of a severed connection.
+ */
+const readJsonBody = async (
+  incoming: IncomingMessage,
+  limit: number,
+): Promise<BodyResult> => {
+  if (!isJsonContent(incoming.headers['content-type'])) {
+    incoming.resume()
+    return {
+      ok: false,
+      status: 415,
+      message: 'Request body must be application/json',
+    }
+  }
+  const chunks: Buffer[] = []
+  let bytes = 0
+  let overflowed = false
+  for await (const chunk of incoming) {
+    const part = chunk as Buffer
+    bytes += part.byteLength
+    if (bytes > limit) {
+      overflowed = true
+      continue
+    }
+    chunks.push(part)
+  }
+  if (overflowed) {
+    return {
+      ok: false,
+      status: 413,
+      message: `Request body of ${bytes} bytes exceeds the ${limit} byte ceiling`,
+    }
+  }
+  try {
+    return {
+      ok: true,
+      value: JSON.parse(Buffer.concat(chunks).toString('utf8')),
+    }
+  } catch {
+    return { ok: false, status: 400, message: 'Request body is not JSON' }
+  }
+}
+
+/**
+ * Widens one validated browser input into the journaled event. The runtime owns
+ * every field the browser is not allowed to choose.
+ */
+const eventFrom = (
+  input: VisualBrowserInput,
+  envelope: VisualEventEnvelope,
+): VisualEvent => {
+  switch (input.type) {
+    case 'chat.message':
+      return { ...envelope, type: input.type, payload: input.payload }
+    case 'choice.selected':
+      return { ...envelope, type: input.type, payload: input.payload }
+    case 'view.navigate':
+      return { ...envelope, type: input.type, payload: input.payload }
+    case 'session.end':
+      return { ...envelope, type: input.type, payload: input.payload }
+  }
+}
+
+/**
+ * Serves one authenticated visual session over loopback. The handle owns the
+ * session directory it created: `stop` recovers the handoff before deleting it,
+ * and answers every later call with that same outcome.
+ */
+export const startVisualServer = async (
+  options: VisualServerOptions,
+): Promise<VisualServerHandle> => {
+  const now = options.now ?? (() => new Date())
+  const randomBytes = options.randomBytes ?? randomSource
+  const agentPollMs = options.agentPollMs ?? VISUAL_SERVER_LIMITS.agentPollMs
+  const assetRoot = resolve(options.assetRoot ?? DEFAULT_ASSET_ROOT)
+  const request = options.request
+
+  const drawHex = (size: number) => {
+    const drawn = randomBytes(size)
+    if (drawn.byteLength < size) {
+      throw serverError(
+        'YMVS301',
+        `Random source returned ${drawn.byteLength} bytes for a ${size}-byte draw`,
+      )
+    }
+    return drawn.subarray(0, size).toString('hex')
+  }
+  const stamp = () => now().toISOString()
+
+  const session = await createVisualSession(request, {
+    baseDir: options.baseDir,
+    now,
+    randomBytes,
+  })
+  const paths = session.paths
+  const sessionId = basename(paths.root)
+  const cookieSecret = drawHex(32)
+
+  // Past this point a session directory exists on disk; a failed start must not
+  // leave one behind for the next run to prune.
+  const abandon = async (cause: unknown): Promise<never> => {
+    await removeVisualSession(paths).catch(() => undefined)
+    throw cause
+  }
+
+  const compilation = await compileVisualModel({
+    model: request.initialModel,
+    command: request.compiler,
+    paths,
+    now,
+  }).catch(abandon)
+  if (!compilation.ok) {
+    const first = compilation.diagnostics[0]
+    return abandon(
+      serverError(
+        first?.code ?? 'YMVS302',
+        `Initial visual model did not compile: ${
+          first?.message ?? 'unknown violation'
+        }`,
+      ),
+    )
+  }
+
+  let rendered: VisualRenderedModel = {
+    candidate: compilation.compiled.candidate,
+    authority: compilation.compiled.authority,
+    initialView: compilation.compiled.initialView,
+    views: compilation.compiled.views,
+  }
+
+  const capabilities: VisualCapabilities = {
+    chat: request.chatEnabled,
+    choices: request.chatEnabled,
+    navigation: true,
+    modelReplacement: true,
+    transcript: true,
+  }
+
+  let lifecycle: VisualLifecycle = 'starting'
+  let listening = false
+  let bootstrapSpent = false
+  let agentAttached = false
+  let lastSequence = 0
+  let transcriptBytes = 0
+  let frozen: VisualFreezeReason | undefined
+  let inFlight: VisualEvent | undefined
+  let lastSeenAt: string | undefined
+  let pending: VisualEvent[] = []
+  const connections = new Map<string, WebSocket>()
+  const polls = new Set<PendingPoll>()
+  const httpSockets = new Set<Socket>()
+
+  /** Every sequence assignment and queue mutation runs in call order. */
+  let admission: Promise<unknown> = Promise.resolve()
+  const admit = <T>(action: () => Promise<T>): Promise<T> => {
+    const next = admission.then(action)
+    admission = next.then(
+      () => undefined,
+      () => undefined,
+    )
+    return next
+  }
+
+  /** The first limit a session reaches is the one it reports for good. */
+  const freeze = (reason: VisualFreezeReason) => {
+    frozen ??= reason
+  }
+
+  const snapshot = (): VisualSessionSnapshot => ({
+    protocolVersion: VISUAL_PROTOCOL_VERSION,
+    sessionId,
+    authority: request.authority,
+    title: request.title,
+    description: request.description,
+    chatEnabled: request.chatEnabled,
+    capabilities,
+    webSocketUrl,
+    model: rendered,
+    lastSequence,
+    frozen: frozen !== undefined,
+  })
+
+  const status = (): VisualStatus => {
+    const value: VisualStatus = {
+      format: 'yarramate/visual-status/v1',
+      protocolVersion: VISUAL_PROTOCOL_VERSION,
+      sessionId,
+      lifecycle,
+      alreadyStopped: lifecycle === 'stopped',
+      server: { listening, origin },
+      browser: {
+        connected: connections.size > 0,
+        connections: connections.size,
+        ...(lastSeenAt === undefined ? {} : { lastSeenAt }),
+        ...(connections.size === 0 && lastSeenAt !== undefined
+          ? {
+              graceExpiresAt: new Date(
+                Date.parse(lastSeenAt) + VISUAL_LIMITS.reconnectMs,
+              ).toISOString(),
+            }
+          : {}),
+      },
+      agent: {
+        attached: agentAttached,
+        inFlightEventId: inFlight?.eventId ?? null,
+      },
+      queue: {
+        pendingEvents: pending.length,
+        lastSequence,
+        frozen: frozen !== undefined,
+        ...(frozen === undefined ? {} : { frozenReason: frozen }),
+      },
+      capabilities,
+      transcriptBytes,
+      updatedAt: stamp(),
+    }
+    // A status document that does not validate is a runtime defect, not
+    // untrusted input: the agent must never have to parse a broken report.
+    const validated = parseVisualStatus(value)
+    if (!validated.ok) {
+      throw serverError(
+        validated.diagnostics[0]?.code ?? 'YMVS108',
+        `Session status is invalid: ${
+          validated.diagnostics[0]?.message ?? 'unknown violation'
+        }`,
+      )
+    }
+    return value
+  }
+
+  const sendFrame = (socket: WebSocket, frame: VisualServerFrame) => {
+    if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(frame))
+  }
+
+  const broadcast = (frame: VisualServerFrame) => {
+    for (const socket of connections.values()) sendFrame(socket, frame)
+  }
+
+  const idleDelivery = (): VisualEventDelivery => ({
+    waiting: true,
+    lastSequence,
+    pendingEvents: pending.length,
+  })
+
+  /**
+   * While a turn is outstanding the only event the agent may see is the one it
+   * already owns, so a repeated poll replays it and a later chat message waits
+   * for the current response.
+   */
+  const deliverable = (after: number) =>
+    inFlight === undefined
+      ? pending.find((event) => event.sequence > after)
+      : inFlight.sequence > after
+        ? inFlight
+        : undefined
+
+  const takeDelivery = (after: number): VisualEventDelivery => {
+    const event = deliverable(after)
+    if (event === undefined) return idleDelivery()
+    inFlight = event
+    return {
+      waiting: false,
+      event,
+      lastSequence,
+      pendingEvents: pending.length,
+    }
+  }
+
+  const wakePolls = () => {
+    for (const poll of [...polls]) {
+      if (deliverable(poll.after) === undefined) continue
+      polls.delete(poll)
+      clearTimeout(poll.timer)
+      poll.settle(takeDelivery(poll.after))
+    }
+  }
+
+  const settleAllPolls = () => {
+    for (const poll of [...polls]) {
+      polls.delete(poll)
+      clearTimeout(poll.timer)
+      poll.settle(idleDelivery())
+    }
+  }
+
+  const httpServer = createServer()
+  httpServer.on('connection', (socket) => {
+    httpSockets.add(socket)
+    socket.on('close', () => httpSockets.delete(socket))
+  })
+  httpServer.on('clientError', (_error, socket) => socket.destroy())
+
+  await new Promise<void>((settle, fail) => {
+    const onError = (error: Error) => fail(error)
+    httpServer.once('error', onError)
+    // Loopback only, on a kernel-assigned port: the session is never reachable
+    // from another host, and never collides with a well-known service.
+    httpServer.listen(0, '127.0.0.1', () => {
+      httpServer.removeListener('error', onError)
+      settle()
+    })
+  }).catch(abandon)
+
+  const address = httpServer.address() as AddressInfo
+  const origin = `http://127.0.0.1:${address.port}`
+  const authority = `127.0.0.1:${address.port}`
+  const webSocketUrl = `ws://${authority}${VISUAL_SOCKET_PATH}`
+  listening = true
+
+  const sockets = new WebSocketServer({
+    noServer: true,
+    maxPayload: VISUAL_SERVER_LIMITS.browserFrameBytes,
+  })
+
+  // ---------------------------------------------------------------- responses
+
+  const respond = (
+    server: ServerResponse,
+    code: number,
+    body: string | Buffer,
+    contentType: string,
+  ) => {
+    server.writeHead(code, {
+      ...VISUAL_BROWSER_HEADERS,
+      'Content-Type': contentType,
+      'Content-Length': Buffer.byteLength(body),
+      // A draining session must not leave a pooled connection behind that
+      // outlives its listener.
+      ...(lifecycle === 'running' ? {} : { Connection: 'close' }),
+    })
+    server.end(body)
+  }
+
+  const respondJson = (server: ServerResponse, code: number, value: unknown) =>
+    respond(
+      server,
+      code,
+      JSON.stringify(value),
+      'application/json; charset=utf-8',
+    )
+
+  const refuse = (server: ServerResponse, code: number, message: string) =>
+    respond(server, code, `${message}\n`, 'text/plain; charset=utf-8')
+
+  // ------------------------------------------------------------ browser input
+
+  const admitBrowserInput = async (
+    socket: WebSocket,
+    raw: RawData,
+    binary: boolean,
+  ) => {
+    if (binary) {
+      sendFrame(socket, {
+        kind: 'rejected',
+        diagnostics: [
+          serverDiagnostic('YMVS303', 'Browser frames must be UTF-8 JSON text'),
+        ],
+      })
+      return
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw.toString())
+    } catch {
+      sendFrame(socket, {
+        kind: 'rejected',
+        diagnostics: [
+          serverDiagnostic('YMVS109', 'Browser frame is not a JSON document'),
+        ],
+      })
+      return
+    }
+    const input = parseVisualBrowserInput(parsed)
+    if (!input.ok) {
+      sendFrame(socket, { kind: 'rejected', diagnostics: input.diagnostics })
+      return
+    }
+    await admit(async () => {
+      if (frozen !== undefined) {
+        sendFrame(socket, {
+          kind: 'rejected',
+          frozen,
+          diagnostics: [
+            serverDiagnostic('YMVS304', `Session input is frozen: ${frozen}`),
+          ],
+        })
+        return
+      }
+      const event = eventFrom(input.value, {
+        format: 'yarramate/visual-event/v1',
+        sessionId,
+        sequence: lastSequence + 1,
+        eventId: drawHex(16),
+        timestamp: stamp(),
+      })
+      const actionable = isActionableVisualEvent(event)
+      if (actionable && pending.length >= VISUAL_LIMITS.pendingEvents) {
+        freeze('pending-events')
+        sendFrame(socket, {
+          kind: 'rejected',
+          frozen,
+          diagnostics: [
+            serverDiagnostic(
+              'YMVS305',
+              `Queue already holds the ${VISUAL_LIMITS.pendingEvents} event maximum`,
+              '#/sequence',
+            ),
+          ],
+        })
+        return
+      }
+      const appended = await appendVisualEvent(paths, event)
+      if (!appended.ok) {
+        if (appended.freeze !== undefined) freeze(appended.freeze)
+        sendFrame(socket, {
+          kind: 'rejected',
+          ...(frozen === undefined ? {} : { frozen }),
+          diagnostics: appended.diagnostics,
+        })
+        return
+      }
+      lastSequence = appended.lastSequence
+      transcriptBytes = appended.transcriptBytes
+      if (actionable) pending.push(event)
+      // A journaled end is the last input this session takes. The agent still
+      // has to see it, so the queue freezes rather than the socket closing.
+      if (event.type === 'session.end') freeze('terminal-event')
+      sendFrame(socket, {
+        kind: 'accepted',
+        sequence: event.sequence,
+        eventId: event.eventId,
+      })
+      wakePolls()
+    })
+  }
+
+  const attachBrowser = (socket: WebSocket) => {
+    const connectionId = drawHex(16)
+    connections.set(connectionId, socket)
+    lastSeenAt = stamp()
+    socket.on('message', (raw, binary) => {
+      void admitBrowserInput(socket, raw, binary)
+    })
+    socket.on('error', (error) => {
+      // ws refuses an oversized frame before buffering it, which is exactly the
+      // byte ceiling the protocol calls a freeze.
+      if (
+        (error as { code?: string }).code ===
+        'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH'
+      ) {
+        freeze('message-bytes')
+      }
+    })
+    socket.on('close', () => {
+      connections.delete(connectionId)
+      lastSeenAt = stamp()
+    })
+    sendFrame(socket, { kind: 'ready', snapshot: snapshot() })
+  }
+
+  // ------------------------------------------------------------- agent routes
+
+  const answerPoll = (server: ServerResponse, query: URLSearchParams) => {
+    const raw = query.get('after') ?? '0'
+    const after = Number(raw)
+    if (!Number.isSafeInteger(after) || after < 0) {
+      refuse(server, 400, `Query "after" must be a sequence, not "${raw}"`)
+      return
+    }
+    const immediate = takeDelivery(after)
+    if (!immediate.waiting || lifecycle !== 'running') {
+      respondJson(server, 200, immediate)
+      return
+    }
+    const poll: PendingPoll = {
+      after,
+      settle: (result) => respondJson(server, 200, result),
+      timer: setTimeout(() => {
+        polls.delete(poll)
+        respondJson(server, 200, idleDelivery())
+      }, agentPollMs),
+    }
+    polls.add(poll)
+    server.on('close', () => {
+      if (polls.delete(poll)) clearTimeout(poll.timer)
+    })
+  }
+
+  const replaceModel = async (
+    response: Extract<VisualResponse, { readonly type: 'model.replace' }>,
+  ): Promise<{
+    readonly model?: VisualRenderedModel
+    readonly diagnostics: readonly VisualDiagnostic[]
+  }> => {
+    const compiled = await compileVisualModel({
+      model: response.payload.model,
+      command: request.compiler,
+      paths,
+      now,
+    })
+    if (compiled.ok) {
+      rendered = {
+        candidate: compiled.compiled.candidate,
+        authority: compiled.compiled.authority,
+        initialView: compiled.compiled.initialView,
+        views: compiled.compiled.views,
+      }
+      broadcast({ kind: 'model', model: rendered })
+      return { model: rendered, diagnostics: [] }
+    }
+    // The candidate is discarded and the last good rendering stays live; the
+    // browser learns why from a journaled diagnostic response.
+    const diagnostic: VisualResponse = {
+      format: 'yarramate/visual-response/v1',
+      sessionId,
+      responseId: drawHex(16),
+      eventId: response.eventId,
+      type: 'diagnostic',
+      timestamp: stamp(),
+      payload: { diagnostics: compiled.diagnostics },
+    }
+    const appended = await appendVisualResponse(paths, diagnostic)
+    if (appended.ok) transcriptBytes = appended.transcriptBytes
+    broadcast({ kind: 'response', response: diagnostic })
+    return { diagnostics: compiled.diagnostics }
+  }
+
+  const completeTurn = (response: VisualResponse) => {
+    if (TURN_COMPLETING[response.type] !== true) return
+    if (inFlight?.eventId !== response.eventId) return
+    pending = pending.filter((event) => event.eventId !== response.eventId)
+    inFlight = undefined
+    wakePolls()
+  }
+
+  const acceptResponse = async (
+    server: ServerResponse,
+    incoming: IncomingMessage,
+  ) => {
+    const body = await readJsonBody(
+      incoming,
+      VISUAL_SERVER_LIMITS.agentBodyBytes,
+    )
+    if (!body.ok) {
+      refuse(server, body.status, body.message)
+      return
+    }
+    const parsed = parseVisualResponse(body.value)
+    if (!parsed.ok) {
+      respondJson(server, 400, {
+        accepted: false,
+        diagnostics: parsed.diagnostics,
+      } satisfies VisualResponseAcceptance)
+      return
+    }
+    const response = parsed.value
+    if (response.sessionId !== sessionId) {
+      respondJson(server, 409, {
+        accepted: false,
+        diagnostics: [
+          serverDiagnostic(
+            'YMVS126',
+            `Response belongs to session "${response.sessionId}", not "${sessionId}"`,
+            '#/sessionId',
+          ),
+        ],
+      } satisfies VisualResponseAcceptance)
+      return
+    }
+    const result = await admit(
+      async (): Promise<{
+        readonly code: number
+        readonly body: VisualResponseAcceptance
+      }> => {
+        const appended = await appendVisualResponse(paths, response)
+        if (!appended.ok) {
+          if (appended.freeze !== undefined) freeze(appended.freeze)
+          return {
+            code: 409,
+            body: { accepted: false, diagnostics: appended.diagnostics },
+          }
+        }
+        transcriptBytes = appended.transcriptBytes
+        // A response the runtime already journaled must not be broadcast or
+        // compiled twice: a retried delivery is not a second turn.
+        if (appended.duplicate) {
+          return {
+            code: 200,
+            body: {
+              accepted: true,
+              duplicate: true,
+              lastSequence: appended.lastSequence,
+              diagnostics: [],
+            },
+          }
+        }
+        broadcast({ kind: 'response', response })
+        const replaced =
+          response.type === 'model.replace'
+            ? await replaceModel(response)
+            : { diagnostics: [] as readonly VisualDiagnostic[] }
+        completeTurn(response)
+        return {
+          code: 200,
+          body: {
+            accepted: true,
+            duplicate: false,
+            lastSequence,
+            ...(replaced.model === undefined ? {} : { model: replaced.model }),
+            diagnostics: replaced.diagnostics,
+          },
+        }
+      },
+    )
+    respondJson(server, result.code, result.body)
+  }
+
+  const acceptStop = async (
+    server: ServerResponse,
+    incoming: IncomingMessage,
+  ) => {
+    const body = await readJsonBody(
+      incoming,
+      VISUAL_SERVER_LIMITS.agentControlBytes,
+    )
+    if (!body.ok) {
+      refuse(server, body.status, body.message)
+      return
+    }
+    const reason = (body.value as { readonly reason?: unknown }).reason
+    if (typeof reason !== 'string' || TERMINATION_REASONS[reason] !== true) {
+      refuse(server, 400, 'Stop requires a known termination reason')
+      return
+    }
+    // The socket answering the stop is the one connection shutdown may not end
+    // before it has been written to.
+    const closed = await stop(
+      reason as VisualTerminationReason,
+      incoming.socket,
+    )
+    server.on('finish', () => incoming.socket.end())
+    respondJson(server, 200, closed)
+  }
+
+  const serveAgent = async (
+    incoming: IncomingMessage,
+    server: ServerResponse,
+    pathname: string,
+    query: URLSearchParams,
+  ) => {
+    // An agent is not a browser. A request carrying an Origin came from a page,
+    // which must never be able to spend a leaked agent capability.
+    if (incoming.headers.origin !== undefined) {
+      refuse(server, 403, 'Agent routes reject browser-originated requests')
+      return
+    }
+    if (
+      !secretEquals(
+        session.agentToken,
+        bearerToken(incoming.headers.authorization),
+      )
+    ) {
+      refuse(server, 401, 'Agent capability required')
+      return
+    }
+    agentAttached = true
+    if (pathname === '/api/agent/events') {
+      if (incoming.method !== 'GET') return refuse(server, 405, 'Use GET')
+      answerPoll(server, query)
+      return
+    }
+    if (pathname === '/api/agent/status') {
+      if (incoming.method !== 'GET') return refuse(server, 405, 'Use GET')
+      respondJson(server, 200, status())
+      return
+    }
+    if (pathname === '/api/agent/responses') {
+      if (incoming.method !== 'POST') return refuse(server, 405, 'Use POST')
+      await acceptResponse(server, incoming)
+      return
+    }
+    if (pathname === '/api/agent/stop') {
+      if (incoming.method !== 'POST') return refuse(server, 405, 'Use POST')
+      await acceptStop(server, incoming)
+      return
+    }
+    refuse(server, 404, 'No such route')
+  }
+
+  // ----------------------------------------------------------- browser routes
+
+  const assetPath = (pathname: string) => {
+    if (pathname === '/') return join(assetRoot, 'index.html')
+    const prefix = '/assets/'
+    if (!pathname.startsWith(prefix)) return undefined
+    const name = pathname.slice(prefix.length)
+    if (!ASSET_NAME.test(name)) return undefined
+    const target = resolve(assetRoot, 'assets', name)
+    // The name cannot carry a separator, so this only confirms what the pattern
+    // already guaranteed — which is the point of having both.
+    return target.startsWith(`${assetRoot}${sep}`) ? target : undefined
+  }
+
+  const serveAsset = async (server: ServerResponse, pathname: string) => {
+    const target = assetPath(pathname)
+    const contentType =
+      target === undefined ? undefined : CONTENT_TYPES[extname(target)]
+    if (target === undefined || contentType === undefined) {
+      refuse(server, 404, 'No such asset')
+      return
+    }
+    try {
+      // lstat, never stat: a symlink inside the asset root is a link out of it.
+      const entry = await lstat(target)
+      if (!entry.isFile()) {
+        refuse(server, 404, 'No such asset')
+        return
+      }
+      respond(server, 200, await readFile(target), contentType)
+    } catch {
+      refuse(server, 404, 'No such asset')
+    }
+  }
+
+  const serveBootstrap = (server: ServerResponse, query: URLSearchParams) => {
+    const key = query.get('key') ?? undefined
+    if (bootstrapSpent || !secretEquals(session.browserToken, key)) {
+      refuse(server, 403, 'Bootstrap capability is not valid')
+      return
+    }
+    // One-time by construction: the URL capability buys exactly one cookie, and
+    // the cookie carries a different secret, so a leaked URL cannot be replayed
+    // and a leaked cookie cannot be pasted into an address bar.
+    bootstrapSpent = true
+    server.writeHead(303, {
+      ...VISUAL_BROWSER_HEADERS,
+      Location: '/',
+      'Set-Cookie': `${COOKIE_NAME}=${cookieSecret}; HttpOnly; SameSite=Strict; Path=/`,
+      'Content-Length': 0,
+    })
+    server.end()
+  }
+
+  const serveBrowser = async (
+    incoming: IncomingMessage,
+    server: ServerResponse,
+    pathname: string,
+    query: URLSearchParams,
+  ) => {
+    const sent = incoming.headers.origin
+    if (sent !== undefined && sent !== origin) {
+      refuse(server, 403, 'Origin is not this session')
+      return
+    }
+    if (incoming.method !== 'GET') {
+      refuse(server, 405, 'Use GET')
+      return
+    }
+    if (pathname === '/bootstrap') {
+      serveBootstrap(server, query)
+      return
+    }
+    if (
+      !secretEquals(
+        cookieSecret,
+        cookieValue(incoming.headers.cookie, COOKIE_NAME),
+      )
+    ) {
+      refuse(server, 401, 'Session cookie required')
+      return
+    }
+    if (pathname === '/api/session') {
+      respondJson(server, 200, snapshot())
+      return
+    }
+    await serveAsset(server, pathname)
+  }
+
+  httpServer.on('request', (incoming, server) => {
+    void (async () => {
+      try {
+        // Rebinding defence: a request that reached this port under any other
+        // name was routed here by something other than the browser we started.
+        if (incoming.headers.host !== authority) {
+          refuse(server, 403, 'Host is not the bound loopback authority')
+          return
+        }
+        const [rawPath = '/', rawQuery = ''] = (incoming.url ?? '/').split('?')
+        let pathname: string
+        try {
+          pathname = decodeURIComponent(rawPath)
+        } catch {
+          refuse(server, 400, 'Request target is not a valid URL path')
+          return
+        }
+        if (pathname.includes('\0')) {
+          refuse(server, 400, 'Request target is not a valid URL path')
+          return
+        }
+        const query = new URLSearchParams(rawQuery)
+        if (pathname.startsWith('/api/agent/')) {
+          await serveAgent(incoming, server, pathname, query)
+          return
+        }
+        await serveBrowser(incoming, server, pathname, query)
+      } catch (cause) {
+        if (server.headersSent) server.destroy(cause as Error)
+        else refuse(server, 500, 'Session server failed')
+      }
+    })()
+  })
+
+  httpServer.on('upgrade', (incoming, socket: Duplex, head) => {
+    const deny = (code: number, message: string) => {
+      socket.write(
+        `HTTP/1.1 ${code} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+      )
+      socket.destroy()
+    }
+    if (lifecycle !== 'running') return deny(503, 'Service Unavailable')
+    if (incoming.headers.host !== authority) return deny(403, 'Forbidden')
+    // An upgrade always carries an Origin, so it is checked without exception.
+    if (incoming.headers.origin !== origin) return deny(403, 'Forbidden')
+    const [rawPath = '/'] = (incoming.url ?? '/').split('?')
+    if (rawPath !== VISUAL_SOCKET_PATH) return deny(404, 'Not Found')
+    if (
+      !secretEquals(
+        cookieSecret,
+        cookieValue(incoming.headers.cookie, COOKIE_NAME),
+      )
+    ) {
+      return deny(401, 'Unauthorized')
+    }
+    if (connections.size >= VISUAL_SERVER_LIMITS.browserConnections) {
+      return deny(503, 'Service Unavailable')
+    }
+    sockets.handleUpgrade(incoming, socket, head, attachBrowser)
+  })
+
+  // ----------------------------------------------------------------- shutdown
+
+  let announceClosed!: (closed: VisualServerClosed) => void
+  const closed = new Promise<VisualServerClosed>((settle) => {
+    announceClosed = settle
+  })
+  let stopping: Promise<VisualServerClosed> | undefined
+
+  const stop = async (
+    reason: VisualTerminationReason,
+    exempt?: Socket,
+  ): Promise<VisualServerClosed> => {
+    if (stopping !== undefined) {
+      return { ...(await stopping), alreadyStopped: true }
+    }
+    stopping = (async () => {
+      lifecycle = 'draining'
+      listening = false
+      httpServer.close()
+      // Waiting agents are answered before any socket is torn down, so a poll
+      // in flight during a stop still receives its non-terminal idle result.
+      settleAllPolls()
+      for (const socket of connections.values()) {
+        sendFrame(socket, { kind: 'closing', reason })
+        socket.close(1001)
+      }
+      sockets.close()
+      for (const socket of httpSockets) {
+        if (socket !== exempt) socket.end()
+      }
+      // Recovery runs before the delete, so shutdown can never be the step that
+      // loses confirmed state.
+      const handoff = await removeVisualSession(
+        paths,
+        options.includeTranscript ?? false,
+      )
+      lifecycle = 'stopped'
+      const outcome: VisualServerClosed = {
+        reason,
+        alreadyStopped: false,
+        handoff,
+      }
+      announceClosed(outcome)
+      return outcome
+    })()
+    return stopping
+  }
+
+  await writeVisualSessionDescriptor(paths, {
+    format: 'yarramate/visual-session-descriptor/v1',
+    protocolVersion: VISUAL_PROTOCOL_VERSION,
+    sessionId,
+    origin,
+    agentCapability: session.agentToken,
+    sessionRoot: paths.root,
+    journalPath: paths.journal,
+    createdAt: stamp(),
+  }).catch(abandon)
+
+  const started: VisualSessionStarted = {
+    format: 'yarramate/visual-session-started/v1',
+    protocolVersion: VISUAL_PROTOCOL_VERSION,
+    sessionId,
+    authority: request.authority,
+    title: request.title,
+    chatEnabled: request.chatEnabled,
+    browserUrl: `${origin}/bootstrap?key=${session.browserToken}`,
+    webSocketUrl,
+    origin,
+    descriptorPath: paths.descriptor,
+    sessionRoot: paths.root,
+    capabilities,
+    startedAt: stamp(),
+  }
+  const validated = parseVisualSessionStarted(started)
+  if (!validated.ok) {
+    return abandon(
+      serverError(
+        validated.diagnostics[0]?.code ?? 'YMVS102',
+        `Started session is invalid: ${
+          validated.diagnostics[0]?.message ?? 'unknown violation'
+        }`,
+      ),
+    )
+  }
+  lifecycle = 'running'
+
+  return { started, closed, status, stop: (reason) => stop(reason) }
+}

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -1,5 +1,6 @@
 import {
   createHash,
+  createHmac,
   randomBytes as randomSource,
   timingSafeEqual,
 } from 'node:crypto'
@@ -477,7 +478,12 @@ export const startVisualServer = async (
   })
   const paths = session.paths
   const sessionId = basename(paths.root)
-  const cookieSecret = drawHex(32)
+  const cookieSigningKey = drawHex(32)
+  // The browser stores only a derived bearer value; the signing key stays in
+  // this server process and disappears with the session.
+  const browserAuthenticator = createHmac('sha256', cookieSigningKey)
+    .update(sessionId)
+    .digest('hex')
   // Not a credential: it authorises inline style for this page, nothing else.
   const styleNonce = drawHex(16)
   const browserHeaders = {
@@ -1519,7 +1525,7 @@ export const startVisualServer = async (
     server.writeHead(303, {
       ...browserHeaders,
       Location: '/',
-      'Set-Cookie': `${COOKIE_NAME}=${cookieSecret}; HttpOnly; SameSite=Strict; Secure; Path=/`,
+      'Set-Cookie': `${COOKIE_NAME}=${browserAuthenticator}; HttpOnly; SameSite=Strict; Secure; Path=/`,
       'Content-Length': 0,
     })
     server.end()
@@ -1546,7 +1552,7 @@ export const startVisualServer = async (
     }
     if (
       !secretEquals(
-        cookieSecret,
+        browserAuthenticator,
         cookieValue(incoming.headers.cookie, COOKIE_NAME),
       )
     ) {
@@ -1609,7 +1615,7 @@ export const startVisualServer = async (
     if (rawPath !== VISUAL_SOCKET_PATH) return deny(404, 'Not Found')
     if (
       !secretEquals(
-        cookieSecret,
+        browserAuthenticator,
         cookieValue(incoming.headers.cookie, COOKIE_NAME),
       )
     ) {

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -989,9 +989,50 @@ export const removeVisualSession = async (
 }
 
 /**
+ * Newest modification time across a session's artefacts, or `undefined` when
+ * none of them could be measured.
+ *
+ * POSIX updates a directory's modification time only when its own entries
+ * change, so the session root records nothing about an appended journal, and
+ * the candidates directory records nothing about a promoted pointer. Every
+ * artefact that can carry activity is therefore measured directly; the
+ * optional ones are simply absent until a session produces them. `lstat`
+ * keeps a symlinked artefact from reporting some other file's activity.
+ */
+const lastActivityMs = async (
+  paths: VisualSessionPaths,
+): Promise<number | undefined> => {
+  let newest: number | undefined
+  for (const path of [
+    paths.root,
+    paths.marker,
+    paths.descriptor,
+    paths.journal,
+    paths.candidates,
+    paths.activeModel,
+  ]) {
+    let entry
+    try {
+      entry = await lstat(path)
+    } catch {
+      continue
+    }
+    if (newest === undefined || entry.mtimeMs > newest) {
+      newest = entry.mtimeMs
+    }
+  }
+  return newest
+}
+
+/**
  * Removes orphaned sessions a previous runtime left behind. Only directories
  * carrying a marker that names them are touched, and never more than `limit`
- * per pass; the oldest go first.
+ * per pass; the least recently active go first.
+ *
+ * Staleness is measured against what the session last wrote, not against the
+ * marker's creation time: a conversation that has run for two days is the
+ * working case, and deleting it under a live runtime would destroy the
+ * transcript the agent is still appending to.
  */
 export const pruneStaleVisualSessions = async (
   baseDir: string,
@@ -1004,7 +1045,7 @@ export const pruneStaleVisualSessions = async (
   } catch {
     return []
   }
-  const stale: { readonly root: string; readonly createdAt: number }[] = []
+  const stale: { readonly root: string; readonly activeAt: number }[] = []
   for (const entry of entries) {
     // Dirent reflects lstat, so a symlink pointing at a directory outside the
     // base directory is never a candidate for removal.
@@ -1012,21 +1053,28 @@ export const pruneStaleVisualSessions = async (
       continue
     }
     const paths = visualSessionPaths(join(baseDir, entry.name))
-    let marker
     try {
-      marker = await readSessionMarker(paths)
+      // Authorisation only: the marker says this directory is a session of
+      // ours and names itself. What it says about creation time is not what
+      // makes it collectable.
+      await readSessionMarker(paths)
     } catch {
       continue
     }
-    const createdAt = Date.parse(marker.createdAt)
-    if (now.getTime() - createdAt <= VISUAL_LIMITS.staleSessionMs) {
+    // A session whose activity cannot be measured is left alone rather than
+    // assumed abandoned.
+    const activeAt = await lastActivityMs(paths)
+    if (
+      activeAt === undefined ||
+      now.getTime() - activeAt <= VISUAL_LIMITS.staleSessionMs
+    ) {
       continue
     }
-    stale.push({ root: paths.root, createdAt })
+    stale.push({ root: paths.root, activeAt })
   }
   stale.sort(
     (left, right) =>
-      left.createdAt - right.createdAt || left.root.localeCompare(right.root),
+      left.activeAt - right.activeAt || left.root.localeCompare(right.root),
   )
   const removed: string[] = []
   for (const candidate of stale.slice(0, Math.max(0, limit))) {

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -659,6 +659,23 @@ export const appendVisualResponse = async (
         ],
       }
     }
+    // A response answers an event, and only an event this session took. Without
+    // this, a capability holder could journal a summary, a diagnostic, or a
+    // whole handoff against an identifier the reviewer never generated — and
+    // recovery, which reads the journal as the record, would believe it.
+    if (!state.eventIds.has(record.eventId)) {
+      return {
+        ok: false,
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS131',
+            `Response answers event "${record.eventId}", which session "${state.sessionId}" never journaled`,
+            paths.journal,
+            '#/eventId',
+          ),
+        ],
+      }
+    }
     // A response the runtime already journaled must not be written twice: the
     // broadcast may be retried after a partial failure.
     if (state.responseIds.has(record.responseId)) {

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -85,6 +85,13 @@ export interface SessionDependencies {
 }
 
 /**
+ * What the runtime needs to mint one terminal event. It is the same clock and
+ * the same random source the session was created with, so a test drives the
+ * closing record exactly as it drives every other one.
+ */
+export type TerminalEventDependencies = Omit<SessionDependencies, 'baseDir'>
+
+/**
  * The only session state that outlives the runtime process. Recovery never
  * resumes the server or the compiler, so the marker carries the session
  * identity, its age for pruning, and the authority label the handoff must
@@ -152,6 +159,11 @@ interface JournalState {
   readonly eventIds: Set<string>
   readonly responseIds: Set<string>
   readonly sessionId: string
+  /**
+   * The one `session.end` this journal carries, once it carries it. A session
+   * ends exactly once, and nothing may be journaled behind that record.
+   */
+  terminal: VisualEvent | undefined
 }
 
 interface JournalRead {
@@ -425,6 +437,11 @@ const syncState = async (paths: VisualSessionPaths): Promise<JournalState> => {
         .map((record) => record.responseId),
     ),
     sessionId: marker.id,
+    terminal: journal.records.find(
+      (record): record is VisualEvent =>
+        record.format === 'yarramate/visual-event/v1' &&
+        record.type === 'session.end',
+    ),
   }
   states.set(paths.journal, state)
   return state
@@ -569,6 +586,22 @@ export const appendVisualEvent = async (
         ],
       }
     }
+    // A session ends once. Nothing may be journaled behind the terminal event,
+    // because recovery has already read the journal as the whole conversation.
+    if (state.terminal !== undefined) {
+      return {
+        ok: false,
+        freeze: 'terminal-event',
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS130',
+            `Session "${state.sessionId}" ended at sequence ${state.terminal.sequence} and takes no further event`,
+            paths.journal,
+            '#/type',
+          ),
+        ],
+      }
+    }
     if (record.sequence <= state.lastSequence) {
       return {
         ok: false,
@@ -592,6 +625,7 @@ export const appendVisualEvent = async (
     state.bytes += bytes
     state.lastSequence = record.sequence
     state.eventIds.add(record.eventId)
+    if (record.type === 'session.end') state.terminal = record
     return {
       ok: true,
       lastSequence: state.lastSequence,
@@ -653,6 +687,54 @@ export const appendVisualResponse = async (
   })
 }
 
+/**
+ * Journals the one record that closes a session, and answers with the record a
+ * session already has. Every terminal cause — a reviewer's End, a failed child,
+ * a browser that never came back, a cancellation, a restart collecting what a
+ * dead runtime left — converges here, so a session ends exactly once no matter
+ * how many of them fire.
+ */
+export const appendTerminalEvent = async (
+  paths: VisualSessionPaths,
+  reason: VisualTerminationReason,
+  deps: TerminalEventDependencies,
+): Promise<VisualEvent> =>
+  serialize(paths.journal, async () => {
+    const state = await syncState(paths)
+    if (state.terminal !== undefined) return state.terminal
+    const event: VisualEvent = {
+      format: 'yarramate/visual-event/v1',
+      sessionId: state.sessionId,
+      sequence: state.lastSequence + 1,
+      eventId: drawHex(deps.randomBytes, 16),
+      type: 'session.end',
+      timestamp: deps.now().toISOString(),
+      payload: { reason },
+    }
+    // The runtime composed this record, so a violation is a defect here rather
+    // than untrusted input, and it must not reach the journal.
+    const validated = parseVisualEvent(event)
+    if (!validated.ok) {
+      const first = validated.diagnostics[0]
+      throw storeError(
+        first?.code ?? 'YMVS104',
+        `Terminal event for "${paths.root}" is invalid: ${
+          first?.message ?? 'unknown violation'
+        }`,
+      )
+    }
+    const line = `${JSON.stringify(event)}\n`
+    // Deliberately exempt from the transcript ceiling: a session that reached
+    // its byte limit is exactly the one that has to be closable, and the
+    // closing record is bounded and written once.
+    await writeJournalLine(paths.journal, line)
+    state.bytes += Buffer.byteLength(line, 'utf8')
+    state.lastSequence = event.sequence
+    state.eventIds.add(event.eventId)
+    state.terminal = event
+    return event
+  })
+
 export const readActionableEventsAfter = async (
   paths: VisualSessionPaths,
   sequence: number,
@@ -674,7 +756,7 @@ export const recoverVisualSession = async (
   const journal = await readJournal(paths.journal)
 
   let summary: VisualHandoffSummary | undefined
-  let endReason: 'user-ended' | 'browser-timeout' | undefined
+  let endReason: VisualTerminationReason | undefined
   const visited: string[] = []
   for (const record of journal.records) {
     if (
@@ -696,17 +778,16 @@ export const recoverVisualSession = async (
     }
   }
 
-  // Every combination below satisfies the protocol's cross-field rule: only a
-  // completed handoff may report `user-ended`, and that requires a summary the
-  // child actually submitted.
+  // The terminal event names the cause; a journal without one lost its runtime
+  // before it could say why. Every combination below satisfies the protocol's
+  // cross-field rule: only a completed handoff may report `user-ended`, and
+  // that requires a summary the child actually submitted.
   const terminationReason: VisualTerminationReason =
-    endReason === 'browser-timeout'
-      ? 'browser-timeout'
-      : endReason === 'user-ended' && summary !== undefined
-        ? 'user-ended'
-        : endReason === 'user-ended'
-          ? 'child-failed'
-          : 'server-failed'
+    endReason === undefined
+      ? 'server-failed'
+      : endReason === 'user-ended' && summary === undefined
+        ? 'child-failed'
+        : endReason
   const decision: VisualHandoffDecision =
     summary === undefined
       ? 'failed'

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -18,6 +18,7 @@ import {
   parseVisualHandoff,
   parseVisualModel,
   parseVisualResponse,
+  parseVisualSessionDescriptor,
   parseVisualSessionRequest,
   type VisualAuthority,
   type VisualDiagnostic,
@@ -28,6 +29,7 @@ import {
   type VisualHandoffSummary,
   type VisualModel,
   type VisualResponse,
+  type VisualSessionDescriptor,
   type VisualSessionRequest,
   type VisualTerminationReason,
 } from './protocol.js'
@@ -51,16 +53,21 @@ const TIMESTAMP =
   /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$/
 const NEWLINE = 0x0a
 
+const ACTIONABLE_EVENT_TYPES: Readonly<Record<string, true>> = {
+  'chat.message': true,
+  'choice.selected': true,
+  'session.end': true,
+}
+
 /**
- * Browser events that require an agent turn. Navigation is journaled for
+ * Whether a journaled event requires an agent turn. Navigation is journaled for
  * context but only interrupts the agent when the browser marked it as needing
- * attention.
+ * attention. The runtime shares this definition rather than restating it, so
+ * the queue the server bounds and the events recovery replays cannot diverge.
  */
-const ACTIONABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
-  'chat.message',
-  'choice.selected',
-  'session.end',
-])
+export const isActionableVisualEvent = (event: VisualEvent): boolean =>
+  ACTIONABLE_EVENT_TYPES[event.type] === true ||
+  (event.type === 'view.navigate' && event.payload.requiresAttention)
 
 export interface VisualSessionPaths {
   readonly root: string
@@ -488,6 +495,43 @@ export const createVisualSession = async (
   }
 }
 
+/**
+ * Publishes the agent's entry point into a live session. The descriptor is the
+ * only file that carries the agent capability, so it is written with the same
+ * private write-then-rename every other session document uses, and only after
+ * the marker confirms the descriptor describes this session and no other.
+ */
+export const writeVisualSessionDescriptor = async (
+  paths: VisualSessionPaths,
+  descriptor: VisualSessionDescriptor,
+): Promise<void> => {
+  const validated = parseVisualSessionDescriptor(descriptor)
+  if (!validated.ok) {
+    const first = validated.diagnostics[0]
+    throw storeError(
+      first?.code ?? 'YMVS103',
+      `Session descriptor is invalid: ${first?.message ?? 'unknown violation'}`,
+    )
+  }
+  const marker = await readSessionMarker(paths)
+  if (validated.value.sessionId !== marker.id) {
+    throw storeError(
+      'YMVS126',
+      `Descriptor belongs to session "${validated.value.sessionId}", not "${marker.id}"`,
+    )
+  }
+  if (
+    validated.value.sessionRoot !== paths.root ||
+    validated.value.journalPath !== paths.journal
+  ) {
+    throw storeError(
+      'YMVS125',
+      `Descriptor for session "${marker.id}" names artefacts outside "${paths.root}"`,
+    )
+  }
+  await writePrivateJson(paths.descriptor, validated.value)
+}
+
 export const appendVisualEvent = async (
   paths: VisualSessionPaths,
   event: VisualEvent,
@@ -618,8 +662,7 @@ export const readActionableEventsAfter = async (
     (record): record is VisualEvent =>
       record.format === 'yarramate/visual-event/v1' &&
       record.sequence > sequence &&
-      (ACTIONABLE_EVENT_TYPES.has(record.type) ||
-        (record.type === 'view.navigate' && record.payload.requiresAttention)),
+      isActionableVisualEvent(record),
   )
 }
 

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -678,6 +678,15 @@ export const appendVisualResponse = async (
     }
     // A response the runtime already journaled must not be written twice: the
     // broadcast may be retried after a partial failure.
+    //
+    // `responseId` is deliberately the only idempotency key. Binding an event
+    // to one answer instead would refuse the multi-part answer the browser
+    // already renders — `recordResponse` appends a transcript line per accepted
+    // response — and would turn previously accepted input into a refusal on a
+    // wire four independently shipped parties read (ADR 0081). An agent that
+    // regenerates identifiers therefore shows the reviewer a second answer;
+    // that is visible, bounded, and does not touch recovery, which takes its
+    // summary from `handoff.complete`.
     if (state.responseIds.has(record.responseId)) {
       return {
         ok: true,
@@ -775,6 +784,15 @@ export const recoverVisualSession = async (
   let summary: VisualHandoffSummary | undefined
   let endReason: VisualTerminationReason | undefined
   const visited: string[] = []
+  // The last journaled `handoff.complete` is the summary, whether or not a
+  // terminal event precedes it. Requiring the terminal event first would drop
+  // the real summary in the two paths that matter most: the mandated
+  // recover-before-stop, which runs while the session is still live, and the
+  // child that publishes its handoff after a terminal diagnostic rather than
+  // after a journaled `session.end`. A premature handoff can therefore shape a
+  // mid-session recovery, which is bounded by the trust model — the same agent
+  // capability authors the genuine handoff, the journal it is read from is
+  // intact, and the terminal handoff supersedes it.
   for (const record of journal.records) {
     if (
       record.format === 'yarramate/visual-response/v1' &&

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -471,7 +471,7 @@ const overflowsTranscript = (
             'YMVS122',
             `Journaling ${bytes} more bytes would exceed the ${VISUAL_LIMITS.transcriptBytes} byte transcript limit`,
             paths.journal,
-            '#/payload',
+            '/payload',
           ),
         ],
       }
@@ -568,7 +568,7 @@ export const appendVisualEvent = async (
             'YMVS126',
             `Event belongs to session "${record.sessionId}", not "${state.sessionId}"`,
             paths.journal,
-            '#/sessionId',
+            '/sessionId',
           ),
         ],
       }
@@ -581,7 +581,7 @@ export const appendVisualEvent = async (
             'YMVS127',
             `Event "${record.eventId}" was already journaled`,
             paths.journal,
-            '#/eventId',
+            '/eventId',
           ),
         ],
       }
@@ -597,7 +597,7 @@ export const appendVisualEvent = async (
             'YMVS130',
             `Session "${state.sessionId}" ended at sequence ${state.terminal.sequence} and takes no further event`,
             paths.journal,
-            '#/type',
+            '/type',
           ),
         ],
       }
@@ -610,7 +610,7 @@ export const appendVisualEvent = async (
             'YMVS121',
             `Event sequence ${record.sequence} does not advance past ${state.lastSequence}`,
             paths.journal,
-            '#/sequence',
+            '/sequence',
           ),
         ],
       }
@@ -654,7 +654,7 @@ export const appendVisualResponse = async (
             'YMVS126',
             `Response belongs to session "${record.sessionId}", not "${state.sessionId}"`,
             paths.journal,
-            '#/sessionId',
+            '/sessionId',
           ),
         ],
       }
@@ -671,7 +671,7 @@ export const appendVisualResponse = async (
             'YMVS131',
             `Response answers event "${record.eventId}", which session "${state.sessionId}" never journaled`,
             paths.journal,
-            '#/eventId',
+            '/eventId',
           ),
         ],
       }

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -1,0 +1,900 @@
+import { constants } from 'node:fs'
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  truncate,
+  writeFile,
+} from 'node:fs/promises'
+import { basename, dirname, join, resolve, sep } from 'node:path'
+import {
+  VISUAL_LIMITS,
+  parseVisualEvent,
+  parseVisualHandoff,
+  parseVisualModel,
+  parseVisualResponse,
+  parseVisualSessionRequest,
+  type VisualAuthority,
+  type VisualDiagnostic,
+  type VisualEvent,
+  type VisualFreezeReason,
+  type VisualHandoff,
+  type VisualHandoffDecision,
+  type VisualHandoffSummary,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionRequest,
+  type VisualTerminationReason,
+} from './protocol.js'
+
+export const VISUAL_SESSION_MARKER_FORMAT =
+  'yarramate/visual-session-marker/v1' as const
+
+export const VISUAL_ACTIVE_MODEL_FORMAT =
+  'yarramate/visual-active-model/v1' as const
+
+/**
+ * Upper bound on how many orphaned sessions one `start` prunes. Cleanup runs on
+ * the critical path of a new session, so a directory full of orphans must cost
+ * a bounded amount of work; the remainder is collected by the next start.
+ */
+export const VISUAL_SESSION_PRUNE_LIMIT = 64
+
+const CANDIDATE_NAME = /^[0-9]{6}$/
+const IDENTIFIER = /^[0-9a-f]{32}$/
+const TIMESTAMP =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$/
+const NEWLINE = 0x0a
+
+/**
+ * Browser events that require an agent turn. Navigation is journaled for
+ * context but only interrupts the agent when the browser marked it as needing
+ * attention.
+ */
+const ACTIONABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'chat.message',
+  'choice.selected',
+  'session.end',
+])
+
+export interface VisualSessionPaths {
+  readonly root: string
+  readonly marker: string
+  readonly descriptor: string
+  readonly journal: string
+  readonly candidates: string
+  readonly activeModel: string
+}
+
+export interface SessionDependencies {
+  readonly baseDir: string
+  readonly now: () => Date
+  readonly randomBytes: (size: number) => Buffer
+}
+
+/**
+ * The only session state that outlives the runtime process. Recovery never
+ * resumes the server or the compiler, so the marker carries the session
+ * identity, its age for pruning, and the authority label the handoff must
+ * report — and deliberately not the candidate model or the compiler vector.
+ */
+export interface VisualSessionMarker {
+  readonly format: typeof VISUAL_SESSION_MARKER_FORMAT
+  readonly id: string
+  readonly createdAt: string
+  readonly authority: VisualAuthority
+}
+
+/**
+ * Last-good rendering pointer. It names a staged candidate directory instead of
+ * embedding the model so the swap is a single rename of a small file.
+ */
+export interface VisualActiveModel {
+  readonly format: typeof VISUAL_ACTIVE_MODEL_FORMAT
+  readonly candidate: string
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly promotedAt: string
+}
+
+export interface VisualSessionCreated {
+  readonly paths: VisualSessionPaths
+  readonly browserToken: string
+  readonly agentToken: string
+}
+
+export interface VisualAppendAccepted {
+  readonly ok: true
+  readonly lastSequence: number
+  readonly transcriptBytes: number
+  readonly duplicate: boolean
+}
+
+export interface VisualAppendRejected {
+  readonly ok: false
+  readonly freeze?: VisualFreezeReason
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+export type VisualAppendResult = VisualAppendAccepted | VisualAppendRejected
+
+export interface ModelPromotion {
+  readonly model: VisualModel
+  readonly now: () => Date
+  readonly compile: (
+    candidateDir: string,
+  ) => Promise<readonly VisualDiagnostic[]>
+}
+
+export interface ModelPromotionResult {
+  readonly promoted: boolean
+  readonly candidate: string
+  readonly candidateDir: string
+  readonly diagnostics: readonly VisualDiagnostic[]
+}
+
+/** In-process append state, rebuilt from disk whenever the journal size drifts. */
+interface JournalState {
+  bytes: number
+  lastSequence: number
+  readonly eventIds: Set<string>
+  readonly responseIds: Set<string>
+  readonly sessionId: string
+}
+
+interface JournalRead {
+  readonly records: readonly (VisualEvent | VisualResponse)[]
+  readonly lastSequence: number
+  /** Bytes up to and including the last newline; a longer file has a torn tail. */
+  readonly completeBytes: number
+  readonly size: number
+}
+
+const states = new Map<string, JournalState>()
+const queues = new Map<string, Promise<unknown>>()
+
+const storeError = (code: string, message: string) =>
+  new Error(`${code}: ${message}`)
+
+const storeDiagnostic = (
+  code: string,
+  message: string,
+  path: string,
+  pointer: string,
+  line = 1,
+): VisualDiagnostic => ({
+  severity: 'error',
+  code,
+  message,
+  path,
+  pointer,
+  line,
+  column: 1,
+})
+
+/**
+ * Reads a persisted runtime document's own fields. Anything that is not a plain
+ * object simply has no fields, so the caller's field checks report the fault.
+ */
+const documentFields = (value: unknown): Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : {}
+
+/**
+ * Every mutation of one session runs in call order. Rejections are absorbed
+ * from the stored chain so a rejected append cannot poison later writes.
+ */
+const serialize = <T>(key: string, action: () => Promise<T>): Promise<T> => {
+  const pending = (queues.get(key) ?? Promise.resolve()).then(action)
+  queues.set(
+    key,
+    pending.then(
+      () => undefined,
+      () => undefined,
+    ),
+  )
+  return pending
+}
+
+const forget = (paths: VisualSessionPaths) => {
+  states.delete(paths.journal)
+  queues.delete(paths.journal)
+  queues.delete(paths.candidates)
+}
+
+const drawHex = (
+  randomBytes: SessionDependencies['randomBytes'],
+  size: number,
+) => {
+  const drawn = randomBytes(size)
+  if (drawn.byteLength < size) {
+    throw storeError(
+      'YMVS129',
+      `Random source returned ${drawn.byteLength} bytes for a ${size}-byte draw`,
+    )
+  }
+  return drawn.subarray(0, size).toString('hex')
+}
+
+/**
+ * A rename is only durable once the containing directory is flushed. Not every
+ * platform and filesystem allows fsync on a directory descriptor, and failing
+ * to harden an already completed write must never fail a session operation.
+ */
+const syncDirectory = async (directory: string) => {
+  try {
+    const handle = await open(directory, constants.O_RDONLY)
+    try {
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+  } catch {
+    return
+  }
+}
+
+const writePrivateFile = async (path: string, contents: string) => {
+  const handle = await open(path, 'w', 0o600)
+  try {
+    // 'w' does not narrow an existing file's mode, and a temporary left behind
+    // by a crash must not keep whatever mode it had.
+    await handle.chmod(0o600)
+    await handle.writeFile(contents, { encoding: 'utf8' })
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+/** Write-then-rename, so a reader never observes a half-written document. */
+const writePrivateJson = async (path: string, value: unknown) => {
+  const temporary = `${path}.tmp`
+  await writePrivateFile(temporary, `${JSON.stringify(value, null, 2)}\n`)
+  await rename(temporary, path)
+  await syncDirectory(dirname(path))
+}
+
+export const visualSessionPaths = (root: string): VisualSessionPaths => {
+  const base = resolve(root)
+  return {
+    root: base,
+    marker: join(base, 'session.json'),
+    descriptor: join(base, 'descriptor.json'),
+    journal: join(base, 'journal.jsonl'),
+    candidates: join(base, 'candidates'),
+    activeModel: join(base, 'active-model.json'),
+  }
+}
+
+const readSessionMarker = async (
+  paths: VisualSessionPaths,
+): Promise<VisualSessionMarker> => {
+  let raw = ''
+  try {
+    raw = await readFile(paths.marker, 'utf8')
+  } catch {
+    throw storeError(
+      'YMVS124',
+      `Directory "${paths.root}" is not a marked visual session`,
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw storeError('YMVS124', `Session marker "${paths.marker}" is not JSON`)
+  }
+  const fields = documentFields(parsed)
+  const id = fields.id
+  const createdAt = fields.createdAt
+  const authority = fields.authority
+  if (
+    fields.format !== VISUAL_SESSION_MARKER_FORMAT ||
+    typeof id !== 'string' ||
+    !IDENTIFIER.test(id) ||
+    typeof createdAt !== 'string' ||
+    !TIMESTAMP.test(createdAt) ||
+    (authority !== 'canonical' && authority !== 'ad-hoc')
+  ) {
+    throw storeError(
+      'YMVS124',
+      `Session marker "${paths.marker}" is not ${VISUAL_SESSION_MARKER_FORMAT}`,
+    )
+  }
+  // A marker that names another directory cannot authorise destructive work on
+  // this one; it is either a copied session or a redirected cleanup target.
+  if (basename(paths.root) !== id) {
+    throw storeError(
+      'YMVS125',
+      `Session marker "${paths.marker}" names session "${id}" outside its own directory`,
+    )
+  }
+  return { format: VISUAL_SESSION_MARKER_FORMAT, id, createdAt, authority }
+}
+
+/**
+ * Reads the journal without mutating it. A torn final line is the expected
+ * shape of a crash mid-append and is ignored; any complete line that is not a
+ * valid protocol record means the journal was corrupted and is rejected.
+ */
+const readJournal = async (journal: string): Promise<JournalRead> => {
+  let buffer: Buffer
+  try {
+    buffer = await readFile(journal)
+  } catch {
+    throw storeError('YMVS124', `Session journal "${journal}" is missing`)
+  }
+  const completeBytes = buffer.lastIndexOf(NEWLINE) + 1
+  const lines =
+    completeBytes === 0
+      ? []
+      : buffer
+          .subarray(0, completeBytes - 1)
+          .toString('utf8')
+          .split('\n')
+  const records: (VisualEvent | VisualResponse)[] = []
+  let lastSequence = 0
+  for (const [index, line] of lines.entries()) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      throw storeError(
+        'YMVS123',
+        `Journal "${journal}" line ${index + 1} is not JSON`,
+      )
+    }
+    const format = documentFields(parsed).format
+    const result =
+      format === 'yarramate/visual-event/v1'
+        ? parseVisualEvent(parsed)
+        : format === 'yarramate/visual-response/v1'
+          ? parseVisualResponse(parsed)
+          : undefined
+    if (result === undefined) {
+      throw storeError(
+        'YMVS123',
+        `Journal "${journal}" line ${index + 1} declares unknown format ${JSON.stringify(
+          format,
+        )}`,
+      )
+    }
+    if (!result.ok) {
+      throw storeError(
+        'YMVS123',
+        `Journal "${journal}" line ${index + 1} is not a valid record: ${
+          result.diagnostics[0]?.message ?? 'unknown violation'
+        }`,
+      )
+    }
+    records.push(result.value)
+    if (result.value.format === 'yarramate/visual-event/v1') {
+      lastSequence = Math.max(lastSequence, result.value.sequence)
+    }
+  }
+  return { records, lastSequence, completeBytes, size: buffer.byteLength }
+}
+
+/**
+ * Append state for the session, reloaded whenever the journal on disk is not
+ * the size this process last wrote — which covers a fresh process after a
+ * restart as well as a crash that left a torn final line. The torn tail is
+ * discarded here, on the append path only, so recovery stays read-only.
+ */
+const syncState = async (paths: VisualSessionPaths): Promise<JournalState> => {
+  let size = 0
+  try {
+    size = (await stat(paths.journal)).size
+  } catch {
+    throw storeError('YMVS124', `Session journal "${paths.journal}" is missing`)
+  }
+  const cached = states.get(paths.journal)
+  if (cached !== undefined && cached.bytes === size) {
+    return cached
+  }
+  const marker = await readSessionMarker(paths)
+  const journal = await readJournal(paths.journal)
+  if (journal.completeBytes !== journal.size) {
+    await truncate(paths.journal, journal.completeBytes)
+  }
+  const state: JournalState = {
+    bytes: journal.completeBytes,
+    lastSequence: journal.lastSequence,
+    eventIds: new Set(
+      journal.records
+        .filter((record) => record.format === 'yarramate/visual-event/v1')
+        .map((record) => record.eventId),
+    ),
+    responseIds: new Set(
+      journal.records
+        .filter((record) => record.format === 'yarramate/visual-response/v1')
+        .map((record) => record.responseId),
+    ),
+    sessionId: marker.id,
+  }
+  states.set(paths.journal, state)
+  return state
+}
+
+const writeJournalLine = async (journal: string, line: string) => {
+  const handle = await open(journal, 'a')
+  try {
+    await handle.writeFile(line, { encoding: 'utf8' })
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+const overflowsTranscript = (
+  paths: VisualSessionPaths,
+  state: JournalState,
+  bytes: number,
+): VisualAppendRejected | undefined =>
+  state.bytes + bytes > VISUAL_LIMITS.transcriptBytes
+    ? {
+        ok: false,
+        freeze: 'transcript-bytes',
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS122',
+            `Journaling ${bytes} more bytes would exceed the ${VISUAL_LIMITS.transcriptBytes} byte transcript limit`,
+            paths.journal,
+            '#/payload',
+          ),
+        ],
+      }
+    : undefined
+
+export const createVisualSession = async (
+  request: VisualSessionRequest,
+  deps: SessionDependencies,
+): Promise<VisualSessionCreated> => {
+  const validated = parseVisualSessionRequest(request)
+  if (!validated.ok) {
+    const first = validated.diagnostics[0]
+    throw storeError(
+      first?.code ?? 'YMVS101',
+      `Session request is invalid: ${first?.message ?? 'unknown violation'}`,
+    )
+  }
+  const id = drawHex(deps.randomBytes, 16)
+  await mkdir(deps.baseDir, { recursive: true, mode: 0o700 })
+  const root = join(deps.baseDir, id)
+  // recursive: false — a colliding directory is a live session or a capability
+  // collision, never something to adopt.
+  await mkdir(root, { recursive: false, mode: 0o700 })
+  const paths = visualSessionPaths(root)
+  await writePrivateJson(paths.marker, {
+    format: VISUAL_SESSION_MARKER_FORMAT,
+    id,
+    createdAt: deps.now().toISOString(),
+    authority: validated.value.authority,
+  })
+  await mkdir(paths.candidates, { recursive: false, mode: 0o700 })
+  await writeFile(paths.journal, '', { mode: 0o600 })
+  await syncDirectory(root)
+  return {
+    paths,
+    browserToken: drawHex(deps.randomBytes, 32),
+    agentToken: drawHex(deps.randomBytes, 32),
+  }
+}
+
+export const appendVisualEvent = async (
+  paths: VisualSessionPaths,
+  event: VisualEvent,
+): Promise<VisualAppendResult> => {
+  const validated = parseVisualEvent(event)
+  if (!validated.ok) {
+    return { ok: false, diagnostics: validated.diagnostics }
+  }
+  const record = validated.value
+  return serialize(paths.journal, async () => {
+    const state = await syncState(paths)
+    if (record.sessionId !== state.sessionId) {
+      return {
+        ok: false,
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS126',
+            `Event belongs to session "${record.sessionId}", not "${state.sessionId}"`,
+            paths.journal,
+            '#/sessionId',
+          ),
+        ],
+      }
+    }
+    if (state.eventIds.has(record.eventId)) {
+      return {
+        ok: false,
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS127',
+            `Event "${record.eventId}" was already journaled`,
+            paths.journal,
+            '#/eventId',
+          ),
+        ],
+      }
+    }
+    if (record.sequence <= state.lastSequence) {
+      return {
+        ok: false,
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS121',
+            `Event sequence ${record.sequence} does not advance past ${state.lastSequence}`,
+            paths.journal,
+            '#/sequence',
+          ),
+        ],
+      }
+    }
+    const line = `${JSON.stringify(record)}\n`
+    const bytes = Buffer.byteLength(line, 'utf8')
+    const overflow = overflowsTranscript(paths, state, bytes)
+    if (overflow !== undefined) {
+      return overflow
+    }
+    await writeJournalLine(paths.journal, line)
+    state.bytes += bytes
+    state.lastSequence = record.sequence
+    state.eventIds.add(record.eventId)
+    return {
+      ok: true,
+      lastSequence: state.lastSequence,
+      transcriptBytes: state.bytes,
+      duplicate: false,
+    }
+  })
+}
+
+export const appendVisualResponse = async (
+  paths: VisualSessionPaths,
+  response: VisualResponse,
+): Promise<VisualAppendResult> => {
+  const validated = parseVisualResponse(response)
+  if (!validated.ok) {
+    return { ok: false, diagnostics: validated.diagnostics }
+  }
+  const record = validated.value
+  return serialize(paths.journal, async () => {
+    const state = await syncState(paths)
+    if (record.sessionId !== state.sessionId) {
+      return {
+        ok: false,
+        diagnostics: [
+          storeDiagnostic(
+            'YMVS126',
+            `Response belongs to session "${record.sessionId}", not "${state.sessionId}"`,
+            paths.journal,
+            '#/sessionId',
+          ),
+        ],
+      }
+    }
+    // A response the runtime already journaled must not be written twice: the
+    // broadcast may be retried after a partial failure.
+    if (state.responseIds.has(record.responseId)) {
+      return {
+        ok: true,
+        lastSequence: state.lastSequence,
+        transcriptBytes: state.bytes,
+        duplicate: true,
+      }
+    }
+    const line = `${JSON.stringify(record)}\n`
+    const bytes = Buffer.byteLength(line, 'utf8')
+    const overflow = overflowsTranscript(paths, state, bytes)
+    if (overflow !== undefined) {
+      return overflow
+    }
+    await writeJournalLine(paths.journal, line)
+    state.bytes += bytes
+    state.responseIds.add(record.responseId)
+    return {
+      ok: true,
+      lastSequence: state.lastSequence,
+      transcriptBytes: state.bytes,
+      duplicate: false,
+    }
+  })
+}
+
+export const readActionableEventsAfter = async (
+  paths: VisualSessionPaths,
+  sequence: number,
+): Promise<readonly VisualEvent[]> => {
+  const journal = await readJournal(paths.journal)
+  return journal.records.filter(
+    (record): record is VisualEvent =>
+      record.format === 'yarramate/visual-event/v1' &&
+      record.sequence > sequence &&
+      (ACTIONABLE_EVENT_TYPES.has(record.type) ||
+        (record.type === 'view.navigate' && record.payload.requiresAttention)),
+  )
+}
+
+export const recoverVisualSession = async (
+  paths: VisualSessionPaths,
+  includeTranscript = false,
+): Promise<VisualHandoff> => {
+  const marker = await readSessionMarker(paths)
+  const journal = await readJournal(paths.journal)
+
+  let summary: VisualHandoffSummary | undefined
+  let endReason: 'user-ended' | 'browser-timeout' | undefined
+  const visited: string[] = []
+  for (const record of journal.records) {
+    if (
+      record.format === 'yarramate/visual-response/v1' &&
+      record.type === 'handoff.complete'
+    ) {
+      summary = record.payload
+    }
+    if (record.format === 'yarramate/visual-event/v1') {
+      if (record.type === 'session.end') {
+        endReason = record.payload.reason
+      }
+      if (
+        record.type === 'view.navigate' &&
+        !visited.includes(record.payload.viewId)
+      ) {
+        visited.push(record.payload.viewId)
+      }
+    }
+  }
+
+  // Every combination below satisfies the protocol's cross-field rule: only a
+  // completed handoff may report `user-ended`, and that requires a summary the
+  // child actually submitted.
+  const terminationReason: VisualTerminationReason =
+    endReason === 'browser-timeout'
+      ? 'browser-timeout'
+      : endReason === 'user-ended' && summary !== undefined
+        ? 'user-ended'
+        : endReason === 'user-ended'
+          ? 'child-failed'
+          : 'server-failed'
+  const decision: VisualHandoffDecision =
+    summary === undefined
+      ? 'failed'
+      : terminationReason === 'user-ended'
+        ? 'completed'
+        : 'cancelled'
+
+  const last = journal.records.at(-1)
+  const handoff: VisualHandoff = {
+    format: 'yarramate/visual-handoff/v1',
+    sessionId: marker.id,
+    authority: marker.authority,
+    decision,
+    terminationReason,
+    lastSequence: journal.lastSequence,
+    summary:
+      summary?.summary ??
+      'No agent handoff was journaled; this summary was reconstructed from the session journal.',
+    confirmedDecisions: summary?.confirmedDecisions ?? [],
+    requestedChanges: summary?.requestedChanges ?? [],
+    unresolvedQuestions: summary?.unresolvedQuestions ?? [],
+    finalViews: summary?.finalViews ?? visited.slice(-256),
+    transcriptPath: paths.journal,
+    completedAt: last?.timestamp ?? marker.createdAt,
+    // Present and undefined rather than absent, so a caller cannot mistake the
+    // summary-only handoff for one whose transcript it forgot to read.
+    transcript: includeTranscript
+      ? // The submitted summary is the handoff itself, not conversation, so it
+        // is not repeated inside the raw transcript.
+        journal.records.filter(
+          (record) =>
+            record.format !== 'yarramate/visual-response/v1' ||
+            record.type !== 'handoff.complete',
+        )
+      : undefined,
+  }
+
+  // The transcript is excluded from validation on purpose: the 5 MiB cap is
+  // enforced on the journal at append time, and re-serializing a whole journal
+  // as a JSON array costs one byte more than the file it came from. Every entry
+  // was validated on the way in and again by readJournal.
+  const validated = parseVisualHandoff({ ...handoff, transcript: undefined })
+  if (!validated.ok) {
+    const first = validated.diagnostics[0]
+    throw storeError(
+      first?.code ?? 'YMVS107',
+      `Recovered handoff for "${paths.root}" is invalid: ${
+        first?.message ?? 'unknown violation'
+      }`,
+    )
+  }
+  return handoff
+}
+
+export const readActiveVisualModel = async (
+  paths: VisualSessionPaths,
+): Promise<VisualActiveModel | undefined> => {
+  let raw = ''
+  try {
+    raw = await readFile(paths.activeModel, 'utf8')
+  } catch {
+    return undefined
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw storeError(
+      'YMVS128',
+      `Active model pointer "${paths.activeModel}" is not JSON`,
+    )
+  }
+  const fields = documentFields(parsed)
+  const candidate = fields.candidate
+  const authority = fields.authority
+  const initialView = fields.initialView
+  const promotedAt = fields.promotedAt
+  if (
+    fields.format !== VISUAL_ACTIVE_MODEL_FORMAT ||
+    typeof candidate !== 'string' ||
+    !CANDIDATE_NAME.test(candidate) ||
+    (authority !== 'canonical' && authority !== 'ad-hoc') ||
+    typeof initialView !== 'string' ||
+    typeof promotedAt !== 'string' ||
+    !TIMESTAMP.test(promotedAt)
+  ) {
+    throw storeError(
+      'YMVS128',
+      `Active model pointer "${paths.activeModel}" is not ${VISUAL_ACTIVE_MODEL_FORMAT}`,
+    )
+  }
+  return {
+    format: VISUAL_ACTIVE_MODEL_FORMAT,
+    candidate,
+    authority,
+    initialView,
+    promotedAt,
+  }
+}
+
+export const promoteCompiledModel = async (
+  paths: VisualSessionPaths,
+  promotion: ModelPromotion,
+): Promise<ModelPromotionResult> => {
+  // The runtime has already parsed the `model.replace` response that carried
+  // this model, so a violation here is a runtime defect rather than untrusted
+  // input, and must not be reported to the browser as a candidate diagnostic.
+  const validated = parseVisualModel(promotion.model)
+  if (!validated.ok) {
+    const first = validated.diagnostics[0]
+    throw storeError(
+      first?.code ?? 'YMVS106',
+      `Candidate model is invalid: ${first?.message ?? 'unknown violation'}`,
+    )
+  }
+  const model = validated.value
+  return serialize(paths.candidates, async () => {
+    await readSessionMarker(paths)
+    const existing = await readdir(paths.candidates)
+    const highest = existing
+      .filter((entry) => CANDIDATE_NAME.test(entry))
+      .reduce((max, entry) => Math.max(max, Number(entry)), 0)
+    const candidate = String(highest + 1).padStart(6, '0')
+    const candidateDir = join(paths.candidates, candidate)
+    await mkdir(candidateDir, { recursive: false, mode: 0o700 })
+    for (const [file, contents] of Object.entries(model.files)) {
+      const target = resolve(candidateDir, file)
+      // Confinement is already enforced by the model schema and by the protocol
+      // path check; re-checking the resolved path means neither of those alone
+      // is load-bearing for a write outside the candidate directory.
+      if (!target.startsWith(`${candidateDir}${sep}`)) {
+        throw storeError(
+          'YMVS125',
+          `Candidate file "${file}" resolves outside "${candidateDir}"`,
+        )
+      }
+      await mkdir(dirname(target), { recursive: true, mode: 0o700 })
+      await writePrivateFile(target, contents)
+    }
+    const diagnostics = await promotion.compile(candidateDir)
+    if (diagnostics.length > 0) {
+      return { promoted: false, candidate, candidateDir, diagnostics }
+    }
+    await writePrivateJson(paths.activeModel, {
+      format: VISUAL_ACTIVE_MODEL_FORMAT,
+      candidate,
+      authority: model.authority,
+      initialView: model.initialView,
+      promotedAt: promotion.now().toISOString(),
+    })
+    return { promoted: true, candidate, candidateDir, diagnostics: [] }
+  })
+}
+
+/**
+ * Recovers the handoff and only then deletes the session, so cleanup can never
+ * be the step that loses confirmed state. Returns `undefined` when the session
+ * is already gone, which makes a repeated stop idempotent.
+ */
+export const removeVisualSession = async (
+  paths: VisualSessionPaths,
+  includeTranscript = false,
+): Promise<VisualHandoff | undefined> => {
+  let entry
+  try {
+    entry = await lstat(paths.root)
+  } catch {
+    forget(paths)
+    return undefined
+  }
+  if (!entry.isDirectory()) {
+    throw storeError(
+      'YMVS125',
+      `Session root "${paths.root}" is not a directory`,
+    )
+  }
+  const handoff = await recoverVisualSession(paths, includeTranscript)
+  await rm(paths.root, { recursive: true, force: true })
+  await syncDirectory(dirname(paths.root))
+  forget(paths)
+  return handoff
+}
+
+/**
+ * Removes orphaned sessions a previous runtime left behind. Only directories
+ * carrying a marker that names them are touched, and never more than `limit`
+ * per pass; the oldest go first.
+ */
+export const pruneStaleVisualSessions = async (
+  baseDir: string,
+  now: Date,
+  limit = VISUAL_SESSION_PRUNE_LIMIT,
+): Promise<readonly string[]> => {
+  let entries
+  try {
+    entries = await readdir(baseDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const stale: { readonly root: string; readonly createdAt: number }[] = []
+  for (const entry of entries) {
+    // Dirent reflects lstat, so a symlink pointing at a directory outside the
+    // base directory is never a candidate for removal.
+    if (!entry.isDirectory()) {
+      continue
+    }
+    const paths = visualSessionPaths(join(baseDir, entry.name))
+    let marker
+    try {
+      marker = await readSessionMarker(paths)
+    } catch {
+      continue
+    }
+    const createdAt = Date.parse(marker.createdAt)
+    if (now.getTime() - createdAt <= VISUAL_LIMITS.staleSessionMs) {
+      continue
+    }
+    stale.push({ root: paths.root, createdAt })
+  }
+  stale.sort(
+    (left, right) =>
+      left.createdAt - right.createdAt || left.root.localeCompare(right.root),
+  )
+  const removed: string[] = []
+  for (const candidate of stale.slice(0, Math.max(0, limit))) {
+    await rm(candidate.root, { recursive: true, force: true })
+    forget(visualSessionPaths(candidate.root))
+    removed.push(candidate.root)
+  }
+  if (removed.length > 0) {
+    await syncDirectory(baseDir)
+  }
+  return removed
+}

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -1,0 +1,66 @@
+import type {
+  VISUAL_PROTOCOL_VERSION,
+  VisualAuthority,
+  VisualCapabilities,
+  VisualDiagnostic,
+  VisualFreezeReason,
+  VisualResponse,
+  VisualTerminationReason,
+} from './protocol-contract.js'
+
+/**
+ * Transport shapes the session server and the browser application both speak.
+ *
+ * These are not protocol documents: they carry validated documents plus the
+ * transport's own acknowledgements, so they are discriminated by `kind` rather
+ * than by a versioned `format`. They live apart from the server because the
+ * browser bundle must import the contract without importing the Node runtime
+ * that serves it — this module holds types only, and every dependency it has on
+ * the protocol is type-only too.
+ */
+
+/** One promoted candidate as the browser receives it. */
+export interface VisualRenderedModel {
+  readonly candidate: string
+  readonly authority: VisualAuthority
+  readonly initialView: string
+  readonly views: readonly string[]
+  /**
+   * The trusted compiler's own LikeC4 export for this candidate, the document
+   * `createLikeC4Model` consumes. Its internals belong to LikeC4, so the
+   * transport carries it verbatim instead of restating a shape it does not own.
+   */
+  readonly compiled: unknown
+}
+
+/** Everything the browser needs to render, and nothing that authenticates it. */
+export interface VisualSessionSnapshot {
+  readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
+  readonly sessionId: string
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly capabilities: VisualCapabilities
+  readonly webSocketUrl: string
+  readonly model: VisualRenderedModel
+  readonly lastSequence: number
+  readonly frozen: boolean
+}
+
+/** Server-to-browser transport frame. */
+export type VisualServerFrame =
+  | { readonly kind: 'ready'; readonly snapshot: VisualSessionSnapshot }
+  | {
+      readonly kind: 'accepted'
+      readonly sequence: number
+      readonly eventId: string
+    }
+  | {
+      readonly kind: 'rejected'
+      readonly diagnostics: readonly VisualDiagnostic[]
+      readonly frozen?: VisualFreezeReason
+    }
+  | { readonly kind: 'response'; readonly response: VisualResponse }
+  | { readonly kind: 'model'; readonly model: VisualRenderedModel }
+  | { readonly kind: 'closing'; readonly reason: VisualTerminationReason }

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -33,6 +33,20 @@ export interface VisualRenderedModel {
   readonly compiled: unknown
 }
 
+/**
+ * One line of the conversation, as plain text.
+ *
+ * The server keeps this beside the journal so a browser that reloads or
+ * reconnects sees the conversation it left. It carries no model source, no
+ * credential, and none of the journal's own bookkeeping — only what was said
+ * and who said it.
+ */
+export interface VisualTranscriptRecord {
+  readonly id: string
+  readonly speaker: 'reviewer' | 'agent'
+  readonly text: string
+}
+
 /** Everything the browser needs to render, and nothing that authenticates it. */
 export interface VisualSessionSnapshot {
   readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION
@@ -44,6 +58,13 @@ export interface VisualSessionSnapshot {
   readonly capabilities: VisualCapabilities
   readonly webSocketUrl: string
   readonly model: VisualRenderedModel
+  readonly transcript: readonly VisualTranscriptRecord[]
+  /**
+   * Nonce this session's policy admits for the inline styles the diagram
+   * renderer injects. It authorises styling and nothing else, and it is not a
+   * credential: the session cookie is what authenticates this snapshot.
+   */
+  readonly styleNonce: string
   readonly lastSequence: number
   readonly frozen: boolean
 }

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -2,6 +2,7 @@ import type {
   VISUAL_PROTOCOL_VERSION,
   VisualAuthority,
   VisualCapabilities,
+  VisualChoicePresentPayload,
   VisualDiagnostic,
   VisualFreezeReason,
   VisualResponse,
@@ -65,6 +66,13 @@ export interface VisualSessionSnapshot {
    * from the transcript, so a reply it never saw does not leave it waiting.
    */
   readonly agentTurnOpen: boolean
+  /**
+   * The structured choice the agent is still waiting on, or `null`. The
+   * question lives in the agent's response and never in the transcript, so a
+   * browser that reloads or reconnects reads it here; without it the reviewer
+   * comes back to a session waiting on a selection they can no longer make.
+   */
+  readonly pendingChoice: VisualChoicePresentPayload | null
   /**
    * Nonce this session's policy admits for the inline styles the diagram
    * renderer injects. It authorises styling and nothing else, and it is not a

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -60,6 +60,12 @@ export interface VisualSessionSnapshot {
   readonly model: VisualRenderedModel
   readonly transcript: readonly VisualTranscriptRecord[]
   /**
+   * Whether the agent still owes an answer to something the reviewer sent. A
+   * browser that reconnects mid-turn reads this rather than inferring the turn
+   * from the transcript, so a reply it never saw does not leave it waiting.
+   */
+  readonly agentTurnOpen: boolean
+  /**
    * Nonce this session's policy admits for the inline styles the diagram
    * renderer injects. It authorises styling and nothing else, and it is not a
    * credential: the session cookie is what authenticates this snapshot.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -273,10 +273,29 @@ const DiagramWorkspace = ({
       ),
     [activeRenderedView],
   )
+  const canvas = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    const host = canvas.current?.querySelector<HTMLElement>(
+      '[data-likec4-instance]',
+    )
+    const sheet = host?.shadowRoot?.adoptedStyleSheets[0]
+    if (
+      sheet === undefined ||
+      [...sheet.cssRules].some((rule) =>
+        rule.cssText.includes('--yarramate-focus-ring'),
+      )
+    ) {
+      return
+    }
+    sheet.insertRule(
+      ':focus-visible { outline: var(--yarramate-focus-ring, 3px solid #2457a6) !important; outline-offset: 3px !important; }',
+      sheet.cssRules.length,
+    )
+  }, [drawing.drawn, state.activeView])
 
   return (
     <section className="diagram-workspace" aria-label="Architecture diagram">
-      <div className="canvas">
+      <div className="canvas" ref={canvas}>
         {drawing.drawn === null ? null : (
           <LikeC4ModelProvider likec4model={drawing.drawn}>
             <ReactLikeC4

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -167,7 +167,9 @@ const CommandStrip = ({
         onClick={onEnd}
         disabled={state.lifecycle !== 'active'}
       >
-        {state.lifecycle === 'active' ? 'End' : 'Ending…'}
+        {state.lifecycle === 'ending' || state.lifecycle === 'closed'
+          ? 'Ending…'
+          : 'End'}
       </button>
     </div>
     {/* Static prose is not worth the canvas: the disclosure is laid over the
@@ -521,6 +523,10 @@ const ConversationPanel = ({
   readonly onNavigate: (viewId: string) => void
 }) => {
   const [draft, setDraft] = useState('')
+  const agentWaiting =
+    state.lifecycle === 'active' && state.awaitingAgent
+  const visibleAgentStatus =
+    state.lifecycle === 'active' ? state.agentStatus : null
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
@@ -623,17 +629,17 @@ const ConversationPanel = ({
             className="agent-status"
             role="status"
             aria-live="polite"
-            aria-busy={state.awaitingAgent}
+            aria-busy={agentWaiting}
           >
-            {state.awaitingAgent ? (
+            {agentWaiting ? (
               <span className="agent-spinner" aria-hidden="true" />
             ) : null}
             <span>
-              {state.agentStatus === null
-                ? state.awaitingAgent
+              {visibleAgentStatus === null
+                ? agentWaiting
                   ? 'Awaiting agent response'
                   : '\u00a0'
-                : (STATUS_WORDS[state.agentStatus.state] ?? '\u00a0')}
+                : (STATUS_WORDS[visibleAgentStatus.state] ?? '\u00a0')}
             </span>
           </p>
           <button type="submit" disabled={disabled || draft.trim() === ''}>

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -119,6 +119,7 @@ const CommandStrip = ({
   <header className="command-strip">
     <div className="command-identity">
       <h1>{state.title === '' ? 'Opening the session' : state.title}</h1>
+      <span className="beta-badge">Beta</span>
       <span className={`authority authority-${state.authority}`}>
         {visualAuthorityLabel(state.authority)}
       </span>

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -2,6 +2,7 @@ import { LikeC4Model, type AnyLikeC4Model } from '@likec4/core/model'
 import { LikeC4ModelProvider, ReactLikeC4 } from 'likec4/react'
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -26,7 +27,11 @@ import {
 import {
   conversationWidthBounds,
   createVisualWorkspaceState,
+  formatContextualQuestion,
+  normalizeSelectedElement,
+  normalizeSelectedRelationship,
   visualWorkspaceReducer,
+  type SelectedDiagramSubject,
 } from './workspace-state.js'
 
 /**
@@ -216,53 +221,245 @@ const DiagramWorkspace = ({
   waiting,
   reduceGraphics,
   onNavigate,
+  onSelect,
 }: {
   readonly state: VisualAppState
   readonly drawing: VisualDrawing<AnyLikeC4Model>
   readonly waiting: string | null
   readonly reduceGraphics: boolean
   readonly onNavigate: (viewId: string) => void
-}) => (
-  <section className="diagram-workspace" aria-label="Architecture diagram">
-    <div className="canvas">
-      {drawing.drawn === null ? null : (
-        <LikeC4ModelProvider likec4model={drawing.drawn}>
-          <ReactLikeC4
-            viewId={state.activeView}
-            onNavigateTo={(viewId) => onNavigate(viewId)}
-            injectFontCss={false}
-            colorScheme="light"
-            background="dots"
-            controls
-            pannable
-            zoomable
-            fitView
-            keepAspectRatio={false}
-            // The custom inspector is the only details surface, so the
-            // renderer's own overlays stay shut.
-            enableElementDetails={false}
-            enableRelationshipDetails={false}
-            enableNotes
-            enableSearch={false}
-            // The renderer injects its own stylesheets; this session's
-            // policy admits them under this nonce and nothing else.
-            styleNonce={state.styleNonce}
-            showNavigationButtons
-            reduceGraphics={reduceGraphics ? true : 'auto'}
-            className="diagram"
-          />
-        </LikeC4ModelProvider>
+  readonly onSelect: (subject: SelectedDiagramSubject) => void
+}) => {
+  // An edge names its endpoints by node id; the reviewer reads titles. The
+  // rendering model the renderer itself draws answers that, so nothing here
+  // reaches into the compiled document.
+  const activeRenderedView = useMemo(
+    () => drawing.drawn?.findView(state.activeView)?.$layouted ?? null,
+    [drawing.drawn, state.activeView],
+  )
+  const nodeTitles = useMemo(
+    () =>
+      new Map(
+        (activeRenderedView?.nodes ?? []).map(
+          (node) => [String(node.id), node.title] as const,
+        ),
+      ),
+    [activeRenderedView],
+  )
+
+  return (
+    <section className="diagram-workspace" aria-label="Architecture diagram">
+      <div className="canvas">
+        {drawing.drawn === null ? null : (
+          <LikeC4ModelProvider likec4model={drawing.drawn}>
+            <ReactLikeC4
+              viewId={state.activeView}
+              onNodeClick={(node) => onSelect(normalizeSelectedElement(node))}
+              onEdgeClick={(edge) =>
+                onSelect(normalizeSelectedRelationship(edge, nodeTitles))
+              }
+              onNavigateTo={(viewId, _event, node) => {
+                if (node !== undefined) onSelect(normalizeSelectedElement(node))
+                onNavigate(viewId)
+              }}
+              injectFontCss={false}
+              colorScheme="light"
+              background="dots"
+              controls
+              pannable
+              zoomable
+              fitView
+              keepAspectRatio={false}
+              // The custom inspector is the only details surface, so the
+              // renderer's own overlays stay shut.
+              enableElementDetails={false}
+              enableRelationshipDetails={false}
+              enableNotes
+              enableSearch={false}
+              // The renderer injects its own stylesheets; this session's
+              // policy admits them under this nonce and nothing else.
+              styleNonce={state.styleNonce}
+              showNavigationButtons
+              reduceGraphics={reduceGraphics ? true : 'auto'}
+              className="diagram"
+            />
+          </LikeC4ModelProvider>
+        )}
+        {waiting === null ? null : <p className="waiting">{waiting}</p>}
+      </div>
+
+      {drawing.fault === null ? null : (
+        // The renderer's exception describes its own internals and may carry
+        // anything: the reviewer reads this application's words instead.
+        <div className="faults" role="alert">
+          <p className="faults-title">{drawing.fault}</p>
+        </div>
       )}
-      {waiting === null ? null : <p className="waiting">{waiting}</p>}
+    </section>
+  )
+}
+
+/**
+ * A description is worth reading in full and worth not burying the rest of the
+ * panel under. Three lines are the default; the disclosure appears only when
+ * the browser actually clipped something, measured rather than guessed, because
+ * panel width and font metrics both move.
+ */
+const ExpandableDescription = ({
+  text,
+  expanded,
+  onToggle,
+}: {
+  readonly text: string | null
+  readonly expanded: boolean
+  readonly onToggle: () => void
+}) => {
+  const description = text ?? 'No description declared in this model'
+  const body = useRef<HTMLParagraphElement>(null)
+  const [canExpand, setCanExpand] = useState(false)
+
+  useLayoutEffect(() => {
+    const element = body.current
+    if (element === null || expanded) return
+    const measure = () =>
+      setCanExpand(element.scrollHeight > element.clientHeight + 1)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [description, expanded])
+
+  return (
+    <div className="subject-description">
+      <p
+        ref={body}
+        className={expanded ? 'description-expanded' : 'description-clamped'}
+      >
+        {description}
+      </p>
+      {canExpand || expanded ? (
+        <button type="button" aria-expanded={expanded} onClick={onToggle}>
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * What the reviewer clicked, said back to them in the model's own words: the
+ * facts the diagram cannot fit, and nothing the renderer would have to be
+ * trusted to render.
+ */
+const SelectedSubjectInspector = ({
+  subject,
+  expanded,
+  onToggleDescription,
+  onClear,
+  onNavigate,
+}: {
+  readonly subject: SelectedDiagramSubject
+  readonly expanded: boolean
+  readonly onToggleDescription: () => void
+  readonly onClear: () => void
+  readonly onNavigate: (viewId: string) => void
+}) => (
+  <section className="subject-inspector" aria-labelledby="subject-heading">
+    <div className="subject-heading-row">
+      <div>
+        <p className="subject-type">
+          {subject.type === 'element'
+            ? 'Selected element'
+            : 'Selected relationship'}
+        </p>
+        <h2 id="subject-heading">
+          {subject.type === 'element'
+            ? subject.title
+            : `${subject.sourceTitle} → ${subject.targetTitle}`}
+        </h2>
+      </div>
+      <button type="button" className="subject-clear" onClick={onClear}>
+        Clear
+      </button>
     </div>
 
-    {drawing.fault === null ? null : (
-      // The renderer's exception describes its own internals and may carry
-      // anything: the reviewer reads this application's words instead.
-      <div className="faults" role="alert">
-        <p className="faults-title">{drawing.fault}</p>
-      </div>
+    {subject.type === 'element' ? (
+      <dl className="subject-facts">
+        <div>
+          <dt>Identity</dt>
+          <dd>
+            <code>{subject.identity}</code>
+          </dd>
+        </div>
+        {subject.kind === null ? null : (
+          <div>
+            <dt>Kind</dt>
+            <dd>{subject.kind}</dd>
+          </div>
+        )}
+        {subject.technology === null ? null : (
+          <div>
+            <dt>Technology</dt>
+            <dd>{subject.technology}</dd>
+          </div>
+        )}
+        {subject.tags.length === 0 ? null : (
+          <div>
+            <dt>Tags</dt>
+            <dd>{subject.tags.join(', ')}</dd>
+          </div>
+        )}
+      </dl>
+    ) : (
+      <dl className="subject-facts">
+        <div>
+          <dt>Label</dt>
+          <dd>{subject.label ?? 'Unlabelled relationship'}</dd>
+        </div>
+        {subject.kind === null ? null : (
+          <div>
+            <dt>Kind</dt>
+            <dd>{subject.kind}</dd>
+          </div>
+        )}
+        {subject.technology === null ? null : (
+          <div>
+            <dt>Technology</dt>
+            <dd>{subject.technology}</dd>
+          </div>
+        )}
+        {subject.notation === null ? null : (
+          <div>
+            <dt>Notation</dt>
+            <dd>{subject.notation}</dd>
+          </div>
+        )}
+        <div>
+          <dt>Model relations</dt>
+          <dd>{subject.aggregateCount}</dd>
+        </div>
+      </dl>
     )}
+
+    <ExpandableDescription
+      text={subject.description}
+      expanded={expanded}
+      onToggle={onToggleDescription}
+    />
+
+    {subject.type === 'element' && subject.navigateTo !== null ? (
+      <button
+        type="button"
+        className="subject-navigate"
+        onClick={() => {
+          if (subject.type === 'element' && subject.navigateTo !== null) {
+            onNavigate(subject.navigateTo)
+          }
+        }}
+      >
+        Open related view
+      </button>
+    ) : null}
   </section>
 )
 
@@ -270,14 +467,24 @@ const ConversationPanel = ({
   state,
   hidden,
   disabled,
+  selectedSubject,
+  descriptionExpanded,
   onSend,
   onChoice,
+  onToggleDescription,
+  onClearSubject,
+  onNavigate,
 }: {
   readonly state: VisualAppState
   readonly hidden: boolean
   readonly disabled: boolean
+  readonly selectedSubject: SelectedDiagramSubject | null
+  readonly descriptionExpanded: boolean
   readonly onSend: (text: string) => void
   readonly onChoice: (optionId: string) => void
+  readonly onToggleDescription: () => void
+  readonly onClearSubject: () => void
+  readonly onNavigate: (viewId: string) => void
 }) => {
   const [draft, setDraft] = useState('')
 
@@ -303,6 +510,16 @@ const ConversationPanel = ({
       hidden={hidden}
     >
       <div className="conversation-scroll">
+        {selectedSubject === null ? null : (
+          <SelectedSubjectInspector
+            subject={selectedSubject}
+            expanded={descriptionExpanded}
+            onToggleDescription={onToggleDescription}
+            onClear={onClearSubject}
+            onNavigate={onNavigate}
+          />
+        )}
+
         <ol className="ledger" role="log" aria-live="polite">
           {state.transcript.length === 0 ? (
             <li className="empty">
@@ -330,6 +547,22 @@ const ConversationPanel = ({
       </div>
 
       <form className="composer" onSubmit={submit}>
+        {selectedSubject === null ? null : (
+          <div className="subject-chip">
+            <span>
+              {selectedSubject.type === 'element'
+                ? selectedSubject.title
+                : `${selectedSubject.sourceTitle} → ${selectedSubject.targetTitle}`}
+            </span>
+            <button
+              type="button"
+              aria-label="Remove selected diagram context"
+              onClick={onClearSubject}
+            >
+              Remove
+            </button>
+          </div>
+        )}
         <label className="offscreen" htmlFor="composer-text">
           Ask about this design
         </label>
@@ -340,9 +573,13 @@ const ConversationPanel = ({
           value={draft}
           disabled={disabled}
           placeholder={
-            state.chatEnabled
-              ? 'Ask about this design'
-              : 'This session is read-only'
+            !state.chatEnabled
+              ? 'This session is read-only'
+              : selectedSubject?.type === 'element'
+                ? 'Ask about this element'
+                : selectedSubject?.type === 'relationship'
+                  ? 'Ask about this relationship'
+                  : 'Ask about this design'
           }
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={keyDown}
@@ -495,6 +732,18 @@ export const App = () => {
     [],
   )
 
+  // Promotion replaces the model the reviewer was pointing at, so a subject
+  // held from the old one no longer describes anything. Views and lifecycle
+  // change under the same model and must leave the selection alone.
+  const activeCandidate = useRef(state.model?.candidate ?? null)
+  useEffect(() => {
+    const candidate = state.model?.candidate ?? null
+    if (candidate !== activeCandidate.current) {
+      activeCandidate.current = candidate
+      dispatchWorkspace({ type: 'model.replaced' })
+    }
+  }, [state.model?.candidate])
+
   // A fault already accounts for the empty canvas, and saying there is no model
   // would contradict the one that arrived and could not be drawn.
   const waiting =
@@ -536,6 +785,9 @@ export const App = () => {
           waiting={waiting}
           reduceGraphics={reduceGraphics}
           onNavigate={navigate}
+          onSelect={(subject) =>
+            dispatchWorkspace({ type: 'subject.selected', subject })
+          }
         />
         {conversationOpen ? (
           <ConversationSeparator
@@ -553,8 +805,17 @@ export const App = () => {
           state={state}
           hidden={!conversationOpen}
           disabled={!state.composerEnabled}
-          onSend={ask}
+          selectedSubject={workspace.selectedSubject}
+          descriptionExpanded={workspace.descriptionExpanded}
+          onSend={(text) =>
+            ask(formatContextualQuestion(text, workspace.selectedSubject))
+          }
           onChoice={choose}
+          onToggleDescription={() =>
+            dispatchWorkspace({ type: 'description.toggled' })
+          }
+          onClearSubject={() => dispatchWorkspace({ type: 'subject.cleared' })}
+          onNavigate={navigate}
         />
       </div>
     </main>

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -111,7 +111,7 @@ const CommandStrip = ({
       <span className={`authority authority-${state.authority}`}>
         {visualAuthorityLabel(state.authority)}
       </span>
-      <span className="connection-state">{connection}</span>
+      <span className="connection-state" role="status">{connection}</span>
     </div>
     <div className="command-actions">
       <label className="offscreen" htmlFor="active-view">Active view</label>
@@ -151,12 +151,18 @@ const CommandStrip = ({
         End
       </button>
     </div>
+    {/* Static prose is not worth the canvas: the disclosure is laid over the
+        workspace from the strip rather than taking a row of its own, so opening
+        it never reflows the diagram or the conversation. */}
     <div
       id="session-details"
       className="session-details"
       hidden={!detailsOpen}
     >
       <p>{state.description}</p>
+      <button type="button" className="details-close" onClick={onToggleDetails}>
+        Close details
+      </button>
     </div>
   </header>
 )
@@ -258,6 +264,15 @@ const DiagramWorkspace = ({
               onEdgeClick={(edge) =>
                 onSelect(normalizeSelectedRelationship(edge, nodeTitles))
               }
+              // LikeC4 1.59.2 declares the originating node optional and never
+              // passes it: the runtime emits `navigateTo` with `viewId` alone,
+              // so this branch is dead against the pinned renderer and the
+              // subject the reviewer clicked is what the reducer keeps across
+              // the navigation. The branch stays because the declared contract
+              // allows the node, but a renderer bump that starts passing it
+              // changes the behaviour from "keep the prior selection" to
+              // "select the navigated node" — a visible change, not a silent
+              // one, and this is where it lands.
               onNavigateTo={(viewId, _event, node) => {
                 if (node !== undefined) onSelect(normalizeSelectedElement(node))
                 onNavigate(viewId)
@@ -601,12 +616,17 @@ const ConversationPanel = ({
 
 const ConversationSeparator = ({
   width,
+  viewportWidth,
   onResize,
 }: {
   readonly width: number
-  readonly onResize: (width: number, viewportWidth: number) => void
+  readonly viewportWidth: number
+  readonly onResize: (width: number) => void
 }) => {
-  const bounds = conversationWidthBounds(window.innerWidth)
+  // From the state the reducer clamped against, never from `window`: a resize
+  // that leaves the panel width alone still changes what this may be dragged
+  // to, and a render that read the live global would only say so by accident.
+  const bounds = conversationWidthBounds(viewportWidth)
   const drag = useRef<{
     readonly pointerId: number
     readonly startX: number
@@ -615,10 +635,7 @@ const ConversationSeparator = ({
   const pointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
     const active = drag.current
     if (active?.pointerId !== event.pointerId) return
-    onResize(
-      active.startWidth + active.startX - event.clientX,
-      window.innerWidth,
-    )
+    onResize(active.startWidth + active.startX - event.clientX)
   }
   const pointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     drag.current = {
@@ -639,10 +656,7 @@ const ConversationSeparator = ({
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
     event.preventDefault()
     const step = event.shiftKey ? 32 : 8
-    onResize(
-      width + (event.key === 'ArrowLeft' ? step : -step),
-      window.innerWidth,
-    )
+    onResize(width + (event.key === 'ArrowLeft' ? step : -step))
   }
   return (
     <div
@@ -792,12 +806,9 @@ export const App = () => {
         {conversationOpen ? (
           <ConversationSeparator
             width={workspace.conversation.width}
-            onResize={(width, viewportWidth) =>
-              dispatchWorkspace({
-                type: 'conversation.resized',
-                width,
-                viewportWidth,
-              })
+            viewportWidth={workspace.viewportWidth}
+            onResize={(width) =>
+              dispatchWorkspace({ type: 'conversation.resized', width })
             }
           />
         ) : null}

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1,0 +1,354 @@
+import { LikeC4Model } from '@likec4/core/model'
+import { LikeC4ModelProvider, ReactLikeC4 } from 'likec4/react'
+import {
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react'
+import type {
+  VisualChoicePresentPayload,
+  VisualDiagnostic,
+} from '../adapters/visual/protocol-contract.js'
+import { useVisualSession } from './session-client.js'
+import {
+  visualAuthorityLabel,
+  type VisualAppRecord,
+  type VisualAppState,
+} from './state.js'
+
+/**
+ * The review desk: the diagram the reviewer is judging, the rail that carries
+ * the four facts they have to trust, and the conversation they answer in.
+ */
+
+/**
+ * The rendered model as LikeC4's own object graph.
+ *
+ * `@likec4/core/model` is the module `likec4/react` imports for the same class,
+ * so the provider and this factory share one instance of it. `likec4/model`'s
+ * `createLikeC4Model` is this exact call — `LikeC4Model.create` — behind an
+ * entry point that takes `createRequire` at load and so cannot run in a
+ * browser. The compiled document belongs to LikeC4, which reads its own shape.
+ */
+const likeC4ModelFrom = (compiled: unknown) =>
+  LikeC4Model.create(compiled as Parameters<typeof LikeC4Model.create>[0])
+
+const SPEAKERS: Readonly<Record<VisualAppRecord['speaker'], string>> = {
+  reviewer: 'You',
+  agent: 'Agent',
+  session: 'Session',
+}
+
+const STATUS_WORDS: Readonly<
+  Record<'thinking' | 'compiling' | 'waiting' | 'idle', string>
+> = {
+  thinking: 'Agent is thinking',
+  compiling: 'Agent is compiling the model',
+  waiting: 'Agent is waiting',
+  idle: 'Agent is idle',
+}
+
+const connectionOf = (state: VisualAppState, connected: boolean): string => {
+  switch (state.lifecycle) {
+    case 'connecting':
+      return 'Opening'
+    case 'active':
+      return connected ? 'Live' : 'Reconnecting'
+    case 'ending':
+      return 'Ending'
+    case 'disconnected':
+      return 'Reconnecting'
+    case 'closed':
+      return 'Closed'
+  }
+}
+
+const Rail = ({
+  authority,
+  connection,
+  view,
+  onEnd,
+  endEnabled,
+}: {
+  readonly authority: 'canonical' | 'ad-hoc'
+  readonly connection: string
+  readonly view: string
+  readonly onEnd: () => void
+  readonly endEnabled: boolean
+}) => (
+  <div className={`rail rail-${authority}`}>
+    <p className="station station-authority">
+      <span className="tick" />
+      <span className="value">
+        {authority === 'canonical' ? 'Checked' : 'Ad hoc'}
+      </span>
+    </p>
+    <p
+      className={`station station-link link-${connection.toLowerCase()}`}
+      role="status"
+    >
+      <span className="tick" />
+      <span className="value">{connection}</span>
+    </p>
+    <p className="station station-view">
+      <span className="tick" />
+      <span className="value">{view === '' ? 'No view' : view}</span>
+    </p>
+    <button
+      type="button"
+      className="end"
+      onClick={onEnd}
+      disabled={!endEnabled}
+      aria-label="End the review and return control to the main agent"
+    >
+      End
+    </button>
+  </div>
+)
+
+const Faults = ({
+  diagnostics,
+}: {
+  readonly diagnostics: readonly VisualDiagnostic[]
+}) =>
+  diagnostics.length === 0 ? null : (
+    <div className="faults" role="alert">
+      <p className="faults-title">
+        The last change did not compile. The diagram still shows the model that
+        did.
+      </p>
+      <ul>
+        {diagnostics.map((diagnostic) => (
+          <li key={`${diagnostic.code}-${diagnostic.pointer}`}>
+            <span className="code">{diagnostic.code}</span> {diagnostic.message}
+            <span className="where">
+              {diagnostic.path}:{diagnostic.line}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+
+const Choices = ({
+  choices,
+  disabled,
+  onChoice,
+}: {
+  readonly choices: VisualChoicePresentPayload
+  readonly disabled: boolean
+  readonly onChoice: (optionId: string) => void
+}) => (
+  <div className="choices">
+    <p className="question">{choices.question}</p>
+    <ul>
+      {choices.options.map((option) => (
+        <li key={option.id}>
+          <button
+            type="button"
+            onClick={() => onChoice(option.id)}
+            disabled={disabled}
+          >
+            <span className="label">{option.label}</span>
+            {option.description === undefined ? null : (
+              <span className="detail">{option.description}</span>
+            )}
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+const ChatPanel = ({
+  state,
+  disabled,
+  onSend,
+  onChoice,
+}: {
+  readonly state: VisualAppState
+  readonly disabled: boolean
+  readonly onSend: (text: string) => void
+  readonly onChoice: (optionId: string) => void
+}) => {
+  const [draft, setDraft] = useState('')
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    const text = draft.trim()
+    if (text === '' || disabled) return
+    onSend(text)
+    setDraft('')
+  }
+
+  const keyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Enter' || event.shiftKey) return
+    event.preventDefault()
+    event.currentTarget.form?.requestSubmit()
+  }
+
+  return (
+    <section className="talk" aria-label="Conversation">
+      <ol className="ledger" role="log" aria-live="polite">
+        {state.transcript.length === 0 ? (
+          <li className="empty">
+            <p>Nothing asked yet. Question anything on the diagram.</p>
+          </li>
+        ) : (
+          state.transcript.map((record) => (
+            <li key={record.id} className={`said said-${record.speaker}`}>
+              <p className="who">{SPEAKERS[record.speaker]}</p>
+              <p className="words">{record.text}</p>
+            </li>
+          ))
+        )}
+      </ol>
+
+      <Faults diagnostics={state.diagnostics} />
+
+      {state.choices === null ? null : (
+        <Choices
+          choices={state.choices}
+          disabled={disabled}
+          onChoice={onChoice}
+        />
+      )}
+
+      <form className="composer" onSubmit={submit}>
+        <label className="offscreen" htmlFor="composer-text">
+          Ask about this design
+        </label>
+        <textarea
+          id="composer-text"
+          name="question"
+          rows={3}
+          value={draft}
+          disabled={disabled}
+          placeholder={
+            state.chatEnabled
+              ? 'Ask about this design'
+              : 'This session is read-only'
+          }
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={keyDown}
+        />
+        <div className="composer-foot">
+          <p className="agent-status">
+            {state.agentStatus === null
+              ? '\u00a0'
+              : (STATUS_WORDS[state.agentStatus.state] ?? '\u00a0')}
+          </p>
+          <button type="submit" disabled={disabled || draft.trim() === ''}>
+            Send
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}
+
+export const App = () => {
+  const { state, connected, ask, choose, navigate, end } = useVisualSession()
+  const lastGood = useRef<ReturnType<typeof likeC4ModelFrom> | null>(null)
+
+  const likec4model = useMemo(() => {
+    if (state.model === null) return lastGood.current
+    try {
+      lastGood.current = likeC4ModelFrom(state.model.compiled)
+    } catch {
+      // A rendering the browser cannot read is the same failure as one that did
+      // not compile: keep the last good drawing on screen.
+      return lastGood.current
+    }
+    return lastGood.current
+  }, [state.model])
+
+  const reduceGraphics = useMemo(
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  )
+
+  const authorityLabel = visualAuthorityLabel(state.authority)
+  const views = state.model?.views ?? []
+
+  return (
+    <main className="desk">
+      <section className="plan" aria-label="Architecture diagram">
+        <header>
+          <p className={`authority authority-${state.authority}`}>
+            {authorityLabel}
+          </p>
+          <h1>{state.title === '' ? 'Opening the session' : state.title}</h1>
+          <p className="lede">{state.description}</p>
+        </header>
+
+        <div className="canvas">
+          {likec4model === null ? (
+            <p className="waiting">
+              {state.lifecycle === 'connecting'
+                ? 'Reading the session'
+                : 'No model to draw'}
+            </p>
+          ) : (
+            <LikeC4ModelProvider likec4model={likec4model}>
+              <ReactLikeC4
+                viewId={state.activeView}
+                onNavigateTo={(viewId) => navigate(viewId)}
+                injectFontCss={false}
+                colorScheme="light"
+                background="dots"
+                controls
+                pannable
+                zoomable
+                fitView
+                keepAspectRatio={false}
+                enableElementDetails
+                enableRelationshipDetails
+                enableNotes
+                enableSearch={false}
+                showNavigationButtons
+                reduceGraphics={reduceGraphics ? true : 'auto'}
+                className="diagram"
+              />
+            </LikeC4ModelProvider>
+          )}
+        </div>
+
+        {views.length < 2 ? null : (
+          <nav className="views" aria-label="Views in this model">
+            <ul>
+              {views.map((viewId) => (
+                <li key={viewId}>
+                  <button
+                    type="button"
+                    onClick={() => navigate(viewId)}
+                    aria-current={viewId === state.activeView ? 'true' : undefined}
+                  >
+                    {viewId}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+      </section>
+
+      <Rail
+        authority={state.authority}
+        connection={connectionOf(state, connected)}
+        view={state.activeView}
+        onEnd={end}
+        endEnabled={state.lifecycle === 'active'}
+      />
+
+      <ChatPanel
+        state={state}
+        disabled={!state.composerEnabled}
+        onSend={ask}
+        onChoice={choose}
+      />
+    </main>
+  )
+}

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -82,6 +82,17 @@ const connectionOf = (state: VisualAppState, connected: boolean): string => {
   }
 }
 
+const endTransitionStatus = (state: VisualAppState): string => {
+  if (state.lifecycle === 'closed') {
+    return 'Visual conversation ended. Continue in the main agent.'
+  }
+  if (state.lifecycle !== 'ending') return ''
+  if (state.handoff !== null) {
+    return 'Handoff ready — returning control to the main agent.'
+  }
+  return 'Ending conversation — preparing a handoff for the main agent.'
+}
+
 const CommandStrip = ({
   state,
   connection,
@@ -114,6 +125,14 @@ const CommandStrip = ({
       <span className="connection-state" role="status">{connection}</span>
     </div>
     <div className="command-actions">
+      <span
+        className="end-transition-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {endTransitionStatus(state)}
+      </span>
       <label className="offscreen" htmlFor="active-view">Active view</label>
       <select
         id="active-view"
@@ -148,7 +167,7 @@ const CommandStrip = ({
         onClick={onEnd}
         disabled={state.lifecycle !== 'active'}
       >
-        End
+        {state.lifecycle === 'active' ? 'End' : 'Ending…'}
       </button>
     </div>
     {/* Static prose is not worth the canvas: the disclosure is laid over the
@@ -600,10 +619,22 @@ const ConversationPanel = ({
           onKeyDown={keyDown}
         />
         <div className="composer-foot">
-          <p className="agent-status">
-            {state.agentStatus === null
-              ? '\u00a0'
-              : (STATUS_WORDS[state.agentStatus.state] ?? '\u00a0')}
+          <p
+            className="agent-status"
+            role="status"
+            aria-live="polite"
+            aria-busy={state.awaitingAgent}
+          >
+            {state.awaitingAgent ? (
+              <span className="agent-spinner" aria-hidden="true" />
+            ) : null}
+            <span>
+              {state.agentStatus === null
+                ? state.awaitingAgent
+                  ? 'Awaiting agent response'
+                  : '\u00a0'
+                : (STATUS_WORDS[state.agentStatus.state] ?? '\u00a0')}
+            </span>
           </p>
           <button type="submit" disabled={disabled || draft.trim() === ''}>
             Send

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1,4 +1,4 @@
-import { LikeC4Model } from '@likec4/core/model'
+import { LikeC4Model, type AnyLikeC4Model } from '@likec4/core/model'
 import { LikeC4ModelProvider, ReactLikeC4 } from 'likec4/react'
 import {
   useMemo,
@@ -14,6 +14,7 @@ import type {
 import { useVisualSession } from './session-client.js'
 import {
   visualAuthorityLabel,
+  visualDrawingFor,
   type VisualAppRecord,
   type VisualAppState,
 } from './state.js'
@@ -32,7 +33,7 @@ import {
  * entry point that takes `createRequire` at load and so cannot run in a
  * browser. The compiled document belongs to LikeC4, which reads its own shape.
  */
-const likeC4ModelFrom = (compiled: unknown) =>
+const likeC4ModelFrom = (compiled: unknown): AnyLikeC4Model =>
   LikeC4Model.create(compiled as Parameters<typeof LikeC4Model.create>[0])
 
 const SPEAKERS: Readonly<Record<VisualAppRecord['speaker'], string>> = {
@@ -251,18 +252,16 @@ const ChatPanel = ({
 
 export const App = () => {
   const { state, connected, ask, choose, navigate, end } = useVisualSession()
-  const lastGood = useRef<ReturnType<typeof likeC4ModelFrom> | null>(null)
+  const lastDrawn = useRef<AnyLikeC4Model | null>(null)
 
-  const likec4model = useMemo(() => {
-    if (state.model === null) return lastGood.current
-    try {
-      lastGood.current = likeC4ModelFrom(state.model.compiled)
-    } catch {
-      // A rendering the browser cannot read is the same failure as one that did
-      // not compile: keep the last good drawing on screen.
-      return lastGood.current
-    }
-    return lastGood.current
+  const drawing = useMemo(() => {
+    const next = visualDrawingFor(
+      state.model,
+      likeC4ModelFrom,
+      lastDrawn.current,
+    )
+    lastDrawn.current = next.drawn
+    return next
   }, [state.model])
 
   const reduceGraphics = useMemo(
@@ -272,6 +271,14 @@ export const App = () => {
 
   const authorityLabel = visualAuthorityLabel(state.authority)
   const views = state.model?.views ?? []
+  // A fault already accounts for the empty canvas, and saying there is no model
+  // would contradict the one that arrived and could not be drawn.
+  const waiting =
+    drawing.drawn !== null || drawing.fault !== null
+      ? null
+      : state.lifecycle === 'connecting'
+        ? 'Reading the session'
+        : 'No model to draw'
 
   return (
     <main className="desk">
@@ -285,14 +292,8 @@ export const App = () => {
         </header>
 
         <div className="canvas">
-          {likec4model === null ? (
-            <p className="waiting">
-              {state.lifecycle === 'connecting'
-                ? 'Reading the session'
-                : 'No model to draw'}
-            </p>
-          ) : (
-            <LikeC4ModelProvider likec4model={likec4model}>
+          {drawing.drawn === null ? null : (
+            <LikeC4ModelProvider likec4model={drawing.drawn}>
               <ReactLikeC4
                 viewId={state.activeView}
                 onNavigateTo={(viewId) => navigate(viewId)}
@@ -317,7 +318,16 @@ export const App = () => {
               />
             </LikeC4ModelProvider>
           )}
+          {waiting === null ? null : <p className="waiting">{waiting}</p>}
         </div>
+
+        {drawing.fault === null ? null : (
+          // The renderer's exception describes its own internals and may carry
+          // anything: the reviewer reads this application's words instead.
+          <div className="faults" role="alert">
+            <p className="faults-title">{drawing.fault}</p>
+          </div>
+        )}
 
         {views.length < 2 ? null : (
           <nav className="views" aria-label="Views in this model">

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -308,6 +308,9 @@ export const App = () => {
                 enableRelationshipDetails
                 enableNotes
                 enableSearch={false}
+                // The renderer injects its own stylesheets; this session's
+                // policy admits them under this nonce and nothing else.
+                styleNonce={state.styleNonce}
                 showNavigationButtons
                 reduceGraphics={reduceGraphics ? true : 'auto'}
                 className="diagram"

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1,11 +1,15 @@
 import { LikeC4Model, type AnyLikeC4Model } from '@likec4/core/model'
 import { LikeC4ModelProvider, ReactLikeC4 } from 'likec4/react'
 import {
+  useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
+  type CSSProperties,
   type FormEvent,
   type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
 } from 'react'
 import type {
   VisualChoicePresentPayload,
@@ -17,11 +21,18 @@ import {
   visualDrawingFor,
   type VisualAppRecord,
   type VisualAppState,
+  type VisualDrawing,
 } from './state.js'
+import {
+  conversationWidthBounds,
+  createVisualWorkspaceState,
+  visualWorkspaceReducer,
+} from './workspace-state.js'
 
 /**
- * The review desk: the diagram the reviewer is judging, the rail that carries
- * the four facts they have to trust, and the conversation they answer in.
+ * A drawing board, not a document: the diagram holds the workspace, one compact
+ * strip carries the facts and the controls above it, and the conversation is a
+ * panel the reviewer sizes or puts away without losing what it holds.
  */
 
 /**
@@ -66,47 +77,83 @@ const connectionOf = (state: VisualAppState, connected: boolean): string => {
   }
 }
 
-const Rail = ({
-  authority,
+const CommandStrip = ({
+  state,
   connection,
-  view,
+  views,
+  detailsOpen,
+  conversationOpen,
+  unread,
+  onNavigate,
+  onToggleDetails,
+  onToggleConversation,
   onEnd,
-  endEnabled,
 }: {
-  readonly authority: 'canonical' | 'ad-hoc'
+  readonly state: VisualAppState
   readonly connection: string
-  readonly view: string
+  readonly views: readonly string[]
+  readonly detailsOpen: boolean
+  readonly conversationOpen: boolean
+  readonly unread: number
+  readonly onNavigate: (viewId: string) => void
+  readonly onToggleDetails: () => void
+  readonly onToggleConversation: () => void
   readonly onEnd: () => void
-  readonly endEnabled: boolean
 }) => (
-  <div className={`rail rail-${authority}`}>
-    <p className="station station-authority">
-      <span className="tick" />
-      <span className="value">
-        {authority === 'canonical' ? 'Checked' : 'Ad hoc'}
+  <header className="command-strip">
+    <div className="command-identity">
+      <h1>{state.title === '' ? 'Opening the session' : state.title}</h1>
+      <span className={`authority authority-${state.authority}`}>
+        {visualAuthorityLabel(state.authority)}
       </span>
-    </p>
-    <p
-      className={`station station-link link-${connection.toLowerCase()}`}
-      role="status"
+      <span className="connection-state">{connection}</span>
+    </div>
+    <div className="command-actions">
+      <label className="offscreen" htmlFor="active-view">Active view</label>
+      <select
+        id="active-view"
+        value={state.activeView}
+        onChange={(event) => onNavigate(event.target.value)}
+        disabled={views.length < 2}
+      >
+        {views.map((viewId) => (
+          <option key={viewId} value={viewId}>{viewId}</option>
+        ))}
+      </select>
+      <button
+        type="button"
+        aria-expanded={detailsOpen}
+        aria-controls="session-details"
+        onClick={onToggleDetails}
+      >
+        Details
+      </button>
+      <button
+        type="button"
+        aria-expanded={conversationOpen}
+        aria-controls="conversation-panel"
+        onClick={onToggleConversation}
+      >
+        Conversation
+        {unread === 0 ? null : <span className="attention-count">{unread}</span>}
+      </button>
+      <button
+        type="button"
+        className="end-session"
+        onClick={onEnd}
+        disabled={state.lifecycle !== 'active'}
+      >
+        End
+      </button>
+    </div>
+    <div
+      id="session-details"
+      className="session-details"
+      hidden={!detailsOpen}
     >
-      <span className="tick" />
-      <span className="value">{connection}</span>
-    </p>
-    <p className="station station-view">
-      <span className="tick" />
-      <span className="value">{view === '' ? 'No view' : view}</span>
-    </p>
-    <button
-      type="button"
-      className="end"
-      onClick={onEnd}
-      disabled={!endEnabled}
-      aria-label="End the review and return control to the main agent"
-    >
-      End
-    </button>
-  </div>
+      <p>{state.description}</p>
+    </div>
+  </header>
 )
 
 const Faults = ({
@@ -163,13 +210,71 @@ const Choices = ({
   </div>
 )
 
-const ChatPanel = ({
+const DiagramWorkspace = ({
   state,
+  drawing,
+  waiting,
+  reduceGraphics,
+  onNavigate,
+}: {
+  readonly state: VisualAppState
+  readonly drawing: VisualDrawing<AnyLikeC4Model>
+  readonly waiting: string | null
+  readonly reduceGraphics: boolean
+  readonly onNavigate: (viewId: string) => void
+}) => (
+  <section className="diagram-workspace" aria-label="Architecture diagram">
+    <div className="canvas">
+      {drawing.drawn === null ? null : (
+        <LikeC4ModelProvider likec4model={drawing.drawn}>
+          <ReactLikeC4
+            viewId={state.activeView}
+            onNavigateTo={(viewId) => onNavigate(viewId)}
+            injectFontCss={false}
+            colorScheme="light"
+            background="dots"
+            controls
+            pannable
+            zoomable
+            fitView
+            keepAspectRatio={false}
+            // The custom inspector is the only details surface, so the
+            // renderer's own overlays stay shut.
+            enableElementDetails={false}
+            enableRelationshipDetails={false}
+            enableNotes
+            enableSearch={false}
+            // The renderer injects its own stylesheets; this session's
+            // policy admits them under this nonce and nothing else.
+            styleNonce={state.styleNonce}
+            showNavigationButtons
+            reduceGraphics={reduceGraphics ? true : 'auto'}
+            className="diagram"
+          />
+        </LikeC4ModelProvider>
+      )}
+      {waiting === null ? null : <p className="waiting">{waiting}</p>}
+    </div>
+
+    {drawing.fault === null ? null : (
+      // The renderer's exception describes its own internals and may carry
+      // anything: the reviewer reads this application's words instead.
+      <div className="faults" role="alert">
+        <p className="faults-title">{drawing.fault}</p>
+      </div>
+    )}
+  </section>
+)
+
+const ConversationPanel = ({
+  state,
+  hidden,
   disabled,
   onSend,
   onChoice,
 }: {
   readonly state: VisualAppState
+  readonly hidden: boolean
   readonly disabled: boolean
   readonly onSend: (text: string) => void
   readonly onChoice: (optionId: string) => void
@@ -191,31 +296,38 @@ const ChatPanel = ({
   }
 
   return (
-    <section className="talk" aria-label="Conversation">
-      <ol className="ledger" role="log" aria-live="polite">
-        {state.transcript.length === 0 ? (
-          <li className="empty">
-            <p>Nothing asked yet. Question anything on the diagram.</p>
-          </li>
-        ) : (
-          state.transcript.map((record) => (
-            <li key={record.id} className={`said said-${record.speaker}`}>
-              <p className="who">{SPEAKERS[record.speaker]}</p>
-              <p className="words">{record.text}</p>
+    <section
+      id="conversation-panel"
+      className="talk"
+      aria-label="Conversation"
+      hidden={hidden}
+    >
+      <div className="conversation-scroll">
+        <ol className="ledger" role="log" aria-live="polite">
+          {state.transcript.length === 0 ? (
+            <li className="empty">
+              <p>Nothing asked yet. Question anything on the diagram.</p>
             </li>
-          ))
+          ) : (
+            state.transcript.map((record) => (
+              <li key={record.id} className={`said said-${record.speaker}`}>
+                <p className="who">{SPEAKERS[record.speaker]}</p>
+                <p className="words">{record.text}</p>
+              </li>
+            ))
+          )}
+        </ol>
+
+        <Faults diagnostics={state.diagnostics} />
+
+        {state.choices === null ? null : (
+          <Choices
+            choices={state.choices}
+            disabled={disabled}
+            onChoice={onChoice}
+          />
         )}
-      </ol>
-
-      <Faults diagnostics={state.diagnostics} />
-
-      {state.choices === null ? null : (
-        <Choices
-          choices={state.choices}
-          disabled={disabled}
-          onChoice={onChoice}
-        />
-      )}
+      </div>
 
       <form className="composer" onSubmit={submit}>
         <label className="offscreen" htmlFor="composer-text">
@@ -250,9 +362,123 @@ const ChatPanel = ({
   )
 }
 
+const ConversationSeparator = ({
+  width,
+  onResize,
+}: {
+  readonly width: number
+  readonly onResize: (width: number, viewportWidth: number) => void
+}) => {
+  const bounds = conversationWidthBounds(window.innerWidth)
+  const drag = useRef<{
+    readonly pointerId: number
+    readonly startX: number
+    readonly startWidth: number
+  } | null>(null)
+  const pointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const active = drag.current
+    if (active?.pointerId !== event.pointerId) return
+    onResize(
+      active.startWidth + active.startX - event.clientX,
+      window.innerWidth,
+    )
+  }
+  const pointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    drag.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: width,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+  const pointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (drag.current?.pointerId !== event.pointerId) return
+    drag.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+  const keyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+    event.preventDefault()
+    const step = event.shiftKey ? 32 : 8
+    onResize(
+      width + (event.key === 'ArrowLeft' ? step : -step),
+      window.innerWidth,
+    )
+  }
+  return (
+    <div
+      className="conversation-separator"
+      role="separator"
+      aria-label="Resize conversation"
+      aria-orientation="vertical"
+      aria-valuemin={bounds.min}
+      aria-valuemax={bounds.max}
+      aria-valuenow={Math.round(width)}
+      tabIndex={0}
+      onPointerDown={pointerDown}
+      onPointerMove={pointerMove}
+      onPointerUp={pointerUp}
+      onPointerCancel={pointerUp}
+      onKeyDown={keyDown}
+    />
+  )
+}
+
 export const App = () => {
   const { state, connected, ask, choose, navigate, end } = useVisualSession()
   const lastDrawn = useRef<AnyLikeC4Model | null>(null)
+
+  const [workspace, dispatchWorkspace] = useReducer(
+    visualWorkspaceReducer,
+    window.innerWidth,
+    createVisualWorkspaceState,
+  )
+
+  useEffect(() => {
+    const resized = () =>
+      dispatchWorkspace({
+        type: 'viewport.resized',
+        viewportWidth: window.innerWidth,
+      })
+    window.addEventListener('resize', resized)
+    return () => window.removeEventListener('resize', resized)
+  }, [])
+
+  // Only what arrived from the agent counts as attention: everything the
+  // reviewer did themselves is already in front of them.
+  const attention = useRef({
+    transcriptLength: state.transcript.length,
+    choices: state.choices,
+    diagnostics: state.diagnostics,
+  })
+
+  useEffect(() => {
+    const previous = attention.current
+    let receivedTranscript = false
+    for (
+      let index = previous.transcriptLength;
+      index < state.transcript.length;
+      index += 1
+    ) {
+      if (state.transcript[index]?.speaker === 'agent') {
+        receivedTranscript = true
+        break
+      }
+    }
+    const received =
+      receivedTranscript ||
+      (state.choices !== null && state.choices !== previous.choices) ||
+      (state.diagnostics.length > 0 &&
+        state.diagnostics !== previous.diagnostics)
+    attention.current = {
+      transcriptLength: state.transcript.length,
+      choices: state.choices,
+      diagnostics: state.diagnostics,
+    }
+    if (received) dispatchWorkspace({ type: 'attention.received' })
+  }, [state.transcript.length, state.choices, state.diagnostics])
 
   const drawing = useMemo(() => {
     const next = visualDrawingFor(
@@ -269,8 +495,6 @@ export const App = () => {
     [],
   )
 
-  const authorityLabel = visualAuthorityLabel(state.authority)
-  const views = state.model?.views ?? []
   // A fault already accounts for the empty canvas, and saying there is no model
   // would contradict the one that arrived and could not be drawn.
   const waiting =
@@ -280,88 +504,59 @@ export const App = () => {
         ? 'Reading the session'
         : 'No model to draw'
 
+  const conversationOpen = workspace.conversation.mode === 'open'
+  const shellStyle = {
+    '--conversation-width': `${workspace.conversation.width}px`,
+  } as CSSProperties
+
   return (
-    <main className="desk">
-      <section className="plan" aria-label="Architecture diagram">
-        <header>
-          <p className={`authority authority-${state.authority}`}>
-            {authorityLabel}
-          </p>
-          <h1>{state.title === '' ? 'Opening the session' : state.title}</h1>
-          <p className="lede">{state.description}</p>
-        </header>
-
-        <div className="canvas">
-          {drawing.drawn === null ? null : (
-            <LikeC4ModelProvider likec4model={drawing.drawn}>
-              <ReactLikeC4
-                viewId={state.activeView}
-                onNavigateTo={(viewId) => navigate(viewId)}
-                injectFontCss={false}
-                colorScheme="light"
-                background="dots"
-                controls
-                pannable
-                zoomable
-                fitView
-                keepAspectRatio={false}
-                enableElementDetails
-                enableRelationshipDetails
-                enableNotes
-                enableSearch={false}
-                // The renderer injects its own stylesheets; this session's
-                // policy admits them under this nonce and nothing else.
-                styleNonce={state.styleNonce}
-                showNavigationButtons
-                reduceGraphics={reduceGraphics ? true : 'auto'}
-                className="diagram"
-              />
-            </LikeC4ModelProvider>
-          )}
-          {waiting === null ? null : <p className="waiting">{waiting}</p>}
-        </div>
-
-        {drawing.fault === null ? null : (
-          // The renderer's exception describes its own internals and may carry
-          // anything: the reviewer reads this application's words instead.
-          <div className="faults" role="alert">
-            <p className="faults-title">{drawing.fault}</p>
-          </div>
-        )}
-
-        {views.length < 2 ? null : (
-          <nav className="views" aria-label="Views in this model">
-            <ul>
-              {views.map((viewId) => (
-                <li key={viewId}>
-                  <button
-                    type="button"
-                    onClick={() => navigate(viewId)}
-                    aria-current={viewId === state.activeView ? 'true' : undefined}
-                  >
-                    {viewId}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        )}
-      </section>
-
-      <Rail
-        authority={state.authority}
-        connection={connectionOf(state, connected)}
-        view={state.activeView}
-        onEnd={end}
-        endEnabled={state.lifecycle === 'active'}
-      />
-
-      <ChatPanel
+    <main className="visual-shell" style={shellStyle}>
+      <CommandStrip
         state={state}
-        disabled={!state.composerEnabled}
-        onSend={ask}
-        onChoice={choose}
+        connection={connectionOf(state, connected)}
+        views={state.model?.views ?? []}
+        detailsOpen={workspace.detailsOpen}
+        conversationOpen={conversationOpen}
+        unread={workspace.conversation.unread}
+        onNavigate={navigate}
+        onToggleDetails={() => dispatchWorkspace({ type: 'details.toggled' })}
+        onToggleConversation={() =>
+          dispatchWorkspace({ type: 'conversation.toggled' })
+        }
+        onEnd={end}
       />
+      <div
+        className={`workspace workspace-conversation-${
+          conversationOpen ? 'open' : 'closed'
+        }`}
+      >
+        <DiagramWorkspace
+          state={state}
+          drawing={drawing}
+          waiting={waiting}
+          reduceGraphics={reduceGraphics}
+          onNavigate={navigate}
+        />
+        {conversationOpen ? (
+          <ConversationSeparator
+            width={workspace.conversation.width}
+            onResize={(width, viewportWidth) =>
+              dispatchWorkspace({
+                type: 'conversation.resized',
+                width,
+                viewportWidth,
+              })
+            }
+          />
+        ) : null}
+        <ConversationPanel
+          state={state}
+          hidden={!conversationOpen}
+          disabled={!state.composerEnabled}
+          onSend={ask}
+          onChoice={choose}
+        />
+      </div>
     </main>
   )
 }

--- a/src/visual-app/index.html
+++ b/src/visual-app/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="no-referrer" />
+    <title>YarraMate visual session</title>
+    <script type="module" src="./main.tsx"></script>
+  </head>
+  <body>
+    <div id="visual-session"></div>
+    <noscript>
+      This review needs JavaScript: the diagram and the conversation are both
+      live.
+    </noscript>
+  </body>
+</html>

--- a/src/visual-app/main.tsx
+++ b/src/visual-app/main.tsx
@@ -1,0 +1,12 @@
+import { createRoot } from 'react-dom/client'
+import { App } from './App.js'
+import './styles.css'
+
+const mount = document.getElementById('visual-session')
+if (mount === null) {
+  throw new Error('The visual session page has no mount point')
+}
+
+// No StrictMode: its double mount would open the session socket twice, and this
+// bundle only ever runs as the production build the session server serves.
+createRoot(mount).render(<App />)

--- a/src/visual-app/session-client.tsx
+++ b/src/visual-app/session-client.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import type {
+  VisualServerFrame,
+  VisualSessionSnapshot,
+} from '../adapters/visual/wire.js'
+import {
+  canReconnect,
+  initialVisualAppState,
+  visualAppActionsForFrame,
+  visualAppReducer,
+  visualAppSnapshotFrom,
+  visualBrowserInputFor,
+  type VisualAppIntent,
+  type VisualAppState,
+} from './state.js'
+
+/**
+ * The session as the page holds it: one reducer, one socket, and nothing that
+ * decides anything on its own.
+ *
+ * Both routes are same-origin, so the session cookie the server minted at
+ * bootstrap authenticates them without this code ever seeing it. Nothing here
+ * reads or writes a credential, and nothing puts an identifier in the URL.
+ */
+
+const SESSION_ROUTE = '/api/session'
+const SOCKET_ROUTE = '/socket'
+
+/** Long enough not to hammer a restarting socket, short enough to feel live. */
+const RETRY_MS = 1000
+
+export interface VisualSession {
+  readonly state: VisualAppState
+  readonly connected: boolean
+  readonly ask: (text: string) => void
+  readonly choose: (optionId: string) => void
+  readonly navigate: (viewId: string) => void
+  readonly end: () => void
+}
+
+export const useVisualSession = (): VisualSession => {
+  const [state, dispatch] = useReducer(visualAppReducer, initialVisualAppState)
+  const [connected, setConnected] = useState(false)
+  const socketRef = useRef<WebSocket | null>(null)
+  // Senders read the settled state rather than a render's copy of it, so every
+  // frame carries the sequence this browser has actually seen acknowledged.
+  const stateRef = useRef(state)
+  stateRef.current = state
+
+  useEffect(() => {
+    let stopped = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let lostAt: number | null = null
+
+    const socketUrl = () => {
+      const url = new URL(SOCKET_ROUTE, window.location.href)
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      // Bootstrap for a resumed socket: where this browser's record stops. The
+      // per-frame acknowledgement is what admission checks against.
+      url.searchParams.set('after', String(stateRef.current.lastSequence))
+      return url
+    }
+
+    const reconnect = () => {
+      if (stopped) return
+      lostAt ??= Date.now()
+      // Past the grace the server has already recovered the handoff, so there
+      // is nothing left to reconnect to.
+      if (!canReconnect(lostAt, Date.now())) {
+        dispatch({ type: 'session.closed', reason: 'browser-timeout' })
+        return
+      }
+      timer = setTimeout(connect, RETRY_MS)
+    }
+
+    const connect = () => {
+      if (stopped) return
+      const socket = new WebSocket(socketUrl())
+      socketRef.current = socket
+      socket.addEventListener('open', () => {
+        lostAt = null
+        setConnected(true)
+      })
+      socket.addEventListener('message', (event: MessageEvent<unknown>) => {
+        if (typeof event.data !== 'string') return
+        let frame: VisualServerFrame
+        try {
+          frame = JSON.parse(event.data) as VisualServerFrame
+        } catch {
+          return
+        }
+        for (const action of visualAppActionsForFrame(frame)) dispatch(action)
+      })
+      socket.addEventListener('close', () => {
+        setConnected(false)
+        socketRef.current = null
+        if (stopped || stateRef.current.lifecycle === 'closed') return
+        dispatch({ type: 'connection.lost' })
+        reconnect()
+      })
+      socket.addEventListener('error', () => socket.close())
+    }
+
+    const load = async () => {
+      const response = await fetch(SESSION_ROUTE, {
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      })
+      if (!response.ok) {
+        throw new Error(`Session request answered ${response.status}`)
+      }
+      const snapshot = (await response.json()) as VisualSessionSnapshot
+      if (stopped) return
+      dispatch({
+        type: 'session.loaded',
+        snapshot: visualAppSnapshotFrom(snapshot),
+      })
+      connect()
+    }
+
+    void load().catch(() => {
+      if (stopped) return
+      dispatch({ type: 'connection.lost' })
+      reconnect()
+    })
+
+    return () => {
+      stopped = true
+      if (timer !== undefined) clearTimeout(timer)
+      socketRef.current?.close()
+    }
+  }, [])
+
+  const send = useCallback((intent: VisualAppIntent) => {
+    const socket = socketRef.current
+    if (socket === null || socket.readyState !== WebSocket.OPEN) return
+    socket.send(JSON.stringify(visualBrowserInputFor(intent, stateRef.current)))
+  }, [])
+
+  const ask = useCallback(
+    (text: string) => {
+      dispatch({ type: 'chat.sent', text })
+      send({ kind: 'chat', text })
+    },
+    [send],
+  )
+
+  const choose = useCallback(
+    (optionId: string) => {
+      const choiceId = stateRef.current.choices?.choiceId
+      if (choiceId === undefined) return
+      dispatch({ type: 'choice.sent', optionId })
+      send({ kind: 'choice', choiceId, optionId })
+    },
+    [send],
+  )
+
+  const navigate = useCallback(
+    (viewId: string) => {
+      // The reviewer moves first; the agent is told where they went.
+      dispatch({ type: 'view.navigated', viewId })
+      send({ kind: 'navigate', viewId })
+    },
+    [send],
+  )
+
+  const end = useCallback(() => {
+    dispatch({ type: 'end.requested' })
+    send({ kind: 'end' })
+  }, [send])
+
+  return { state, connected, ask, choose, navigate, end }
+}

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -30,6 +30,19 @@ export const RECONNECT_WINDOW_MS = VISUAL_LIMITS.reconnectMs
 /** Shown the moment End is requested, and kept in the record. */
 export const VISUAL_END_NOTICE = 'Returning control to the main agent'
 
+/**
+ * What the reviewer is told when a rendering the server compiled is one this
+ * browser's renderer cannot read: one for a canvas that still has the drawing
+ * before it, one for a canvas that has nothing to keep. The renderer's own
+ * exception names its internals and may carry anything, so it never reaches the
+ * page; these are the only words for that failure.
+ */
+export const VISUAL_DRAW_FAULT_KEPT =
+  'The latest model could not be drawn. The diagram still shows the last one that could.'
+
+export const VISUAL_DRAW_FAULT_BARE =
+  'The model could not be drawn. Nothing is on the canvas until one that can be drawn arrives.'
+
 export type VisualAppLifecycle =
   | 'connecting'
   | 'active'
@@ -91,7 +104,7 @@ export type VisualAppAction =
   | { readonly type: 'model.received'; readonly model: VisualRenderedModel }
   | {
       readonly type: 'diagnostic.received'
-      readonly diagnostic: VisualDiagnostic
+      readonly diagnostics: readonly VisualDiagnostic[]
     }
   | { readonly type: 'chat.sent'; readonly text: string }
   | {
@@ -117,7 +130,7 @@ export type VisualAppAction =
   | { readonly type: 'event.acknowledged'; readonly sequence: number }
   | {
       readonly type: 'input.refused'
-      readonly diagnostic: VisualDiagnostic
+      readonly diagnostics: readonly VisualDiagnostic[]
       readonly frozen: boolean
     }
   | { readonly type: 'end.requested' }
@@ -173,6 +186,39 @@ export const visualAuthorityLabel = (authority: VisualAuthority): string =>
  */
 export const canReconnect = (lostAt: number, now: number): boolean =>
   now - lostAt < RECONNECT_WINDOW_MS
+
+/** What is on the canvas, and why nothing newer is. */
+export interface VisualDrawing<TDrawing> {
+  /** The rendering to draw: the new one, or the last one that could be drawn. */
+  readonly drawn: TDrawing | null
+  /** Why the newest rendering is not on screen, in this application's words. */
+  readonly fault: string | null
+}
+
+/**
+ * The candidate as a drawing, or the last good drawing and a fault.
+ *
+ * A rendering the server compiled can still be one the renderer here refuses,
+ * and a desk that answers that by blanking the canvas has taken away the
+ * reviewer's place for a reason only a console would hold. The failed candidate
+ * is dropped; the drawing that worked is not, and the reviewer is told why.
+ */
+export const visualDrawingFor = <TDrawing>(
+  model: VisualRenderedModel | null,
+  draw: (compiled: unknown) => TDrawing,
+  lastDrawn: TDrawing | null,
+): VisualDrawing<TDrawing> => {
+  if (model === null) return { drawn: lastDrawn, fault: null }
+  try {
+    return { drawn: draw(model.compiled), fault: null }
+  } catch {
+    return {
+      drawn: lastDrawn,
+      fault:
+        lastDrawn === null ? VISUAL_DRAW_FAULT_BARE : VISUAL_DRAW_FAULT_KEPT,
+    }
+  }
+}
 
 /**
  * A record this browser wrote itself, keyed by a counter rather than by
@@ -249,9 +295,11 @@ const transition = (
       }
     case 'diagnostic.received':
       // The candidate that failed is gone; what is on screen still compiled.
+      // One failure has as many reasons as it has, and the reviewer reads all
+      // of them: keeping only the last would hide the one they need.
       return {
         ...state,
-        diagnostics: [action.diagnostic],
+        diagnostics: action.diagnostics,
         ...turnAnswered,
       }
     case 'chat.sent':
@@ -319,7 +367,7 @@ const transition = (
     case 'input.refused':
       return {
         ...state,
-        diagnostics: [action.diagnostic],
+        diagnostics: action.diagnostics,
         frozen: state.frozen || action.frozen,
         ...turnAnswered,
       }
@@ -429,11 +477,14 @@ export const visualAppActionsForFrame = (
     case 'accepted':
       return [{ type: 'event.acknowledged', sequence: frame.sequence }]
     case 'rejected':
-      return frame.diagnostics.map((diagnostic) => ({
-        type: 'input.refused',
-        diagnostic,
-        frozen: frame.frozen !== undefined,
-      }))
+      // One refusal, however many reasons it carries.
+      return [
+        {
+          type: 'input.refused',
+          diagnostics: frame.diagnostics,
+          frozen: frame.frozen !== undefined,
+        },
+      ]
     case 'model':
       return [{ type: 'model.received', model: frame.model }]
     case 'closing':
@@ -461,10 +512,12 @@ export const visualAppActionsForFrame = (
             },
           ]
         case 'diagnostic':
-          return frame.response.payload.diagnostics.map((diagnostic) => ({
-            type: 'diagnostic.received',
-            diagnostic,
-          }))
+          return [
+            {
+              type: 'diagnostic.received',
+              diagnostics: frame.response.payload.diagnostics,
+            },
+          ]
         case 'model.replace':
           // The promoted candidate arrives as its own frame, compiled. The
           // response is the journal's copy of the request, not a rendering.

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -55,6 +55,7 @@ export interface VisualAppSnapshot {
   readonly chatEnabled: boolean
   readonly model: VisualRenderedModel
   readonly transcript: readonly VisualTranscriptRecord[]
+  readonly agentTurnOpen: boolean
   readonly styleNonce: string
   readonly lastSequence: number
   readonly frozen: boolean
@@ -77,6 +78,8 @@ export interface VisualAppState {
   readonly handoff: VisualHandoffSummary | null
   readonly composerEnabled: boolean
   readonly awaitingAgent: boolean
+  /** Records this browser has written itself, so a key is never reused. */
+  readonly localRecords: number
   readonly lastSequence: number
   readonly frozen: boolean
   readonly closedReason: string | null
@@ -136,6 +139,7 @@ export const initialVisualAppState: VisualAppState = {
   handoff: null,
   composerEnabled: false,
   awaitingAgent: false,
+  localRecords: 0,
   lastSequence: 0,
   frozen: false,
   closedReason: null,
@@ -150,6 +154,7 @@ export const visualAppSnapshotFrom = (
   chatEnabled: snapshot.chatEnabled,
   model: snapshot.model,
   transcript: snapshot.transcript,
+  agentTurnOpen: snapshot.agentTurnOpen,
   styleNonce: snapshot.styleNonce,
   lastSequence: snapshot.lastSequence,
   frozen: snapshot.frozen,
@@ -167,21 +172,33 @@ export const visualAuthorityLabel = (authority: VisualAuthority): string =>
 export const canReconnect = (lostAt: number, now: number): boolean =>
   now - lostAt < RECONNECT_WINDOW_MS
 
-/** A record keyed by its position, for the records the server never named. */
+/**
+ * A record this browser wrote itself, keyed by a counter rather than by
+ * position: a restored conversation changes the position of everything, and a
+ * key that moves is a key that can collide.
+ */
 const localRecord = (
   state: VisualAppState,
   speaker: VisualAppSpeaker,
   text: string,
 ): VisualAppRecord => ({
-  id: `local-${state.transcript.length}`,
+  id: `local-${state.localRecords}`,
   speaker,
   text,
 })
 
+/**
+ * The record appended, unless the conversation already holds it. A reconnect
+ * can restore a record and then replay the frame that produced it; both name it
+ * by the same identifier, and it was said once.
+ */
 const withRecord = (
   state: VisualAppState,
   record: VisualAppRecord,
-): readonly VisualAppRecord[] => [...state.transcript, record]
+): readonly VisualAppRecord[] =>
+  state.transcript.some((existing) => existing.id === record.id)
+    ? state.transcript
+    : [...state.transcript, record]
 
 /** The view the reviewer keeps, or the one the new model opens on. */
 const viewWithin = (model: VisualRenderedModel, activeView: string): string =>
@@ -214,6 +231,11 @@ const transition = (
           ...action.snapshot.transcript,
           ...state.transcript.filter((record) => record.speaker === 'session'),
         ],
+        // The session knows whether the turn is still open; a browser that was
+        // away while the agent answered must not stay locked out, and one that
+        // reconnects mid-turn must not be told the agent is idle.
+        awaitingAgent: action.snapshot.agentTurnOpen,
+        agentStatus: action.snapshot.agentTurnOpen ? state.agentStatus : null,
         lastSequence: Math.max(state.lastSequence, action.snapshot.lastSequence),
       }
     case 'model.received':
@@ -237,6 +259,7 @@ const transition = (
           state,
           localRecord(state, 'reviewer', action.text),
         ),
+        localRecords: state.localRecords + 1,
         choices: null,
         awaitingAgent: true,
       }
@@ -303,6 +326,7 @@ const transition = (
           state,
           localRecord(state, 'session', VISUAL_END_NOTICE),
         ),
+        localRecords: state.localRecords + 1,
       }
     case 'connection.lost':
       return { ...state, lifecycle: 'disconnected' }

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -11,6 +11,7 @@ import type {
   VisualRenderedModel,
   VisualServerFrame,
   VisualSessionSnapshot,
+  VisualTranscriptRecord,
 } from '../adapters/visual/wire.js'
 
 /**
@@ -36,12 +37,14 @@ export type VisualAppLifecycle =
   | 'disconnected'
   | 'closed'
 
-export type VisualAppSpeaker = 'reviewer' | 'agent' | 'session'
+/**
+ * The session speaks too: it is the browser, not the agent, that tells the
+ * reviewer control is going back.
+ */
+export type VisualAppSpeaker = VisualTranscriptRecord['speaker'] | 'session'
 
-export interface VisualAppRecord {
-  readonly id: string
+export interface VisualAppRecord extends Omit<VisualTranscriptRecord, 'speaker'> {
   readonly speaker: VisualAppSpeaker
-  readonly text: string
 }
 
 /** The part of the server snapshot that decides what the browser renders. */
@@ -51,6 +54,8 @@ export interface VisualAppSnapshot {
   readonly description: string
   readonly chatEnabled: boolean
   readonly model: VisualRenderedModel
+  readonly transcript: readonly VisualTranscriptRecord[]
+  readonly styleNonce: string
   readonly lastSequence: number
   readonly frozen: boolean
 }
@@ -63,6 +68,7 @@ export interface VisualAppState {
   readonly chatEnabled: boolean
   /** Last model that compiled. A failed candidate never replaces it. */
   readonly model: VisualRenderedModel | null
+  readonly styleNonce: string
   readonly activeView: string
   readonly transcript: readonly VisualAppRecord[]
   readonly choices: VisualChoicePresentPayload | null
@@ -121,6 +127,7 @@ export const initialVisualAppState: VisualAppState = {
   description: '',
   chatEnabled: false,
   model: null,
+  styleNonce: '',
   activeView: '',
   transcript: [],
   choices: null,
@@ -142,6 +149,8 @@ export const visualAppSnapshotFrom = (
   description: snapshot.description,
   chatEnabled: snapshot.chatEnabled,
   model: snapshot.model,
+  transcript: snapshot.transcript,
+  styleNonce: snapshot.styleNonce,
   lastSequence: snapshot.lastSequence,
   frozen: snapshot.frozen,
 })
@@ -198,6 +207,13 @@ const transition = (
         // holds — never that a session the reviewer already ended is open.
         lifecycle: state.lifecycle === 'ending' ? 'ending' : 'active',
         activeView: viewWithin(action.snapshot.model, state.activeView),
+        // The session owns what was said; this browser owns only what it told
+        // the reviewer itself, so a reload restores the record and keeps its
+        // own notices.
+        transcript: [
+          ...action.snapshot.transcript,
+          ...state.transcript.filter((record) => record.speaker === 'session'),
+        ],
         lastSequence: Math.max(state.lastSequence, action.snapshot.lastSequence),
       }
     case 'model.received':

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -56,6 +56,7 @@ export interface VisualAppSnapshot {
   readonly model: VisualRenderedModel
   readonly transcript: readonly VisualTranscriptRecord[]
   readonly agentTurnOpen: boolean
+  readonly choices: VisualChoicePresentPayload | null
   readonly styleNonce: string
   readonly lastSequence: number
   readonly frozen: boolean
@@ -155,6 +156,7 @@ export const visualAppSnapshotFrom = (
   model: snapshot.model,
   transcript: snapshot.transcript,
   agentTurnOpen: snapshot.agentTurnOpen,
+  choices: snapshot.pendingChoice,
   styleNonce: snapshot.styleNonce,
   lastSequence: snapshot.lastSequence,
   frozen: snapshot.frozen,

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -1,0 +1,428 @@
+import {
+  VISUAL_LIMITS,
+  type VisualAgentStatusPayload,
+  type VisualAuthority,
+  type VisualBrowserInput,
+  type VisualChoicePresentPayload,
+  type VisualDiagnostic,
+  type VisualHandoffSummary,
+} from '../adapters/visual/protocol-contract.js'
+import type {
+  VisualRenderedModel,
+  VisualServerFrame,
+  VisualSessionSnapshot,
+} from '../adapters/visual/wire.js'
+
+/**
+ * Everything the browser knows about a visual session, and the only place it
+ * is decided.
+ *
+ * The reducer is pure and total: every frame the server can send, and every
+ * intent the reviewer can express, becomes one action, and nothing else in the
+ * application may change what is on screen. Transcript records are plain text
+ * and are rendered through React text nodes, never as markup.
+ */
+
+/** How long after losing the socket the server still holds this session. */
+export const RECONNECT_WINDOW_MS = VISUAL_LIMITS.reconnectMs
+
+/** Shown the moment End is requested, and kept in the record. */
+export const VISUAL_END_NOTICE = 'Returning control to the main agent'
+
+export type VisualAppLifecycle =
+  | 'connecting'
+  | 'active'
+  | 'ending'
+  | 'disconnected'
+  | 'closed'
+
+export type VisualAppSpeaker = 'reviewer' | 'agent' | 'session'
+
+export interface VisualAppRecord {
+  readonly id: string
+  readonly speaker: VisualAppSpeaker
+  readonly text: string
+}
+
+/** The part of the server snapshot that decides what the browser renders. */
+export interface VisualAppSnapshot {
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  readonly model: VisualRenderedModel
+  readonly lastSequence: number
+  readonly frozen: boolean
+}
+
+export interface VisualAppState {
+  readonly lifecycle: VisualAppLifecycle
+  readonly authority: VisualAuthority
+  readonly title: string
+  readonly description: string
+  readonly chatEnabled: boolean
+  /** Last model that compiled. A failed candidate never replaces it. */
+  readonly model: VisualRenderedModel | null
+  readonly activeView: string
+  readonly transcript: readonly VisualAppRecord[]
+  readonly choices: VisualChoicePresentPayload | null
+  readonly agentStatus: VisualAgentStatusPayload | null
+  readonly diagnostics: readonly VisualDiagnostic[]
+  readonly handoff: VisualHandoffSummary | null
+  readonly composerEnabled: boolean
+  readonly awaitingAgent: boolean
+  readonly lastSequence: number
+  readonly frozen: boolean
+  readonly closedReason: string | null
+}
+
+export type VisualAppAction =
+  | { readonly type: 'session.loaded'; readonly snapshot: VisualAppSnapshot }
+  | { readonly type: 'model.received'; readonly model: VisualRenderedModel }
+  | {
+      readonly type: 'diagnostic.received'
+      readonly diagnostic: VisualDiagnostic
+    }
+  | { readonly type: 'chat.sent'; readonly text: string }
+  | {
+      readonly type: 'chat.received'
+      readonly id: string
+      readonly text: string
+    }
+  | {
+      readonly type: 'status.received'
+      readonly status: VisualAgentStatusPayload
+    }
+  | {
+      readonly type: 'choice.presented'
+      readonly choice: VisualChoicePresentPayload
+    }
+  | { readonly type: 'choice.sent'; readonly optionId: string }
+  | { readonly type: 'view.navigated'; readonly viewId: string }
+  | {
+      readonly type: 'handoff.received'
+      readonly id: string
+      readonly handoff: VisualHandoffSummary
+    }
+  | { readonly type: 'event.acknowledged'; readonly sequence: number }
+  | {
+      readonly type: 'input.refused'
+      readonly diagnostic: VisualDiagnostic
+      readonly frozen: boolean
+    }
+  | { readonly type: 'end.requested' }
+  | { readonly type: 'connection.lost' }
+  | { readonly type: 'session.closed'; readonly reason: string }
+
+export const initialVisualAppState: VisualAppState = {
+  lifecycle: 'connecting',
+  authority: 'ad-hoc',
+  title: '',
+  description: '',
+  chatEnabled: false,
+  model: null,
+  activeView: '',
+  transcript: [],
+  choices: null,
+  agentStatus: null,
+  diagnostics: [],
+  handoff: null,
+  composerEnabled: false,
+  awaitingAgent: false,
+  lastSequence: 0,
+  frozen: false,
+  closedReason: null,
+}
+
+export const visualAppSnapshotFrom = (
+  snapshot: VisualSessionSnapshot,
+): VisualAppSnapshot => ({
+  authority: snapshot.authority,
+  title: snapshot.title,
+  description: snapshot.description,
+  chatEnabled: snapshot.chatEnabled,
+  model: snapshot.model,
+  lastSequence: snapshot.lastSequence,
+  frozen: snapshot.frozen,
+})
+
+/** The exact words for what the reviewer is looking at. */
+export const visualAuthorityLabel = (authority: VisualAuthority): string =>
+  authority === 'canonical' ? 'Checked YarraMate model' : 'Ad hoc · non-canonical'
+
+/**
+ * A dropped socket is recoverable only while the server still holds the
+ * session. Past the grace it has already recovered the handoff, so retrying
+ * would only spend the reviewer's attention on a session that no longer exists.
+ */
+export const canReconnect = (lostAt: number, now: number): boolean =>
+  now - lostAt < RECONNECT_WINDOW_MS
+
+/** A record keyed by its position, for the records the server never named. */
+const localRecord = (
+  state: VisualAppState,
+  speaker: VisualAppSpeaker,
+  text: string,
+): VisualAppRecord => ({
+  id: `local-${state.transcript.length}`,
+  speaker,
+  text,
+})
+
+const withRecord = (
+  state: VisualAppState,
+  record: VisualAppRecord,
+): readonly VisualAppRecord[] => [...state.transcript, record]
+
+/** The view the reviewer keeps, or the one the new model opens on. */
+const viewWithin = (model: VisualRenderedModel, activeView: string): string =>
+  model.views.includes(activeView) ? activeView : model.initialView
+
+/**
+ * The turn is over. The composer reopens, and the status the agent reported
+ * while it worked is dropped: nobody may be told the agent is still thinking
+ * about a question it has answered.
+ */
+const turnAnswered = { awaitingAgent: false, agentStatus: null } as const
+
+const transition = (
+  state: VisualAppState,
+  action: VisualAppAction,
+): VisualAppState => {
+  switch (action.type) {
+    case 'session.loaded':
+      return {
+        ...state,
+        ...action.snapshot,
+        // A reconnect re-sends the snapshot, and it reports what the session
+        // holds — never that a session the reviewer already ended is open.
+        lifecycle: state.lifecycle === 'ending' ? 'ending' : 'active',
+        activeView: viewWithin(action.snapshot.model, state.activeView),
+        lastSequence: Math.max(state.lastSequence, action.snapshot.lastSequence),
+      }
+    case 'model.received':
+      return {
+        ...state,
+        model: action.model,
+        activeView: viewWithin(action.model, state.activeView),
+        diagnostics: [],
+      }
+    case 'diagnostic.received':
+      // The candidate that failed is gone; what is on screen still compiled.
+      return {
+        ...state,
+        diagnostics: [action.diagnostic],
+        ...turnAnswered,
+      }
+    case 'chat.sent':
+      return {
+        ...state,
+        transcript: withRecord(
+          state,
+          localRecord(state, 'reviewer', action.text),
+        ),
+        choices: null,
+        awaitingAgent: true,
+      }
+    case 'chat.received':
+      return {
+        ...state,
+        transcript: withRecord(state, {
+          id: action.id,
+          speaker: 'agent',
+          text: action.text,
+        }),
+        ...turnAnswered,
+      }
+    case 'status.received':
+      return { ...state, agentStatus: action.status }
+    case 'choice.presented':
+      return { ...state, choices: action.choice, ...turnAnswered }
+    case 'choice.sent': {
+      const chosen = state.choices?.options.find(
+        (option) => option.id === action.optionId,
+      )
+      if (chosen === undefined) return state
+      return {
+        ...state,
+        transcript: withRecord(state, localRecord(state, 'reviewer', chosen.label)),
+        choices: null,
+        awaitingAgent: true,
+      }
+    }
+    case 'view.navigated':
+      // Drill-down is local: the reviewer never waits for the agent to redraw.
+      return state.activeView === action.viewId
+        ? state
+        : { ...state, activeView: action.viewId }
+    case 'handoff.received':
+      return {
+        ...state,
+        handoff: action.handoff,
+        transcript: withRecord(state, {
+          id: action.id,
+          speaker: 'agent',
+          text: action.handoff.summary,
+        }),
+        ...turnAnswered,
+      }
+    case 'event.acknowledged':
+      return {
+        ...state,
+        lastSequence: Math.max(state.lastSequence, action.sequence),
+      }
+    case 'input.refused':
+      return {
+        ...state,
+        diagnostics: [action.diagnostic],
+        frozen: state.frozen || action.frozen,
+        ...turnAnswered,
+      }
+    case 'end.requested':
+      return {
+        ...state,
+        lifecycle: 'ending',
+        choices: null,
+        transcript: withRecord(
+          state,
+          localRecord(state, 'session', VISUAL_END_NOTICE),
+        ),
+      }
+    case 'connection.lost':
+      return { ...state, lifecycle: 'disconnected' }
+    case 'session.closed':
+      return { ...state, lifecycle: 'closed', closedReason: action.reason }
+  }
+}
+
+/**
+ * Whether the reviewer may type. Derived rather than assigned, so no transition
+ * can leave a live session with dead controls or a closed one with live ones.
+ */
+const composerOpen = (state: VisualAppState): boolean =>
+  state.lifecycle === 'active' &&
+  state.chatEnabled &&
+  !state.frozen &&
+  !state.awaitingAgent
+
+export function visualAppReducer(
+  state: VisualAppState,
+  action: VisualAppAction,
+): VisualAppState {
+  // A closed session is the end of the record: the server has already recovered
+  // the handoff, so nothing that arrives afterwards may change what it says.
+  if (state.lifecycle === 'closed') return state
+  const next = transition(state, action)
+  if (next === state) return state
+  return { ...next, composerEnabled: composerOpen(next) }
+}
+
+/** Everything the reviewer can ask the session to do. */
+export type VisualAppIntent =
+  | { readonly kind: 'chat'; readonly text: string }
+  | {
+      readonly kind: 'choice'
+      readonly choiceId: string
+      readonly optionId: string
+    }
+  | { readonly kind: 'navigate'; readonly viewId: string }
+  | { readonly kind: 'end' }
+
+/**
+ * One intent as the frame the server admits. Every frame carries the sequence
+ * this browser last saw acknowledged, so a session that reconnected mid-turn
+ * cannot slip a frame in behind a journal it never read.
+ */
+export const visualBrowserInputFor = (
+  intent: VisualAppIntent,
+  state: VisualAppState,
+): VisualBrowserInput => {
+  const lastAcknowledgedSequence = state.lastSequence
+  switch (intent.kind) {
+    case 'chat':
+      return {
+        type: 'chat.message',
+        lastAcknowledgedSequence,
+        payload: { text: intent.text },
+      }
+    case 'choice':
+      return {
+        type: 'choice.selected',
+        lastAcknowledgedSequence,
+        payload: { choiceId: intent.choiceId, optionId: intent.optionId },
+      }
+    case 'navigate':
+      return {
+        type: 'view.navigate',
+        lastAcknowledgedSequence,
+        // Drill-down is the reviewer reading, not a question: the agent is told
+        // where they went without being asked to answer for it.
+        payload: { viewId: intent.viewId, requiresAttention: false },
+      }
+    case 'end':
+      return {
+        type: 'session.end',
+        lastAcknowledgedSequence,
+        payload: { reason: 'user-ended' },
+      }
+  }
+}
+
+/**
+ * One server frame as the actions it means. Translation is pure so the socket
+ * owns nothing but the socket.
+ */
+export const visualAppActionsForFrame = (
+  frame: VisualServerFrame,
+): readonly VisualAppAction[] => {
+  switch (frame.kind) {
+    case 'ready':
+      return [
+        { type: 'session.loaded', snapshot: visualAppSnapshotFrom(frame.snapshot) },
+      ]
+    case 'accepted':
+      return [{ type: 'event.acknowledged', sequence: frame.sequence }]
+    case 'rejected':
+      return frame.diagnostics.map((diagnostic) => ({
+        type: 'input.refused',
+        diagnostic,
+        frozen: frame.frozen !== undefined,
+      }))
+    case 'model':
+      return [{ type: 'model.received', model: frame.model }]
+    case 'closing':
+      return [{ type: 'session.closed', reason: frame.reason }]
+    case 'response':
+      switch (frame.response.type) {
+        case 'chat.response':
+          return [
+            {
+              type: 'chat.received',
+              id: frame.response.responseId,
+              text: frame.response.payload.text,
+            },
+          ]
+        case 'agent.status':
+          return [{ type: 'status.received', status: frame.response.payload }]
+        case 'choice.present':
+          return [{ type: 'choice.presented', choice: frame.response.payload }]
+        case 'handoff.complete':
+          return [
+            {
+              type: 'handoff.received',
+              id: frame.response.responseId,
+              handoff: frame.response.payload,
+            },
+          ]
+        case 'diagnostic':
+          return frame.response.payload.diagnostics.map((diagnostic) => ({
+            type: 'diagnostic.received',
+            diagnostic,
+          }))
+        case 'model.replace':
+          // The promoted candidate arrives as its own frame, compiled. The
+          // response is the journal's copy of the request, not a rendering.
+          return []
+      }
+  }
+}

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -284,7 +284,11 @@ const transition = (
       if (chosen === undefined) return state
       return {
         ...state,
-        transcript: withRecord(state, localRecord(state, 'reviewer', chosen.label)),
+        transcript: withRecord(
+          state,
+          localRecord(state, 'reviewer', chosen.label),
+        ),
+        localRecords: state.localRecords + 1,
         choices: null,
         awaitingAgent: true,
       }

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -262,6 +262,78 @@ body {
   overflow: auto;
 }
 
+.subject-inspector {
+  padding: calc(var(--step) * 1.5);
+  border-bottom: 1px solid var(--rule);
+  background: color-mix(in srgb, var(--sheet) 92%, var(--cobalt) 8%);
+}
+
+.subject-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--step);
+}
+
+.subject-type {
+  margin: 0 0 calc(var(--step) * 0.25);
+  color: var(--quiet);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.subject-heading-row h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.subject-facts {
+  display: grid;
+  gap: calc(var(--step) * 0.5);
+  margin: var(--step) 0;
+}
+
+.subject-facts > div {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr);
+  gap: var(--step);
+}
+
+.subject-facts dt {
+  color: var(--quiet);
+  font-size: 11px;
+}
+
+.subject-facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.subject-description p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.description-clamped {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.subject-description button,
+.subject-navigate,
+.subject-clear {
+  margin-top: calc(var(--step) * 0.5);
+  min-height: 28px;
+}
+
 .ledger {
   margin: 0;
   padding: calc(var(--step) * 2) calc(var(--step) * 2.5);
@@ -449,6 +521,34 @@ body {
   background: transparent;
   border-color: var(--rule-firm);
   cursor: not-allowed;
+}
+
+.subject-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--step);
+  margin-bottom: calc(var(--step) * 0.75);
+  padding: calc(var(--step) * 0.5) calc(var(--step) * 0.75);
+  border: 1px solid var(--cobalt);
+  border-radius: 999px;
+  color: var(--cobalt);
+}
+
+.subject-chip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subject-chip button {
+  flex: none;
+  min-height: 24px;
+  padding: 0 calc(var(--step) * 0.5);
+  border: 0;
+  background: transparent;
+  color: inherit;
 }
 
 /* ---------------------------------------------------------------- narrow */

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1,0 +1,581 @@
+/*
+ * A drafting desk, not a dashboard: paper ground, charcoal ink, hairline rules,
+ * and one signature — the handoff rail that joins the drawing to the
+ * conversation and ends at the control that hands the review back.
+ *
+ * Every face is a system stack, every colour is one of the six the session
+ * speaks in, and nothing is loaded from anywhere but this origin.
+ */
+
+:root {
+  --paper: #e8eef0;
+  --ink: #182228;
+  --eucalyptus: #416f65;
+  --ochre: #b66a2c;
+  --cobalt: #2457a6;
+  --failure: #a3403a;
+
+  --sheet: color-mix(in oklab, var(--paper) 55%, white);
+  --rule: color-mix(in oklab, var(--ink) 16%, transparent);
+  --rule-firm: color-mix(in oklab, var(--ink) 34%, transparent);
+  --quiet: color-mix(in oklab, var(--ink) 62%, var(--paper));
+
+  --display: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua',
+    Georgia, serif;
+  --body: 'Avenir Next', Avenir, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    system-ui, sans-serif;
+  --utility: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+
+  --step: 0.5rem;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 3px solid var(--cobalt);
+  outline-offset: 2px;
+}
+
+.offscreen {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* ------------------------------------------------------------------ desk */
+
+.desk {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 3.5rem minmax(21rem, 26vw);
+  height: 100dvh;
+  overflow: hidden;
+}
+
+/* ------------------------------------------------------------------ plan */
+
+.plan {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  background: var(--sheet);
+}
+
+.plan > header {
+  padding: calc(var(--step) * 3) calc(var(--step) * 3) calc(var(--step) * 2);
+  border-bottom: 1px solid var(--rule);
+}
+
+.authority {
+  margin: 0;
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eucalyptus);
+}
+
+.authority::before {
+  content: '';
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.5rem;
+  vertical-align: 0;
+  background: currentColor;
+}
+
+.authority-ad-hoc {
+  color: var(--ochre);
+}
+
+.plan h1 {
+  margin: calc(var(--step) * 1.25) 0 0;
+  font-family: var(--display);
+  font-size: clamp(1.5rem, 1.1rem + 1.2vw, 2.15rem);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+
+.lede {
+  margin: calc(var(--step) * 0.75) 0 0;
+  max-width: 62ch;
+  color: var(--quiet);
+}
+
+.canvas {
+  position: relative;
+  min-height: 0;
+  padding: var(--step);
+}
+
+/* The diagram owns its box. LikeC4 sizes its shadow host from a stylesheet it
+   injects at runtime, which this page's policy does not admit, so the host is
+   sized from here instead. Only the host: the blocked <style> element is a
+   sibling, and a display rule would put its source text on the page. */
+.canvas > .diagram {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.waiting {
+  margin: 0;
+  padding: calc(var(--step) * 4);
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.views {
+  border-top: 1px solid var(--rule);
+  padding: var(--step) calc(var(--step) * 3);
+}
+
+.views ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--step);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.views button {
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--quiet);
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.views button:hover {
+  color: var(--ink);
+  border-color: var(--rule-firm);
+}
+
+.views button[aria-current] {
+  color: var(--paper);
+  background: var(--ink);
+  border-color: var(--ink);
+}
+
+/* --------------------------------------------------------------- the rail */
+
+.rail {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(var(--step) * 3);
+  padding: calc(var(--step) * 2) 0;
+  border-left: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+  background: var(--paper);
+}
+
+/* The spine: one hairline joining authority, connection, view, and End. */
+.rail::before {
+  content: '';
+  position: absolute;
+  top: calc(var(--step) * 2);
+  bottom: calc(var(--step) * 2);
+  left: 50%;
+  width: 1px;
+  background: var(--rule-firm);
+}
+
+.station {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--step);
+  margin: 0;
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.station .value {
+  writing-mode: vertical-rl;
+  max-height: 11rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.station .tick {
+  width: 9px;
+  height: 9px;
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+}
+
+.rail-canonical .station-authority .tick {
+  background: var(--eucalyptus);
+  border-color: var(--eucalyptus);
+}
+
+.rail-ad-hoc .station-authority .tick {
+  background: var(--ochre);
+  border-color: var(--ochre);
+}
+
+.station-link.link-live .tick {
+  background: var(--cobalt);
+  border-color: var(--cobalt);
+}
+
+.station-link.link-reconnecting .tick,
+.station-link.link-closed .tick {
+  background: var(--failure);
+  border-color: var(--failure);
+}
+
+.station-link.link-ending .tick {
+  background: var(--ink);
+  border-color: var(--ink);
+}
+
+.station-view .tick {
+  background: var(--ink);
+  border-color: var(--ink);
+}
+
+.rail .end {
+  position: relative;
+  margin-top: auto;
+  padding: 0.55rem 0.4rem;
+  min-width: 2.5rem;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--paper);
+  background: var(--ink);
+  border: 1px solid var(--ink);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.rail .end:hover:enabled {
+  background: var(--failure);
+  border-color: var(--failure);
+}
+
+.rail .end:disabled {
+  color: var(--quiet);
+  background: transparent;
+  border-color: var(--rule-firm);
+  cursor: not-allowed;
+}
+
+/* ------------------------------------------------------------------ talk */
+
+.talk {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto auto;
+  min-width: 0;
+  min-height: 0;
+  background: var(--sheet);
+}
+
+.ledger {
+  margin: 0;
+  padding: calc(var(--step) * 2) calc(var(--step) * 2.5);
+  list-style: none;
+  overflow-y: auto;
+}
+
+.ledger .empty p {
+  margin: 0;
+  color: var(--quiet);
+  font-family: var(--utility);
+  font-size: 12px;
+}
+
+.said {
+  padding: 0 0 calc(var(--step) * 1.75) calc(var(--step) * 1.5);
+  border-left: 2px solid var(--rule);
+}
+
+.said + .said {
+  padding-top: calc(var(--step) * 1.75);
+}
+
+.said-reviewer {
+  border-left-color: var(--cobalt);
+}
+
+.said-agent {
+  border-left-color: var(--eucalyptus);
+}
+
+.said-session {
+  border-left-color: var(--ochre);
+}
+
+.who {
+  margin: 0 0 0.15rem;
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.words {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.faults {
+  padding: calc(var(--step) * 1.5) calc(var(--step) * 2.5);
+  border-top: 1px solid var(--failure);
+  background: color-mix(in oklab, var(--failure) 8%, var(--sheet));
+}
+
+.faults-title {
+  margin: 0 0 var(--step);
+  font-size: 13px;
+  color: var(--failure);
+}
+
+.faults ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-family: var(--utility);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.faults .code {
+  font-weight: 700;
+}
+
+.faults .where {
+  color: var(--quiet);
+  margin-left: 0.4rem;
+}
+
+.choices {
+  padding: calc(var(--step) * 1.5) calc(var(--step) * 2.5);
+  border-top: 1px solid var(--rule);
+}
+
+.question {
+  margin: 0 0 var(--step);
+  font-family: var(--display);
+  font-size: 1.05rem;
+}
+
+.choices ul {
+  display: grid;
+  gap: var(--step);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.choices button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  font-family: var(--body);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.choices button:hover:enabled {
+  border-color: var(--cobalt);
+}
+
+.choices button:disabled {
+  color: var(--quiet);
+  cursor: not-allowed;
+}
+
+.choices .detail {
+  display: block;
+  font-size: 12px;
+  color: var(--quiet);
+}
+
+.composer {
+  padding: calc(var(--step) * 1.5) calc(var(--step) * 2.5)
+    calc(var(--step) * 2);
+  border-top: 1px solid var(--rule);
+}
+
+.composer textarea {
+  display: block;
+  width: 100%;
+  resize: vertical;
+  padding: 0.55rem 0.65rem;
+  font-family: var(--body);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+}
+
+.composer textarea:disabled {
+  color: var(--quiet);
+  background: color-mix(in oklab, var(--paper) 70%, var(--sheet));
+  cursor: not-allowed;
+}
+
+.composer-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--step);
+  margin-top: var(--step);
+}
+
+.agent-status {
+  margin: 0;
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.composer button {
+  padding: 0.45rem 1.1rem;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--paper);
+  background: var(--cobalt);
+  border: 1px solid var(--cobalt);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.composer button:disabled {
+  color: var(--quiet);
+  background: transparent;
+  border-color: var(--rule-firm);
+  cursor: not-allowed;
+}
+
+/* ---------------------------------------------------------------- narrow */
+
+@media (max-width: 900px) {
+  .desk {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
+  }
+
+  .plan {
+    grid-template-rows: auto 45vh auto;
+  }
+
+  .plan > header {
+    padding: calc(var(--step) * 2);
+  }
+
+  /* The rail turns with the layout and stays in reach: authority, connection,
+     view, and End remain one strip, pinned while the conversation scrolls. */
+  .rail {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    flex-direction: row;
+    align-items: center;
+    gap: calc(var(--step) * 2);
+    padding: var(--step) calc(var(--step) * 2);
+    border-left: 0;
+    border-right: 0;
+    border-top: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .rail::before {
+    top: 50%;
+    bottom: auto;
+    left: calc(var(--step) * 2);
+    right: calc(var(--step) * 2);
+    width: auto;
+    height: 1px;
+  }
+
+  .station {
+    flex-direction: row;
+  }
+
+  .station .value {
+    writing-mode: horizontal-tb;
+    max-height: none;
+    max-width: 9rem;
+  }
+
+  .rail .end {
+    margin-top: 0;
+    margin-left: auto;
+    padding: 0.5rem 1rem;
+  }
+
+  .talk {
+    grid-template-rows: auto auto auto auto;
+  }
+
+  .ledger {
+    overflow-y: visible;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -165,6 +165,18 @@ body {
   color: var(--quiet);
 }
 
+.end-transition-status {
+  max-width: 28rem;
+  font-family: var(--utility);
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--quiet);
+}
+
+.end-transition-status:empty {
+  display: none;
+}
+
 .authority {
   margin: 0;
   font-family: var(--utility);
@@ -579,12 +591,31 @@ body {
 }
 
 .agent-status {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--step) * 0.5);
   margin: 0;
   font-family: var(--utility);
   font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--quiet);
+}
+
+.agent-spinner {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex: none;
+  border: 1px solid currentcolor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: agent-spinner-turn 700ms linear infinite;
+}
+
+@keyframes agent-spinner-turn {
+  to {
+    transform: rotate(1turn);
+  }
 }
 
 .composer button {

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1,7 +1,7 @@
 /*
  * A drafting desk, not a dashboard: paper ground, charcoal ink, hairline rules,
- * and one signature — the handoff rail that joins the drawing to the
- * conversation and ends at the control that hands the review back.
+ * and one signature — the diagram holds the whole workspace, with a single
+ * compact strip above it and a conversation the reviewer sizes or puts away.
  *
  * Every face is a system stack, every colour is one of the six the session
  * speaks in, and nothing is loaded from anywhere but this origin.
@@ -65,28 +65,55 @@ body {
   white-space: nowrap;
 }
 
-/* ------------------------------------------------------------------ desk */
+/* ----------------------------------------------------------------- shell */
 
-.desk {
+.visual-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 3.5rem minmax(21rem, 26vw);
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
   height: 100dvh;
   overflow: hidden;
+  background: var(--paper);
+  color: var(--ink);
 }
 
-/* ------------------------------------------------------------------ plan */
+/* --------------------------------------------------------- command strip */
 
-.plan {
+.command-strip {
+  position: relative;
+  z-index: 10;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  min-width: 0;
-  min-height: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: calc(var(--step) * 2);
+  min-height: 48px;
+  padding: calc(var(--step) * 0.75) calc(var(--step) * 2);
+  border-bottom: 1px solid var(--rule);
   background: var(--sheet);
 }
 
-.plan > header {
-  padding: calc(var(--step) * 3) calc(var(--step) * 3) calc(var(--step) * 2);
-  border-bottom: 1px solid var(--rule);
+.command-identity,
+.command-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--step);
+}
+
+.command-identity h1 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  font-family: var(--display);
+  font-size: 15px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-actions select,
+.command-actions button {
+  min-height: 32px;
 }
 
 .authority {
@@ -112,35 +139,96 @@ body {
   color: var(--ochre);
 }
 
-.plan h1 {
-  margin: calc(var(--step) * 1.25) 0 0;
-  font-family: var(--display);
-  font-size: clamp(1.5rem, 1.1rem + 1.2vw, 2.15rem);
-  font-weight: 400;
-  letter-spacing: -0.01em;
-  line-height: 1.15;
+.session-details {
+  grid-column: 1 / -1;
+  padding-top: var(--step);
+  border-top: 1px solid var(--rule);
 }
 
-.lede {
-  margin: calc(var(--step) * 0.75) 0 0;
-  max-width: 62ch;
+.session-details p {
+  max-width: 90ch;
+  margin: 0;
   color: var(--quiet);
 }
 
-.canvas {
-  position: relative;
+.attention-count {
+  min-width: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: var(--cobalt);
+  color: white;
+  font-size: 11px;
+  text-align: center;
+}
+
+/* ------------------------------------------------------------- workspace */
+
+.workspace {
+  display: grid;
+  min-width: 0;
   min-height: 0;
-  padding: var(--step);
+  overflow: hidden;
+}
+
+.workspace-conversation-open {
+  grid-template-columns: minmax(0, 1fr) auto var(--conversation-width);
+}
+
+.workspace-conversation-closed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.diagram-workspace {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--paper);
 }
 
 /* The diagram owns its box. LikeC4 sizes its shadow host from a stylesheet it
    injects at runtime, which this page's policy does not admit, so the host is
    sized from here instead. Only the host: the blocked <style> element is a
    sibling, and a display rule would put its source text on the page. */
-.canvas > .diagram {
-  display: block;
+.canvas,
+.diagram {
   width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* The canvas fills the workspace, so the renderer's own fault is laid over the
+   drawing it could not replace rather than clipped out of the page. */
+.diagram-workspace > .faults {
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 4;
+  max-height: 50%;
+  overflow: auto;
+}
+
+.conversation-separator {
+  position: relative;
+  z-index: 3;
+  width: 10px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.conversation-separator::before {
+  position: absolute;
+  inset: 0 auto 0 4px;
+  width: 1px;
+  background: var(--rule);
+  content: '';
+}
+
+.conversation-separator:hover::before,
+.conversation-separator:focus-visible::before {
+  width: 2px;
+  background: var(--cobalt);
 }
 
 .waiting {
@@ -153,170 +241,33 @@ body {
   color: var(--quiet);
 }
 
-.views {
-  border-top: 1px solid var(--rule);
-  padding: var(--step) calc(var(--step) * 3);
-}
-
-.views ul {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--step);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.views button {
-  font-family: var(--utility);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  color: var(--quiet);
-  background: transparent;
-  border: 1px solid var(--rule);
-  border-radius: 0;
-  padding: 0.3rem 0.6rem;
-  cursor: pointer;
-}
-
-.views button:hover {
-  color: var(--ink);
-  border-color: var(--rule-firm);
-}
-
-.views button[aria-current] {
-  color: var(--paper);
-  background: var(--ink);
-  border-color: var(--ink);
-}
-
-/* --------------------------------------------------------------- the rail */
-
-.rail {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: calc(var(--step) * 3);
-  padding: calc(var(--step) * 2) 0;
-  border-left: 1px solid var(--rule);
-  border-right: 1px solid var(--rule);
-  background: var(--paper);
-}
-
-/* The spine: one hairline joining authority, connection, view, and End. */
-.rail::before {
-  content: '';
-  position: absolute;
-  top: calc(var(--step) * 2);
-  bottom: calc(var(--step) * 2);
-  left: 50%;
-  width: 1px;
-  background: var(--rule-firm);
-}
-
-.station {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--step);
-  margin: 0;
-  font-family: var(--utility);
-  font-size: 10px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--quiet);
-}
-
-.station .value {
-  writing-mode: vertical-rl;
-  max-height: 11rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.station .tick {
-  width: 9px;
-  height: 9px;
-  background: var(--paper);
-  border: 1px solid var(--rule-firm);
-}
-
-.rail-canonical .station-authority .tick {
-  background: var(--eucalyptus);
-  border-color: var(--eucalyptus);
-}
-
-.rail-ad-hoc .station-authority .tick {
-  background: var(--ochre);
-  border-color: var(--ochre);
-}
-
-.station-link.link-live .tick {
-  background: var(--cobalt);
-  border-color: var(--cobalt);
-}
-
-.station-link.link-reconnecting .tick,
-.station-link.link-closed .tick {
-  background: var(--failure);
-  border-color: var(--failure);
-}
-
-.station-link.link-ending .tick {
-  background: var(--ink);
-  border-color: var(--ink);
-}
-
-.station-view .tick {
-  background: var(--ink);
-  border-color: var(--ink);
-}
-
-.rail .end {
-  position: relative;
-  margin-top: auto;
-  padding: 0.55rem 0.4rem;
-  min-width: 2.5rem;
-  font-family: var(--utility);
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  color: var(--paper);
-  background: var(--ink);
-  border: 1px solid var(--ink);
-  border-radius: 0;
-  cursor: pointer;
-}
-
-.rail .end:hover:enabled {
-  background: var(--failure);
-  border-color: var(--failure);
-}
-
-.rail .end:disabled {
-  color: var(--quiet);
-  background: transparent;
-  border-color: var(--rule-firm);
-  cursor: not-allowed;
-}
-
 /* ------------------------------------------------------------------ talk */
 
 .talk {
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto auto auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--rule);
   background: var(--sheet);
+}
+
+.talk[hidden] {
+  display: none;
+}
+
+.conversation-scroll {
+  min-height: 0;
+  overflow: auto;
 }
 
 .ledger {
   margin: 0;
   padding: calc(var(--step) * 2) calc(var(--step) * 2.5);
   list-style: none;
-  overflow-y: auto;
+  min-height: 0;
+  overflow: visible;
 }
 
 .ledger .empty p {
@@ -502,70 +453,38 @@ body {
 
 /* ---------------------------------------------------------------- narrow */
 
-@media (max-width: 900px) {
-  .desk {
+@media (max-width: 899px) {
+  .command-strip {
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto minmax(0, 1fr);
-    height: auto;
-    min-height: 100dvh;
-    overflow: visible;
+    gap: calc(var(--step) * 0.5);
+    padding-inline: var(--step);
   }
 
-  .plan {
-    grid-template-rows: auto 45vh auto;
+  .command-identity,
+  .command-actions {
+    gap: calc(var(--step) * 0.5);
   }
 
-  .plan > header {
-    padding: calc(var(--step) * 2);
+  .command-actions {
+    overflow-x: auto;
   }
 
-  /* The rail turns with the layout and stays in reach: authority, connection,
-     view, and End remain one strip, pinned while the conversation scrolls. */
-  .rail {
-    position: sticky;
-    top: 0;
-    z-index: 5;
-    flex-direction: row;
-    align-items: center;
-    gap: calc(var(--step) * 2);
-    padding: var(--step) calc(var(--step) * 2);
-    border-left: 0;
-    border-right: 0;
-    border-top: 1px solid var(--rule);
-    border-bottom: 1px solid var(--rule);
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
+    min-height: 0;
   }
 
-  .rail::before {
-    top: 50%;
-    bottom: auto;
-    left: calc(var(--step) * 2);
-    right: calc(var(--step) * 2);
-    width: auto;
-    height: 1px;
-  }
-
-  .station {
-    flex-direction: row;
-  }
-
-  .station .value {
-    writing-mode: horizontal-tb;
-    max-height: none;
-    max-width: 9rem;
-  }
-
-  .rail .end {
-    margin-top: 0;
-    margin-left: auto;
-    padding: 0.5rem 1rem;
+  .conversation-separator {
+    display: none;
   }
 
   .talk {
-    grid-template-rows: auto auto auto auto;
-  }
-
-  .ledger {
-    overflow-y: visible;
+    max-height: 56dvh;
+    border-top: 1px solid var(--rule);
+    border-left: 0;
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -12px 36px rgb(19 35 57 / 14%);
   }
 }
 

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -11,7 +11,7 @@
   --paper: #e8eef0;
   --ink: #182228;
   --eucalyptus: #416f65;
-  --ochre: #b66a2c;
+  --ochre: #8c4d18;
   --cobalt: #2457a6;
   --failure: #a3403a;
 
@@ -340,6 +340,7 @@ body {
 
 .talk {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
@@ -353,21 +354,29 @@ body {
 }
 
 .conversation-scroll {
+  min-width: 0;
   min-height: 0;
   overflow: auto;
 }
 
 .subject-inspector {
+  min-width: 0;
   padding: calc(var(--step) * 1.5);
   border-bottom: 1px solid var(--rule);
   background: color-mix(in srgb, var(--sheet) 92%, var(--cobalt) 8%);
 }
 
 .subject-heading-row {
+  min-width: 0;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--step);
+}
+
+.subject-heading-row > :first-child,
+.subject-heading-row h2 {
+  min-width: 0;
 }
 
 .subject-type {
@@ -384,6 +393,7 @@ body {
   font-family: var(--display);
   font-size: 16px;
   line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .subject-facts {

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -114,6 +114,55 @@ body {
 .command-actions select,
 .command-actions button {
   min-height: 32px;
+  padding: 0 0.7rem;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.command-actions select {
+  /* The native arrow is the one piece of OS chrome worth keeping: it is the
+     only affordance saying this control has a list behind it. */
+  padding-right: 0.35rem;
+}
+
+.command-actions select:hover:enabled,
+.command-actions button:hover:enabled {
+  border-color: var(--cobalt);
+}
+
+.command-actions select:disabled,
+.command-actions button:disabled {
+  color: var(--quiet);
+  background: transparent;
+  border-color: var(--rule);
+  cursor: not-allowed;
+}
+
+.command-actions button[aria-expanded='true'] {
+  color: var(--paper);
+  background: var(--cobalt);
+  border-color: var(--cobalt);
+}
+
+.command-actions .end-session:hover:enabled {
+  color: var(--paper);
+  background: var(--failure);
+  border-color: var(--failure);
+}
+
+.connection-state {
+  flex: none;
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--quiet);
 }
 
 .authority {
@@ -139,16 +188,50 @@ body {
   color: var(--ochre);
 }
 
+/* Laid over the workspace, never in it: static prose must not cost the diagram
+   a single pixel of height, so the disclosure hangs off the strip instead of
+   taking a row in the shell grid. */
 .session-details {
-  grid-column: 1 / -1;
-  padding-top: var(--step);
-  border-top: 1px solid var(--rule);
+  position: absolute;
+  top: 100%;
+  right: 0;
+  left: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--step) * 2);
+  padding: var(--step) calc(var(--step) * 2) calc(var(--step) * 1.5);
+  border-bottom: 1px solid var(--rule);
+  background: var(--sheet);
+  box-shadow: 0 12px 28px rgb(19 35 57 / 12%);
+}
+
+.session-details[hidden] {
+  display: none;
 }
 
 .session-details p {
   max-width: 90ch;
   margin: 0;
   color: var(--quiet);
+}
+
+.details-close {
+  flex: none;
+  margin-left: auto;
+  min-height: 28px;
+  padding: 0 0.6rem;
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.details-close:hover {
+  border-color: var(--cobalt);
 }
 
 .attention-count {

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -200,6 +200,21 @@ body {
   color: var(--ochre);
 }
 
+/* A static claim about the feature, not a live status — bordered like a tag
+   rather than dot-prefixed like `.authority`, so it never reads as part of
+   the session's own state. */
+.beta-badge {
+  flex: none;
+  padding: 0.05rem 0.4rem;
+  font-family: var(--utility);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ochre);
+  border: 1px solid var(--ochre);
+}
+
 /* Laid over the workspace, never in it: static prose must not cost the diagram
    a single pixel of height, so the disclosure hangs off the strip instead of
    taking a row in the shell grid. */

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -160,12 +160,24 @@ const clampConversationWidth = (width: number, viewportWidth: number) => {
   return Math.min(max, Math.max(min, width))
 }
 
+// Initial width follows `clamp(320px, 28vw, 480px)` per the approved design;
+// only a manual drag may widen the panel up to CONVERSATION_MAX_WIDTH (640).
+const CONVERSATION_DEFAULT_MAX_WIDTH = 480
+
+const clampInitialConversationWidth = (
+  width: number,
+  viewportWidth: number,
+) => {
+  const { min, max } = conversationWidthBounds(viewportWidth)
+  return Math.min(Math.min(max, CONVERSATION_DEFAULT_MAX_WIDTH), Math.max(min, width))
+}
+
 export const createVisualWorkspaceState = (
   viewportWidth: number,
 ): VisualWorkspaceState => ({
   conversation: {
     mode: 'auto',
-    width: clampConversationWidth(viewportWidth * 0.28, viewportWidth),
+    width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
     unread: 0,
   },
   selectedSubject: null,

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -82,7 +82,7 @@ export const normalizeSelectedElement = (
     id: String(node.id),
     modelRef,
     deploymentRef,
-    identity: modelRef ?? deploymentRef ?? String(node.id),
+    identity: deploymentRef ?? modelRef ?? String(node.id),
     title: node.title,
     kind: optionalText(node.kind),
     description: visualDescriptionText(node.description),

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -1,0 +1,258 @@
+import {
+  flattenMarkdownOrString,
+  type MarkdownOrString,
+} from '@likec4/core/types'
+
+export type ConversationMode = 'auto' | 'open' | 'closed'
+
+export interface DiagramElementInput {
+  readonly id: string
+  readonly modelRef?: string | null
+  readonly deploymentRef?: string | null
+  readonly title: string
+  readonly kind?: string | null
+  readonly description?: MarkdownOrString | null
+  readonly technology?: string | null
+  readonly tags?: readonly string[] | null
+  readonly navigateTo?: string | null
+  readonly metadata?: Readonly<Record<string, unknown>> | null
+}
+
+export interface DiagramRelationshipInput {
+  readonly id: string
+  readonly source: string
+  readonly target: string
+  readonly label?: string | null
+  readonly description?: MarkdownOrString | null
+  readonly kind?: string | null
+  readonly technology?: string | null
+  readonly notation?: string | null
+  readonly relations?: readonly string[] | null
+}
+
+export interface SelectedElement {
+  readonly type: 'element'
+  readonly id: string
+  readonly modelRef: string | null
+  readonly deploymentRef: string | null
+  readonly identity: string
+  readonly title: string
+  readonly kind: string | null
+  readonly description: string | null
+  readonly technology: string | null
+  readonly tags: readonly string[]
+  readonly navigateTo: string | null
+  readonly metadata: Readonly<Record<string, unknown>> | null
+}
+
+export interface SelectedRelationship {
+  readonly type: 'relationship'
+  readonly id: string
+  readonly sourceId: string
+  readonly sourceTitle: string
+  readonly targetId: string
+  readonly targetTitle: string
+  readonly label: string | null
+  readonly description: string | null
+  readonly kind: string | null
+  readonly technology: string | null
+  readonly notation: string | null
+  readonly relationshipIds: readonly string[]
+  readonly aggregateCount: number
+}
+
+export type SelectedDiagramSubject = SelectedElement | SelectedRelationship
+
+const optionalText = (value: string | null | undefined): string | null => {
+  const text = value?.trim() ?? ''
+  return text === '' ? null : text
+}
+
+export const visualDescriptionText = (
+  value: MarkdownOrString | null | undefined,
+): string | null => optionalText(flattenMarkdownOrString(value))
+
+export const normalizeSelectedElement = (
+  node: DiagramElementInput,
+): SelectedElement => {
+  const modelRef = optionalText(node.modelRef)
+  const deploymentRef = optionalText(node.deploymentRef)
+  return {
+    type: 'element',
+    id: String(node.id),
+    modelRef,
+    deploymentRef,
+    identity: modelRef ?? deploymentRef ?? String(node.id),
+    title: node.title,
+    kind: optionalText(node.kind),
+    description: visualDescriptionText(node.description),
+    technology: optionalText(node.technology),
+    tags: node.tags?.map(String) ?? [],
+    navigateTo: optionalText(node.navigateTo),
+    metadata: node.metadata ?? null,
+  }
+}
+
+export const normalizeSelectedRelationship = (
+  edge: DiagramRelationshipInput,
+  nodeTitles: ReadonlyMap<string, string>,
+): SelectedRelationship => {
+  const sourceId = String(edge.source)
+  const targetId = String(edge.target)
+  const relationshipIds = edge.relations?.map(String) ?? []
+  return {
+    type: 'relationship',
+    id: String(edge.id),
+    sourceId,
+    sourceTitle: nodeTitles.get(sourceId) ?? sourceId,
+    targetId,
+    targetTitle: nodeTitles.get(targetId) ?? targetId,
+    label: optionalText(edge.label),
+    description: visualDescriptionText(edge.description),
+    kind: optionalText(edge.kind),
+    technology: optionalText(edge.technology),
+    notation: optionalText(edge.notation),
+    relationshipIds,
+    aggregateCount: relationshipIds.length,
+  }
+}
+
+export const CONVERSATION_MIN_WIDTH = 320
+export const CONVERSATION_MAX_WIDTH = 640
+export const CANVAS_MIN_WIDTH = 520
+const CONVERSATION_SEPARATOR_WIDTH = 10
+
+export interface VisualWorkspaceState {
+  readonly conversation: {
+    readonly mode: ConversationMode
+    readonly width: number
+    readonly unread: number
+  }
+  readonly selectedSubject: SelectedDiagramSubject | null
+  readonly descriptionExpanded: boolean
+  readonly detailsOpen: boolean
+}
+
+export type VisualWorkspaceAction =
+  | { readonly type: 'conversation.toggled' }
+  | { readonly type: 'conversation.resized'; readonly width: number; readonly viewportWidth: number }
+  | { readonly type: 'viewport.resized'; readonly viewportWidth: number }
+  | { readonly type: 'attention.received' }
+  | { readonly type: 'subject.selected'; readonly subject: SelectedDiagramSubject }
+  | { readonly type: 'subject.cleared' }
+  | { readonly type: 'description.toggled' }
+  | { readonly type: 'details.toggled' }
+  | { readonly type: 'model.replaced' }
+
+export const conversationWidthBounds = (viewportWidth: number) => ({
+  min: CONVERSATION_MIN_WIDTH,
+  max: Math.max(
+    CONVERSATION_MIN_WIDTH,
+    Math.min(
+      CONVERSATION_MAX_WIDTH,
+      viewportWidth - CANVAS_MIN_WIDTH - CONVERSATION_SEPARATOR_WIDTH,
+    ),
+  ),
+})
+
+const clampConversationWidth = (width: number, viewportWidth: number) => {
+  const { min, max } = conversationWidthBounds(viewportWidth)
+  return Math.min(max, Math.max(min, width))
+}
+
+export const createVisualWorkspaceState = (
+  viewportWidth: number,
+): VisualWorkspaceState => ({
+  conversation: {
+    mode: 'auto',
+    width: clampConversationWidth(viewportWidth * 0.28, viewportWidth),
+    unread: 0,
+  },
+  selectedSubject: null,
+  descriptionExpanded: false,
+  detailsOpen: false,
+})
+
+export const visualWorkspaceReducer = (
+  state: VisualWorkspaceState,
+  action: VisualWorkspaceAction,
+): VisualWorkspaceState => {
+  switch (action.type) {
+    case 'conversation.toggled': {
+      const mode = state.conversation.mode === 'open' ? 'closed' : 'open'
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          mode,
+          unread: mode === 'open' ? 0 : state.conversation.unread,
+        },
+      }
+    }
+    case 'conversation.resized':
+    case 'viewport.resized': {
+      const requested =
+        action.type === 'conversation.resized'
+          ? action.width
+          : state.conversation.width
+      const width = clampConversationWidth(requested, action.viewportWidth)
+      return width === state.conversation.width
+        ? state
+        : { ...state, conversation: { ...state.conversation, width } }
+    }
+    case 'attention.received':
+      if (state.conversation.mode === 'open') return state
+      if (state.conversation.mode === 'auto') {
+        return {
+          ...state,
+          conversation: { ...state.conversation, mode: 'open', unread: 0 },
+        }
+      }
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          unread: state.conversation.unread + 1,
+        },
+      }
+    case 'subject.selected':
+      return {
+        ...state,
+        conversation: { ...state.conversation, mode: 'open', unread: 0 },
+        selectedSubject: action.subject,
+        descriptionExpanded: false,
+      }
+    case 'subject.cleared':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, selectedSubject: null, descriptionExpanded: false }
+    case 'description.toggled':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, descriptionExpanded: !state.descriptionExpanded }
+    case 'details.toggled':
+      return { ...state, detailsOpen: !state.detailsOpen }
+    case 'model.replaced':
+      return state.selectedSubject === null
+        ? state
+        : { ...state, selectedSubject: null, descriptionExpanded: false }
+  }
+}
+
+export const formatContextualQuestion = (
+  question: string,
+  subject: SelectedDiagramSubject | null,
+): string => {
+  const text = question.trim()
+  if (subject === null) return text
+  if (subject.type === 'element') {
+    return `About “${subject.title}” (${subject.identity}): ${text}`
+  }
+  const route = `${subject.sourceTitle} → ${subject.targetTitle}`
+  const name = subject.label === null ? route : `${route} — ${subject.label}`
+  const aggregate =
+    subject.aggregateCount > 1
+      ? ` (${subject.aggregateCount} model relationships)`
+      : ''
+  return `About relationship “${name}”${aggregate}: ${text}`
+}

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -119,8 +119,8 @@ export const normalizeSelectedRelationship = (
 
 export const CONVERSATION_MIN_WIDTH = 320
 export const CONVERSATION_MAX_WIDTH = 640
-export const CANVAS_MIN_WIDTH = 520
-const CONVERSATION_SEPARATOR_WIDTH = 10
+/** The share of the viewport the approved design lets the conversation take. */
+const CONVERSATION_MAX_VIEWPORT_SHARE = 0.45
 
 export interface VisualWorkspaceState {
   readonly conversation: {
@@ -128,6 +128,12 @@ export interface VisualWorkspaceState {
     readonly width: number
     readonly unread: number
   }
+  /**
+   * The viewport this state was last clamped against. Presentation reads its
+   * resize bounds from here rather than from `window`, so every viewport change
+   * reaches the separator's reported minimum and maximum.
+   */
+  readonly viewportWidth: number
   readonly selectedSubject: SelectedDiagramSubject | null
   readonly descriptionExpanded: boolean
   readonly detailsOpen: boolean
@@ -135,7 +141,7 @@ export interface VisualWorkspaceState {
 
 export type VisualWorkspaceAction =
   | { readonly type: 'conversation.toggled' }
-  | { readonly type: 'conversation.resized'; readonly width: number; readonly viewportWidth: number }
+  | { readonly type: 'conversation.resized'; readonly width: number }
   | { readonly type: 'viewport.resized'; readonly viewportWidth: number }
   | { readonly type: 'attention.received' }
   | { readonly type: 'subject.selected'; readonly subject: SelectedDiagramSubject }
@@ -144,13 +150,14 @@ export type VisualWorkspaceAction =
   | { readonly type: 'details.toggled' }
   | { readonly type: 'model.replaced' }
 
+// `min(45vw, 640px)`, never below the 320px floor the panel is usable at.
 export const conversationWidthBounds = (viewportWidth: number) => ({
   min: CONVERSATION_MIN_WIDTH,
   max: Math.max(
     CONVERSATION_MIN_WIDTH,
     Math.min(
       CONVERSATION_MAX_WIDTH,
-      viewportWidth - CANVAS_MIN_WIDTH - CONVERSATION_SEPARATOR_WIDTH,
+      viewportWidth * CONVERSATION_MAX_VIEWPORT_SHARE,
     ),
   ),
 })
@@ -180,6 +187,7 @@ export const createVisualWorkspaceState = (
     width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
     unread: 0,
   },
+  viewportWidth,
   selectedSubject: null,
   descriptionExpanded: false,
   detailsOpen: false,
@@ -201,16 +209,25 @@ export const visualWorkspaceReducer = (
         },
       }
     }
-    case 'conversation.resized':
-    case 'viewport.resized': {
-      const requested =
-        action.type === 'conversation.resized'
-          ? action.width
-          : state.conversation.width
-      const width = clampConversationWidth(requested, action.viewportWidth)
+    case 'conversation.resized': {
+      const width = clampConversationWidth(action.width, state.viewportWidth)
       return width === state.conversation.width
         ? state
         : { ...state, conversation: { ...state.conversation, width } }
+    }
+    case 'viewport.resized': {
+      const width = clampConversationWidth(
+        state.conversation.width,
+        action.viewportWidth,
+      )
+      return width === state.conversation.width &&
+        action.viewportWidth === state.viewportWidth
+        ? state
+        : {
+            ...state,
+            conversation: { ...state.conversation, width },
+            viewportWidth: action.viewportWidth,
+          }
     }
     case 'attention.received':
       if (state.conversation.mode === 'open') return state
@@ -258,7 +275,7 @@ export const formatContextualQuestion = (
   const text = question.trim()
   if (subject === null) return text
   if (subject.type === 'element') {
-    return `About “${subject.title}” (${subject.identity}): ${text}`
+    return `About element “${subject.title}” (${subject.identity}): ${text}`
   }
   const route = `${subject.sourceTitle} → ${subject.targetTitle}`
   const name = subject.label === null ? route : `${route} — ${subject.label}`

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -82,7 +82,7 @@ export const normalizeSelectedElement = (
     id: String(node.id),
     modelRef,
     deploymentRef,
-    identity: deploymentRef ?? modelRef ?? String(node.id),
+    identity: modelRef ?? deploymentRef ?? String(node.id),
     title: node.title,
     kind: optionalText(node.kind),
     description: visualDescriptionText(node.description),

--- a/test/fixtures/visual/browser-assets/assets/app-1a2b3c4d.css
+++ b/test/fixtures/visual/browser-assets/assets/app-1a2b3c4d.css
@@ -1,0 +1,5 @@
+/* Hashed stylesheet stand-in; see app-1a2b3c4d.js. */
+#visual-session {
+  font-family: system-ui, sans-serif;
+  margin: 2rem;
+}

--- a/test/fixtures/visual/browser-assets/assets/app-1a2b3c4d.js
+++ b/test/fixtures/visual/browser-assets/assets/app-1a2b3c4d.js
@@ -1,0 +1,16 @@
+/**
+ * Hashed asset stand-in for the browser application bundle.
+ *
+ * The session server serves `/assets/{hashed-file}` as an opaque static route,
+ * so the fixture only has to be a real, same-origin module that the static
+ * route can resolve, read, and label with a content type.
+ */
+const state = document.getElementById('visual-session-state')
+
+const socket = new WebSocket(`ws://${location.host}/socket`)
+socket.addEventListener('open', () => {
+  if (state !== null) state.textContent = 'Connected'
+})
+socket.addEventListener('close', () => {
+  if (state !== null) state.textContent = 'Disconnected'
+})

--- a/test/fixtures/visual/browser-assets/index.html
+++ b/test/fixtures/visual/browser-assets/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+  Self-contained stand-in for the browser application the session server ships.
+
+  It exists so the server's static route, security headers, and asset
+  confinement can be exercised for real before the production application is
+  built. It loads only same-origin assets: the Content-Security-Policy the
+  server returns forbids inline script, inline style, and every external
+  origin, so a fixture that needed any of those would prove the wrong thing.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>YarraMate visual session</title>
+    <link rel="stylesheet" href="/assets/app-1a2b3c4d.css" />
+    <script type="module" src="/assets/app-1a2b3c4d.js"></script>
+  </head>
+  <body>
+    <main id="visual-session">
+      <h1>YarraMate visual session</h1>
+      <p id="visual-session-state">Connecting…</p>
+    </main>
+  </body>
+</html>

--- a/test/fixtures/visual/fake-likec4.mjs
+++ b/test/fixtures/visual/fake-likec4.mjs
@@ -11,7 +11,14 @@
  * file, which keeps every failure mode a property of the model under
  * compilation rather than of a mocked adapter seam.
  */
-import { appendFileSync, readFileSync, readdirSync, writeFileSync, writeSync } from 'node:fs'
+import {
+  appendFileSync,
+  chmodSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 const argv = process.argv.slice(2)
@@ -122,6 +129,11 @@ if (argv[0] === 'validate') {
     const padded = { ...exported, _padding: 'x'.repeat(64 * 1024) }
     writeFileSync(outfile, JSON.stringify(padded, null, 2))
   } else writeFileSync(outfile, JSON.stringify(exported, null, 2))
+  // The real CLI creates its output under the ambient umask, which on an
+  // ordinary developer or CI account leaves the document group- and
+  // world-readable. Stating the mode here makes the adapter's hardening
+  // observable however restrictive the umask running this suite happens to be.
+  chmodSync(outfile, 0o644)
   exit(0, 1)
 } else {
   exit(64, 2, `fake-likec4: unsupported command "${argv.join(' ')}"\n`)

--- a/test/fixtures/visual/fake-likec4.mjs
+++ b/test/fixtures/visual/fake-likec4.mjs
@@ -90,7 +90,32 @@ if (argv[0] === 'validate') {
   const exported = JSON.parse(
     readFileSync(new URL('./model.json', import.meta.url), 'utf8'),
   )
-  if (marker === 'malformed-export') writeFileSync(outfile, '{"views": ')
+  if (marker === 'default-project') {
+    // What the real CLI writes for two projects: a bare array. A staged
+    // configuration resolves the named project beside an empty default one.
+    writeFileSync(
+      outfile,
+      JSON.stringify(
+        [exported, { ...exported, projectId: 'default', views: {} }],
+        null,
+        2,
+      ),
+    )
+  } else if (marker === 'ambiguous-projects') {
+    writeFileSync(
+      outfile,
+      JSON.stringify(
+        [
+          { ...exported, projectId: 'other' },
+          { ...exported, projectId: 'another' },
+        ],
+        null,
+        2,
+      ),
+    )
+  } else if (marker === 'one-project') {
+    writeFileSync(outfile, JSON.stringify([exported], null, 2))
+  } else if (marker === 'malformed-export') writeFileSync(outfile, '{"views": ')
   else if (marker === 'no-views') {
     writeFileSync(outfile, JSON.stringify({ ...exported, views: {} }, null, 2))
   } else if (marker === 'huge-export') {

--- a/test/fixtures/visual/fake-likec4.mjs
+++ b/test/fixtures/visual/fake-likec4.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Deterministic stand-in for the LikeC4 CLI.
+ *
+ * It emulates only the public command contract the visual compiler adapter
+ * depends on — `validate --json --no-layout <root>` and
+ * `export json --pretty -o <file> <root>` — so the adapter's own process
+ * handling, diagnostic conversion, and promotion are exercised for real.
+ *
+ * Behaviour is selected by a `// fake:<marker>` comment inside a staged source
+ * file, which keeps every failure mode a property of the model under
+ * compilation rather than of a mocked adapter seam.
+ */
+import { appendFileSync, readFileSync, readdirSync, writeFileSync, writeSync } from 'node:fs'
+import { join } from 'node:path'
+
+const argv = process.argv.slice(2)
+const root = argv.at(-1)
+
+const log = process.env.YARRAMATE_FAKE_LIKEC4_LOG
+if (log !== undefined) appendFileSync(log, `${JSON.stringify(argv)}\n`)
+
+const sourcesIn = (directory) =>
+  readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) return sourcesIn(path)
+      return /\.(c4|likec4)$/.test(entry.name) ? [path] : []
+    })
+
+let marker = 'clean'
+let markedFile = root
+for (const source of sourcesIn(root)) {
+  const found = /\/\/ fake:([a-z-]+)/.exec(readFileSync(source, 'utf8'))
+  if (!found) continue
+  marker = found[1]
+  markedFile = source
+  break
+}
+
+const exit = (status, stream, text) => {
+  if (text !== undefined) writeSync(stream, text)
+  process.exit(status)
+}
+
+if (argv[0] === 'validate') {
+  switch (marker) {
+    case 'hang':
+      // Outlives any budget the adapter grants it.
+      setInterval(() => {}, 1000)
+      break
+    case 'crash':
+      exit(3, 2, 'fake-likec4: project not found\n')
+      break
+    case 'garbage':
+      exit(1, 1, 'validation finished with 1 error\n')
+      break
+    case 'flood':
+      for (let written = 0; written < 512 * 1024; written += 64 * 1024) {
+        writeSync(1, 'x'.repeat(64 * 1024))
+      }
+      exit(0, 1)
+      break
+    case 'invalid':
+      exit(
+        1,
+        1,
+        JSON.stringify({
+          success: false,
+          diagnostics: [
+            {
+              severity: 1,
+              message: 'Unresolved reference "ghost"',
+              sourceFsPath: markedFile,
+              range: {
+                start: { line: 1, character: 4 },
+                end: { line: 1, character: 9 },
+              },
+            },
+          ],
+        }),
+      )
+      break
+    default:
+      exit(0, 1, JSON.stringify({ success: true, diagnostics: [] }))
+  }
+} else if (argv[0] === 'export' && argv[1] === 'json') {
+  const outfile = argv[argv.indexOf('-o') + 1]
+  const exported = JSON.parse(
+    readFileSync(new URL('./model.json', import.meta.url), 'utf8'),
+  )
+  if (marker === 'malformed-export') writeFileSync(outfile, '{"views": ')
+  else if (marker === 'no-views') {
+    writeFileSync(outfile, JSON.stringify({ ...exported, views: {} }, null, 2))
+  } else if (marker === 'huge-export') {
+    const padded = { ...exported, _padding: 'x'.repeat(64 * 1024) }
+    writeFileSync(outfile, JSON.stringify(padded, null, 2))
+  } else writeFileSync(outfile, JSON.stringify(exported, null, 2))
+  exit(0, 1)
+} else {
+  exit(64, 2, `fake-likec4: unsupported command "${argv.join(' ')}"\n`)
+}

--- a/test/fixtures/visual/fake-likec4.mjs
+++ b/test/fixtures/visual/fake-likec4.mjs
@@ -108,6 +108,18 @@ if (argv[0] === 'validate') {
         2,
       ),
     )
+  } else if (marker === 'misowned-project') {
+    writeFileSync(
+      outfile,
+      JSON.stringify(
+        [
+          { ...exported, projectId: 'visual', views: {} },
+          { ...exported, projectId: 'other' },
+        ],
+        null,
+        2,
+      ),
+    )
   } else if (marker === 'ambiguous-projects') {
     writeFileSync(
       outfile,

--- a/test/fixtures/visual/model.json
+++ b/test/fixtures/visual/model.json
@@ -8,7 +8,13 @@
   "specification": {
     "tags": {},
     "elements": {
-      "system": {
+      "review": {
+        "style": {}
+      },
+      "option": {
+        "style": {}
+      },
+      "part": {
         "style": {}
       }
     },
@@ -17,70 +23,1041 @@
     "customColors": {}
   },
   "elements": {
-    "system": {
+    "desk": {
       "style": {},
-      "title": "System",
-      "kind": "system",
-      "id": "system"
+      "description": {
+        "txt": "The question this session was opened to answer."
+      },
+      "title": "Delivery design review",
+      "kind": "review",
+      "id": "desk"
+    },
+    "streaming": {
+      "style": {},
+      "description": {
+        "txt": "Each change is published as an event and applied as it arrives."
+      },
+      "title": "Option 1 - Event-driven delivery",
+      "kind": "option",
+      "id": "streaming"
+    },
+    "nightly": {
+      "style": {},
+      "description": {
+        "txt": "Changes are collected and applied once per night."
+      },
+      "title": "Option 2 - Nightly batch delivery",
+      "kind": "option",
+      "id": "nightly"
+    },
+    "streaming.publisher": {
+      "style": {},
+      "description": {
+        "txt": "Emits one event per committed change."
+      },
+      "title": "Change publisher",
+      "kind": "part",
+      "id": "streaming.publisher"
+    },
+    "streaming.bus": {
+      "style": {},
+      "description": {
+        "txt": "At-least-once fan-out with replay."
+      },
+      "title": "Event bus",
+      "kind": "part",
+      "id": "streaming.bus"
+    },
+    "streaming.consumer": {
+      "style": {},
+      "description": {
+        "txt": "Applies each event on arrival."
+      },
+      "title": "Streaming consumer",
+      "kind": "part",
+      "id": "streaming.consumer"
+    },
+    "nightly.collector": {
+      "style": {},
+      "description": {
+        "txt": "Accumulates changes through the day."
+      },
+      "title": "Change collector",
+      "kind": "part",
+      "id": "nightly.collector"
+    },
+    "nightly.window": {
+      "style": {},
+      "description": {
+        "txt": "One scheduled run, no partial state."
+      },
+      "title": "Nightly window",
+      "kind": "part",
+      "id": "nightly.window"
+    },
+    "nightly.loader": {
+      "style": {},
+      "description": {
+        "txt": "Applies the whole night in one transaction."
+      },
+      "title": "Batch loader",
+      "kind": "part",
+      "id": "nightly.loader"
     }
   },
-  "relations": {},
+  "relations": {
+    "5l0pi9": {
+      "title": "compares",
+      "source": {
+        "model": "desk"
+      },
+      "target": {
+        "model": "streaming"
+      },
+      "id": "5l0pi9"
+    },
+    "191xp83": {
+      "title": "compares",
+      "source": {
+        "model": "desk"
+      },
+      "target": {
+        "model": "nightly"
+      },
+      "id": "191xp83"
+    },
+    "e6bltu": {
+      "title": "publishes change",
+      "source": {
+        "model": "streaming.publisher"
+      },
+      "target": {
+        "model": "streaming.bus"
+      },
+      "id": "e6bltu"
+    },
+    "xkk6qd": {
+      "title": "delivers event",
+      "source": {
+        "model": "streaming.bus"
+      },
+      "target": {
+        "model": "streaming.consumer"
+      },
+      "id": "xkk6qd"
+    },
+    "1w5wchw": {
+      "title": "stages change",
+      "source": {
+        "model": "nightly.collector"
+      },
+      "target": {
+        "model": "nightly.window"
+      },
+      "id": "1w5wchw"
+    },
+    "soe31t": {
+      "title": "hands over batch",
+      "source": {
+        "model": "nightly.window"
+      },
+      "target": {
+        "model": "nightly.loader"
+      },
+      "id": "soe31t"
+    }
+  },
   "globals": {
     "predicates": {},
     "dynamicPredicates": {},
     "styles": {}
   },
   "views": {
-    "choices": {
+    "index": {
       "_type": "element",
-      "_stage": "layouted",
-      "id": "choices",
-      "title": null,
-      "description": null,
       "tags": null,
       "links": null,
+      "_stage": "layouted",
       "sourcePath": "views/choices.likec4",
+      "description": {
+        "txt": "The two candidate deliveries and the review that compares them."
+      },
+      "title": "Delivery options - comparison",
+      "id": "index",
       "autoLayout": {
         "direction": "TB"
       },
-      "hash": "w_sb3-EaQesp_nbNDKqaYUVIin1fRfjw7nrVhyJO-B8",
+      "hash": "rgsX2IkDhkcwwrzKeNnXnPduGlxbb9YsOdJvjA7KVLs",
       "bounds": {
         "x": 0,
         "y": 0,
-        "width": 320,
-        "height": 180
+        "width": 766,
+        "height": 503
       },
       "nodes": [
         {
-          "id": "system",
+          "id": "desk",
           "parent": null,
           "level": 0,
           "children": [],
           "inEdges": [],
-          "outEdges": [],
-          "title": "System",
-          "modelRef": "system",
+          "outEdges": [
+            "18l3bv3",
+            "19v07zu"
+          ],
+          "title": "Delivery design review",
+          "modelRef": "desk",
           "shape": "rectangle",
           "color": "primary",
           "style": {
             "opacity": 15,
             "size": "md"
           },
+          "description": {
+            "txt": "The question this session was opened to answer."
+          },
           "tags": [],
-          "kind": "system",
-          "x": 0,
+          "kind": "review",
+          "x": 220,
           "y": 0,
           "width": 320,
           "height": 180,
           "labelBBox": {
-            "x": 125,
-            "y": 76,
-            "width": 71,
-            "height": 24
+            "x": 22,
+            "y": 56,
+            "width": 275,
+            "height": 65
+          }
+        },
+        {
+          "id": "streaming",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [
+            "18l3bv3"
+          ],
+          "outEdges": [],
+          "title": "Option 1 - Event-driven delivery",
+          "modelRef": "streaming",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Each change is published as an event and applied as it arrives."
+          },
+          "tags": [],
+          "kind": "option",
+          "navigateTo": "detailStreaming",
+          "x": 0,
+          "y": 323,
+          "width": 321,
+          "height": 180,
+          "labelBBox": {
+            "x": 18,
+            "y": 56,
+            "width": 286,
+            "height": 65
+          }
+        },
+        {
+          "id": "nightly",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [
+            "19v07zu"
+          ],
+          "outEdges": [],
+          "title": "Option 2 - Nightly batch delivery",
+          "modelRef": "nightly",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Changes are collected and applied once per night."
+          },
+          "tags": [],
+          "kind": "option",
+          "navigateTo": "detailNightly",
+          "x": 432,
+          "y": 323,
+          "width": 333,
+          "height": 180,
+          "labelBBox": {
+            "x": 18,
+            "y": 56,
+            "width": 298,
+            "height": 65
           }
         }
       ],
-      "edges": []
+      "edges": [
+        {
+          "id": "18l3bv3",
+          "source": "desk",
+          "target": "streaming",
+          "label": "compares",
+          "points": [
+            [
+              319,
+              180
+            ],
+            [
+              291,
+              222
+            ],
+            [
+              257,
+              272
+            ],
+            [
+              227,
+              315
+            ]
+          ],
+          "labelBBox": {
+            "x": 278,
+            "y": 241,
+            "width": 65,
+            "height": 18
+          },
+          "parent": null,
+          "relations": [
+            "5l0pi9"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        },
+        {
+          "id": "19v07zu",
+          "source": "desk",
+          "target": "nightly",
+          "label": "compares",
+          "points": [
+            [
+              441,
+              180
+            ],
+            [
+              469,
+              222
+            ],
+            [
+              503,
+              272
+            ],
+            [
+              533,
+              315
+            ]
+          ],
+          "labelBBox": {
+            "x": 497,
+            "y": 241,
+            "width": 65,
+            "height": 18
+          },
+          "parent": null,
+          "relations": [
+            "191xp83"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        }
+      ]
+    },
+    "choices": {
+      "_type": "element",
+      "tags": null,
+      "links": null,
+      "_stage": "layouted",
+      "sourcePath": "views/choices.likec4",
+      "description": {
+        "txt": "Ad hoc, non-canonical. Both candidates, each opening its own detail."
+      },
+      "title": "Delivery options - comparison",
+      "id": "choices",
+      "autoLayout": {
+        "direction": "TB"
+      },
+      "hash": "oaajO0MLKAReHfZcyiHRW8Bb6KIFPxUat0N-EhP7O6I",
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "width": 766,
+        "height": 503
+      },
+      "nodes": [
+        {
+          "id": "desk",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [],
+          "outEdges": [
+            "18l3bv3",
+            "19v07zu"
+          ],
+          "title": "Delivery design review",
+          "modelRef": "desk",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "The question this session was opened to answer."
+          },
+          "tags": [],
+          "kind": "review",
+          "x": 220,
+          "y": 0,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 22,
+            "y": 56,
+            "width": 275,
+            "height": 65
+          }
+        },
+        {
+          "id": "streaming",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [
+            "18l3bv3"
+          ],
+          "outEdges": [],
+          "title": "Option 1 - Event-driven delivery",
+          "modelRef": "streaming",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Each change is published as an event and applied as it arrives."
+          },
+          "tags": [],
+          "kind": "option",
+          "navigateTo": "detailStreaming",
+          "x": 0,
+          "y": 323,
+          "width": 321,
+          "height": 180,
+          "labelBBox": {
+            "x": 18,
+            "y": 56,
+            "width": 286,
+            "height": 65
+          }
+        },
+        {
+          "id": "nightly",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [
+            "19v07zu"
+          ],
+          "outEdges": [],
+          "title": "Option 2 - Nightly batch delivery",
+          "modelRef": "nightly",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Changes are collected and applied once per night."
+          },
+          "tags": [],
+          "kind": "option",
+          "navigateTo": "detailNightly",
+          "x": 432,
+          "y": 323,
+          "width": 333,
+          "height": 180,
+          "labelBBox": {
+            "x": 18,
+            "y": 56,
+            "width": 298,
+            "height": 65
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "18l3bv3",
+          "source": "desk",
+          "target": "streaming",
+          "label": "compares",
+          "points": [
+            [
+              319,
+              180
+            ],
+            [
+              291,
+              222
+            ],
+            [
+              257,
+              272
+            ],
+            [
+              227,
+              315
+            ]
+          ],
+          "labelBBox": {
+            "x": 278,
+            "y": 241,
+            "width": 65,
+            "height": 18
+          },
+          "parent": null,
+          "relations": [
+            "5l0pi9"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        },
+        {
+          "id": "19v07zu",
+          "source": "desk",
+          "target": "nightly",
+          "label": "compares",
+          "points": [
+            [
+              441,
+              180
+            ],
+            [
+              469,
+              222
+            ],
+            [
+              503,
+              272
+            ],
+            [
+              533,
+              315
+            ]
+          ],
+          "labelBBox": {
+            "x": 497,
+            "y": 241,
+            "width": 65,
+            "height": 18
+          },
+          "parent": null,
+          "relations": [
+            "191xp83"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        }
+      ]
+    },
+    "detailStreaming": {
+      "_type": "element",
+      "tags": null,
+      "links": null,
+      "viewOf": "streaming",
+      "_stage": "layouted",
+      "sourcePath": "views/choices.likec4",
+      "description": {
+        "txt": "Ad hoc, non-canonical. Inside the event-driven option."
+      },
+      "title": "Option 1 detail - event-driven delivery",
+      "id": "detailStreaming",
+      "autoLayout": {
+        "direction": "LR"
+      },
+      "hash": "EKAs9oznq_lmtXrN7NfN67_sA3_AcC31R_1u2UVVisI",
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "width": 1504,
+        "height": 317
+      },
+      "nodes": [
+        {
+          "id": "streaming",
+          "parent": null,
+          "level": 0,
+          "children": [
+            "streaming.publisher",
+            "streaming.bus",
+            "streaming.consumer"
+          ],
+          "inEdges": [],
+          "outEdges": [],
+          "title": "Option 1 - Event-driven delivery",
+          "modelRef": "streaming",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Each change is published as an event and applied as it arrives."
+          },
+          "tags": [],
+          "kind": "option",
+          "depth": 1,
+          "x": 8,
+          "y": 8,
+          "width": 1488,
+          "height": 301,
+          "labelBBox": {
+            "x": 6,
+            "y": 0,
+            "width": 205,
+            "height": 15
+          }
+        },
+        {
+          "id": "streaming.publisher",
+          "parent": "streaming",
+          "level": 1,
+          "children": [],
+          "inEdges": [],
+          "outEdges": [
+            "rh73b4"
+          ],
+          "title": "Change publisher",
+          "modelRef": "streaming.publisher",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Emits one event per committed change."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 48,
+          "y": 69,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 26,
+            "y": 65,
+            "width": 268,
+            "height": 47
+          }
+        },
+        {
+          "id": "streaming.bus",
+          "parent": "streaming",
+          "level": 1,
+          "children": [],
+          "inEdges": [
+            "rh73b4"
+          ],
+          "outEdges": [
+            "1pwggkw"
+          ],
+          "title": "Event bus",
+          "modelRef": "streaming.bus",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "At-least-once fan-out with replay."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 603,
+          "y": 69,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 48,
+            "y": 65,
+            "width": 223,
+            "height": 47
+          }
+        },
+        {
+          "id": "streaming.consumer",
+          "parent": "streaming",
+          "level": 1,
+          "children": [],
+          "inEdges": [
+            "1pwggkw"
+          ],
+          "outEdges": [],
+          "title": "Streaming consumer",
+          "modelRef": "streaming.consumer",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Applies each event on arrival."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 1136,
+          "y": 69,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 59,
+            "y": 65,
+            "width": 201,
+            "height": 47
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "rh73b4",
+          "source": "streaming.publisher",
+          "target": "streaming.bus",
+          "label": "publishes change",
+          "points": [
+            [
+              368,
+              159
+            ],
+            [
+              438,
+              159
+            ],
+            [
+              521,
+              159
+            ],
+            [
+              593,
+              159
+            ]
+          ],
+          "labelBBox": {
+            "x": 429,
+            "y": 137,
+            "width": 113,
+            "height": 18
+          },
+          "parent": "streaming",
+          "relations": [
+            "e6bltu"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        },
+        {
+          "id": "1pwggkw",
+          "source": "streaming.bus",
+          "target": "streaming.consumer",
+          "label": "delivers event",
+          "points": [
+            [
+              923,
+              159
+            ],
+            [
+              987,
+              159
+            ],
+            [
+              1060,
+              159
+            ],
+            [
+              1125,
+              159
+            ]
+          ],
+          "labelBBox": {
+            "x": 984,
+            "y": 137,
+            "width": 90,
+            "height": 18
+          },
+          "parent": "streaming",
+          "relations": [
+            "xkk6qd"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        }
+      ]
+    },
+    "detailNightly": {
+      "_type": "element",
+      "tags": null,
+      "links": null,
+      "viewOf": "nightly",
+      "_stage": "layouted",
+      "sourcePath": "views/choices.likec4",
+      "description": {
+        "txt": "Ad hoc, non-canonical. Inside the nightly batch option."
+      },
+      "title": "Option 2 detail - nightly batch delivery",
+      "id": "detailNightly",
+      "autoLayout": {
+        "direction": "LR"
+      },
+      "hash": "pJBXxCW1z2ajDed_K4-ly6QohfJIj5XiiOgBPbDmPQE",
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "width": 1508,
+        "height": 317
+      },
+      "nodes": [
+        {
+          "id": "nightly",
+          "parent": null,
+          "level": 0,
+          "children": [
+            "nightly.collector",
+            "nightly.window",
+            "nightly.loader"
+          ],
+          "inEdges": [],
+          "outEdges": [],
+          "title": "Option 2 - Nightly batch delivery",
+          "modelRef": "nightly",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Changes are collected and applied once per night."
+          },
+          "tags": [],
+          "kind": "option",
+          "depth": 1,
+          "x": 8,
+          "y": 8,
+          "width": 1492,
+          "height": 301,
+          "labelBBox": {
+            "x": 6,
+            "y": 0,
+            "width": 213,
+            "height": 15
+          }
+        },
+        {
+          "id": "nightly.collector",
+          "parent": "nightly",
+          "level": 1,
+          "children": [],
+          "inEdges": [],
+          "outEdges": [
+            "1ukk291"
+          ],
+          "title": "Change collector",
+          "modelRef": "nightly.collector",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Accumulates changes through the day."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 48,
+          "y": 69,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 28,
+            "y": 65,
+            "width": 263,
+            "height": 47
+          }
+        },
+        {
+          "id": "nightly.window",
+          "parent": "nightly",
+          "level": 1,
+          "children": [],
+          "inEdges": [
+            "1ukk291"
+          ],
+          "outEdges": [
+            "1ijh3ef"
+          ],
+          "title": "Nightly window",
+          "modelRef": "nightly.window",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "One scheduled run, no partial state."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 585,
+          "y": 69,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 39,
+            "y": 65,
+            "width": 242,
+            "height": 47
+          }
+        },
+        {
+          "id": "nightly.loader",
+          "parent": "nightly",
+          "level": 1,
+          "children": [],
+          "inEdges": [
+            "1ijh3ef"
+          ],
+          "outEdges": [],
+          "title": "Batch loader",
+          "modelRef": "nightly.loader",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "description": {
+            "txt": "Applies the whole night in one transaction."
+          },
+          "tags": [],
+          "kind": "part",
+          "x": 1138,
+          "y": 69,
+          "width": 321,
+          "height": 180,
+          "labelBBox": {
+            "x": 19,
+            "y": 65,
+            "width": 285,
+            "height": 47
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "1ukk291",
+          "source": "nightly.collector",
+          "target": "nightly.window",
+          "label": "stages change",
+          "points": [
+            [
+              368,
+              159
+            ],
+            [
+              433,
+              159
+            ],
+            [
+              509,
+              159
+            ],
+            [
+              575,
+              159
+            ]
+          ],
+          "labelBBox": {
+            "x": 429,
+            "y": 137,
+            "width": 95,
+            "height": 18
+          },
+          "parent": "nightly",
+          "relations": [
+            "1w5wchw"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        },
+        {
+          "id": "1ijh3ef",
+          "source": "nightly.window",
+          "target": "nightly.loader",
+          "label": "hands over batch",
+          "points": [
+            [
+              905,
+              159
+            ],
+            [
+              975,
+              159
+            ],
+            [
+              1057,
+              159
+            ],
+            [
+              1128,
+              159
+            ]
+          ],
+          "labelBBox": {
+            "x": 966,
+            "y": 137,
+            "width": 111,
+            "height": 18
+          },
+          "parent": "nightly",
+          "relations": [
+            "soe31t"
+          ],
+          "color": "gray",
+          "line": "dashed",
+          "head": "normal"
+        }
+      ]
     }
-  }
+  },
+  "deployments": {
+    "elements": {},
+    "relations": {}
+  },
+  "imports": {},
+  "manualLayouts": {}
 }

--- a/test/fixtures/visual/model.json
+++ b/test/fixtures/visual/model.json
@@ -35,7 +35,7 @@
     "streaming": {
       "style": {},
       "description": {
-        "txt": "Each change is published as an event and applied as it arrives."
+        "txt": "This option delivers each committed change as an event and applies it as it arrives. The path favors fast feedback over batch coordination. Operators can replay the event stream after an interruption. Literal safety probe: <img src=x onerror=window.visualSubjectPwned=true>."
       },
       "title": "Option 1 - Event-driven delivery",
       "kind": "option",
@@ -114,7 +114,10 @@
       "target": {
         "model": "streaming"
       },
-      "id": "5l0pi9"
+      "id": "5l0pi9",
+      "description": {
+        "txt": "The review compares an event-driven delivery path with the current decision context. This relationship exists only in the temporary explanatory model."
+      }
     },
     "191xp83": {
       "title": "compares",
@@ -247,7 +250,7 @@
             "size": "md"
           },
           "description": {
-            "txt": "Each change is published as an event and applied as it arrives."
+            "txt": "This option delivers each committed change as an event and applies it as it arrives. The path favors fast feedback over batch coordination. Operators can replay the event stream after an interruption. Literal safety probe: <img src=x onerror=window.visualSubjectPwned=true>."
           },
           "tags": [],
           "kind": "option",
@@ -334,7 +337,10 @@
           ],
           "color": "gray",
           "line": "dashed",
-          "head": "normal"
+          "head": "normal",
+          "description": {
+            "txt": "The review compares an event-driven delivery path with the current decision context. This relationship exists only in the temporary explanatory model."
+          }
         },
         {
           "id": "19v07zu",
@@ -449,7 +455,7 @@
             "size": "md"
           },
           "description": {
-            "txt": "Each change is published as an event and applied as it arrives."
+            "txt": "This option delivers each committed change as an event and applies it as it arrives. The path favors fast feedback over batch coordination. Operators can replay the event stream after an interruption. Literal safety probe: <img src=x onerror=window.visualSubjectPwned=true>."
           },
           "tags": [],
           "kind": "option",
@@ -536,7 +542,10 @@
           ],
           "color": "gray",
           "line": "dashed",
-          "head": "normal"
+          "head": "normal",
+          "description": {
+            "txt": "The review compares an event-driven delivery path with the current decision context. This relationship exists only in the temporary explanatory model."
+          }
         },
         {
           "id": "19v07zu",
@@ -620,7 +629,7 @@
             "size": "md"
           },
           "description": {
-            "txt": "Each change is published as an event and applied as it arrives."
+            "txt": "This option delivers each committed change as an event and applies it as it arrives. The path favors fast feedback over batch coordination. Operators can replay the event stream after an interruption. Literal safety probe: <img src=x onerror=window.visualSubjectPwned=true>."
           },
           "tags": [],
           "kind": "option",

--- a/test/fixtures/visual/model.json
+++ b/test/fixtures/visual/model.json
@@ -1,0 +1,86 @@
+{
+  "_stage": "layouted",
+  "projectId": "visual",
+  "project": {
+    "id": "visual",
+    "title": "visual"
+  },
+  "specification": {
+    "tags": {},
+    "elements": {
+      "system": {
+        "style": {}
+      }
+    },
+    "relationships": {},
+    "deployments": {},
+    "customColors": {}
+  },
+  "elements": {
+    "system": {
+      "style": {},
+      "title": "System",
+      "kind": "system",
+      "id": "system"
+    }
+  },
+  "relations": {},
+  "globals": {
+    "predicates": {},
+    "dynamicPredicates": {},
+    "styles": {}
+  },
+  "views": {
+    "choices": {
+      "_type": "element",
+      "_stage": "layouted",
+      "id": "choices",
+      "title": null,
+      "description": null,
+      "tags": null,
+      "links": null,
+      "sourcePath": "views/choices.likec4",
+      "autoLayout": {
+        "direction": "TB"
+      },
+      "hash": "w_sb3-EaQesp_nbNDKqaYUVIin1fRfjw7nrVhyJO-B8",
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "width": 320,
+        "height": 180
+      },
+      "nodes": [
+        {
+          "id": "system",
+          "parent": null,
+          "level": 0,
+          "children": [],
+          "inEdges": [],
+          "outEdges": [],
+          "title": "System",
+          "modelRef": "system",
+          "shape": "rectangle",
+          "color": "primary",
+          "style": {
+            "opacity": 15,
+            "size": "md"
+          },
+          "tags": [],
+          "kind": "system",
+          "x": 0,
+          "y": 0,
+          "width": 320,
+          "height": 180,
+          "labelBBox": {
+            "x": 125,
+            "y": 76,
+            "width": 71,
+            "height": 24
+          }
+        }
+      ],
+      "edges": []
+    }
+  }
+}

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1574,7 +1574,7 @@ views:
 
       expect(result.exitCode).toBe(0)
       const model = readFileSync(join(project, 'model.likec4'), 'utf8')
-      expect(model.match(/^  (?:dynamic )?view /gm)).toHaveLength(21)
+      expect(model.match(/^  (?:dynamic )?view /gm)).toHaveLength(22)
       expect(model).not.toMatch(/^    include \*$/gm)
       expect(model).toContain('view index')
       expect(model).not.toContain('view starter-landscape')
@@ -1601,7 +1601,7 @@ views:
         "view starter-technology-deployment {\n" +
           "    title '4 · ArchiMate viewpoints / Technology and deployment'\n" +
           "    description 'Technology structure, behavior, services, networks, and deployed artifacts.'\n" +
-          '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, likec4ExportAdapter, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli',
+          '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, likec4ExportAdapter, localWebBrowser, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli, visualBrowser, visualRuntime',
       )
       const marker = JSON.parse(
         readFileSync(
@@ -1609,7 +1609,7 @@ views:
           'utf8',
         ),
       )
-      expect(marker.views).toHaveLength(21)
+      expect(marker.views).toHaveLength(22)
       expect(marker.views[0]).toEqual({
         id: 'index',
         projection: 'starter-landscape@1.0',
@@ -2579,7 +2579,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/124',
-            line: 1274,
+            line: 1325,
             column: 5,
           },
           {
@@ -2590,7 +2590,7 @@ mappings:
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
             pointer: '/relationships/125',
-            line: 1278,
+            line: 1329,
             column: 5,
           },
           {

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -58,6 +58,20 @@ describe('consumer package contract', () => {
     expect(consumerGuide).toContain('diagram-only mode')
     expect(consumerGuide).toContain('yarramate-visual')
     expect(consumerGuide).not.toContain('pnpm exec yarramate')
+
+    const visualGuide = readFileSync(
+      join(
+        repositoryRoot,
+        'skills/yarramate-architecture/references/visual-conversations.md',
+      ),
+      'utf8',
+    )
+    expect(visualGuide).toContain('must be an absolute executable path')
+    expect(visualGuide).toContain('command -v npx')
+    expect(visualGuide).not.toContain(
+      '"command": "./node_modules/.bin/likec4"',
+    )
+    expect(visualGuide).not.toContain('"command": "npx"')
   })
 
   it('packs only a self-contained consumer surface', { timeout: 30_000 }, () => {

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -38,6 +38,13 @@ describe('consumer package contract', () => {
     expect(
       packageJson.exports['./schema/reconciliation-report'],
     ).toBe('./schema/yarramate-reconciliation-report.schema.json')
+    expect(packageJson.bin['yarramate-visual']).toBe(
+      'dist/adapters/visual-cli.js',
+    )
+    expect(packageJson.files).toContain('dist')
+    expect(
+      packageJson.exports['./schema/visual-diagnostic-result'],
+    ).toBe('./schema/yarramate-visual-diagnostic-result.schema.json')
 
     const consumerGuide = readFileSync(
       join(repositoryRoot, 'docs/CONSUMING-YARRAMATE.md'),
@@ -47,6 +54,9 @@ describe('consumer package contract', () => {
       'npx skills add yarrasys/yarramate --skill yarramate-architecture',
     )
     expect(consumerGuide).toContain('yarramate init .')
+    expect(consumerGuide).toContain('visually explain')
+    expect(consumerGuide).toContain('diagram-only mode')
+    expect(consumerGuide).toContain('yarramate-visual')
     expect(consumerGuide).not.toContain('pnpm exec yarramate')
   })
 
@@ -84,6 +94,28 @@ describe('consumer package contract', () => {
       expect(files).toContain(
         'package/skills/yarramate-architecture/references/native-authoring.md',
       )
+      expect(files).toContain(
+        'package/skills/yarramate-architecture/references/visual-conversations.md',
+      )
+      expect(files).toContain('package/dist/adapters/visual-cli.js')
+      expect(files).toContain('package/dist/visual-app/index.html')
+      // The nine standalone visual protocol documents a consumer validates
+      // against, each exported under `./schema/visual-*`.
+      for (const schema of [
+        'session-request',
+        'session-started',
+        'session-descriptor',
+        'event',
+        'response',
+        'model',
+        'handoff',
+        'status',
+        'diagnostic-result',
+      ]) {
+        expect(files).toContain(
+          `package/schema/yarramate-visual-${schema}.schema.json`,
+        )
+      }
       expect(files).toContain('package/docs/CONSUMING-YARRAMATE.md')
       expect(
         files.some((file) =>
@@ -150,6 +182,9 @@ describe('consumer package contract', () => {
       const mcpCli = join(binDirectory, 'yarramate-mcp')
       chmodSync(join(packagePath, 'dist/adapters/mcp-cli.js'), 0o755)
       symlinkSync('../yarramate/dist/adapters/mcp-cli.js', mcpCli)
+      const visualCli = join(binDirectory, 'yarramate-visual')
+      chmodSync(join(packagePath, 'dist/adapters/visual-cli.js'), 0o755)
+      symlinkSync('../yarramate/dist/adapters/visual-cli.js', visualCli)
       const run = (args: readonly string[]) =>
         execFileSync(cli, args, {
           cwd: consumer,
@@ -384,6 +419,7 @@ views:
         [likec4Cli, 'yarramate-likec4'],
         [graphifyCli, 'yarramate-graphify'],
         [mcpCli, 'yarramate-mcp'],
+        [visualCli, 'yarramate-visual'],
       ] as const) {
         expect(
           spawnSync(binary, ['--version'], {
@@ -414,6 +450,11 @@ views:
           packagePath,
           'schema/yarramate-reconciliation-report.schema.json',
         ),
+      )
+      expect(
+        requireFromConsumer.resolve('yarramate/schema/visual-handoff'),
+      ).toBe(
+        join(packagePath, 'schema/yarramate-visual-handoff.schema.json'),
       )
 
       for (const harness of ['.agents', '.claude']) {

--- a/test/self-model.test.ts
+++ b/test/self-model.test.ts
@@ -60,15 +60,25 @@ const coreContractProjection = {
   ),
 }
 
+const repositorySource = (path: string) => ({
+  path,
+  source: readFileSync(
+    fileURLToPath(new URL(`../${path}`, import.meta.url)),
+    'utf8',
+  ),
+})
+
+const selfModelSources = [
+  developmentProfile,
+  model('product'),
+  model('engine'),
+  model('repository'),
+  model('evolution'),
+]
+
 describe('YarraMate repository model', () => {
   it('conforms through the native compiler and exposes core architecture claims', () => {
-    const result = compileWorkspace([
-      developmentProfile,
-      model('product'),
-      model('engine'),
-      model('repository'),
-      model('evolution'),
-    ])
+    const result = compileWorkspace(selfModelSources)
 
     expect(result.ok).toBe(true)
     if (result.ok) {
@@ -183,22 +193,48 @@ describe('YarraMate repository model', () => {
     }
   })
 
+  it('models the recoverable visual conversation path', () => {
+    const result = compileWorkspace(selfModelSources)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.graph.subjects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'yarramate-engine#visual-runtime' }),
+        expect.objectContaining({
+          id: 'yarramate-engine#visual-session-service',
+        }),
+        expect.objectContaining({ id: 'yarramate-engine#visual-browser' }),
+        expect.objectContaining({
+          id: 'yarramate-engine#visual-session-protocol',
+        }),
+        expect.objectContaining({ id: 'yarramate-engine#visual-handoff' }),
+      ]),
+    )
+
+    const projection = loadProjection(
+      repositorySource('.yarramate/projections/visual-conversation-path.yaml'),
+    )
+    expect(projection.ok).toBe(true)
+    if (!projection.ok) return
+
+    const rendered = evaluateProjection(result.graph, projection.projection)
+    expect(rendered.subjects.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        'yarramate-engine#visual-runtime',
+        'yarramate-engine#visual-browser',
+        'yarramate-engine#visual-session-protocol',
+        'yarramate-engine#visual-handoff',
+        'yarramate-product#agent-harness',
+        'yarramate-repository#agent-skill-source',
+      ]),
+    )
+  })
+
   it('renders its architecture-state change through the optional LikeC4 adapter', () => {
-    const repositorySource = (path: string) => ({
-      path,
-      source: readFileSync(
-        fileURLToPath(new URL(`../${path}`, import.meta.url)),
-        'utf8',
-      ),
-    })
     const result = prepareLikeC4Export({
-      sources: [
-        developmentProfile,
-        model('product'),
-        model('engine'),
-        model('repository'),
-        model('evolution'),
-      ],
+      sources: selfModelSources,
       projection: repositorySource(
         '.yarramate/projections/state-engine-change.yaml',
       ),

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -118,4 +118,30 @@ describe('visual conversation rendering', () => {
       'Visual conversation ended. Continue in the main agent.',
     )
   })
+
+  it.each(['connecting', 'disconnected'] as const)(
+    'keeps the End label before an End request while %s',
+    (lifecycle) => {
+      const markup = renderSession({ lifecycle })
+
+      expect(markup).toContain('>End</button>')
+      expect(markup).not.toContain('>Ending…</button>')
+    },
+  )
+
+  it.each(['ending', 'closed'] as const)(
+    'stops showing an active agent wait while %s',
+    (lifecycle) => {
+      const markup = renderSession({
+        lifecycle,
+        awaitingAgent: true,
+        agentStatus: { state: 'thinking' },
+      })
+
+      expect(markup).toContain('aria-busy="false"')
+      expect(markup).not.toContain('class="agent-spinner"')
+      expect(markup).not.toContain('Awaiting agent response')
+      expect(markup).not.toContain('Agent is thinking')
+    },
+  )
 })

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -119,6 +119,12 @@ describe('visual conversation rendering', () => {
     )
   })
 
+  it('labels the session Beta in the command strip', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('class="beta-badge">Beta</span>')
+  })
+
   it.each(['connecting', 'disconnected'] as const)(
     'keeps the End label before an End request while %s',
     (lifecycle) => {

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -1,0 +1,121 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { VisualAppState } from '../src/visual-app/state.js'
+
+const session = vi.hoisted(() => {
+  const baseState: VisualAppState = {
+    lifecycle: 'active',
+    authority: 'canonical',
+    title: 'Visual architecture conversation',
+    description: 'Checked architecture slice',
+    chatEnabled: true,
+    model: null,
+    styleNonce: '',
+    activeView: '',
+    transcript: [
+      {
+        id: 'local-0',
+        speaker: 'reviewer',
+        text: 'What happens next?',
+      },
+    ],
+    choices: null,
+    agentStatus: null,
+    diagnostics: [],
+    handoff: null,
+    composerEnabled: false,
+    awaitingAgent: true,
+    localRecords: 1,
+    lastSequence: 1,
+    frozen: false,
+    closedReason: null,
+  }
+  return { baseState, state: baseState }
+})
+
+vi.mock('../src/visual-app/session-client.js', () => ({
+  useVisualSession: () => ({
+    state: session.state,
+    connected: true,
+    ask: vi.fn(),
+    choose: vi.fn(),
+    navigate: vi.fn(),
+    end: vi.fn(),
+  }),
+}))
+
+import { App } from '../src/visual-app/App.js'
+
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      innerWidth: 1280,
+      matchMedia: () => ({ matches: false }),
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    },
+  })
+})
+
+afterAll(() => {
+  if (previousWindow === undefined) {
+    Reflect.deleteProperty(globalThis, 'window')
+  } else {
+    Object.defineProperty(globalThis, 'window', previousWindow)
+  }
+})
+const renderSession = (overrides: Partial<VisualAppState> = {}): string => {
+  session.state = { ...session.baseState, ...overrides }
+  return renderToStaticMarkup(createElement(App))
+}
+
+
+describe('visual conversation rendering', () => {
+  it('shows an active waiting indicator immediately after a question is submitted', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('class="agent-spinner"')
+    expect(markup).toContain('Awaiting agent response')
+  })
+
+  it('explains that End is preparing the main-agent handoff', () => {
+    const markup = renderSession({ lifecycle: 'ending', handoff: null })
+
+    expect(markup).toContain('class="end-transition-status"')
+    expect(markup).toContain('aria-live="polite"')
+    expect(markup).toContain(
+      'Ending conversation — preparing a handoff for the main agent.',
+    )
+    expect(markup).toContain('>Ending…</button>')
+  })
+
+  it('reports when the handoff is ready for the main agent', () => {
+    const markup = renderSession({
+      lifecycle: 'ending',
+      handoff: {
+        summary: 'Option B confirmed.',
+        confirmedDecisions: ['option-b'],
+        requestedChanges: [],
+        unresolvedQuestions: [],
+        finalViews: ['overview'],
+      },
+    })
+
+    expect(markup).toContain(
+      'Handoff ready — returning control to the main agent.',
+    )
+  })
+
+  it('directs the reviewer to continue after the visual session closes', () => {
+    const markup = renderSession({ lifecycle: 'closed' })
+
+    expect(markup).toContain(
+      'Visual conversation ended. Continue in the main agent.',
+    )
+  })
+})

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -10,6 +10,8 @@ import type {
 } from '../src/adapters/visual/wire.js'
 import {
   RECONNECT_WINDOW_MS,
+  VISUAL_DRAW_FAULT_BARE,
+  VISUAL_DRAW_FAULT_KEPT,
   VISUAL_END_NOTICE,
   canReconnect,
   initialVisualAppState,
@@ -18,6 +20,7 @@ import {
   visualAppSnapshotFrom,
   visualAuthorityLabel,
   visualBrowserInputFor,
+  visualDrawingFor,
   type VisualAppState,
 } from '../src/visual-app/state.js'
 
@@ -80,6 +83,34 @@ const compileDiagnostic = {
   line: 2,
   column: 5,
 } as const
+
+/** A second fault of the same failure, so dropping one of them is visible. */
+const secondDiagnostic = {
+  ...compileDiagnostic,
+  code: 'YMVS202',
+  message: 'Unresolved reference "phantom"',
+  line: 9,
+} as const
+
+const responseEnvelope = {
+  format: 'yarramate/visual-response/v1',
+  sessionId: '0'.repeat(32),
+  responseId: 'a'.repeat(32),
+  eventId: 'b'.repeat(32),
+  timestamp: '2026-08-08T00:00:01.000Z',
+} as const
+
+/**
+ * One frame as the reviewer ends up seeing it: every action it means, in order.
+ */
+const applyFrame = (
+  state: VisualAppState,
+  frame: VisualServerFrame,
+): VisualAppState =>
+  visualAppActionsForFrame(frame).reduce(
+    (carried, action) => visualAppReducer(carried, action),
+    state,
+  )
 
 describe('visualAppReducer session lifecycle', () => {
   it('starts connecting with nothing to draw and no way to type', () => {
@@ -305,7 +336,7 @@ describe('visualAppReducer model rendering', () => {
   it('renders a replacement model and clears the diagnostics it answers', () => {
     const failed = visualAppReducer(activeState, {
       type: 'diagnostic.received',
-      diagnostic: compileDiagnostic,
+      diagnostics: [compileDiagnostic],
     })
     const next = visualAppReducer(failed, {
       type: 'model.received',
@@ -318,10 +349,25 @@ describe('visualAppReducer model rendering', () => {
   it('keeps the last rendered model when compilation fails', () => {
     const next = visualAppReducer(activeState, {
       type: 'diagnostic.received',
-      diagnostic: compileDiagnostic,
+      diagnostics: [compileDiagnostic],
     })
     expect(next.model).toBe(activeState.model)
     expect(next.diagnostics).toEqual([compileDiagnostic])
+  })
+
+  it('shows every fault of one failed compilation, not only the last', () => {
+    // A compilation fails for several reasons at once, and the reviewer has to
+    // read all of them: a frame is one failure, not a queue of replacements.
+    const next = applyFrame(activeState, {
+      kind: 'response',
+      response: {
+        ...responseEnvelope,
+        type: 'diagnostic',
+        payload: { diagnostics: [compileDiagnostic, secondDiagnostic] },
+      },
+    })
+    expect(next.diagnostics).toEqual([compileDiagnostic, secondDiagnostic])
+    expect(next.model).toBe(activeState.model)
   })
 
   it('keeps the reviewer on the view they were reading', () => {
@@ -521,7 +567,7 @@ describe('visualAppReducer conversation', () => {
     expect(
       visualAppReducer(thinking, {
         type: 'diagnostic.received',
-        diagnostic: compileDiagnostic,
+        diagnostics: [compileDiagnostic],
       }).agentStatus,
     ).toBe(null)
   })
@@ -564,7 +610,7 @@ describe('visualAppReducer acknowledgement and refusal', () => {
   it('shuts the composer for good when the server freezes input', () => {
     const next = visualAppReducer(activeState, {
       type: 'input.refused',
-      diagnostic: compileDiagnostic,
+      diagnostics: [compileDiagnostic],
       frozen: true,
     })
     expect(next.frozen).toBe(true)
@@ -575,11 +621,22 @@ describe('visualAppReducer acknowledgement and refusal', () => {
   it('leaves the composer open when a single frame was refused', () => {
     const next = visualAppReducer(activeState, {
       type: 'input.refused',
-      diagnostic: compileDiagnostic,
+      diagnostics: [compileDiagnostic],
       frozen: false,
     })
     expect(next.frozen).toBe(false)
     expect(next.composerEnabled).toBe(true)
+  })
+
+  it('shows every reason one frame was refused, not only the last', () => {
+    const next = applyFrame(activeState, {
+      kind: 'rejected',
+      diagnostics: [compileDiagnostic, secondDiagnostic],
+      frozen: 'pending-events',
+    })
+    expect(next.diagnostics).toEqual([compileDiagnostic, secondDiagnostic])
+    expect(next.frozen).toBe(true)
+    expect(next.composerEnabled).toBe(false)
   })
 })
 
@@ -661,20 +718,26 @@ describe('visualAppActionsForFrame', () => {
         frozen: 'pending-events',
       }),
     ).toEqual([
-      { type: 'input.refused', diagnostic: compileDiagnostic, frozen: true },
+      {
+        type: 'input.refused',
+        diagnostics: [compileDiagnostic],
+        frozen: true,
+      },
     ])
   })
 
-  it('keeps every diagnostic of a refused frame in the record', () => {
-    const second = { ...compileDiagnostic, code: 'YMVS202', line: 9 }
+  it('carries every diagnostic of a refused frame in one refusal', () => {
     expect(
       actionsFor({
         kind: 'rejected',
-        diagnostics: [compileDiagnostic, second],
+        diagnostics: [compileDiagnostic, secondDiagnostic],
       }),
     ).toEqual([
-      { type: 'input.refused', diagnostic: compileDiagnostic, frozen: false },
-      { type: 'input.refused', diagnostic: second, frozen: false },
+      {
+        type: 'input.refused',
+        diagnostics: [compileDiagnostic, secondDiagnostic],
+        frozen: false,
+      },
     ])
   })
 
@@ -692,18 +755,11 @@ describe('visualAppActionsForFrame', () => {
   })
 
   it('turns each agent response into the record it belongs to', () => {
-    const envelope = {
-      format: 'yarramate/visual-response/v1',
-      sessionId: '0'.repeat(32),
-      responseId: 'a'.repeat(32),
-      eventId: 'b'.repeat(32),
-      timestamp: '2026-08-08T00:00:01.000Z',
-    } as const
     expect(
       actionsFor({
         kind: 'response',
         response: {
-          ...envelope,
+          ...responseEnvelope,
           type: 'chat.response',
           payload: { text: 'Option B reuses the queue' },
         },
@@ -711,7 +767,7 @@ describe('visualAppActionsForFrame', () => {
     ).toEqual([
       {
         type: 'chat.received',
-        id: envelope.responseId,
+        id: responseEnvelope.responseId,
         text: 'Option B reuses the queue',
       },
     ])
@@ -719,7 +775,7 @@ describe('visualAppActionsForFrame', () => {
       actionsFor({
         kind: 'response',
         response: {
-          ...envelope,
+          ...responseEnvelope,
           type: 'agent.status',
           payload: { state: 'thinking' },
         },
@@ -729,12 +785,14 @@ describe('visualAppActionsForFrame', () => {
       actionsFor({
         kind: 'response',
         response: {
-          ...envelope,
+          ...responseEnvelope,
           type: 'diagnostic',
           payload: { diagnostics: [compileDiagnostic] },
         },
       }),
-    ).toEqual([{ type: 'diagnostic.received', diagnostic: compileDiagnostic }])
+    ).toEqual([
+      { type: 'diagnostic.received', diagnostics: [compileDiagnostic] },
+    ])
   })
 
   it('ignores a model replacement response, because the model frame carries it', () => {
@@ -783,5 +841,66 @@ describe('visualAuthorityLabel', () => {
   it('names a checked model and an ad hoc one in the reviewer’s words', () => {
     expect(visualAuthorityLabel('canonical')).toBe('Checked YarraMate model')
     expect(visualAuthorityLabel('ad-hoc')).toBe('Ad hoc · non-canonical')
+  })
+})
+
+describe('visualDrawingFor', () => {
+  /** A renderer stands for its drawing: what it read is what is on screen. */
+  const drawn = (model: VisualRenderedModel) => ({ read: model.compiled })
+  const readable = (compiled: unknown) => ({ read: compiled })
+  const unreadable = () => {
+    throw new Error('Invalid element kind "ghost" in views/choices')
+  }
+
+  it('draws a rendering the renderer can read', () => {
+    const rendered = model('000002', 'choices')
+    expect(visualDrawingFor(rendered, readable, null)).toEqual({
+      drawn: { read: rendered.compiled },
+      fault: null,
+    })
+  })
+
+  it('keeps the drawing on screen while the session has no model', () => {
+    const kept = drawn(model('000001', 'choices'))
+    expect(visualDrawingFor(null, unreadable, kept)).toEqual({
+      drawn: kept,
+      fault: null,
+    })
+  })
+
+  it('keeps the last good drawing and says so when a replacement cannot be drawn', () => {
+    const kept = drawn(model('000001', 'choices'))
+    const drawing = visualDrawingFor(
+      model('000002', 'choices'),
+      unreadable,
+      kept,
+    )
+    expect(drawing.drawn).toBe(kept)
+    expect(drawing.fault).toBe(VISUAL_DRAW_FAULT_KEPT)
+  })
+
+  it('says nothing could be drawn when the first model cannot be drawn', () => {
+    const drawing = visualDrawingFor(
+      model('000001', 'choices'),
+      unreadable,
+      null,
+    )
+    expect(drawing.drawn).toBe(null)
+    expect(drawing.fault).toBe(VISUAL_DRAW_FAULT_BARE)
+  })
+
+  it('never puts the renderer’s own exception in front of the reviewer', () => {
+    // The words the reviewer reads are this application's, in every case: a
+    // renderer's internals are not an explanation and may carry anything.
+    for (const lastDrawn of [null, drawn(model('000001', 'choices'))]) {
+      const { fault } = visualDrawingFor(
+        model('000002', 'choices'),
+        unreadable,
+        lastDrawn,
+      )
+      expect(fault).not.toBe(null)
+      expect(fault).not.toContain('ghost')
+      expect(fault).not.toContain('Invalid element kind')
+    }
   })
 })

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -1,0 +1,595 @@
+import { describe, expect, it } from 'vitest'
+import {
+  VISUAL_LIMITS,
+  type VisualBrowserInput,
+} from '../src/adapters/visual/protocol.js'
+import type {
+  VisualRenderedModel,
+  VisualServerFrame,
+  VisualSessionSnapshot,
+} from '../src/adapters/visual/wire.js'
+import {
+  RECONNECT_WINDOW_MS,
+  VISUAL_END_NOTICE,
+  canReconnect,
+  initialVisualAppState,
+  visualAppActionsForFrame,
+  visualAppReducer,
+  visualAppSnapshotFrom,
+  visualAuthorityLabel,
+  visualBrowserInputFor,
+  type VisualAppState,
+} from '../src/visual-app/state.js'
+
+const compiledOf = (...views: readonly string[]) => ({
+  _stage: 'layouted',
+  views: Object.fromEntries(views.map((id) => [id, { id }])),
+})
+
+const model = (
+  candidate: string,
+  ...views: readonly string[]
+): VisualRenderedModel => ({
+  candidate,
+  authority: 'ad-hoc',
+  initialView: views[0] as string,
+  views,
+  compiled: compiledOf(...views),
+})
+
+const serverSnapshot: VisualSessionSnapshot = {
+  protocolVersion: 'yarramate/visual-protocol/v1',
+  sessionId: '0'.repeat(32),
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  capabilities: {
+    chat: true,
+    choices: true,
+    navigation: true,
+    modelReplacement: true,
+    transcript: true,
+  },
+  webSocketUrl: 'ws://127.0.0.1:4321/socket',
+  model: model('000001', 'choices', 'option-b'),
+  lastSequence: 0,
+  frozen: false,
+}
+
+const loaded = (
+  overrides: Partial<VisualSessionSnapshot> = {},
+): VisualAppState =>
+  visualAppReducer(initialVisualAppState, {
+    type: 'session.loaded',
+    snapshot: visualAppSnapshotFrom({ ...serverSnapshot, ...overrides }),
+  })
+
+const activeState = loaded()
+
+const compileDiagnostic = {
+  severity: 'error',
+  code: 'YMVS201',
+  message: 'Unresolved reference "ghost"',
+  path: 'model.likec4',
+  pointer: '/files/model.likec4',
+  line: 2,
+  column: 5,
+} as const
+
+describe('visualAppReducer session lifecycle', () => {
+  it('starts connecting with nothing to draw and no way to type', () => {
+    expect(initialVisualAppState).toMatchObject({
+      lifecycle: 'connecting',
+      model: null,
+      composerEnabled: false,
+      transcript: [],
+      lastSequence: 0,
+    })
+  })
+
+  it('activates the session from the server snapshot', () => {
+    expect(activeState).toMatchObject({
+      lifecycle: 'active',
+      authority: 'ad-hoc',
+      title: 'Choose a delivery design',
+      description: 'Temporary non-canonical comparison',
+      activeView: 'choices',
+      composerEnabled: true,
+    })
+    expect(activeState.model?.candidate).toBe('000001')
+  })
+
+  it('leaves the composer shut when the session arrives already frozen', () => {
+    expect(loaded({ frozen: true }).composerEnabled).toBe(false)
+  })
+
+  it('leaves the composer shut when the session has no chat', () => {
+    expect(loaded({ chatEnabled: false }).composerEnabled).toBe(false)
+  })
+
+  it('freezes input immediately when End is requested', () => {
+    const next = visualAppReducer(activeState, { type: 'end.requested' })
+    expect(next.lifecycle).toBe('ending')
+    expect(next.composerEnabled).toBe(false)
+  })
+
+  it('tells the reviewer control is going back to the main agent', () => {
+    const next = visualAppReducer(activeState, { type: 'end.requested' })
+    expect(next.transcript.at(-1)).toMatchObject({
+      speaker: 'session',
+      text: 'Returning control to the main agent',
+    })
+    expect(VISUAL_END_NOTICE).toBe('Returning control to the main agent')
+  })
+
+  it('keeps a session that already requested End ending when it reconnects', () => {
+    const ending = visualAppReducer(activeState, { type: 'end.requested' })
+    const reconnected = visualAppReducer(ending, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom(serverSnapshot),
+    })
+    expect(reconnected.lifecycle).toBe('ending')
+    expect(reconnected.composerEnabled).toBe(false)
+  })
+
+  it('marks the session disconnected and shuts input when the socket drops', () => {
+    const next = visualAppReducer(activeState, { type: 'connection.lost' })
+    expect(next.lifecycle).toBe('disconnected')
+    expect(next.composerEnabled).toBe(false)
+    expect(next.model).toBe(activeState.model)
+  })
+
+  it('closes the session on the reason the server reports', () => {
+    const next = visualAppReducer(
+      visualAppReducer(activeState, { type: 'end.requested' }),
+      { type: 'session.closed', reason: 'user-ended' },
+    )
+    expect(next.lifecycle).toBe('closed')
+    expect(next.closedReason).toBe('user-ended')
+    expect(next.composerEnabled).toBe(false)
+  })
+
+  it('stays closed when a late frame arrives', () => {
+    const closed = visualAppReducer(activeState, {
+      type: 'session.closed',
+      reason: 'main-cancelled',
+    })
+    expect(
+      visualAppReducer(closed, {
+        type: 'session.loaded',
+        snapshot: visualAppSnapshotFrom(serverSnapshot),
+      }).lifecycle,
+    ).toBe('closed')
+    expect(visualAppReducer(closed, { type: 'connection.lost' }).lifecycle).toBe(
+      'closed',
+    )
+  })
+})
+
+describe('visualAppReducer model rendering', () => {
+  it('renders a replacement model and clears the diagnostics it answers', () => {
+    const failed = visualAppReducer(activeState, {
+      type: 'diagnostic.received',
+      diagnostic: compileDiagnostic,
+    })
+    const next = visualAppReducer(failed, {
+      type: 'model.received',
+      model: model('000002', 'choices'),
+    })
+    expect(next.model?.candidate).toBe('000002')
+    expect(next.diagnostics).toEqual([])
+  })
+
+  it('keeps the last rendered model when compilation fails', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'diagnostic.received',
+      diagnostic: compileDiagnostic,
+    })
+    expect(next.model).toBe(activeState.model)
+    expect(next.diagnostics).toEqual([compileDiagnostic])
+  })
+
+  it('keeps the reviewer on the view they were reading', () => {
+    const drilled = visualAppReducer(activeState, {
+      type: 'view.navigated',
+      viewId: 'option-b',
+    })
+    const next = visualAppReducer(drilled, {
+      type: 'model.received',
+      model: model('000002', 'choices', 'option-b'),
+    })
+    expect(next.activeView).toBe('option-b')
+  })
+
+  it('falls back to the initial view when the replacement dropped it', () => {
+    const drilled = visualAppReducer(activeState, {
+      type: 'view.navigated',
+      viewId: 'option-b',
+    })
+    const next = visualAppReducer(drilled, {
+      type: 'model.received',
+      model: model('000002', 'choices'),
+    })
+    expect(next.activeView).toBe('choices')
+  })
+
+  it('moves the active view locally without touching the transcript', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'view.navigated',
+      viewId: 'option-b',
+    })
+    expect(next.activeView).toBe('option-b')
+    expect(next.transcript).toBe(activeState.transcript)
+    expect(next.composerEnabled).toBe(true)
+  })
+})
+
+describe('visualAppReducer conversation', () => {
+  it('records the reviewer question verbatim and waits for the answer', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'chat.sent',
+      text: 'Why is <b>option B</b> cheaper?',
+    })
+    expect(next.transcript.at(-1)).toMatchObject({
+      speaker: 'reviewer',
+      text: 'Why is <b>option B</b> cheaper?',
+    })
+    expect(next.composerEnabled).toBe(false)
+  })
+
+  it('reopens the composer when the agent answers', () => {
+    const asked = visualAppReducer(activeState, {
+      type: 'chat.sent',
+      text: 'Why is option B cheaper?',
+    })
+    const next = visualAppReducer(asked, {
+      type: 'chat.received',
+      id: 'r1',
+      text: 'Option B reuses the existing queue.',
+    })
+    expect(next.transcript.at(-1)).toMatchObject({
+      id: 'r1',
+      speaker: 'agent',
+      text: 'Option B reuses the existing queue.',
+    })
+    expect(next.composerEnabled).toBe(true)
+  })
+
+  it('gives every transcript record its own key', () => {
+    const first = visualAppReducer(activeState, {
+      type: 'chat.sent',
+      text: 'one',
+    })
+    const second = visualAppReducer(first, { type: 'chat.sent', text: 'one' })
+    const keys = second.transcript.map((entry) => entry.id)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('presents choices and closes them the moment one is selected', () => {
+    const presented = visualAppReducer(activeState, {
+      type: 'choice.presented',
+      choice: {
+        choiceId: 'delivery',
+        question: 'Which delivery design should we keep?',
+        options: [
+          { id: 'option-a', label: 'Isolated worker' },
+          { id: 'option-b', label: 'Shared queue' },
+        ],
+      },
+    })
+    expect(presented.choices?.options).toHaveLength(2)
+    expect(presented.composerEnabled).toBe(true)
+
+    const chosen = visualAppReducer(presented, {
+      type: 'choice.sent',
+      optionId: 'option-b',
+    })
+    expect(chosen.choices).toBe(null)
+    expect(chosen.transcript.at(-1)).toMatchObject({
+      speaker: 'reviewer',
+      text: 'Shared queue',
+    })
+    expect(chosen.composerEnabled).toBe(false)
+  })
+
+  it('reports agent status without disturbing the transcript', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'status.received',
+      status: { state: 'compiling', detail: 'Rendering option B' },
+    })
+    expect(next.agentStatus).toEqual({
+      state: 'compiling',
+      detail: 'Rendering option B',
+    })
+    expect(next.transcript).toBe(activeState.transcript)
+  })
+
+  it('drops the agent status once the turn it described is answered', () => {
+    const thinking = visualAppReducer(
+      visualAppReducer(activeState, { type: 'chat.sent', text: 'why?' }),
+      { type: 'status.received', status: { state: 'thinking' } },
+    )
+    expect(thinking.agentStatus).not.toBe(null)
+    // The reviewer must never be told the agent is still thinking about a
+    // question it has already answered.
+    expect(
+      visualAppReducer(thinking, {
+        type: 'chat.received',
+        id: 'r2',
+        text: 'Because it reuses the intake path.',
+      }).agentStatus,
+    ).toBe(null)
+    expect(
+      visualAppReducer(thinking, {
+        type: 'choice.presented',
+        choice: { choiceId: 'c', question: 'Which?', options: [] },
+      }).agentStatus,
+    ).toBe(null)
+    expect(
+      visualAppReducer(thinking, {
+        type: 'diagnostic.received',
+        diagnostic: compileDiagnostic,
+      }).agentStatus,
+    ).toBe(null)
+  })
+
+  it('records the handoff summary the agent closed with', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'handoff.received',
+      id: 'r9',
+      handoff: {
+        summary: 'Option B confirmed',
+        confirmedDecisions: ['Reuse the shared queue'],
+        requestedChanges: [],
+        unresolvedQuestions: [],
+        finalViews: ['option-b'],
+      },
+    })
+    expect(next.handoff?.summary).toBe('Option B confirmed')
+    expect(next.transcript.at(-1)).toMatchObject({
+      speaker: 'agent',
+      text: 'Option B confirmed',
+    })
+  })
+})
+
+describe('visualAppReducer acknowledgement and refusal', () => {
+  it('tracks the highest sequence the server acknowledged', () => {
+    const first = visualAppReducer(activeState, {
+      type: 'event.acknowledged',
+      sequence: 2,
+    })
+    expect(first.lastSequence).toBe(2)
+    // A late acknowledgement for an earlier event never rewinds the browser's
+    // view of the journal, because that view is what every frame carries.
+    expect(
+      visualAppReducer(first, { type: 'event.acknowledged', sequence: 1 })
+        .lastSequence,
+    ).toBe(2)
+  })
+
+  it('shuts the composer for good when the server freezes input', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'input.refused',
+      diagnostic: compileDiagnostic,
+      frozen: true,
+    })
+    expect(next.frozen).toBe(true)
+    expect(next.composerEnabled).toBe(false)
+    expect(next.diagnostics).toEqual([compileDiagnostic])
+  })
+
+  it('leaves the composer open when a single frame was refused', () => {
+    const next = visualAppReducer(activeState, {
+      type: 'input.refused',
+      diagnostic: compileDiagnostic,
+      frozen: false,
+    })
+    expect(next.frozen).toBe(false)
+    expect(next.composerEnabled).toBe(true)
+  })
+})
+
+describe('visualBrowserInputFor', () => {
+  it('carries the last acknowledged sequence on every browser frame', () => {
+    const acknowledged = visualAppReducer(activeState, {
+      type: 'event.acknowledged',
+      sequence: 7,
+    })
+    const frames: readonly VisualBrowserInput[] = [
+      visualBrowserInputFor(
+        { kind: 'chat', text: 'Why option B?' },
+        acknowledged,
+      ),
+      visualBrowserInputFor(
+        { kind: 'choice', choiceId: 'delivery', optionId: 'option-b' },
+        acknowledged,
+      ),
+      visualBrowserInputFor(
+        { kind: 'navigate', viewId: 'option-b' },
+        acknowledged,
+      ),
+      visualBrowserInputFor({ kind: 'end' }, acknowledged),
+    ]
+    expect(frames.map((frame) => frame.lastAcknowledgedSequence)).toEqual([
+      7, 7, 7, 7,
+    ])
+    expect(frames.map((frame) => frame.type)).toEqual([
+      'chat.message',
+      'choice.selected',
+      'view.navigate',
+      'session.end',
+    ])
+  })
+
+  it('never asks the agent for attention on a local drill-down', () => {
+    expect(
+      visualBrowserInputFor({ kind: 'navigate', viewId: 'option-b' }, activeState),
+    ).toEqual({
+      type: 'view.navigate',
+      lastAcknowledgedSequence: 0,
+      payload: { viewId: 'option-b', requiresAttention: false },
+    })
+  })
+
+  it('ends only for the reason the reviewer chose', () => {
+    expect(visualBrowserInputFor({ kind: 'end' }, activeState)).toEqual({
+      type: 'session.end',
+      lastAcknowledgedSequence: 0,
+      payload: { reason: 'user-ended' },
+    })
+  })
+})
+
+describe('visualAppActionsForFrame', () => {
+  const actionsFor = (frame: VisualServerFrame) =>
+    visualAppActionsForFrame(frame)
+
+  it('loads the session from a ready frame', () => {
+    expect(actionsFor({ kind: 'ready', snapshot: serverSnapshot })).toEqual([
+      {
+        type: 'session.loaded',
+        snapshot: visualAppSnapshotFrom(serverSnapshot),
+      },
+    ])
+  })
+
+  it('acknowledges an accepted event', () => {
+    expect(actionsFor({ kind: 'accepted', sequence: 3, eventId: 'e3' })).toEqual(
+      [{ type: 'event.acknowledged', sequence: 3 }],
+    )
+  })
+
+  it('refuses input and reports whether the session froze', () => {
+    expect(
+      actionsFor({
+        kind: 'rejected',
+        diagnostics: [compileDiagnostic],
+        frozen: 'pending-events',
+      }),
+    ).toEqual([
+      { type: 'input.refused', diagnostic: compileDiagnostic, frozen: true },
+    ])
+  })
+
+  it('keeps every diagnostic of a refused frame in the record', () => {
+    const second = { ...compileDiagnostic, code: 'YMVS202', line: 9 }
+    expect(
+      actionsFor({
+        kind: 'rejected',
+        diagnostics: [compileDiagnostic, second],
+      }),
+    ).toEqual([
+      { type: 'input.refused', diagnostic: compileDiagnostic, frozen: false },
+      { type: 'input.refused', diagnostic: second, frozen: false },
+    ])
+  })
+
+  it('replaces the rendered model from a model frame', () => {
+    const rendered = model('000002', 'choices')
+    expect(actionsFor({ kind: 'model', model: rendered })).toEqual([
+      { type: 'model.received', model: rendered },
+    ])
+  })
+
+  it('closes the session from a closing frame', () => {
+    expect(actionsFor({ kind: 'closing', reason: 'user-ended' })).toEqual([
+      { type: 'session.closed', reason: 'user-ended' },
+    ])
+  })
+
+  it('turns each agent response into the record it belongs to', () => {
+    const envelope = {
+      format: 'yarramate/visual-response/v1',
+      sessionId: '0'.repeat(32),
+      responseId: 'a'.repeat(32),
+      eventId: 'b'.repeat(32),
+      timestamp: '2026-08-08T00:00:01.000Z',
+    } as const
+    expect(
+      actionsFor({
+        kind: 'response',
+        response: {
+          ...envelope,
+          type: 'chat.response',
+          payload: { text: 'Option B reuses the queue' },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'chat.received',
+        id: envelope.responseId,
+        text: 'Option B reuses the queue',
+      },
+    ])
+    expect(
+      actionsFor({
+        kind: 'response',
+        response: {
+          ...envelope,
+          type: 'agent.status',
+          payload: { state: 'thinking' },
+        },
+      }),
+    ).toEqual([{ type: 'status.received', status: { state: 'thinking' } }])
+    expect(
+      actionsFor({
+        kind: 'response',
+        response: {
+          ...envelope,
+          type: 'diagnostic',
+          payload: { diagnostics: [compileDiagnostic] },
+        },
+      }),
+    ).toEqual([{ type: 'diagnostic.received', diagnostic: compileDiagnostic }])
+  })
+
+  it('ignores a model replacement response, because the model frame carries it', () => {
+    expect(
+      actionsFor({
+        kind: 'response',
+        response: {
+          format: 'yarramate/visual-response/v1',
+          sessionId: '0'.repeat(32),
+          responseId: 'c'.repeat(32),
+          eventId: 'd'.repeat(32),
+          timestamp: '2026-08-08T00:00:02.000Z',
+          type: 'model.replace',
+          payload: {
+            model: {
+              format: 'yarramate/visual-model/v1',
+              authority: 'ad-hoc',
+              initialView: 'choices',
+              sourceDigests: {},
+              files: { 'model.likec4': 'model {}' },
+            },
+          },
+        },
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('canReconnect', () => {
+  it('pins the browser grace to the protocol reconnect window', () => {
+    expect(RECONNECT_WINDOW_MS).toBe(VISUAL_LIMITS.reconnectMs)
+  })
+
+  it('reconnects inside the grace and stops at its edge', () => {
+    const lostAt = 1_000_000
+    expect(canReconnect(lostAt, lostAt)).toBe(true)
+    expect(canReconnect(lostAt, lostAt + RECONNECT_WINDOW_MS - 1)).toBe(true)
+    expect(canReconnect(lostAt, lostAt + RECONNECT_WINDOW_MS)).toBe(false)
+    expect(canReconnect(lostAt, lostAt + RECONNECT_WINDOW_MS + 60_000)).toBe(
+      false,
+    )
+  })
+})
+
+describe('visualAuthorityLabel', () => {
+  it('names a checked model and an ad hoc one in the reviewer’s words', () => {
+    expect(visualAuthorityLabel('canonical')).toBe('Checked YarraMate model')
+    expect(visualAuthorityLabel('ad-hoc')).toBe('Ad hoc · non-canonical')
+  })
+})

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -54,6 +54,7 @@ const serverSnapshot: VisualSessionSnapshot = {
   webSocketUrl: 'ws://127.0.0.1:4321/socket',
   model: model('000001', 'choices', 'option-b'),
   transcript: [],
+  agentTurnOpen: false,
   styleNonce: 'a'.repeat(32),
   lastSequence: 0,
   frozen: false,
@@ -100,6 +101,75 @@ describe('visualAppReducer session lifecycle', () => {
       composerEnabled: true,
     })
     expect(activeState.model?.candidate).toBe('000001')
+  })
+
+  it('keeps input shut when the turn was still open at reconnect', () => {
+    const asked = visualAppReducer(
+      visualAppReducer(activeState, { type: 'chat.sent', text: 'Why B?' }),
+      { type: 'status.received', status: { state: 'thinking' } },
+    )
+    const reconnected = visualAppReducer(asked, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom({
+        ...serverSnapshot,
+        transcript: [{ id: 'e1', speaker: 'reviewer', text: 'Why B?' }],
+        agentTurnOpen: true,
+        lastSequence: 1,
+      }),
+    })
+    expect(reconnected.composerEnabled).toBe(false)
+    expect(reconnected.agentStatus).toEqual({ state: 'thinking' })
+  })
+
+  it('reopens input when the agent answered while the browser was away', () => {
+    const asked = visualAppReducer(
+      visualAppReducer(activeState, { type: 'chat.sent', text: 'Why B?' }),
+      { type: 'status.received', status: { state: 'thinking' } },
+    )
+    const lost = visualAppReducer(asked, { type: 'connection.lost' })
+    const reconnected = visualAppReducer(lost, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom({
+        ...serverSnapshot,
+        transcript: [
+          { id: 'e1', speaker: 'reviewer', text: 'Why B?' },
+          { id: 'r1', speaker: 'agent', text: 'It reuses the intake path.' },
+        ],
+        agentTurnOpen: false,
+        lastSequence: 1,
+      }),
+    })
+    expect(reconnected.lifecycle).toBe('active')
+    expect(reconnected.composerEnabled).toBe(true)
+    expect(reconnected.agentStatus).toBe(null)
+    expect(reconnected.transcript).toHaveLength(2)
+
+    // The server may replay the response this browser missed; the record it
+    // already holds is the same record, not a second one.
+    const replayed = visualAppReducer(reconnected, {
+      type: 'chat.received',
+      id: 'r1',
+      text: 'It reuses the intake path.',
+    })
+    expect(replayed.transcript).toHaveLength(2)
+    expect(replayed.composerEnabled).toBe(true)
+  })
+
+  it('never reuses a record key across a restored conversation', () => {
+    const ending = visualAppReducer(activeState, { type: 'end.requested' })
+    const restored = visualAppReducer(ending, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom({
+        ...serverSnapshot,
+        transcript: [
+          { id: 'e1', speaker: 'reviewer', text: 'one' },
+          { id: 'r1', speaker: 'agent', text: 'two' },
+        ],
+      }),
+    })
+    const asked = visualAppReducer(restored, { type: 'chat.sent', text: 'next' })
+    const keys = asked.transcript.map((record) => record.id)
+    expect(new Set(keys).size).toBe(keys.length)
   })
 
   it('carries the session style nonce to the renderer', () => {

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -400,6 +400,64 @@ describe('visualAppReducer conversation', () => {
     expect(chosen.composerEnabled).toBe(false)
   })
 
+  describe('after a choice, every later record keeps its own key', () => {
+    const present = (state: VisualAppState, choiceId: string) =>
+      visualAppReducer(state, {
+        type: 'choice.presented',
+        choice: {
+          choiceId,
+          question: 'Which delivery design should we keep?',
+          options: [
+            { id: 'option-a', label: 'Isolated worker' },
+            { id: 'option-b', label: 'Shared queue' },
+          ],
+        },
+      })
+
+    const chosen = visualAppReducer(present(activeState, 'first'), {
+      type: 'choice.sent',
+      optionId: 'option-b',
+    })
+
+    const unique = (state: VisualAppState) => {
+      const keys = state.transcript.map((record) => record.id)
+      expect(new Set(keys).size).toBe(keys.length)
+    }
+
+    it('records a second choice beside the first', () => {
+      const next = visualAppReducer(present(chosen, 'second'), {
+        type: 'choice.sent',
+        optionId: 'option-a',
+      })
+      expect(next.transcript.map((record) => record.text)).toEqual([
+        'Shared queue',
+        'Isolated worker',
+      ])
+      unique(next)
+    })
+
+    it('records a question asked after a choice', () => {
+      const next = visualAppReducer(chosen, {
+        type: 'chat.sent',
+        text: 'What does that cost?',
+      })
+      expect(next.transcript.map((record) => record.text)).toEqual([
+        'Shared queue',
+        'What does that cost?',
+      ])
+      unique(next)
+    })
+
+    it('still shows the End notice after a choice', () => {
+      const next = visualAppReducer(chosen, { type: 'end.requested' })
+      expect(next.transcript.map((record) => record.text)).toEqual([
+        'Shared queue',
+        VISUAL_END_NOTICE,
+      ])
+      unique(next)
+    })
+  })
+
   it('reports agent status without disturbing the transcript', () => {
     const next = visualAppReducer(activeState, {
       type: 'status.received',

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -55,6 +55,7 @@ const serverSnapshot: VisualSessionSnapshot = {
   model: model('000001', 'choices', 'option-b'),
   transcript: [],
   agentTurnOpen: false,
+  pendingChoice: null,
   styleNonce: 'a'.repeat(32),
   lastSequence: 0,
   frozen: false,
@@ -119,6 +120,32 @@ describe('visualAppReducer session lifecycle', () => {
     })
     expect(reconnected.composerEnabled).toBe(false)
     expect(reconnected.agentStatus).toEqual({ state: 'thinking' })
+  })
+
+  it('restores the choice the agent is still waiting on at reconnect', () => {
+    const question = {
+      choiceId: 'delivery',
+      question: 'Which delivery design should we keep?',
+      options: [
+        { id: 'shared-queue', label: 'Shared queue' },
+        { id: 'isolated-worker', label: 'Isolated worker' },
+      ],
+    }
+    // Nothing in the transcript says a question was asked, so a reviewer who
+    // reloads can only answer it if the snapshot brings it back.
+    expect(loaded({ pendingChoice: question }).choices).toEqual(question)
+  })
+
+  it('closes a choice the session no longer waits on', () => {
+    const presented = visualAppReducer(activeState, {
+      type: 'choice.presented',
+      choice: { choiceId: 'delivery', question: 'Which?', options: [] },
+    })
+    const reconnected = visualAppReducer(presented, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom(serverSnapshot),
+    })
+    expect(reconnected.choices).toBe(null)
   })
 
   it('reopens input when the agent answered while the browser was away', () => {

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -53,6 +53,8 @@ const serverSnapshot: VisualSessionSnapshot = {
   },
   webSocketUrl: 'ws://127.0.0.1:4321/socket',
   model: model('000001', 'choices', 'option-b'),
+  transcript: [],
+  styleNonce: 'a'.repeat(32),
   lastSequence: 0,
   frozen: false,
 }
@@ -98,6 +100,41 @@ describe('visualAppReducer session lifecycle', () => {
       composerEnabled: true,
     })
     expect(activeState.model?.candidate).toBe('000001')
+  })
+
+  it('carries the session style nonce to the renderer', () => {
+    expect(activeState.styleNonce).toBe('a'.repeat(32))
+  })
+
+  it('restores the conversation the session already holds', () => {
+    const restored = loaded({
+      transcript: [
+        { id: 'e1', speaker: 'reviewer', text: 'Why option B?' },
+        { id: 'r1', speaker: 'agent', text: 'It reuses the intake path.' },
+      ],
+      lastSequence: 1,
+    })
+    expect(restored.transcript).toEqual([
+      { id: 'e1', speaker: 'reviewer', text: 'Why option B?' },
+      { id: 'r1', speaker: 'agent', text: 'It reuses the intake path.' },
+    ])
+    expect(restored.lastSequence).toBe(1)
+  })
+
+  it('keeps its own session notices when the server restores the record', () => {
+    const ending = visualAppReducer(activeState, { type: 'end.requested' })
+    const restored = visualAppReducer(ending, {
+      type: 'session.loaded',
+      snapshot: visualAppSnapshotFrom({
+        ...serverSnapshot,
+        transcript: [{ id: 'e1', speaker: 'reviewer', text: 'Why option B?' }],
+      }),
+    })
+    // The server owns what was said; the browser owns what it told the reviewer.
+    expect(restored.transcript).toEqual([
+      { id: 'e1', speaker: 'reviewer', text: 'Why option B?' },
+      { id: 'local-0', speaker: 'session', text: VISUAL_END_NOTICE },
+    ])
   })
 
   it('leaves the composer shut when the session arrives already frozen', () => {

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync, spawnSync } from 'node:child_process'
 import { EventEmitter, once } from 'node:events'
 import { existsSync } from 'node:fs'
 import {
@@ -54,6 +55,7 @@ import {
 } from '../src/adapters/visual-cli.js'
 import { packageVersion, type CliResult } from '../src/cli-support.js'
 
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const fixtures = fileURLToPath(new URL('./fixtures/visual/', import.meta.url))
 const fakeCompiler = join(fixtures, 'fake-likec4.mjs')
 const assetRoot = join(fixtures, 'browser-assets')
@@ -463,6 +465,33 @@ describe('descriptor confinement', () => {
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS401'])
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'refuses a FIFO descriptor without waiting for a writer',
+    () => {
+      const fifo = join(workDir, 'descriptor.fifo')
+      execFileSync('mkfifo', [fifo])
+
+      const result = spawnSync(
+        process.execPath,
+        ['dist/adapters/visual-cli.js', 'status', fifo],
+        {
+          cwd: repositoryRoot,
+          encoding: 'utf8',
+          timeout: 1000,
+        },
+      )
+
+      expect(result.signal).toBeNull()
+      expect(result.status).toBe(1)
+      expect(
+        parseVisualDiagnosticResult(JSON.parse(result.stderr)),
+      ).toMatchObject({
+        ok: true,
+        value: { diagnostics: [{ code: 'YMVS401' }] },
+      })
+    },
+  )
 
   it('refuses a descriptor that is not JSON', async () => {
     const path = join(workDir, 'descriptor.json')

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -939,14 +939,52 @@ describe('stop', () => {
     })
   })
 
-  it('reports a vanished descriptor rather than a second stop', async () => {
-    const { descriptorPath } = await plantSession()
+  it('reports the already-stopped state when the stop is repeated', async () => {
+    const { descriptorPath, root } = await plantSession()
     expect(
       (await runVisualClientCli(['stop', descriptorPath], workDir)).exitCode,
     ).toBe(0)
-    const repeated = await runVisualClientCli(['stop', descriptorPath], workDir)
-    expect(repeated.exitCode).toBe(1)
-    expect(refusalCodes(repeated)).toEqual(['YMVS401'])
+    expect(existsSync(root)).toBe(false)
+
+    // The first stop took the descriptor and the session root together, which
+    // is the one shape of unreadable descriptor that means "already stopped".
+    await expect(
+      runVisualClientCli(['stop', descriptorPath], workDir),
+    ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
+    await expect(
+      runVisualClientCli(['stop', descriptorPath, '--transcript'], workDir),
+    ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
+  })
+
+  it('keeps a descriptor missing from a live session root fail-closed', async () => {
+    const { descriptorPath, root } = await plantSession()
+    await rm(descriptorPath)
+
+    const orphaned = await runVisualClientCli(['stop', descriptorPath], workDir)
+
+    expect(orphaned.exitCode).toBe(1)
+    expect(refusalCodes(orphaned)).toEqual(['YMVS401'])
+    // Nothing was torn down on the strength of a descriptor that never read.
+    expect(existsSync(root)).toBe(true)
+  })
+
+  it('refuses an unreadable descriptor rather than calling it stopped', async () => {
+    const { descriptorPath } = await plantSession()
+    await writeFile(descriptorPath, '{"format":')
+
+    const corrupt = await runVisualClientCli(['stop', descriptorPath], workDir)
+
+    expect(corrupt.exitCode).toBe(1)
+    expect(refusalCodes(corrupt)).toEqual(['YMVS402'])
+
+    // A path that never was a session directory is not a stop either: only
+    // commands aimed at a vanished session root report the benign state.
+    const stray = await runVisualClientCli(
+      ['stop', join(workDir, 'stray.json')],
+      workDir,
+    )
+    expect(stray.exitCode).toBe(1)
+    expect(refusalCodes(stray)).toEqual(['YMVS401'])
   })
 
   it('never deletes a directory whose marker names another session', async () => {

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -26,6 +26,7 @@ import {
   parseVisualHandoff,
   parseVisualSessionStarted,
   parseVisualStatus,
+  type VisualBrowserInput,
   type VisualEvent,
   type VisualHandoff,
   type VisualModel,
@@ -167,7 +168,7 @@ const nextFrame = async <Kind extends VisualServerFrame['kind']>(
  */
 const sendBrowserEvent = async (
   started: VisualSessionStarted,
-  input: typeof chatEventInput,
+  input: VisualBrowserInput,
 ) => {
   const bootstrapped = await fetch(started.browserUrl, { redirect: 'manual' })
   const header = bootstrapped.headers.get('set-cookie')
@@ -855,7 +856,10 @@ describe('stop', () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       format: 'yarramate/visual-handoff/v1',
       sessionId: handle.started.sessionId,
-      lastSequence: 1,
+      // The runtime's own terminal event, past the chat message, and the cause
+      // this stop closed the session under.
+      lastSequence: 2,
+      terminationReason: 'main-cancelled',
     })
     // Recovered before cleanup: the summary above came out of a journal the
     // same command then deleted.
@@ -1105,6 +1109,34 @@ describe('runVisualStart', () => {
     expect(refusalCodes(result)).toEqual(['YMVS409'])
     expect(existsSync(started.sessionRoot)).toBe(false)
     expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  it('reports a reviewer End the child never answered as a failed session', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+    await sendBrowserEvent(started, {
+      type: 'session.end',
+      lastAcknowledgedSequence: 0,
+      payload: { reason: 'user-ended' },
+    })
+
+    // The child died before submitting its handoff, so the main agent closes
+    // the session under its own cancellation.
+    const stopped = await runVisualClientCli(
+      ['stop', started.descriptorPath],
+      workDir,
+    )
+    expect(stopped.exitCode).toBe(0)
+    expect(JSON.parse(stopped.stdout)).toMatchObject({
+      decision: 'failed',
+      terminationReason: 'child-failed',
+    })
+
+    // The journal, not the reason someone asked to stop under, is what says
+    // whether this session did what it was opened to do.
+    const result = await foreground.result
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS409'])
   })
 
   it('refuses a request document that is not there', async () => {

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -84,6 +84,7 @@ const requestWith = (marker?: string): VisualSessionRequest => ({
 
 const chatEventInput = {
   type: 'chat.message',
+  lastAcknowledgedSequence: 0,
   payload: { text: 'Compare the two delivery designs' },
 } as const
 

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -98,6 +98,8 @@ const line = (value: unknown) => `${JSON.stringify(value)}\n`
 let baseDir = ''
 let workDir = ''
 const running: VisualServerHandle[] = []
+/** Browser sockets a test opened, closed once the session behind them is gone. */
+const attached: WebSocket[] = []
 
 const startServer = async (overrides: Partial<VisualServerOptions> = {}) => {
   const handle = await startVisualServer({
@@ -167,6 +169,10 @@ const nextFrame = async <Kind extends VisualServerFrame['kind']>(
  * Drives one real browser input into a session: bootstrap for the cookie,
  * upgrade, send, and wait for the runtime's acknowledgement, so the event is
  * journaled before the CLI is asked for it.
+ *
+ * The socket is left open and closed by the teardown. A session journals a
+ * browser going away, so closing it here would leave every sequence the CLI
+ * then reads racing an append nothing in the test is waiting on.
  */
 const sendBrowserEvent = async (
   started: VisualSessionStarted,
@@ -187,11 +193,10 @@ const sendBrowserEvent = async (
     frames.push(JSON.parse(String(data)) as VisualServerFrame)
   })
   await once(socket, 'open')
+  attached.push(socket)
   const accepted = nextFrame(socket, 'accepted')
   socket.send(JSON.stringify(input))
-  const acknowledged = await accepted
-  socket.close()
-  return acknowledged
+  return accepted
 }
 
 const agentPost = (
@@ -345,6 +350,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  for (const socket of attached.splice(0)) socket.close()
   for (const handle of running.splice(0)) {
     await handle.stop('main-cancelled')
   }
@@ -531,7 +537,8 @@ describe('wait', () => {
       format: 'yarramate/visual-event/v1',
       sessionId: handle.started.sessionId,
       type: 'chat.message',
-      sequence: 1,
+      // Sequence 1 is the arrival the runtime journaled for this browser.
+      sequence: 2,
       eventId: acknowledged.eventId,
       payload: { text: chatEventInput.payload.text },
     })
@@ -547,7 +554,7 @@ describe('wait', () => {
       ['wait', handle.started.descriptorPath],
       workDir,
     )
-    expect(JSON.parse(result.stdout)).toMatchObject({ sequence: 1 })
+    expect(JSON.parse(result.stdout)).toMatchObject({ sequence: 2 })
   })
 
   it('reports nothing when the poll window closes idle', async () => {
@@ -565,7 +572,7 @@ describe('wait', () => {
     await sendBrowserEvent(handle.started, chatEventInput)
     await expect(
       runVisualClientCli(
-        ['wait', handle.started.descriptorPath, '--after', '1'],
+        ['wait', handle.started.descriptorPath, '--after', '2'],
         workDir,
       ),
     ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
@@ -628,7 +635,7 @@ describe('respond', () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       accepted: true,
       duplicate: false,
-      lastSequence: 1,
+      lastSequence: 2,
     })
     expect(
       await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'),
@@ -762,7 +769,7 @@ describe('status', () => {
       lifecycle: 'running',
       alreadyStopped: false,
       server: { listening: true, origin: handle.started.origin },
-      queue: { pendingEvents: 1, lastSequence: 1, frozen: false },
+      queue: { pendingEvents: 1, lastSequence: 2, frozen: false },
     })
   })
 
@@ -877,9 +884,9 @@ describe('stop', () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       format: 'yarramate/visual-handoff/v1',
       sessionId: handle.started.sessionId,
-      // The runtime's own terminal event, past the chat message, and the cause
-      // this stop closed the session under.
-      lastSequence: 2,
+      // The runtime's own terminal event, past the arrival and the chat
+      // message, and the cause this stop closed the session under.
+      lastSequence: 3,
       terminationReason: 'main-cancelled',
     })
     // Recovered before cleanup: the summary above came out of a journal the
@@ -1197,7 +1204,7 @@ describe('runVisualStart', () => {
     )
     expect(JSON.parse(waited.stdout)).toMatchObject({
       type: 'chat.message',
-      sequence: 1,
+      sequence: 2,
     })
 
     foreground.signals.emit('SIGTERM')

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -8,6 +8,7 @@ import {
   readdir,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -1298,16 +1299,26 @@ describe('runVisualStart', () => {
   it('prunes a session a previous runtime abandoned', async () => {
     const stale = identifier(0x5747)
     const root = join(workDir, VISUAL_SESSION_DIRECTORY, stale)
+    const abandonedAt = new Date(
+      Date.now() - VISUAL_LIMITS.staleSessionMs - 60_000,
+    )
     await mkdir(root, { recursive: true, mode: 0o700 })
     await writeJson(join(root, 'session.json'), {
       format: 'yarramate/visual-session-marker/v1',
       id: stale,
-      createdAt: new Date(
-        Date.now() - VISUAL_LIMITS.staleSessionMs - 60_000,
-      ).toISOString(),
+      createdAt: abandonedAt.toISOString(),
       authority: 'ad-hoc',
     })
     await writeFile(join(root, 'journal.jsonl'), '', { mode: 0o600 })
+    // Collection follows what nothing has written to, so the abandonment has
+    // to be on the filesystem and not only in the marker.
+    for (const artefact of [
+      join(root, 'journal.jsonl'),
+      join(root, 'session.json'),
+      root,
+    ]) {
+      await utimes(artefact, abandonedAt, abandonedAt)
+    }
 
     const foreground = startForeground(await writeRequest(), workDir)
     const started = await foreground.started

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter, once } from 'node:events'
 import { existsSync } from 'node:fs'
 import {
+  chmod,
   mkdir,
   mkdtemp,
   readFile,
@@ -708,6 +709,25 @@ describe('respond', () => {
     expect(refusalCodes(result)).toEqual(['YMVS126'])
   })
 
+  it('surfaces the store refusal of a response for an event never taken', async () => {
+    const handle = await startServer()
+    await sendBrowserEvent(handle.started, chatEventInput)
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(
+      responsePath,
+      responseFor(handle.started.sessionId, identifier(0xbad)),
+    )
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    // The store's own code, and not the transport refusal this is laundered
+    // into when the carried diagnostic does not survive the client's strict
+    // read of the diagnostic result the server answered with.
+    expect(refusalCodes(result)).toEqual(['YMVS131'])
+  })
+
   it('reports a session server that is not listening', async () => {
     const { descriptor, descriptorPath } = await plantSession()
     const responsePath = join(workDir, 'response.json')
@@ -1046,6 +1066,100 @@ describe('runVisualStart', () => {
     })
     expect(existsSync(started.sessionRoot)).toBe(false)
   })
+
+  /**
+   * A signal is not a caller: nothing awaits the stop it starts, so a teardown
+   * that fails there reaches the runtime as an unhandled rejection unless the
+   * handler observes it. The failure is injected through the filesystem rather
+   * than the clock — a session root nothing may unlink from refuses the removal
+   * every time, and stops refusing the moment the permission comes back.
+   */
+  const enforcesPermissions =
+    process.platform !== 'win32' && process.getuid?.() !== 0
+
+  /**
+   * A ceiling on the turns of the loop one teardown takes, measured in turns
+   * rather than milliseconds so a slow machine spends no longer here than a
+   * fast one: nothing in this test waits for a duration.
+   */
+  const teardownTurns = 5000
+
+  it.skipIf(!enforcesPermissions)(
+    'observes a signal stop that failed instead of crashing the runtime',
+    async () => {
+      const foreground = startForeground(await writeRequest(), workDir)
+      const started = await foreground.started
+      const journal = join(started.sessionRoot, 'journal.jsonl')
+      const rejections: unknown[] = []
+      const observe = (reason: unknown) => rejections.push(reason)
+      // One turn of the loop, which is also one turn of the teardown's own
+      // filesystem work: waiting is spent on the runtime's progress rather
+      // than on a duration guessed to be long enough.
+      const turn = async () => {
+        const next = Promise.withResolvers<undefined>()
+        setImmediate(() => next.resolve(undefined))
+        return Promise.race([foreground.result, next.promise])
+      }
+      process.on('unhandledRejection', observe)
+      try {
+        // Readable and traversable, so the recovery a stop reads still
+        // succeeds; not writable, so the removal that follows it cannot.
+        await chmod(started.sessionRoot, 0o500)
+        foreground.signals.emit('SIGTERM')
+
+        // The terminal event is the last thing journaled before the removal
+        // this permission denies, and the refusal is a few hundred turns of
+        // the loop past it. The ceiling is not a wait: a runtime that lost a
+        // rejection reports it in the turn after it is raised, and leaves this
+        // loop there.
+        let journaled = await readFile(journal, 'utf8')
+        while (!journaled.includes('"session.end"')) {
+          journaled = await readFile(journal, 'utf8')
+        }
+        let blocked = await turn()
+        for (
+          let spin = 0;
+          spin < teardownTurns &&
+          blocked === undefined &&
+          rejections.length === 0;
+          spin += 1
+        ) {
+          blocked = await turn()
+        }
+
+        // The teardown failed: the command is still blocked, its session is
+        // still on disk, and the runtime was told about none of it.
+        expect(blocked).toBeUndefined()
+        expect(existsSync(started.sessionRoot)).toBe(true)
+        expect(rejections).toEqual([])
+
+        // A stop that failed stopped nothing: a later signal runs the teardown
+        // again. One that lands on an attempt still in flight is absorbed by
+        // it, so the command is signalled every turn until it returns.
+        await chmod(started.sessionRoot, 0o700)
+        let closed = await turn()
+        for (
+          let spin = 0;
+          closed === undefined && spin < teardownTurns;
+          spin += 1
+        ) {
+          foreground.signals.emit('SIGTERM')
+          closed = await turn()
+        }
+
+        expect(closed).toMatchObject({ exitCode: 0 })
+        expect(existsSync(started.sessionRoot)).toBe(false)
+        expect(rejections).toEqual([])
+      } finally {
+        process.off('unhandledRejection', observe)
+        // Whatever failed, the temporary directory cannot be collected while
+        // one of its sessions refuses to be unlinked from.
+        if (existsSync(started.sessionRoot)) {
+          await chmod(started.sessionRoot, 0o700)
+        }
+      }
+    },
+  )
 
   it('observes the process signals when no source is injected', async () => {
     const requestPath = await writeRequest()

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -1,0 +1,1185 @@
+import { EventEmitter, once } from 'node:events'
+import { existsSync } from 'node:fs'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WebSocket } from 'ws'
+import {
+  VISUAL_CLIENT_LIMITS,
+  stopVisualSessionClient,
+} from '../src/adapters/visual/client.js'
+import {
+  VISUAL_LIMITS,
+  VISUAL_PROTOCOL_VERSION,
+  parseVisualDiagnosticResult,
+  parseVisualEvent,
+  parseVisualHandoff,
+  parseVisualSessionStarted,
+  parseVisualStatus,
+  type VisualEvent,
+  type VisualHandoff,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionDescriptor,
+  type VisualSessionRequest,
+  type VisualSessionStarted,
+} from '../src/adapters/visual/protocol.js'
+import {
+  VISUAL_SERVER_LIMITS,
+  startVisualServer,
+  type VisualServerFrame,
+  type VisualServerHandle,
+  type VisualServerOptions,
+} from '../src/adapters/visual/session-server.js'
+import {
+  VISUAL_SESSION_DIRECTORY,
+  runVisualCli,
+  runVisualClientCli,
+  runVisualStart,
+  visualUsage,
+  type VisualStartIo,
+} from '../src/adapters/visual-cli.js'
+import { packageVersion, type CliResult } from '../src/cli-support.js'
+
+const fixtures = fileURLToPath(new URL('./fixtures/visual/', import.meta.url))
+const fakeCompiler = join(fixtures, 'fake-likec4.mjs')
+const assetRoot = join(fixtures, 'browser-assets')
+
+/** Nothing listens on port 1, so a client reaches it only to be refused. */
+const CLOSED_PORT = 1
+
+const modelWith = (marker?: string): VisualModel => ({
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    'model.likec4': `model { system = system "System" }${
+      marker === undefined ? '' : `\n// fake:${marker}`
+    }`,
+    'views/choices.likec4': 'views { view choices { include * } }',
+  },
+})
+
+const requestWith = (marker?: string): VisualSessionRequest => ({
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler: { command: process.execPath, args: [fakeCompiler] },
+  initialModel: modelWith(marker),
+})
+
+const chatEventInput = {
+  type: 'chat.message',
+  payload: { text: 'Compare the two delivery designs' },
+} as const
+
+const identifier = (index: number) => index.toString(16).padStart(32, '0')
+
+const line = (value: unknown) => `${JSON.stringify(value)}\n`
+
+let baseDir = ''
+let workDir = ''
+const running: VisualServerHandle[] = []
+
+const startServer = async (overrides: Partial<VisualServerOptions> = {}) => {
+  const handle = await startVisualServer({
+    request: requestWith(),
+    baseDir,
+    assetRoot,
+    // Long enough that an event racing a poll always wins; the idle tests set
+    // their own ceiling.
+    agentPollMs: 4000,
+    ...overrides,
+  })
+  running.push(handle)
+  return handle
+}
+
+const writeJson = (path: string, value: unknown) =>
+  writeFile(path, line(value), { mode: 0o600 })
+
+/**
+ * Every diagnostic code the refusal on stderr carries. Reading it back through
+ * the protocol parser means a test that asserts a code also asserts the refusal
+ * is a valid `yarramate/visual-diagnostic-result/v1` document.
+ */
+const refusalCodes = (result: CliResult): readonly string[] => {
+  const parsed = parseVisualDiagnosticResult(JSON.parse(result.stderr))
+  if (!parsed.ok) {
+    throw new Error(
+      `stderr is not a diagnostic result: ${result.stderr} (${parsed.diagnostics[0]?.message})`,
+    )
+  }
+  return parsed.value.diagnostics.map((diagnostic) => diagnostic.code)
+}
+
+const readDescriptorFile = async (path: string) =>
+  JSON.parse(await readFile(path, 'utf8')) as VisualSessionDescriptor
+
+const entriesIn = async (directory: string) => {
+  try {
+    return await readdir(directory)
+  } catch {
+    return []
+  }
+}
+
+// ------------------------------------------------------- live browser traffic
+
+const buffered = new WeakMap<WebSocket, VisualServerFrame[]>()
+
+const nextFrame = async <Kind extends VisualServerFrame['kind']>(
+  socket: WebSocket,
+  kind: Kind,
+): Promise<Extract<VisualServerFrame, { kind: Kind }>> => {
+  const frames = buffered.get(socket) ?? []
+  for (;;) {
+    const index = frames.findIndex((frame) => frame.kind === kind)
+    if (index >= 0) {
+      return frames.splice(index, 1)[0] as Extract<
+        VisualServerFrame,
+        { kind: Kind }
+      >
+    }
+    await once(socket, 'message')
+  }
+}
+
+/**
+ * Drives one real browser input into a session: bootstrap for the cookie,
+ * upgrade, send, and wait for the runtime's acknowledgement, so the event is
+ * journaled before the CLI is asked for it.
+ */
+const sendBrowserEvent = async (
+  started: VisualSessionStarted,
+  input: typeof chatEventInput,
+) => {
+  const bootstrapped = await fetch(started.browserUrl, { redirect: 'manual' })
+  const header = bootstrapped.headers.get('set-cookie')
+  if (header === null) throw new Error('bootstrap returned no cookie')
+  const socket = new WebSocket(started.webSocketUrl, {
+    headers: {
+      Cookie: header.split(';')[0] as string,
+      Origin: started.origin,
+    },
+  })
+  const frames: VisualServerFrame[] = []
+  buffered.set(socket, frames)
+  socket.on('message', (data) => {
+    frames.push(JSON.parse(String(data)) as VisualServerFrame)
+  })
+  await once(socket, 'open')
+  const accepted = nextFrame(socket, 'accepted')
+  socket.send(JSON.stringify(input))
+  const acknowledged = await accepted
+  socket.close()
+  return acknowledged
+}
+
+const agentPost = (
+  descriptor: VisualSessionDescriptor,
+  path: string,
+  body: unknown,
+) =>
+  fetch(`${descriptor.origin}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${descriptor.agentCapability}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+// ------------------------------------------------------------ planted session
+
+let plantedIndex = 0
+
+const plantedJournal = (
+  id: string,
+): readonly (VisualEvent | VisualResponse)[] => [
+  {
+    format: 'yarramate/visual-event/v1',
+    sessionId: id,
+    sequence: 1,
+    eventId: identifier(1),
+    type: 'chat.message',
+    timestamp: '2026-08-08T00:00:01.000Z',
+    payload: { text: 'Compare the two delivery designs' },
+  },
+  {
+    format: 'yarramate/visual-response/v1',
+    sessionId: id,
+    responseId: identifier(2),
+    eventId: identifier(1),
+    type: 'handoff.complete',
+    timestamp: '2026-08-08T00:00:02.000Z',
+    payload: {
+      summary: 'Design A isolates delivery.',
+      confirmedDecisions: ['Isolate delivery'],
+      requestedChanges: [],
+      unresolvedQuestions: [],
+      finalViews: ['choices'],
+    },
+  },
+  {
+    format: 'yarramate/visual-event/v1',
+    sessionId: id,
+    sequence: 2,
+    eventId: identifier(3),
+    type: 'session.end',
+    timestamp: '2026-08-08T00:00:03.000Z',
+    payload: { reason: 'user-ended' },
+  },
+]
+
+/**
+ * A correctly marked session directory whose server is gone. This is the shape
+ * every server-down path has to cope with: local recovery, the status fallback,
+ * and a stop that has nothing left to ask.
+ */
+const plantSession = async (
+  options: {
+    readonly port?: number
+    readonly createdAt?: string
+    readonly marker?: unknown
+  } = {},
+) => {
+  plantedIndex += 1
+  const id = identifier(0x100000 + plantedIndex)
+  const root = join(baseDir, id)
+  await mkdir(join(root, 'candidates'), { recursive: true, mode: 0o700 })
+  const createdAt = options.createdAt ?? '2026-08-08T00:00:00.000Z'
+  await writeJson(
+    join(root, 'session.json'),
+    options.marker ?? {
+      format: 'yarramate/visual-session-marker/v1',
+      id,
+      createdAt,
+      authority: 'ad-hoc',
+    },
+  )
+  const records = plantedJournal(id)
+  await writeFile(
+    join(root, 'journal.jsonl'),
+    records.map((record) => line(record)).join(''),
+    { mode: 0o600 },
+  )
+  const descriptor: VisualSessionDescriptor = {
+    format: 'yarramate/visual-session-descriptor/v1',
+    protocolVersion: VISUAL_PROTOCOL_VERSION,
+    sessionId: id,
+    origin: `http://127.0.0.1:${options.port ?? CLOSED_PORT}`,
+    agentCapability: 'a'.repeat(64),
+    sessionRoot: root,
+    journalPath: join(root, 'journal.jsonl'),
+    createdAt,
+  }
+  const descriptorPath = join(root, 'descriptor.json')
+  await writeJson(descriptorPath, descriptor)
+  return { id, root, descriptor, descriptorPath, records }
+}
+
+// --------------------------------------------------------- foreground `start`
+
+interface Foreground {
+  readonly result: Promise<CliResult>
+  readonly started: Promise<VisualSessionStarted>
+  readonly stdout: string[]
+  readonly stderr: string[]
+  readonly signals: EventEmitter
+}
+
+/**
+ * Runs the blocking command the way the executable does, with the signal source
+ * injected: emitting on the process itself would also wake the test runner's
+ * own handlers. One test covers the uninjected default.
+ */
+const startForeground = (requestPath: string, cwd: string): Foreground => {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const signals = new EventEmitter()
+  const first = Promise.withResolvers<VisualSessionStarted>()
+  const result = runVisualStart(requestPath, cwd, {
+    stdout: (chunk) => {
+      stdout.push(chunk)
+      const parsed = parseVisualSessionStarted(JSON.parse(chunk))
+      if (parsed.ok) first.resolve(parsed.value)
+      else first.reject(new Error(`start published no document: ${chunk}`))
+    },
+    stderr: (chunk) => stderr.push(chunk),
+    signals,
+  })
+  // A start that refuses before listening never publishes; the waiter has to
+  // fail with that refusal instead of hanging on it.
+  result.then(
+    () =>
+      first.reject(
+        new Error(`start returned before publishing: ${stderr.join('')}`),
+      ),
+    (cause: unknown) => first.reject(cause),
+  )
+  return { result, started: first.promise, stdout, stderr, signals }
+}
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'yarramate-visual-cli-'))
+  workDir = await mkdtemp(join(tmpdir(), 'yarramate-visual-work-'))
+})
+
+afterEach(async () => {
+  for (const handle of running.splice(0)) {
+    await handle.stop('main-cancelled')
+  }
+  await rm(baseDir, { recursive: true, force: true })
+  await rm(workDir, { recursive: true, force: true })
+})
+
+describe('runVisualClientCli usage', () => {
+  it('prints the package version', async () => {
+    await expect(
+      runVisualClientCli(['--version'], workDir),
+    ).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: `yarramate-visual ${packageVersion}\n`,
+      stderr: '',
+    })
+  })
+
+  it('prints usage without arguments', async () => {
+    await expect(runVisualClientCli([], workDir)).resolves.toEqual({
+      exitCode: 2,
+      stdout: '',
+      stderr: visualUsage,
+    })
+  })
+
+  it('prints usage for an unknown command', async () => {
+    await expect(
+      runVisualClientCli(['inspect', 'descriptor.json'], workDir),
+    ).resolves.toEqual({ exitCode: 2, stdout: '', stderr: visualUsage })
+  })
+
+  it('prints usage for a command without a descriptor', async () => {
+    for (const command of ['wait', 'respond', 'status', 'recover', 'stop']) {
+      await expect(
+        runVisualClientCli([command], workDir),
+      ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
+    }
+  })
+
+  it('prints usage for an unknown flag', async () => {
+    const { descriptorPath } = await plantSession()
+    for (const rest of [['--since', '1'], ['--transcript']]) {
+      await expect(
+        runVisualClientCli(['wait', descriptorPath, ...rest], workDir),
+      ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
+    }
+  })
+
+  it('prints usage for an --after that is not a sequence', async () => {
+    const { descriptorPath } = await plantSession()
+    for (const value of ['-1', 'first', '1.5', '', '0x2', ' 1']) {
+      await expect(
+        runVisualClientCli(['wait', descriptorPath, '--after', value], workDir),
+      ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
+    }
+    await expect(
+      runVisualClientCli(['wait', descriptorPath, '--after'], workDir),
+    ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
+  })
+
+  it('prints usage when respond has no response document', async () => {
+    const { descriptorPath } = await plantSession()
+    await expect(
+      runVisualClientCli(['respond', descriptorPath], workDir),
+    ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
+  })
+
+  it('prints usage for a trailing argument', async () => {
+    const { descriptorPath } = await plantSession()
+    const rejected: readonly (readonly string[])[] = [
+      ['status', descriptorPath, '--transcript'],
+      ['recover', descriptorPath, '--transcript', '--transcript'],
+      ['stop', descriptorPath, 'now'],
+      ['respond', descriptorPath, 'response.json', 'extra.json'],
+      ['wait', descriptorPath, '--after', '1', '--transcript'],
+    ]
+    for (const args of rejected) {
+      await expect(runVisualClientCli(args, workDir)).resolves.toMatchObject({
+        exitCode: 2,
+        stderr: visualUsage,
+      })
+    }
+  })
+
+  it('prints usage when start is invoked without a request', async () => {
+    await expect(runVisualCli(['start'], workDir)).resolves.toEqual({
+      exitCode: 2,
+      stdout: '',
+      stderr: visualUsage,
+    })
+  })
+})
+
+describe('descriptor confinement', () => {
+  it('refuses a descriptor that is not there', async () => {
+    const result = await runVisualClientCli(
+      ['status', join(workDir, 'missing.json')],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS401'])
+  })
+
+  it('refuses a descriptor that is a symlink', async () => {
+    const { descriptorPath } = await plantSession()
+    const link = join(workDir, 'linked.json')
+    await symlink(descriptorPath, link)
+    const result = await runVisualClientCli(['status', link], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS401'])
+  })
+
+  it('refuses a descriptor that is not JSON', async () => {
+    const path = join(workDir, 'descriptor.json')
+    await writeFile(path, '{"format":')
+    const result = await runVisualClientCli(['status', path], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS402'])
+  })
+
+  it('refuses a document that is not a session descriptor', async () => {
+    const path = join(workDir, 'descriptor.json')
+    await writeJson(path, { format: 'yarramate/visual-status/v1' })
+    const result = await runVisualClientCli(['status', path], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toContain('YMVS103')
+  })
+
+  it('refuses a descriptor whose origin is not loopback', async () => {
+    const { descriptor, root } = await plantSession()
+    const path = join(root, 'descriptor.json')
+    await writeJson(path, { ...descriptor, origin: 'http://model.example.com' })
+    const result = await runVisualClientCli(['status', path], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toContain('YMVS103')
+  })
+
+  it('refuses a descriptor that names a session outside its own directory', async () => {
+    const { descriptor } = await plantSession()
+    const copied = join(workDir, 'descriptor.json')
+    await writeJson(copied, descriptor)
+    const result = await runVisualClientCli(['stop', copied], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS403'])
+    // The session a redirected descriptor would have deleted is still there.
+    expect(existsSync(descriptor.sessionRoot)).toBe(true)
+  })
+
+  it('refuses a descriptor whose journal is not the session journal', async () => {
+    const { descriptor, root } = await plantSession()
+    const path = join(root, 'descriptor.json')
+    await writeJson(path, {
+      ...descriptor,
+      journalPath: join(root, 'candidates', 'journal.jsonl'),
+    })
+    const result = await runVisualClientCli(['recover', path], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS403'])
+  })
+
+  it('resolves a descriptor path against the working directory', async () => {
+    const { descriptor, root } = await plantSession()
+    const result = await runVisualClientCli(['recover', 'descriptor.json'], root)
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      sessionId: descriptor.sessionId,
+    })
+  })
+})
+
+describe('wait', () => {
+  it('waits for the event the browser sent', async () => {
+    const handle = await startServer()
+    const acknowledged = await sendBrowserEvent(handle.started, chatEventInput)
+
+    const result = await runVisualClientCli(
+      ['wait', handle.started.descriptorPath, '--after', '0'],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    const event: unknown = JSON.parse(result.stdout)
+    expect(event).toMatchObject({
+      format: 'yarramate/visual-event/v1',
+      sessionId: handle.started.sessionId,
+      type: 'chat.message',
+      sequence: 1,
+      eventId: acknowledged.eventId,
+      payload: { text: chatEventInput.payload.text },
+    })
+    expect(parseVisualEvent(event).ok).toBe(true)
+    // One document per poll, on one line.
+    expect(result.stdout).toBe(line(event))
+  })
+
+  it('defaults to waiting from the start of the session', async () => {
+    const handle = await startServer()
+    await sendBrowserEvent(handle.started, chatEventInput)
+    const result = await runVisualClientCli(
+      ['wait', handle.started.descriptorPath],
+      workDir,
+    )
+    expect(JSON.parse(result.stdout)).toMatchObject({ sequence: 1 })
+  })
+
+  it('reports nothing when the poll window closes idle', async () => {
+    const handle = await startServer({ agentPollMs: 50 })
+    await expect(
+      runVisualClientCli(
+        ['wait', handle.started.descriptorPath, '--after', '0'],
+        workDir,
+      ),
+    ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
+  })
+
+  it('skips an event the caller has already seen', async () => {
+    const handle = await startServer({ agentPollMs: 50 })
+    await sendBrowserEvent(handle.started, chatEventInput)
+    await expect(
+      runVisualClientCli(
+        ['wait', handle.started.descriptorPath, '--after', '1'],
+        workDir,
+      ),
+    ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
+  })
+
+  it('outlasts the whole poll window the server may hold it for', () => {
+    expect(VISUAL_CLIENT_LIMITS.requestTimeoutMs).toBeGreaterThan(
+      VISUAL_SERVER_LIMITS.agentPollMs,
+    )
+  })
+
+  it('reports a server that refuses the descriptor capability', async () => {
+    const handle = await startServer()
+    const descriptor = await readDescriptorFile(handle.started.descriptorPath)
+    await writeJson(handle.started.descriptorPath, {
+      ...descriptor,
+      agentCapability: 'b'.repeat(64),
+    })
+    const result = await runVisualClientCli(
+      ['wait', handle.started.descriptorPath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS405'])
+  })
+
+  it('reports a session server that is not listening', async () => {
+    const { descriptorPath } = await plantSession()
+    const result = await runVisualClientCli(['wait', descriptorPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS404'])
+  })
+})
+
+describe('respond', () => {
+  const responseFor = (sessionId: string, eventId: string): VisualResponse => ({
+    format: 'yarramate/visual-response/v1',
+    sessionId,
+    responseId: identifier(7),
+    eventId,
+    type: 'chat.response',
+    timestamp: '2026-08-08T00:00:04.000Z',
+    payload: { text: 'Design A isolates delivery; design B shares it.' },
+  })
+
+  it('journals the response the agent wrote for the browser event', async () => {
+    const handle = await startServer()
+    const acknowledged = await sendBrowserEvent(handle.started, chatEventInput)
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(
+      responsePath,
+      responseFor(handle.started.sessionId, acknowledged.eventId),
+    )
+
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      accepted: true,
+      duplicate: false,
+      lastSequence: 1,
+    })
+    expect(
+      await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'),
+    ).toContain('"type":"chat.response"')
+  })
+
+  it('reports the second delivery of one response as a duplicate', async () => {
+    const handle = await startServer()
+    const acknowledged = await sendBrowserEvent(handle.started, chatEventInput)
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(
+      responsePath,
+      responseFor(handle.started.sessionId, acknowledged.eventId),
+    )
+    const args = ['respond', handle.started.descriptorPath, responsePath]
+    expect((await runVisualClientCli(args, workDir)).exitCode).toBe(0)
+    const repeated = await runVisualClientCli(args, workDir)
+    expect(repeated.exitCode).toBe(0)
+    expect(JSON.parse(repeated.stdout)).toMatchObject({
+      accepted: true,
+      duplicate: true,
+    })
+  })
+
+  it('refuses a response document that is not there', async () => {
+    const handle = await startServer()
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, join(workDir, 'missing.json')],
+      workDir,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS407'])
+  })
+
+  it('refuses a response document that is not JSON', async () => {
+    const handle = await startServer()
+    const responsePath = join(workDir, 'response.json')
+    await writeFile(responsePath, 'chat.response')
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS407'])
+  })
+
+  it('refuses an invalid response before the server is asked', async () => {
+    const handle = await startServer()
+    const acknowledged = await sendBrowserEvent(handle.started, chatEventInput)
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(responsePath, {
+      ...responseFor(handle.started.sessionId, acknowledged.eventId),
+      payload: { text: '' },
+    })
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toContain('YMVS105')
+    expect(
+      await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'),
+    ).not.toContain('"type":"chat.response"')
+  })
+
+  it('surfaces the server refusal of a response for another session', async () => {
+    const handle = await startServer()
+    const acknowledged = await sendBrowserEvent(handle.started, chatEventInput)
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(
+      responsePath,
+      responseFor(identifier(0xbad), acknowledged.eventId),
+    )
+    const result = await runVisualClientCli(
+      ['respond', handle.started.descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS126'])
+  })
+
+  it('reports a session server that is not listening', async () => {
+    const { descriptor, descriptorPath } = await plantSession()
+    const responsePath = join(workDir, 'response.json')
+    await writeJson(
+      responsePath,
+      responseFor(descriptor.sessionId, identifier(1)),
+    )
+    const result = await runVisualClientCli(
+      ['respond', descriptorPath, responsePath],
+      workDir,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS404'])
+  })
+})
+
+describe('status', () => {
+  it('reports the status the running server serves', async () => {
+    const handle = await startServer()
+    await sendBrowserEvent(handle.started, chatEventInput)
+    const result = await runVisualClientCli(
+      ['status', handle.started.descriptorPath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    const status: unknown = JSON.parse(result.stdout)
+    expect(parseVisualStatus(status).ok).toBe(true)
+    expect(status).toMatchObject({
+      format: 'yarramate/visual-status/v1',
+      sessionId: handle.started.sessionId,
+      lifecycle: 'running',
+      alreadyStopped: false,
+      server: { listening: true, origin: handle.started.origin },
+      queue: { pendingEvents: 1, lastSequence: 1, frozen: false },
+    })
+  })
+
+  it('falls back to a stopped status when the server is gone', async () => {
+    const { descriptorPath, id } = await plantSession()
+    const result = await runVisualClientCli(['status', descriptorPath], workDir)
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    const status: unknown = JSON.parse(result.stdout)
+    expect(parseVisualStatus(status).ok).toBe(true)
+    expect(status).toMatchObject({
+      sessionId: id,
+      lifecycle: 'stopped',
+      alreadyStopped: true,
+      server: { listening: false, origin: `http://127.0.0.1:${CLOSED_PORT}` },
+      browser: { connected: false, connections: 0 },
+      agent: { attached: false, inFlightEventId: null },
+      // Read back from the journal that outlived the runtime.
+      queue: { pendingEvents: 0, lastSequence: 2, frozen: false },
+      capabilities: { chat: false, modelReplacement: false },
+    })
+  })
+
+  it('reports a stopped status for a session that is already gone', async () => {
+    const { descriptor, descriptorPath, root } = await plantSession()
+    await rm(root, { recursive: true, force: true })
+    // Only the descriptor is restored, so confinement still holds while every
+    // other session document has gone with the runtime that owned it.
+    await mkdir(root, { recursive: true, mode: 0o700 })
+    await writeJson(descriptorPath, descriptor)
+    const result = await runVisualClientCli(['status', descriptorPath], workDir)
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      lifecycle: 'stopped',
+      queue: { lastSequence: 0 },
+      transcriptBytes: 0,
+    })
+  })
+})
+
+describe('recover', () => {
+  it('recovers the journaled handoff while the server is gone', async () => {
+    const { descriptorPath, id, root } = await plantSession()
+    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    const handoff = JSON.parse(result.stdout) as VisualHandoff
+    expect(parseVisualHandoff(handoff).ok).toBe(true)
+    expect(handoff).toMatchObject({
+      format: 'yarramate/visual-handoff/v1',
+      sessionId: id,
+      authority: 'ad-hoc',
+      decision: 'completed',
+      terminationReason: 'user-ended',
+      lastSequence: 2,
+      summary: 'Design A isolates delivery.',
+      confirmedDecisions: ['Isolate delivery'],
+      finalViews: ['choices'],
+      transcriptPath: join(root, 'journal.jsonl'),
+    })
+    expect('transcript' in handoff).toBe(false)
+    // Recovery is a read: the session survives it.
+    expect(existsSync(root)).toBe(true)
+  })
+
+  it('includes the raw transcript when asked', async () => {
+    const { descriptorPath } = await plantSession()
+    const result = await runVisualClientCli(
+      ['recover', descriptorPath, '--transcript'],
+      workDir,
+    )
+    expect(result.exitCode).toBe(0)
+    const handoff = JSON.parse(result.stdout) as VisualHandoff
+    // The submitted summary is the handoff itself, not conversation.
+    expect(handoff.transcript).toMatchObject([
+      { type: 'chat.message', sequence: 1 },
+      { type: 'session.end', sequence: 2 },
+    ])
+  })
+
+  it('refuses a journal that is not a valid transcript', async () => {
+    const { descriptorPath, root } = await plantSession()
+    await writeFile(join(root, 'journal.jsonl'), '{"format":"nonsense"}\n')
+    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS123'])
+  })
+
+  it('refuses a directory whose marker names another session', async () => {
+    const { descriptorPath, root } = await plantSession({
+      marker: {
+        format: 'yarramate/visual-session-marker/v1',
+        id: identifier(0xfeed),
+        createdAt: '2026-08-08T00:00:00.000Z',
+        authority: 'ad-hoc',
+      },
+    })
+    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS125'])
+    expect(existsSync(root)).toBe(true)
+  })
+})
+
+describe('stop', () => {
+  it('stops the running server and hands back the recovered summary', async () => {
+    const handle = await startServer()
+    await sendBrowserEvent(handle.started, chatEventInput)
+    const result = await runVisualClientCli(
+      ['stop', handle.started.descriptorPath],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      format: 'yarramate/visual-handoff/v1',
+      sessionId: handle.started.sessionId,
+      lastSequence: 1,
+    })
+    // Recovered before cleanup: the summary above came out of a journal the
+    // same command then deleted.
+    expect(existsSync(handle.started.sessionRoot)).toBe(false)
+    await expect(handle.closed).resolves.toMatchObject({
+      reason: 'main-cancelled',
+      alreadyStopped: false,
+    })
+    running.splice(running.indexOf(handle), 1)
+    await expect(
+      fetch(`${handle.started.origin}/api/session`),
+    ).rejects.toThrow()
+  })
+
+  it('converges when the server is already absent', async () => {
+    const { descriptorPath, root, id } = await plantSession()
+    const result = await runVisualClientCli(['stop', descriptorPath], workDir)
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      sessionId: id,
+      lastSequence: 2,
+      decision: 'completed',
+    })
+    expect(existsSync(root)).toBe(false)
+  })
+
+  it('includes the raw transcript when asked', async () => {
+    const { descriptorPath } = await plantSession()
+    const result = await runVisualClientCli(
+      ['stop', descriptorPath, '--transcript'],
+      workDir,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(
+      (JSON.parse(result.stdout) as VisualHandoff).transcript,
+    ).toHaveLength(2)
+  })
+
+  it('answers a repeated stop with nothing left to hand off', async () => {
+    const { descriptor, root } = await plantSession()
+    await expect(stopVisualSessionClient(descriptor)).resolves.toMatchObject({
+      ok: true,
+      value: { sessionId: descriptor.sessionId },
+    })
+    expect(existsSync(root)).toBe(false)
+    await expect(stopVisualSessionClient(descriptor)).resolves.toEqual({
+      ok: true,
+      value: undefined,
+    })
+  })
+
+  it('reports a vanished descriptor rather than a second stop', async () => {
+    const { descriptorPath } = await plantSession()
+    expect(
+      (await runVisualClientCli(['stop', descriptorPath], workDir)).exitCode,
+    ).toBe(0)
+    const repeated = await runVisualClientCli(['stop', descriptorPath], workDir)
+    expect(repeated.exitCode).toBe(1)
+    expect(refusalCodes(repeated)).toEqual(['YMVS401'])
+  })
+
+  it('never deletes a directory whose marker names another session', async () => {
+    const { descriptorPath, root } = await plantSession({
+      marker: {
+        format: 'yarramate/visual-session-marker/v1',
+        id: identifier(0xfeed),
+        createdAt: '2026-08-08T00:00:00.000Z',
+        authority: 'ad-hoc',
+      },
+    })
+    const result = await runVisualClientCli(['stop', descriptorPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS125'])
+    expect(existsSync(root)).toBe(true)
+  })
+
+  it('never deletes a session the server refused to hand over', async () => {
+    const handle = await startServer()
+    const descriptor = await readDescriptorFile(handle.started.descriptorPath)
+    await writeJson(handle.started.descriptorPath, {
+      ...descriptor,
+      agentCapability: 'b'.repeat(64),
+    })
+    const result = await runVisualClientCli(
+      ['stop', handle.started.descriptorPath],
+      workDir,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS405'])
+    expect(existsSync(handle.started.sessionRoot)).toBe(true)
+    expect(handle.status().lifecycle).toBe('running')
+  })
+})
+
+describe('runVisualStart', () => {
+  const writeRequest = async (marker?: string) => {
+    const path = join(workDir, 'request.json')
+    await writeJson(path, requestWith(marker))
+    return path
+  }
+
+  it('publishes exactly one started document and then blocks', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+
+    expect(foreground.stdout).toEqual([line(started)])
+    expect(foreground.stderr).toEqual([])
+    expect(started).toMatchObject({
+      format: 'yarramate/visual-session-started/v1',
+      protocolVersion: VISUAL_PROTOCOL_VERSION,
+      authority: 'ad-hoc',
+      title: 'Choose a delivery design',
+      chatEnabled: true,
+      capabilities: { chat: true, transcript: true },
+    })
+    expect(started.sessionRoot).toBe(
+      join(workDir, VISUAL_SESSION_DIRECTORY, started.sessionId),
+    )
+
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toEqual({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    })
+  })
+
+  it('keeps the agent capability out of the published document', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+    const descriptor = await readDescriptorFile(started.descriptorPath)
+
+    expect(descriptor.agentCapability).toMatch(/^[0-9a-f]{64}$/)
+    expect(foreground.stdout.join('')).not.toContain(descriptor.agentCapability)
+    expect(Object.keys(started)).not.toContain('agentCapability')
+    expect(descriptor.origin).toBe(started.origin)
+
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
+  })
+
+  it('stops and cleans up on SIGTERM', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
+    expect(existsSync(started.sessionRoot)).toBe(false)
+    await expect(fetch(`${started.origin}/api/session`)).rejects.toThrow()
+  })
+
+  it('stops and cleans up on SIGINT', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+
+    foreground.signals.emit('SIGINT')
+    await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
+    expect(existsSync(started.sessionRoot)).toBe(false)
+  })
+
+  it('removes its signal handlers once it returns', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    await foreground.started
+
+    expect(foreground.signals.listenerCount('SIGINT')).toBe(1)
+    expect(foreground.signals.listenerCount('SIGTERM')).toBe(1)
+    foreground.signals.emit('SIGTERM')
+    await foreground.result
+    expect(foreground.signals.listenerCount('SIGINT')).toBe(0)
+    expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  it('absorbs a repeated signal', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+
+    foreground.signals.emit('SIGTERM')
+    foreground.signals.emit('SIGINT')
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toEqual({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    })
+    expect(existsSync(started.sessionRoot)).toBe(false)
+  })
+
+  it('observes the process signals when no source is injected', async () => {
+    const requestPath = await writeRequest()
+    const before = {
+      interrupt: process.listenerCount('SIGINT'),
+      terminate: process.listenerCount('SIGTERM'),
+    }
+    const stdout: string[] = []
+    const result = runVisualStart(requestPath, workDir, {
+      stdout: (chunk) => stdout.push(chunk),
+      stderr: () => undefined,
+    })
+    while (stdout.length === 0) await new Promise(setImmediate)
+    expect(process.listenerCount('SIGINT')).toBe(before.interrupt + 1)
+    expect(process.listenerCount('SIGTERM')).toBe(before.terminate + 1)
+
+    const started = JSON.parse(stdout[0] as string) as VisualSessionStarted
+    await expect(
+      runVisualClientCli(['stop', started.descriptorPath], workDir),
+    ).resolves.toMatchObject({ exitCode: 0 })
+    await expect(result).resolves.toMatchObject({ exitCode: 0 })
+    expect(process.listenerCount('SIGINT')).toBe(before.interrupt)
+    expect(process.listenerCount('SIGTERM')).toBe(before.terminate)
+  })
+
+  it('serves the browser and the agent until it is stopped', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+    await sendBrowserEvent(started, chatEventInput)
+
+    const waited = await runVisualClientCli(
+      ['wait', started.descriptorPath, '--after', '0'],
+      workDir,
+    )
+    expect(JSON.parse(waited.stdout)).toMatchObject({
+      type: 'chat.message',
+      sequence: 1,
+    })
+
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
+  })
+
+  it('exits non-zero when the session ends in a failure state', async () => {
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+    const descriptor = await readDescriptorFile(started.descriptorPath)
+
+    const stopped = await agentPost(descriptor, '/api/agent/stop', {
+      reason: 'child-failed',
+    })
+    expect(stopped.status).toBe(200)
+    // The runtime recovered the handoff before it deleted the session.
+    expect(await stopped.json()).toMatchObject({
+      reason: 'child-failed',
+      handoff: { format: 'yarramate/visual-handoff/v1' },
+    })
+
+    const result = await foreground.result
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS409'])
+    expect(existsSync(started.sessionRoot)).toBe(false)
+    expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  it('refuses a request document that is not there', async () => {
+    const result = await runVisualCli(
+      ['start', join(workDir, 'missing.json')],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS407'])
+    expect(existsSync(join(workDir, VISUAL_SESSION_DIRECTORY))).toBe(false)
+  })
+
+  it('refuses a request that is not JSON', async () => {
+    const requestPath = join(workDir, 'request.json')
+    await writeFile(requestPath, 'authority: ad-hoc')
+    const result = await runVisualCli(['start', requestPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS407'])
+  })
+
+  it('refuses an invalid request before any filesystem effect', async () => {
+    const requestPath = join(workDir, 'request.json')
+    await writeJson(requestPath, {
+      ...requestWith(),
+      compiler: { command: 'likec4', args: [] },
+    })
+    const result = await runVisualCli(['start', requestPath], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toContain('YMVS101')
+    expect(existsSync(join(workDir, VISUAL_SESSION_DIRECTORY))).toBe(false)
+  })
+
+  it('leaves no session behind when the initial model does not compile', async () => {
+    const result = await runVisualCli(
+      ['start', await writeRequest('invalid')],
+      workDir,
+    )
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(refusalCodes(result)).toEqual(['YMVS201'])
+    await expect(
+      entriesIn(join(workDir, VISUAL_SESSION_DIRECTORY)),
+    ).resolves.toEqual([])
+  })
+
+  it('prunes a session a previous runtime abandoned', async () => {
+    const stale = identifier(0x5747)
+    const root = join(workDir, VISUAL_SESSION_DIRECTORY, stale)
+    await mkdir(root, { recursive: true, mode: 0o700 })
+    await writeJson(join(root, 'session.json'), {
+      format: 'yarramate/visual-session-marker/v1',
+      id: stale,
+      createdAt: new Date(
+        Date.now() - VISUAL_LIMITS.staleSessionMs - 60_000,
+      ).toISOString(),
+      authority: 'ad-hoc',
+    })
+    await writeFile(join(root, 'journal.jsonl'), '', { mode: 0o600 })
+
+    const foreground = startForeground(await writeRequest(), workDir)
+    const started = await foreground.started
+    expect(existsSync(root)).toBe(false)
+    expect(existsSync(started.sessionRoot)).toBe(true)
+
+    foreground.signals.emit('SIGTERM')
+    await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
+  })
+
+  it('dispatches every command that is not start to the one-shot client', async () => {
+    await expect(runVisualCli(['--version'], workDir)).resolves.toEqual({
+      exitCode: 0,
+      stdout: `yarramate-visual ${packageVersion}\n`,
+      stderr: '',
+    })
+    const { descriptorPath, id } = await plantSession()
+    const dispatched = await runVisualCli(['recover', descriptorPath], workDir)
+    expect(dispatched).toMatchObject({ exitCode: 0, stderr: '' })
+    expect(JSON.parse(dispatched.stdout)).toMatchObject({ sessionId: id })
+  })
+})

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -1016,6 +1016,14 @@ describe('stop', () => {
     expect(refusalCodes(stray)).toEqual(['YMVS401'])
   })
 
+  it('does not call an arbitrary missing parent an already-stopped session', async () => {
+    const missing = join(workDir, 'missing', 'parent', 'descriptor.json')
+    const result = await runVisualClientCli(['stop', missing], workDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS401'])
+  })
+
   it('never deletes a directory whose marker names another session', async () => {
     const { descriptorPath, root } = await plantSession({
       marker: {
@@ -1278,27 +1286,28 @@ describe('runVisualStart', () => {
     await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
   })
 
-  it('exits non-zero when the session ends in a failure state', async () => {
-    const foreground = startForeground(await writeRequest(), workDir)
-    const started = await foreground.started
-    const descriptor = await readDescriptorFile(started.descriptorPath)
+  it.each(['child-failed', 'browser-timeout'] as const)(
+    'exits non-zero when the session ends as %s',
+    async (reason) => {
+      const foreground = startForeground(await writeRequest(), workDir)
+      const started = await foreground.started
+      const descriptor = await readDescriptorFile(started.descriptorPath)
 
-    const stopped = await agentPost(descriptor, '/api/agent/stop', {
-      reason: 'child-failed',
-    })
-    expect(stopped.status).toBe(200)
-    // The runtime recovered the handoff before it deleted the session.
-    expect(await stopped.json()).toMatchObject({
-      reason: 'child-failed',
-      handoff: { format: 'yarramate/visual-handoff/v1' },
-    })
+      const stopped = await agentPost(descriptor, '/api/agent/stop', { reason })
+      expect(stopped.status).toBe(200)
+      // The runtime recovered the handoff before it deleted the session.
+      expect(await stopped.json()).toMatchObject({
+        reason,
+        handoff: { format: 'yarramate/visual-handoff/v1' },
+      })
 
-    const result = await foreground.result
-    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
-    expect(refusalCodes(result)).toEqual(['YMVS409'])
-    expect(existsSync(started.sessionRoot)).toBe(false)
-    expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
-  })
+      const result = await foreground.result
+      expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+      expect(refusalCodes(result)).toEqual(['YMVS409'])
+      expect(existsSync(started.sessionRoot)).toBe(false)
+      expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
+    },
+  )
 
   it('reports a reviewer End the child never answered as a failed session', async () => {
     const foreground = startForeground(await writeRequest(), workDir)

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -972,7 +972,7 @@ describe('the visual recovery matrix', () => {
     expect(borrowed.status).toBe(409)
     expect(await borrowed.json()).toMatchObject({
       accepted: false,
-      diagnostics: [{ code: 'YMVS131', pointer: '#/eventId' }],
+      diagnostics: [{ code: 'YMVS131', pointer: '/eventId' }],
     })
     // Nothing forged reaches the handoff the main agent will read.
     expect(await recoverVisualSessionClient(one.descriptorPath)).toMatchObject({

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -509,7 +509,8 @@ describe('the complete visual conversation', () => {
     const browser = await connectFixtureBrowser(visual)
 
     send(browser, sessionEnd())
-    const ending = await waitForVisualEvent(visual.descriptorPath, 0)
+    // Sequence 1 is the arrival the runtime journaled for this browser.
+    const ending = await waitForVisualEvent(visual.descriptorPath, 1)
     await sendVisualResponse(
       visual.descriptorPath,
       completeHandoff(ending, {
@@ -552,6 +553,7 @@ describe('the complete visual conversation', () => {
     // The runtime's own terminal record is in the transcript it hands over,
     // and the transcript is the last thing read before the directory goes.
     expect(handoff?.transcript?.map((record) => record.type)).toEqual([
+      'browser.connected',
       'chat.message',
       'session.end',
     ])
@@ -640,8 +642,10 @@ describe('the visual recovery matrix', () => {
 
     // Nothing terminal was journaled, so the reviewer can still speak.
     send(second, chatMessage('still here'))
+    // Two arrivals and the departure between them are journaled ahead of it,
+    // so the reviewer's first message is the fourth record either way.
     await expect(nextFrame(second, 'accepted')).resolves.toMatchObject({
-      sequence: 1,
+      sequence: 4,
     })
     expect(visual.handle.status().lifecycle).toBe('running')
     await closeSocket(second)
@@ -945,7 +949,8 @@ describe('the visual recovery matrix', () => {
         .map((record) => record.eventId)
     const inOne = await identifiersOf(one.sessionRoot)
     const inOther = await identifiersOf(other.sessionRoot)
-    expect(inOne).toHaveLength(1)
+    // Every identifier is this session's alone, so the two journals share none.
+    expect(inOne.length).toBeGreaterThan(0)
     expect(inOne.filter((id) => inOther.includes(id))).toEqual([])
 
     // An event identifier is one session's alone: presenting the other's, under
@@ -1004,7 +1009,8 @@ describe('the visual recovery matrix', () => {
 
     // Navigation is the capability a diagram-only session does grant.
     send(browser, viewNavigate('choices'))
-    expect(await nextFrame(browser, 'accepted')).toMatchObject({ sequence: 1 })
+    // Sequence 1 is this browser's arrival, so its first move is the second.
+    expect(await nextFrame(browser, 'accepted')).toMatchObject({ sequence: 2 })
 
     // The agent cannot speak into a session that has no conversation either.
     const refused = await agentFetch(
@@ -1026,8 +1032,11 @@ describe('the visual recovery matrix', () => {
     })
 
     const journal = await journalRecords(visual.sessionRoot)
-    expect(journal).toHaveLength(1)
-    expect(journal[0]).toMatchObject({ type: 'view.navigate' })
+    // The arrival, and the one move the session granted: nothing it refused.
+    expect(journal.map((record) => record.type)).toEqual([
+      'browser.connected',
+      'view.navigate',
+    ])
     await closeSocket(browser)
   })
 })

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -1,0 +1,1001 @@
+import { randomBytes } from 'node:crypto'
+import { once } from 'node:events'
+import { existsSync } from 'node:fs'
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  watch,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WebSocket } from 'ws'
+import {
+  readVisualSessionDescriptor,
+  recoverVisualSessionClient as clientRecover,
+  sendVisualResponse as clientRespond,
+  stopVisualSessionClient as clientStop,
+} from '../src/adapters/visual/client.js'
+import {
+  VISUAL_LIMITS,
+  type VisualBrowserInput,
+  type VisualEvent,
+  type VisualHandoff,
+  type VisualHandoffSummary,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionDescriptor,
+  type VisualSessionRequest,
+} from '../src/adapters/visual/protocol.js'
+import {
+  startVisualServer,
+  type VisualServerFrame,
+  type VisualServerHandle,
+  type VisualServerOptions,
+} from '../src/adapters/visual/session-server.js'
+import {
+  appendTerminalEvent,
+  appendVisualEvent,
+  createVisualSession,
+  recoverVisualSession,
+} from '../src/adapters/visual/session-store.js'
+
+/**
+ * The complete visual conversation, driven end to end over the real transport:
+ * a real session server, a real browser socket, the real agent client, and the
+ * trusted-compiler stand-in. Nothing is mocked, so every terminal cause below
+ * converges through the one transition the runtime actually ships.
+ */
+
+const fixtures = fileURLToPath(new URL('./fixtures/visual/', import.meta.url))
+const fakeCompiler = join(fixtures, 'fake-likec4.mjs')
+const assetRoot = join(fixtures, 'browser-assets')
+
+const modelWith = (marker?: string): VisualModel => ({
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    // The fake compiler selects its behaviour from a marker comment inside a
+    // staged source file, so a hanging compile is a property of the model.
+    'model.likec4': `model { system = system "System" }${
+      marker === undefined ? '' : `\n// fake:${marker}`
+    }`,
+    'views/choices.likec4': 'views { view choices { include * } }',
+  },
+})
+
+const requestWith = (
+  overrides: Partial<VisualSessionRequest> = {},
+): VisualSessionRequest => ({
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler: { command: process.execPath, args: [fakeCompiler] },
+  initialModel: modelWith(),
+  ...overrides,
+})
+
+const identifier = (index: number) => index.toString(16).padStart(32, '0')
+
+let responses = 0
+const nextResponseId = () => identifier(0xa0000 + responses++)
+
+// --------------------------------------------------------------- browser side
+
+const chatMessage = (text: string): VisualBrowserInput => ({
+  type: 'chat.message',
+  lastAcknowledgedSequence: 0,
+  payload: { text },
+})
+
+const choiceSelected = (optionId: string): VisualBrowserInput => ({
+  type: 'choice.selected',
+  lastAcknowledgedSequence: 0,
+  payload: { choiceId: 'delivery', optionId },
+})
+
+const viewNavigate = (viewId: string): VisualBrowserInput => ({
+  type: 'view.navigate',
+  lastAcknowledgedSequence: 0,
+  payload: { viewId, requiresAttention: false },
+})
+
+const sessionEnd = (): VisualBrowserInput => ({
+  type: 'session.end',
+  lastAcknowledgedSequence: 0,
+  payload: { reason: 'user-ended' },
+})
+
+// ----------------------------------------------------------------- agent side
+
+const responseTo = <Type extends VisualResponse['type']>(
+  event: VisualEvent,
+  type: Type,
+  payload: Extract<VisualResponse, { readonly type: Type }>['payload'],
+): VisualResponse =>
+  ({
+    format: 'yarramate/visual-response/v1',
+    sessionId: event.sessionId,
+    responseId: nextResponseId(),
+    eventId: event.eventId,
+    type,
+    timestamp: '2026-08-08T00:00:02.000Z',
+    payload,
+  }) as VisualResponse
+
+const chatReply = (event: VisualEvent, text: string) =>
+  responseTo(event, 'chat.response', { text })
+
+const choiceAcknowledged = (event: VisualEvent) =>
+  responseTo(event, 'chat.response', { text: 'Recorded that choice.' })
+
+const completeHandoff = (event: VisualEvent, summary: VisualHandoffSummary) =>
+  responseTo(event, 'handoff.complete', summary)
+
+// -------------------------------------------------------------------- harness
+
+interface VisualFixture {
+  readonly handle: VisualServerHandle
+  readonly descriptorPath: string
+  readonly sessionRoot: string
+  readonly sessionId: string
+  readonly origin: string
+  /** Resolves with the reconnect window, in milliseconds, this session armed. */
+  readonly graceScheduled: Promise<number>
+  /** Windows that were cancelled before they could fire. */
+  readonly cancelledGraces: number[]
+  /** Elapses the armed reconnect window without waiting out real time. */
+  readonly expireGrace: () => Promise<void>
+}
+
+let baseDir = ''
+let compilerLog = ''
+const running: VisualServerHandle[] = []
+
+const startVisualFixture = async (
+  overrides: Partial<VisualServerOptions> & {
+    readonly chatEnabled?: boolean
+  } = {},
+): Promise<VisualFixture> => {
+  const { chatEnabled = true, ...serverOverrides } = overrides
+  const armed = Promise.withResolvers<number>()
+  const cancelledGraces: number[] = []
+  let pending: (() => Promise<void>) | undefined
+  const handle = await startVisualServer({
+    request: requestWith({ chatEnabled }),
+    baseDir,
+    assetRoot,
+    // Long enough that an event racing a poll always wins.
+    agentPollMs: 4000,
+    // The reconnect grace is observed rather than waited out: the window the
+    // session asks for is recorded, and the test decides when it elapses.
+    schedule: (task, ms) => {
+      pending = task
+      armed.resolve(ms)
+      return () => {
+        cancelledGraces.push(ms)
+        pending = undefined
+      }
+    },
+    ...serverOverrides,
+  })
+  running.push(handle)
+  return {
+    handle,
+    descriptorPath: handle.started.descriptorPath,
+    sessionRoot: handle.started.sessionRoot,
+    sessionId: handle.started.sessionId,
+    origin: handle.started.origin,
+    graceScheduled: armed.promise,
+    cancelledGraces,
+    expireGrace: async () => {
+      const fire = pending
+      if (fire === undefined) throw new Error('no reconnect grace is armed')
+      pending = undefined
+      await fire()
+    },
+  }
+}
+
+const buffered = new WeakMap<WebSocket, VisualServerFrame[]>()
+
+const bootstrapCookie = async (visual: VisualFixture) => {
+  const response = await fetch(visual.handle.started.browserUrl, {
+    redirect: 'manual',
+  })
+  const header = response.headers.get('set-cookie')
+  if (header === null) throw new Error('bootstrap returned no cookie')
+  return header.split(';')[0] as string
+}
+
+const openBrowserSocket = async (visual: VisualFixture, cookie: string) => {
+  const socket = new WebSocket(visual.handle.started.webSocketUrl, {
+    headers: { Cookie: cookie, Origin: visual.origin },
+  })
+  const frames: VisualServerFrame[] = []
+  buffered.set(socket, frames)
+  socket.on('message', (data) => {
+    frames.push(JSON.parse(String(data)) as VisualServerFrame)
+  })
+  await once(socket, 'open')
+  return socket
+}
+
+const connectFixtureBrowser = async (visual: VisualFixture) =>
+  openBrowserSocket(visual, await bootstrapCookie(visual))
+
+/**
+ * The next frame of one kind. The server sends `ready` the moment it accepts
+ * the upgrade, which can land before a test starts listening, so frames are
+ * buffered from construction and claimed here.
+ */
+const nextFrame = async <Kind extends VisualServerFrame['kind']>(
+  socket: WebSocket,
+  kind: Kind,
+): Promise<Extract<VisualServerFrame, { kind: Kind }>> => {
+  const frames = buffered.get(socket) ?? []
+  for (;;) {
+    const index = frames.findIndex((frame) => frame.kind === kind)
+    if (index >= 0) {
+      return frames.splice(index, 1)[0] as Extract<
+        VisualServerFrame,
+        { kind: Kind }
+      >
+    }
+    await once(socket, 'message')
+  }
+}
+
+const send = (socket: WebSocket, input: VisualBrowserInput) =>
+  socket.send(JSON.stringify(input))
+
+const closeSocket = async (socket: WebSocket) => {
+  if (socket.readyState === socket.CLOSED) return
+  const closed = once(socket, 'close')
+  socket.close()
+  await closed
+}
+
+// --------------------------------------------------------- agent-side clients
+
+const descriptorAt = async (
+  descriptorPath: string,
+): Promise<VisualSessionDescriptor> => {
+  const descriptor = await readVisualSessionDescriptor(descriptorPath)
+  if (!descriptor.ok) {
+    throw new Error(
+      `descriptor "${descriptorPath}" is unusable: ${descriptor.diagnostics[0]?.message}`,
+    )
+  }
+  return descriptor.value
+}
+
+const sendVisualResponse = async (
+  descriptorPath: string,
+  response: VisualResponse,
+) => {
+  const accepted = await clientRespond(
+    await descriptorAt(descriptorPath),
+    response,
+  )
+  if (!accepted.ok) {
+    throw new Error(
+      `response was refused: ${JSON.stringify(accepted.diagnostics)}`,
+    )
+  }
+  return accepted.value
+}
+
+const recoverVisualSessionClient = async (
+  descriptorPath: string,
+  options: { readonly includeTranscript: boolean } = {
+    includeTranscript: false,
+  },
+): Promise<VisualHandoff> => {
+  const recovered = await clientRecover(
+    await descriptorAt(descriptorPath),
+    options.includeTranscript,
+  )
+  if (!recovered.ok) {
+    throw new Error(
+      `recovery was refused: ${JSON.stringify(recovered.diagnostics)}`,
+    )
+  }
+  return recovered.value
+}
+
+const stopVisualSessionClient = async (
+  descriptorPath: string,
+  options: { readonly includeTranscript: boolean } = {
+    includeTranscript: false,
+  },
+): Promise<VisualHandoff | undefined> => {
+  const stopped = await clientStop(
+    await descriptorAt(descriptorPath),
+    options.includeTranscript,
+  )
+  if (!stopped.ok) {
+    throw new Error(`stop was refused: ${JSON.stringify(stopped.diagnostics)}`)
+  }
+  return stopped.value
+}
+
+const agentFetch = async (
+  descriptorPath: string,
+  route: string,
+  body?: unknown,
+) => {
+  const descriptor = await descriptorAt(descriptorPath)
+  return fetch(`${descriptor.origin}${route}`, {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: {
+      Authorization: `Bearer ${descriptor.agentCapability}`,
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+}
+
+// ------------------------------------------------------------------- journals
+
+const journalRecords = async (
+  root: string,
+): Promise<readonly (VisualEvent | VisualResponse)[]> =>
+  (await readFile(join(root, 'journal.jsonl'), 'utf8'))
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as VisualEvent | VisualResponse)
+
+/**
+ * Waits for the journal a descriptor names to carry an event past `after`. The
+ * journal is the record an out-of-process agent reads, so the wait is on the
+ * file's own change events rather than on a guessed delay.
+ */
+const waitForVisualEvent = async (
+  descriptorPath: string,
+  after: number,
+): Promise<VisualEvent> => {
+  const { journalPath } = await descriptorAt(descriptorPath)
+  // The journal exists from session creation, and the watcher buffers from
+  // here, so an append racing the first read is still delivered below.
+  const changes = watch(journalPath)
+  const journaled = async () => {
+    const lines = (await readFile(journalPath, 'utf8'))
+      .split('\n')
+      .filter((line) => line.length > 0)
+    for (const line of lines) {
+      const record = JSON.parse(line) as VisualEvent | VisualResponse
+      if (
+        record.format === 'yarramate/visual-event/v1' &&
+        record.sequence > after
+      ) {
+        return record
+      }
+    }
+    return undefined
+  }
+  const already = await journaled()
+  if (already !== undefined) {
+    await changes.return?.(undefined)
+    return already
+  }
+  for await (const _change of changes) {
+    const appended = await journaled()
+    if (appended !== undefined) return appended
+  }
+  throw new Error(`no event past ${after} in "${journalPath}"`)
+}
+
+/**
+ * Runs `action` and returns once the trusted compiler has been executed once
+ * more than before it. The fake command records every execution before it does
+ * anything else, so a run that appears here and does not finish is a compile
+ * stage that is genuinely in flight.
+ */
+const whileCompiling = async (action: () => void) => {
+  const executions = async () =>
+    (await readFile(compilerLog, 'utf8')).split('\n').filter(Boolean).length
+  const before = await executions()
+  const changes = watch(compilerLog)
+  action()
+  for await (const _change of changes) {
+    if ((await executions()) > before) return
+  }
+}
+
+/** A session directory whose runtime is gone, as a restart finds it. */
+const plantVisualSession = async (
+  records: (sessionId: string) => readonly (VisualEvent | VisualResponse)[],
+  torn = '',
+) => {
+  const created = await createVisualSession(requestWith(), {
+    baseDir,
+    now: () => new Date('2026-08-08T00:00:00.000Z'),
+    randomBytes,
+  })
+  const sessionId = basename(created.paths.root)
+  await writeFile(
+    created.paths.journal,
+    `${records(sessionId)
+      .map((record) => `${JSON.stringify(record)}\n`)
+      .join('')}${torn}`,
+  )
+  return { paths: created.paths, sessionId }
+}
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'yarramate-visual-journey-'))
+  compilerLog = join(baseDir, 'compiler.log')
+  await writeFile(compilerLog, '')
+  process.env.YARRAMATE_FAKE_LIKEC4_LOG = compilerLog
+})
+
+afterEach(async () => {
+  delete process.env.YARRAMATE_FAKE_LIKEC4_LOG
+  for (const handle of running.splice(0)) {
+    await handle.stop('main-cancelled').catch(() => undefined)
+  }
+  await rm(baseDir, { recursive: true, force: true })
+})
+
+describe('the complete visual conversation', () => {
+  it('returns a summary, optionally exposes the transcript, and removes the session on End', async () => {
+    const visual = await startVisualFixture({ chatEnabled: true })
+    const browser = await connectFixtureBrowser(visual)
+
+    send(browser, chatMessage('Explain option B'))
+    const message = await waitForVisualEvent(visual.descriptorPath, 0)
+    await sendVisualResponse(
+      visual.descriptorPath,
+      chatReply(message, 'Option B isolates rendering.'),
+    )
+
+    send(browser, choiceSelected('option-b'))
+    await sendVisualResponse(
+      visual.descriptorPath,
+      choiceAcknowledged(await waitForVisualEvent(visual.descriptorPath, 1)),
+    )
+
+    send(browser, sessionEnd())
+    const ending = await waitForVisualEvent(visual.descriptorPath, 2)
+    await sendVisualResponse(
+      visual.descriptorPath,
+      completeHandoff(ending, {
+        summary: 'Selected option B.',
+        confirmedDecisions: ['option-b'],
+        requestedChanges: [],
+        unresolvedQuestions: [],
+        finalViews: ['choices', 'option-b'],
+      }),
+    )
+
+    expect(
+      await recoverVisualSessionClient(visual.descriptorPath, {
+        includeTranscript: false,
+      }),
+    ).toMatchObject({
+      decision: 'completed',
+      terminationReason: 'user-ended',
+      summary: 'Selected option B.',
+      confirmedDecisions: ['option-b'],
+      transcript: undefined,
+    })
+    expect(
+      await recoverVisualSessionClient(visual.descriptorPath, {
+        includeTranscript: true,
+      }),
+    ).toMatchObject({ transcript: expect.any(Array) })
+    // Recovery is a read: the raw transcript stays available until the stop.
+    expect(existsSync(visual.sessionRoot)).toBe(true)
+
+    await stopVisualSessionClient(visual.descriptorPath)
+    expect(existsSync(visual.sessionRoot)).toBe(false)
+    await expect(fetch(visual.origin)).rejects.toThrow()
+    await closeSocket(browser)
+  })
+
+  it('journals the reviewer End once and hands it back as the terminal cause', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+
+    send(browser, sessionEnd())
+    const ending = await waitForVisualEvent(visual.descriptorPath, 0)
+    await sendVisualResponse(
+      visual.descriptorPath,
+      completeHandoff(ending, {
+        summary: 'Ended without a decision.',
+        confirmedDecisions: [],
+        requestedChanges: [],
+        unresolvedQuestions: [],
+        finalViews: ['choices'],
+      }),
+    )
+    const beforeStop = await journalRecords(visual.sessionRoot)
+    expect(
+      beforeStop.filter(
+        (record) =>
+          record.format === 'yarramate/visual-event/v1' &&
+          record.type === 'session.end',
+      ),
+    ).toHaveLength(1)
+
+    // The stop asks for `main-cancelled`, but the reviewer's End is already
+    // this session's terminal event, and a session has exactly one.
+    const closed = await visual.handle.stop('main-cancelled')
+    expect(closed.handoff).toMatchObject({
+      decision: 'completed',
+      terminationReason: 'user-ended',
+      lastSequence: ending.sequence,
+    })
+    await closeSocket(browser)
+  })
+
+  it('hands the raw transcript to the stop that asked for it', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+    send(browser, chatMessage('one question'))
+    await nextFrame(browser, 'accepted')
+
+    const handoff = await stopVisualSessionClient(visual.descriptorPath, {
+      includeTranscript: true,
+    })
+    // The runtime's own terminal record is in the transcript it hands over,
+    // and the transcript is the last thing read before the directory goes.
+    expect(handoff?.transcript?.map((record) => record.type)).toEqual([
+      'chat.message',
+      'session.end',
+    ])
+    expect(handoff).toMatchObject({ terminationReason: 'main-cancelled' })
+    expect(existsSync(visual.sessionRoot)).toBe(false)
+    await closeSocket(browser)
+  })
+})
+
+describe('the visual recovery matrix', () => {
+  it('derives a partial summary when the child fails before the handoff', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+
+    send(browser, viewNavigate('option-b'))
+    await nextFrame(browser, 'accepted')
+    send(browser, chatMessage('Why option B?'))
+    await waitForVisualEvent(visual.descriptorPath, 1)
+
+    // The child died without submitting a handoff, so the main agent closes
+    // the session under the reason it observed.
+    const stopped = await agentFetch(visual.descriptorPath, '/api/agent/stop', {
+      reason: 'child-failed',
+    })
+    expect(stopped.status).toBe(200)
+    expect(await stopped.json()).toMatchObject({
+      reason: 'child-failed',
+      alreadyStopped: false,
+      handoff: {
+        decision: 'failed',
+        terminationReason: 'child-failed',
+        summary: expect.stringContaining('reconstructed'),
+        finalViews: ['option-b'],
+      },
+    })
+    expect(existsSync(visual.sessionRoot)).toBe(false)
+    await closeSocket(browser)
+  })
+
+  it('ends the session exactly five minutes after the browser disconnects', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+    await nextFrame(browser, 'ready')
+
+    await closeSocket(browser)
+    expect(await visual.graceScheduled).toBe(VISUAL_LIMITS.reconnectMs)
+    expect(VISUAL_LIMITS.reconnectMs).toBe(5 * 60 * 1000)
+    // The session says, while it is still true, when it stops waiting.
+    expect(visual.handle.status().browser.graceExpiresAt).toBe(
+      new Date(
+        Date.parse(visual.handle.status().browser.lastSeenAt as string) +
+          VISUAL_LIMITS.reconnectMs,
+      ).toISOString(),
+    )
+
+    await visual.expireGrace()
+
+    expect((await journalRecords(visual.sessionRoot)).at(-1)).toMatchObject({
+      format: 'yarramate/visual-event/v1',
+      type: 'session.end',
+      payload: { reason: 'browser-timeout' },
+    })
+    expect(visual.handle.status().queue).toMatchObject({
+      frozen: true,
+      frozenReason: 'terminal-event',
+    })
+    // The window is spent, so the session no longer claims to be holding one.
+    expect(visual.handle.status().browser.graceExpiresAt).toBeUndefined()
+    expect(
+      await recoverVisualSessionClient(visual.descriptorPath),
+    ).toMatchObject({ terminationReason: 'browser-timeout' })
+  })
+
+  it('cancels the disconnect grace when the browser reconnects inside it', async () => {
+    const visual = await startVisualFixture()
+    const cookie = await bootstrapCookie(visual)
+    const first = await openBrowserSocket(visual, cookie)
+    await nextFrame(first, 'ready')
+
+    await closeSocket(first)
+    expect(await visual.graceScheduled).toBe(VISUAL_LIMITS.reconnectMs)
+
+    const second = await openBrowserSocket(visual, cookie)
+    await nextFrame(second, 'ready')
+    expect(visual.cancelledGraces).toEqual([VISUAL_LIMITS.reconnectMs])
+
+    // Nothing terminal was journaled, so the reviewer can still speak.
+    send(second, chatMessage('still here'))
+    await expect(nextFrame(second, 'accepted')).resolves.toMatchObject({
+      sequence: 1,
+    })
+    expect(visual.handle.status().lifecycle).toBe('running')
+    await closeSocket(second)
+  })
+
+  it('aborts an active compiler process when the main agent cancels', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+    send(browser, chatMessage('redraw it'))
+    const asked = await nextFrame(browser, 'accepted')
+
+    let posted: Promise<Response> | undefined
+    await whileCompiling(() => {
+      posted = agentFetch(visual.descriptorPath, '/api/agent/responses', {
+        format: 'yarramate/visual-response/v1',
+        sessionId: visual.sessionId,
+        responseId: nextResponseId(),
+        eventId: asked.eventId,
+        type: 'model.replace',
+        timestamp: '2026-08-08T00:00:03.000Z',
+        // This candidate never finishes compiling on its own.
+        payload: { model: modelWith('hang') },
+      })
+    })
+
+    const started = Date.now()
+    const closed = await visual.handle.stop('main-cancelled')
+    // Cancelled, not waited out: the compiler's own budget is 30 seconds.
+    expect(Date.now() - started).toBeLessThan(15_000)
+
+    const body = (await (await posted)?.json()) as {
+      readonly diagnostics: readonly { readonly code: string }[]
+    }
+    expect(body.diagnostics.map((entry) => entry.code)).toContain('YMVS204')
+    expect(closed.handoff).toMatchObject({
+      terminationReason: 'main-cancelled',
+      decision: 'failed',
+    })
+    await closeSocket(browser)
+  }, 45_000)
+
+  it('recovers a restarted runtime from the journal without acknowledging a truncated record', async () => {
+    const torn = '{"format":"yarramate/visual-event/v1","sessionId":"0000'
+    const { paths, sessionId } = await plantVisualSession(
+      (id) => [
+        {
+          format: 'yarramate/visual-event/v1',
+          sessionId: id,
+          sequence: 1,
+          eventId: identifier(1),
+          type: 'chat.message',
+          timestamp: '2026-08-08T00:00:01.000Z',
+          payload: { text: 'Compare the two designs' },
+        },
+        {
+          format: 'yarramate/visual-response/v1',
+          sessionId: id,
+          responseId: identifier(2),
+          eventId: identifier(1),
+          type: 'chat.response',
+          timestamp: '2026-08-08T00:00:02.000Z',
+          payload: { text: 'They differ in delivery.' },
+        },
+      ],
+      torn,
+    )
+    const size = (await stat(paths.journal)).size
+
+    expect(await recoverVisualSession(paths)).toMatchObject({
+      sessionId,
+      lastSequence: 1,
+      decision: 'failed',
+      terminationReason: 'server-failed',
+    })
+    // Recovery is read-only: the torn tail is ignored, never acknowledged.
+    expect((await stat(paths.journal)).size).toBe(size)
+
+    // The restarted runtime closes the session it inherited.
+    await appendTerminalEvent(paths, 'server-failed', {
+      now: () => new Date('2026-08-08T00:05:00.000Z'),
+      randomBytes,
+    })
+    const journal = await readFile(paths.journal, 'utf8')
+    expect(journal).not.toContain(torn)
+    const records = journal
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as VisualEvent | VisualResponse)
+    expect(records).toHaveLength(3)
+    expect(records.at(-1)).toMatchObject({
+      type: 'session.end',
+      sequence: 2,
+      payload: { reason: 'server-failed' },
+    })
+    expect(await recoverVisualSession(paths)).toMatchObject({
+      lastSequence: 2,
+      terminationReason: 'server-failed',
+    })
+  })
+
+  it('appends the terminal event exactly once however often it is asked', async () => {
+    const { paths } = await plantVisualSession((id) => [
+      {
+        format: 'yarramate/visual-event/v1',
+        sessionId: id,
+        sequence: 1,
+        eventId: identifier(1),
+        type: 'chat.message',
+        timestamp: '2026-08-08T00:00:01.000Z',
+        payload: { text: 'Compare the two designs' },
+      },
+    ])
+    const deps = { now: () => new Date('2026-08-08T00:05:00.000Z'), randomBytes }
+    const first = await appendTerminalEvent(paths, 'child-failed', deps)
+    expect(await appendTerminalEvent(paths, 'main-cancelled', deps)).toEqual(
+      first,
+    )
+    expect(
+      (await readFile(paths.journal, 'utf8')).split('\n').filter(Boolean),
+    ).toHaveLength(2)
+
+    // Nothing may follow a terminal event: the journal is closed.
+    expect(
+      await appendVisualEvent(paths, {
+        format: 'yarramate/visual-event/v1',
+        sessionId: first.sessionId,
+        sequence: 3,
+        eventId: identifier(7),
+        type: 'chat.message',
+        timestamp: '2026-08-08T00:06:00.000Z',
+        payload: { text: 'one more thing' },
+      }),
+    ).toMatchObject({ ok: false })
+    expect(
+      (await readFile(paths.journal, 'utf8')).split('\n').filter(Boolean),
+    ).toHaveLength(2)
+  })
+
+  it('answers a repeated stop as already stopped without recovering again', async () => {
+    const visual = await startVisualFixture()
+    // The agent holds its descriptor from before the stop; the file itself
+    // goes with the session, credential and all.
+    const descriptor = await descriptorAt(visual.descriptorPath)
+
+    const first = await visual.handle.stop('user-ended')
+    expect(first.alreadyStopped).toBe(false)
+    expect(existsSync(visual.sessionRoot)).toBe(false)
+
+    expect(await visual.handle.stop('child-failed')).toMatchObject({
+      alreadyStopped: true,
+      reason: 'user-ended',
+      handoff: first.handoff,
+    })
+
+    // A session that is gone stops to nothing rather than to an invented
+    // handoff, and leaves no credential-bearing remains behind.
+    await expect(clientStop(descriptor)).resolves.toEqual({
+      ok: true,
+      value: undefined,
+    })
+    expect(existsSync(visual.descriptorPath)).toBe(false)
+  })
+
+  it('refuses every write once the runtime has taken the session terminal', async () => {
+    const visual = await startVisualFixture()
+    const browser = await connectFixtureBrowser(visual)
+    await nextFrame(browser, 'ready')
+
+    await closeSocket(browser)
+    await visual.graceScheduled
+    await visual.expireGrace()
+    const terminal = await journalRecords(visual.sessionRoot)
+
+    const refused = await agentFetch(
+      visual.descriptorPath,
+      '/api/agent/responses',
+      {
+        format: 'yarramate/visual-response/v1',
+        sessionId: visual.sessionId,
+        responseId: nextResponseId(),
+        eventId: identifier(9),
+        type: 'chat.response',
+        timestamp: '2026-08-08T00:00:09.000Z',
+        payload: { text: 'too late' },
+      },
+    )
+    expect(refused.status).toBe(503)
+    expect(await journalRecords(visual.sessionRoot)).toEqual(terminal)
+  })
+
+  it('gives back the port and the directory when a started session cannot be published', async () => {
+    // How many times a start that works reads the clock. The last of those
+    // reads stamps the started document, which is published well after the
+    // port is bound — so failing it is the post-listen abandon path.
+    let reads = 0
+    await startVisualFixture({
+      now: () => {
+        reads += 1
+        return new Date('2026-08-08T00:00:00.000Z')
+      },
+    })
+    const published = reads
+    const listeners = () =>
+      process
+        .getActiveResourcesInfo()
+        .filter((resource) => resource === 'TCPServerWrap').length
+    const before = listeners()
+    const roots = await readdir(baseDir)
+
+    let taken = 0
+    await expect(
+      startVisualServer({
+        request: requestWith(),
+        baseDir,
+        assetRoot,
+        now: () => {
+          taken += 1
+          return taken < published
+            ? new Date('2026-08-08T00:00:00.000Z')
+            : new Date(Number.NaN)
+        },
+      }),
+    ).rejects.toThrow()
+
+    expect(listeners()).toBe(before)
+    expect(await readdir(baseDir)).toEqual(roots)
+  })
+
+  it('keeps two sessions isolated across cookies, capabilities, and identifiers', async () => {
+    const one = await startVisualFixture()
+    const other = await startVisualFixture()
+    const cookies = new Map([
+      [one, await bootstrapCookie(one)],
+      [other, await bootstrapCookie(other)],
+    ])
+    const cookieForOne = cookies.get(one) as string
+    const descriptorOfOne = await descriptorAt(one.descriptorPath)
+
+    // One session's browser cookie authenticates nothing in the other.
+    const crossedCookie = await fetch(`${other.origin}/api/session`, {
+      headers: { Cookie: cookieForOne, Origin: other.origin },
+    })
+    expect(crossedCookie.status).toBe(401)
+
+    // Nor does its agent capability.
+    const crossedCapability = await fetch(`${other.origin}/api/agent/status`, {
+      headers: { Authorization: `Bearer ${descriptorOfOne.agentCapability}` },
+    })
+    expect(crossedCapability.status).toBe(401)
+
+    // A response naming another session is refused whatever it carries.
+    const foreign = await agentFetch(
+      other.descriptorPath,
+      '/api/agent/responses',
+      {
+        format: 'yarramate/visual-response/v1',
+        sessionId: one.sessionId,
+        responseId: identifier(0x11),
+        eventId: identifier(0x12),
+        type: 'chat.response',
+        timestamp: '2026-08-08T00:00:04.000Z',
+        payload: { text: 'crossing over' },
+      },
+    )
+    expect(foreign.status).toBe(409)
+    expect(await foreign.json()).toMatchObject({
+      accepted: false,
+      diagnostics: [{ code: 'YMVS126', pointer: '/sessionId' }],
+    })
+
+    // Identifiers are per-session namespaces: the same response id spends once
+    // in each, and neither journal learns the other's event identifiers.
+    const shared = identifier(0x21)
+    for (const visual of [one, other]) {
+      const browser = await openBrowserSocket(visual, cookies.get(visual) as string)
+      send(browser, chatMessage('same question'))
+      const asked = await nextFrame(browser, 'accepted')
+      const accepted = await agentFetch(
+        visual.descriptorPath,
+        '/api/agent/responses',
+        {
+          format: 'yarramate/visual-response/v1',
+          sessionId: visual.sessionId,
+          responseId: shared,
+          eventId: asked.eventId,
+          type: 'chat.response',
+          timestamp: '2026-08-08T00:00:05.000Z',
+          payload: { text: 'same answer' },
+        },
+      )
+      expect(await accepted.json()).toMatchObject({
+        accepted: true,
+        duplicate: false,
+      })
+      await closeSocket(browser)
+    }
+
+    const identifiersOf = async (root: string) =>
+      (await journalRecords(root))
+        .filter((record) => record.format === 'yarramate/visual-event/v1')
+        .map((record) => record.eventId)
+    const inOne = await identifiersOf(one.sessionRoot)
+    const inOther = await identifiersOf(other.sessionRoot)
+    expect(inOne).toHaveLength(1)
+    expect(inOne.filter((id) => inOther.includes(id))).toEqual([])
+
+    // And a descriptor recovers only the session it lives in.
+    expect(await recoverVisualSessionClient(one.descriptorPath)).toMatchObject({
+      sessionId: one.sessionId,
+    })
+  })
+
+  it('rejects chat in a diagram-only session while navigation still journals', async () => {
+    const visual = await startVisualFixture({ chatEnabled: false })
+    const browser = await connectFixtureBrowser(visual)
+    expect((await nextFrame(browser, 'ready')).snapshot.capabilities).toMatchObject(
+      { chat: false, choices: false, navigation: true },
+    )
+
+    send(browser, chatMessage('let me talk'))
+    expect(await nextFrame(browser, 'rejected')).toMatchObject({
+      diagnostics: [{ code: 'YMVS309' }],
+    })
+    send(browser, choiceSelected('option-b'))
+    expect(await nextFrame(browser, 'rejected')).toMatchObject({
+      diagnostics: [{ code: 'YMVS309' }],
+    })
+
+    // Navigation is the capability a diagram-only session does grant.
+    send(browser, viewNavigate('choices'))
+    expect(await nextFrame(browser, 'accepted')).toMatchObject({ sequence: 1 })
+
+    // The agent cannot speak into a session that has no conversation either.
+    const refused = await agentFetch(
+      visual.descriptorPath,
+      '/api/agent/responses',
+      {
+        format: 'yarramate/visual-response/v1',
+        sessionId: visual.sessionId,
+        responseId: nextResponseId(),
+        eventId: identifier(9),
+        type: 'chat.response',
+        timestamp: '2026-08-08T00:00:06.000Z',
+        payload: { text: 'talking anyway' },
+      },
+    )
+    expect(refused.status).toBe(409)
+    expect(await refused.json()).toMatchObject({
+      diagnostics: [{ code: 'YMVS309' }],
+    })
+
+    const journal = await journalRecords(visual.sessionRoot)
+    expect(journal).toHaveLength(1)
+    expect(journal[0]).toMatchObject({ type: 'view.navigate' })
+    await closeSocket(browser)
+  })
+})

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { once } from 'node:events'
-import { existsSync } from 'node:fs'
+import { existsSync, watch as watchEagerly } from 'node:fs'
 import {
   mkdtemp,
   readdir,
@@ -357,43 +357,58 @@ const journalRecords = async (
     .map((line) => JSON.parse(line) as VisualEvent | VisualResponse)
 
 /**
- * Waits for the journal a descriptor names to carry an event past `after`. The
+ * Waits for the next event the journal a descriptor names carries past `after`,
+ * and answers only if it is the `type` the caller is correlating against. The
  * journal is the record an out-of-process agent reads, so the wait is on the
  * file's own change events rather than on a guessed delay.
+ *
+ * Naming the type is what makes the wait a correlation rather than a cursor.
+ * The runtime journals records of its own — a browser arriving, a browser
+ * leaving — and a wait that took whatever came next would hand one of those
+ * back as the event a response is about to answer, which the store accepts and
+ * nothing downstream could tell apart from the reviewer's own turn.
  */
-const waitForVisualEvent = async (
+const waitForVisualEvent = async <Type extends VisualEvent['type']>(
   descriptorPath: string,
   after: number,
-): Promise<VisualEvent> => {
+  type: Type,
+): Promise<Extract<VisualEvent, { readonly type: Type }>> => {
   const { journalPath } = await descriptorAt(descriptorPath)
-  // The journal exists from session creation, and the watcher buffers from
-  // here, so an append racing the first read is still delivered below.
-  const changes = watch(journalPath)
-  const journaled = async () => {
-    const lines = (await readFile(journalPath, 'utf8'))
-      .split('\n')
-      .filter((line) => line.length > 0)
-    for (const line of lines) {
-      const record = JSON.parse(line) as VisualEvent | VisualResponse
-      if (
-        record.format === 'yarramate/visual-event/v1' &&
-        record.sequence > after
-      ) {
-        return record
+  // The callback watcher, not `fs/promises.watch`: the promise form is an async
+  // generator that registers nothing until its first iteration, so it cannot be
+  // armed ahead of the read. This one is watching from the moment it is
+  // constructed, and every change it sees is counted, so an append landing
+  // during the read below is observed rather than lost.
+  let changes = 0
+  let changed = Promise.withResolvers<void>()
+  const watcher = watchEagerly(journalPath, () => {
+    changes += 1
+    changed.resolve()
+    changed = Promise.withResolvers<void>()
+  })
+  try {
+    for (;;) {
+      const seen = changes
+      const lines = (await readFile(journalPath, 'utf8'))
+        .split('\n')
+        .filter((line) => line.length > 0)
+      for (const line of lines) {
+        const record = JSON.parse(line) as VisualEvent | VisualResponse
+        if (record.format !== 'yarramate/visual-event/v1') continue
+        if (record.sequence <= after) continue
+        if (record.type !== type) {
+          throw new Error(
+            `journal holds ${record.type} at sequence ${record.sequence}, not the ${type} this wait is for`,
+          )
+        }
+        return record as Extract<VisualEvent, { readonly type: Type }>
       }
+      // Nothing since the read began, so there is a change worth waiting for.
+      if (changes === seen) await changed.promise
     }
-    return undefined
+  } finally {
+    watcher.close()
   }
-  const already = await journaled()
-  if (already !== undefined) {
-    await changes.return?.(undefined)
-    return already
-  }
-  for await (const _change of changes) {
-    const appended = await journaled()
-    if (appended !== undefined) return appended
-  }
-  throw new Error(`no event past ${after} in "${journalPath}"`)
 }
 
 /**
@@ -453,21 +468,35 @@ describe('the complete visual conversation', () => {
     const visual = await startVisualFixture({ chatEnabled: true })
     const browser = await connectFixtureBrowser(visual)
 
+    // The runtime journals this browser's arrival, so the conversation the
+    // reviewer drives starts past it.
+    const arrival = (await nextFrame(browser, 'ready')).snapshot.lastSequence
+
     send(browser, chatMessage('Explain option B'))
-    const message = await waitForVisualEvent(visual.descriptorPath, 0)
+    const message = await waitForVisualEvent(
+      visual.descriptorPath,
+      arrival,
+      'chat.message',
+    )
     await sendVisualResponse(
       visual.descriptorPath,
       chatReply(message, 'Option B isolates rendering.'),
     )
 
     send(browser, choiceSelected('option-b'))
-    await sendVisualResponse(
+    const chose = await waitForVisualEvent(
       visual.descriptorPath,
-      choiceAcknowledged(await waitForVisualEvent(visual.descriptorPath, 1)),
+      message.sequence,
+      'choice.selected',
     )
+    await sendVisualResponse(visual.descriptorPath, choiceAcknowledged(chose))
 
     send(browser, sessionEnd())
-    const ending = await waitForVisualEvent(visual.descriptorPath, 2)
+    const ending = await waitForVisualEvent(
+      visual.descriptorPath,
+      chose.sequence,
+      'session.end',
+    )
     await sendVisualResponse(
       visual.descriptorPath,
       completeHandoff(ending, {
@@ -508,9 +537,13 @@ describe('the complete visual conversation', () => {
     const visual = await startVisualFixture()
     const browser = await connectFixtureBrowser(visual)
 
+    const arrival = (await nextFrame(browser, 'ready')).snapshot.lastSequence
     send(browser, sessionEnd())
-    // Sequence 1 is the arrival the runtime journaled for this browser.
-    const ending = await waitForVisualEvent(visual.descriptorPath, 1)
+    const ending = await waitForVisualEvent(
+      visual.descriptorPath,
+      arrival,
+      'session.end',
+    )
     await sendVisualResponse(
       visual.descriptorPath,
       completeHandoff(ending, {
@@ -569,9 +602,13 @@ describe('the visual recovery matrix', () => {
     const browser = await connectFixtureBrowser(visual)
 
     send(browser, viewNavigate('option-b'))
-    await nextFrame(browser, 'accepted')
+    const visited = await nextFrame(browser, 'accepted')
     send(browser, chatMessage('Why option B?'))
-    await waitForVisualEvent(visual.descriptorPath, 1)
+    await waitForVisualEvent(
+      visual.descriptorPath,
+      visited.sequence,
+      'chat.message',
+    )
 
     // The child died without submitting a handoff, so the main agent closes
     // the session under the reason it observed.

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -647,21 +647,22 @@ describe('the visual recovery matrix', () => {
     )
 
     await visual.expireGrace()
+    const closed = await visual.handle.closed
 
-    expect((await journalRecords(visual.sessionRoot)).at(-1)).toMatchObject({
-      format: 'yarramate/visual-event/v1',
-      type: 'session.end',
-      payload: { reason: 'browser-timeout' },
+    expect(closed).toMatchObject({
+      reason: 'browser-timeout',
+      handoff: { terminationReason: 'browser-timeout' },
     })
+    expect(existsSync(visual.sessionRoot)).toBe(false)
     expect(visual.handle.status().queue).toMatchObject({
       frozen: true,
       frozenReason: 'terminal-event',
     })
     // The window is spent, so the session no longer claims to be holding one.
     expect(visual.handle.status().browser.graceExpiresAt).toBeUndefined()
-    expect(
-      await recoverVisualSessionClient(visual.descriptorPath),
-    ).toMatchObject({ terminationReason: 'browser-timeout' })
+    expect(closed.handoff).toMatchObject({
+      terminationReason: 'browser-timeout',
+    })
   })
 
   it('cancels the disconnect grace when the browser reconnects inside it', async () => {
@@ -846,7 +847,7 @@ describe('the visual recovery matrix', () => {
     expect(existsSync(visual.descriptorPath)).toBe(false)
   })
 
-  it('refuses every write once the runtime has taken the session terminal', async () => {
+  it('closes every write path once the reconnect window expires', async () => {
     const visual = await startVisualFixture()
     const browser = await connectFixtureBrowser(visual)
     await nextFrame(browser, 'ready')
@@ -854,23 +855,9 @@ describe('the visual recovery matrix', () => {
     await closeSocket(browser)
     await visual.graceScheduled
     await visual.expireGrace()
-    const terminal = await journalRecords(visual.sessionRoot)
+    await visual.handle.closed
 
-    const refused = await agentFetch(
-      visual.descriptorPath,
-      '/api/agent/responses',
-      {
-        format: 'yarramate/visual-response/v1',
-        sessionId: visual.sessionId,
-        responseId: nextResponseId(),
-        eventId: identifier(9),
-        type: 'chat.response',
-        timestamp: '2026-08-08T00:00:09.000Z',
-        payload: { text: 'too late' },
-      },
-    )
-    expect(refused.status).toBe(503)
-    expect(await journalRecords(visual.sessionRoot)).toEqual(terminal)
+    await expect(fetch(`${visual.origin}/api/session`)).rejects.toThrow()
   })
 
   it('gives back the port and the directory when a started session cannot be published', async () => {

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -948,6 +948,38 @@ describe('the visual recovery matrix', () => {
     expect(inOne).toHaveLength(1)
     expect(inOne.filter((id) => inOther.includes(id))).toEqual([])
 
+    // An event identifier is one session's alone: presenting the other's, under
+    // this session's own id and capability, buys nothing.
+    const borrowed = await agentFetch(
+      one.descriptorPath,
+      '/api/agent/responses',
+      {
+        format: 'yarramate/visual-response/v1',
+        sessionId: one.sessionId,
+        responseId: nextResponseId(),
+        eventId: inOther[0] as string,
+        type: 'handoff.complete',
+        timestamp: '2026-08-08T00:00:06.000Z',
+        payload: {
+          summary: 'Borrowed a turn that was never taken here.',
+          confirmedDecisions: ['forged'],
+          requestedChanges: [],
+          unresolvedQuestions: [],
+          finalViews: ['choices'],
+        },
+      },
+    )
+    expect(borrowed.status).toBe(409)
+    expect(await borrowed.json()).toMatchObject({
+      accepted: false,
+      diagnostics: [{ code: 'YMVS131', pointer: '#/eventId' }],
+    })
+    // Nothing forged reaches the handoff the main agent will read.
+    expect(await recoverVisualSessionClient(one.descriptorPath)).toMatchObject({
+      decision: 'failed',
+      confirmedDecisions: [],
+    })
+
     // And a descriptor recovers only the session it lives in.
     expect(await recoverVisualSessionClient(one.descriptorPath)).toMatchObject({
       sessionId: one.sessionId,

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -1,0 +1,421 @@
+import { existsSync, watch } from 'node:fs'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  VISUAL_COMPILER_DOCUMENT,
+  VISUAL_COMPILER_EXPORT_FILE,
+  compileVisualModel,
+} from '../src/adapters/visual/likec4-compiler.js'
+import type {
+  VisualCompilerCommand,
+  VisualModel,
+  VisualSessionRequest,
+} from '../src/adapters/visual/protocol.js'
+import {
+  createVisualSession,
+  readActiveVisualModel,
+  type VisualSessionPaths,
+} from '../src/adapters/visual/session-store.js'
+
+const fakeLikeC4 = fileURLToPath(
+  new URL('./fixtures/visual/fake-likec4.mjs', import.meta.url),
+)
+
+const compiler: VisualCompilerCommand = {
+  command: process.execPath,
+  args: [fakeLikeC4],
+}
+
+/**
+ * The fixture compiler reads its behaviour from a marker comment in a staged
+ * source file, so every failure mode is driven by the model under compilation
+ * rather than by mocking the adapter's own process handling.
+ */
+const marked = (marker?: string): VisualModel => ({
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    'model.likec4': `model {\n  system = system "System"\n}\n${
+      marker === undefined ? '' : `// fake:${marker}\n`
+    }`,
+    'views/choices.likec4': 'views { view choices { include * } }',
+  },
+})
+
+const model = marked()
+
+const request: VisualSessionRequest = {
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler,
+  initialModel: model,
+}
+
+const sessionId = '07'.repeat(16)
+
+const compile = (
+  paths: VisualSessionPaths,
+  overrides: Partial<Parameters<typeof compileVisualModel>[0]> = {},
+) =>
+  compileVisualModel({
+    model,
+    command: compiler,
+    paths,
+    now: () => new Date('2026-08-08T00:00:05.000Z'),
+    ...overrides,
+  })
+
+describe('trusted LikeC4 compiler adapter', () => {
+  let parent = ''
+  let invocations = ''
+
+  beforeEach(async () => {
+    parent = await mkdtemp(join(tmpdir(), 'yarramate-visual-compiler-'))
+    invocations = join(parent, 'invocations.jsonl')
+    process.env.YARRAMATE_FAKE_LIKEC4_LOG = invocations
+  })
+
+  afterEach(async () => {
+    delete process.env.YARRAMATE_FAKE_LIKEC4_LOG
+    await rm(parent, { recursive: true, force: true })
+  })
+
+  const startSession = async () =>
+    createVisualSession(request, {
+      baseDir: parent,
+      now: () => new Date('2026-08-08T00:00:00.000Z'),
+      randomBytes: () => Buffer.alloc(32, 7),
+    })
+
+  const argVectors = async () =>
+    (await readFile(invocations, 'utf8'))
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as readonly string[])
+
+  describe('successful compilation', () => {
+    it('validates, exports, and promotes one complete visual model', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths)
+
+      expect(result).toMatchObject({
+        ok: true,
+        compiled: {
+          initialView: 'choices',
+          authority: 'ad-hoc',
+          candidate: '000001',
+          views: ['choices'],
+        },
+      })
+      expect(
+        JSON.parse(await readFile(session.paths.activeModel, 'utf8')),
+      ).toMatchObject({
+        candidate: '000001',
+        initialView: 'choices',
+        authority: 'ad-hoc',
+        promotedAt: '2026-08-08T00:00:05.000Z',
+      })
+    })
+
+    it('runs validate before export with a deterministic argument vector', async () => {
+      const session = await startSession()
+      const candidateDir = join(session.paths.candidates, '000001')
+
+      await compile(session.paths)
+
+      expect(await argVectors()).toEqual([
+        [
+          'validate',
+          '--json',
+          '--no-layout',
+          '--file',
+          'model.likec4',
+          '--file',
+          'views/choices.likec4',
+          candidateDir,
+        ],
+        [
+          'export',
+          'json',
+          '--pretty',
+          '-o',
+          join(candidateDir, VISUAL_COMPILER_EXPORT_FILE),
+          candidateDir,
+        ],
+      ])
+    })
+
+    it('keeps every written artefact inside the allocated candidate root', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths)
+
+      if (!result.ok) throw new Error('expected a compiled model')
+      expect(result.compiled.exportPath).toBe(
+        join(result.compiled.candidateDir, VISUAL_COMPILER_EXPORT_FILE),
+      )
+      expect((await readdir(result.compiled.candidateDir)).sort()).toEqual([
+        VISUAL_COMPILER_EXPORT_FILE,
+        'likec4.config.json',
+        'model.likec4',
+        'views',
+      ])
+      expect((await readdir(session.paths.root)).sort()).toEqual([
+        'active-model.json',
+        'candidates',
+        'journal.jsonl',
+        'session.json',
+      ])
+      expect((await readdir(parent)).sort()).toEqual([
+        sessionId,
+        'invocations.jsonl',
+      ])
+    })
+  })
+
+  describe('compiler rejection', () => {
+    it('reports LikeC4 validation errors as source-located diagnostics', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, { model: marked('invalid') })
+
+      expect(result).toEqual({
+        ok: false,
+        diagnostics: [
+          {
+            severity: 'error',
+            code: 'YMVS201',
+            message: 'Unresolved reference "ghost"',
+            path: 'model.likec4',
+            pointer: '/files/model.likec4',
+            line: 2,
+            column: 5,
+          },
+        ],
+      })
+    })
+
+    it('never exports a model that failed validation', async () => {
+      const session = await startSession()
+
+      await compile(session.paths, { model: marked('invalid') })
+
+      expect((await argVectors()).map((argv) => argv[0])).toEqual(['validate'])
+    })
+
+    it('reports a compiler that exits without a validation report', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, { model: marked('crash') })
+
+      expect(result.diagnostics).toEqual([
+        {
+          severity: 'error',
+          code: 'YMVS203',
+          message:
+            'LikeC4 validate exited with status 3: fake-likec4: project not found',
+          path: VISUAL_COMPILER_DOCUMENT,
+          pointer: '/files',
+          line: 1,
+          column: 1,
+        },
+      ])
+    })
+
+    it('reports validation output that is not a JSON report', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, { model: marked('garbage') })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS206', path: VISUAL_COMPILER_DOCUMENT, pointer: '/files' },
+      ])
+    })
+
+    it('rejects an export document that is not JSON', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('malformed-export'),
+      })
+
+      expect(result.diagnostics).toMatchObject([{ code: 'YMVS207' }])
+    })
+
+    it('rejects an export that carries no views', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('no-views'),
+      })
+
+      expect(result.diagnostics).toMatchObject([{ code: 'YMVS208' }])
+    })
+
+    it('rejects an export that omits the requested initial view', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: { ...model, initialView: 'detail' },
+      })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS209', message: expect.stringContaining('detail') },
+      ])
+    })
+  })
+
+  describe('process bounds', () => {
+    // The fixture compiler never exits, so the budget can only be observed
+    // against the platform clock; a fake timer cannot bound a real child.
+    it('abandons a compiler that outruns its time budget', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('hang'),
+        timeoutMs: 100,
+      })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS204', message: expect.stringContaining('100ms') },
+      ])
+    })
+
+    it('abandons a compiler when the caller cancels the compilation', async () => {
+      const session = await startSession()
+      const controller = new AbortController()
+      // Cancel only once the fixture compiler has recorded its invocation, so
+      // this exercises killing a live child rather than a pre-aborted spawn.
+      const started = new Promise<void>((resolve) => {
+        const watcher = watch(parent, () => {
+          if (!existsSync(invocations)) return
+          watcher.close()
+          resolve()
+        })
+      })
+
+      const running = compile(session.paths, {
+        model: marked('hang'),
+        signal: controller.signal,
+      })
+      await started
+      controller.abort()
+
+      expect((await running).diagnostics).toMatchObject([
+        { code: 'YMVS204', message: expect.stringContaining('cancelled') },
+      ])
+    })
+
+    it('stops a compiler that floods its output budget', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('flood'),
+        maxOutputBytes: 4096,
+      })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS205', message: expect.stringContaining('4096') },
+      ])
+    })
+
+    it('rejects an export document larger than its budget', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('huge-export'),
+        maxExportBytes: 4096,
+      })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS205', message: expect.stringContaining('4096') },
+      ])
+      expect(existsSync(session.paths.activeModel)).toBe(false)
+    })
+  })
+
+  describe('trusted command vector', () => {
+    it('refuses a compiler command that is not an absolute path', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        command: { command: 'node', args: [fakeLikeC4] },
+      })
+
+      expect(result).toEqual({
+        ok: false,
+        diagnostics: [
+          {
+            severity: 'error',
+            code: 'YMVS202',
+            message:
+              'LikeC4 compiler command "node" must be an absolute executable path',
+            path: VISUAL_COMPILER_DOCUMENT,
+            pointer: '/files',
+            line: 1,
+            column: 1,
+          },
+        ],
+      })
+      expect(existsSync(join(session.paths.candidates, '000001'))).toBe(false)
+      expect(existsSync(session.paths.activeModel)).toBe(false)
+    })
+
+    it('refuses a relative command before spawning anything', async () => {
+      const session = await startSession()
+
+      // A bare 'node' would resolve and run the fixture compiler if the guard
+      // were dropped, so an empty invocation log proves nothing was executed.
+      await compile(session.paths, {
+        command: { command: 'node', args: [fakeLikeC4] },
+      })
+
+      expect(existsSync(invocations)).toBe(false)
+    })
+  })
+
+  describe('last-good preservation', () => {
+    it('leaves the active model unchanged after validation failure', async () => {
+      const session = await startSession()
+      await compile(session.paths)
+      const before = await readFile(session.paths.activeModel, 'utf8')
+
+      const failed = await compile(session.paths, {
+        model: { ...marked('invalid'), initialView: 'detail' },
+        now: () => new Date('2026-08-08T00:00:09.000Z'),
+      })
+
+      expect(failed.ok).toBe(false)
+      expect(await readFile(session.paths.activeModel, 'utf8')).toBe(before)
+      expect(await readActiveVisualModel(session.paths)).toMatchObject({
+        candidate: '000001',
+        initialView: 'choices',
+      })
+    })
+
+    it('keeps the last good export readable after a failed candidate', async () => {
+      const session = await startSession()
+      const first = await compile(session.paths)
+      if (!first.ok) throw new Error('expected a compiled model')
+      const exported = await readFile(first.compiled.exportPath, 'utf8')
+
+      await compile(session.paths, {
+        model: marked('malformed-export'),
+        now: () => new Date('2026-08-08T00:00:09.000Z'),
+      })
+
+      expect(await readFile(first.compiled.exportPath, 'utf8')).toBe(exported)
+      expect(existsSync(join(session.paths.candidates, '000002'))).toBe(true)
+    })
+  })
+})

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -148,6 +148,10 @@ describe('trusted LikeC4 compiler adapter', () => {
           'export',
           'json',
           '--pretty',
+          // The staged configuration names the project, so the CLI is told
+          // which one to export instead of writing all of them.
+          '--project',
+          'visual',
           '-o',
           join(candidateDir, VISUAL_COMPILER_EXPORT_FILE),
           candidateDir,
@@ -272,6 +276,55 @@ describe('trusted LikeC4 compiler adapter', () => {
       expect(result.diagnostics).toMatchObject([
         { code: 'YMVS209', message: expect.stringContaining('detail') },
       ])
+    })
+
+    it('promotes the only project an export document carries', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('one-project'),
+      })
+
+      expect(result).toMatchObject({
+        ok: true,
+        compiled: { views: ['choices'] },
+      })
+      // What is promoted is the project document itself, because that is what
+      // the browser's model factory reads.
+      const exported: unknown = JSON.parse(
+        await readFile(
+          join(session.paths.candidates, '000001', VISUAL_COMPILER_EXPORT_FILE),
+          'utf8',
+        ),
+      )
+      expect(exported).toMatchObject({ views: { choices: {} } })
+    })
+
+    it('picks the project that defines the requested view over an empty default', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('default-project'),
+      })
+
+      expect(result).toMatchObject({
+        ok: true,
+        compiled: { views: ['choices'] },
+      })
+    })
+
+    it('refuses an export where more than one project defines the view', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('ambiguous-projects'),
+      })
+
+      expect(result).toMatchObject({ ok: false })
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS210', message: expect.stringContaining('choices') },
+      ])
+      expect(existsSync(session.paths.activeModel)).toBe(false)
     })
   })
 
@@ -456,4 +509,67 @@ describe('trusted LikeC4 compiler adapter', () => {
       expect(existsSync(join(session.paths.candidates, '000002'))).toBe(true)
     })
   })
+})
+
+/**
+ * The fixture compiler proves the adapter's own handling; this proves the
+ * command vector still fits the CLI the adapter actually drives. A real
+ * workspace with a staged `likec4.config.json` resolves two projects, and
+ * without `--project` the CLI writes a collection instead of the project
+ * document the browser renders.
+ */
+describe('real LikeC4 CLI compatibility', () => {
+  const realCompiler: VisualCompilerCommand = {
+    command: fileURLToPath(new URL('../node_modules/.bin/likec4', import.meta.url)),
+    args: [],
+  }
+
+  let parent = ''
+
+  beforeEach(async () => {
+    parent = await mkdtemp(join(tmpdir(), 'visual-real-likec4-'))
+  })
+
+  afterEach(async () => {
+    await rm(parent, { recursive: true, force: true })
+  })
+
+  it('compiles a configured workspace into one layouted project document', async () => {
+    const configured: VisualModel = {
+      format: 'yarramate/visual-model/v1',
+      authority: 'ad-hoc',
+      initialView: 'choices',
+      sourceDigests: {},
+      files: {
+        'likec4.config.json': '{"name":"visual"}',
+        'model.likec4':
+          'specification {\n  element system\n}\nmodel {\n  delivery = system "Delivery"\n}\n',
+        'views.likec4': 'views {\n  view choices {\n    include *\n  }\n}\n',
+      },
+    }
+    const session = await createVisualSession(
+      { ...request, initialModel: configured },
+      {
+        baseDir: parent,
+        now: () => new Date('2026-08-08T00:00:00.000Z'),
+        randomBytes: () => Buffer.alloc(32, 3),
+      },
+    )
+
+    const result = await compileVisualModel({
+      model: configured,
+      command: realCompiler,
+      paths: session.paths,
+    })
+
+    expect(result).toMatchObject({ ok: true })
+    if (!result.ok) return
+    expect(result.compiled.views).toContain('choices')
+    const exported = JSON.parse(
+      await readFile(result.compiled.exportPath, 'utf8'),
+    ) as { readonly _stage?: string; readonly views?: Record<string, unknown> }
+    // Layouted, and one project deep: exactly what `LikeC4Model.create` reads.
+    expect(exported._stage).toBe('layouted')
+    expect(Object.keys(exported.views ?? {})).toContain('choices')
+  }, 120_000)
 })

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -469,12 +469,24 @@ describe('trusted LikeC4 compiler adapter', () => {
       const controller = new AbortController()
       // Cancel only once the fixture compiler has recorded its invocation, so
       // this exercises killing a live child rather than a pre-aborted spawn.
+      // `fs.watch` is not guaranteed to deliver every event on every platform
+      // (see the Node docs' own "Caveats" section), so a short poll runs
+      // alongside it rather than trusting the single watch callback.
       const started = new Promise<void>((resolve) => {
-        const watcher = watch(parent, () => {
-          if (!existsSync(invocations)) return
+        let settled = false
+        const settle = () => {
+          if (settled) return
+          settled = true
           watcher.close()
+          clearInterval(poll)
           resolve()
+        }
+        const watcher = watch(parent, () => {
+          if (existsSync(invocations)) settle()
         })
+        const poll = setInterval(() => {
+          if (existsSync(invocations)) settle()
+        }, 5)
       })
 
       const running = compile(session.paths, {

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { existsSync, watch } from 'node:fs'
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -40,6 +40,9 @@ interface ExportedProject {
     >
   >
 }
+
+const posixOnly = process.platform !== 'win32'
+const modeOf = async (path: string) => (await stat(path)).mode & 0o777
 
 const repositoryRoot = fileURLToPath(new URL('../', import.meta.url))
 
@@ -254,6 +257,36 @@ describe('trusted LikeC4 compiler adapter', () => {
         'invocations.jsonl',
       ])
     })
+
+    it.skipIf(!posixOnly)(
+      'narrows the exported document to owner-only before reading it',
+      async () => {
+        const session = await startSession()
+
+        const result = await compile(session.paths)
+
+        if (!result.ok) throw new Error('expected a compiled model')
+        // The compiler is a separate process writing under its own umask, so
+        // the rendering it hands back is only private once this adapter says
+        // so — the enclosing 0700 candidate root is not the whole guarantee.
+        expect(await modeOf(result.compiled.exportPath)).toBe(0o600)
+        expect(await modeOf(result.compiled.candidateDir)).toBe(0o700)
+      },
+    )
+
+    it.skipIf(!posixOnly)(
+      'narrows a reduced single-project document to owner-only',
+      async () => {
+        const session = await startSession()
+
+        const result = await compile(session.paths, {
+          model: marked('one-project'),
+        })
+
+        if (!result.ok) throw new Error('expected a compiled model')
+        expect(await modeOf(result.compiled.exportPath)).toBe(0o600)
+      },
+    )
   })
 
   describe('compiler rejection', () => {

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -311,9 +311,47 @@ describe('trusted LikeC4 compiler adapter', () => {
       await started
       controller.abort()
 
+      const result = await running
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS204', message: expect.stringContaining('cancelled') },
+      ])
+      // Cancelling one stage must not let the next one start.
+      expect((await argVectors()).map((argv) => argv[0])).toEqual(['validate'])
+      expect(existsSync(session.paths.activeModel)).toBe(false)
+    })
+
+    it('refuses an already-aborted compilation before staging a candidate', async () => {
+      const session = await startSession()
+      const controller = new AbortController()
+      controller.abort()
+
+      const result = await compile(session.paths, {
+        signal: controller.signal,
+      })
+
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS204', message: expect.stringContaining('cancelled') },
+      ])
+      expect(existsSync(join(session.paths.candidates, '000001'))).toBe(false)
+      expect(existsSync(invocations)).toBe(false)
+      expect(existsSync(session.paths.activeModel)).toBe(false)
+    })
+
+    it('never spawns a stage once the caller has cancelled', async () => {
+      const session = await startSession()
+      const controller = new AbortController()
+
+      // Aborting after the call has returned its promise, but before staging
+      // has resolved, lands in the window between one stage settling and the
+      // next one registering its abort listener.
+      const running = compile(session.paths, { signal: controller.signal })
+      controller.abort()
+
       expect((await running).diagnostics).toMatchObject([
         { code: 'YMVS204', message: expect.stringContaining('cancelled') },
       ])
+      expect(existsSync(invocations)).toBe(false)
+      expect(existsSync(session.paths.activeModel)).toBe(false)
     })
 
     it('stops a compiler that floods its output budget', async () => {

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -419,6 +419,20 @@ describe('trusted LikeC4 compiler adapter', () => {
       })
     })
 
+    it('does not borrow the requested view from a different project', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths, {
+        model: marked('misowned-project'),
+      })
+
+      expect(result).toMatchObject({ ok: false })
+      expect(result.diagnostics).toMatchObject([
+        { code: 'YMVS208', message: expect.stringContaining('no views') },
+      ])
+      expect(existsSync(session.paths.activeModel)).toBe(false)
+    })
+
     it('refuses an export where more than one project defines the view', async () => {
       const session = await startSession()
 

--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -1,8 +1,10 @@
+import { execFile } from 'node:child_process'
 import { existsSync, watch } from 'node:fs'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   VISUAL_COMPILER_DOCUMENT,
@@ -27,6 +29,47 @@ const fakeLikeC4 = fileURLToPath(
 const compiler: VisualCompilerCommand = {
   command: process.execPath,
   args: [fakeLikeC4],
+}
+
+/** Only the parts of an exported project document this suite reads back. */
+interface ExportedProject {
+  readonly views: Readonly<
+    Record<
+      string,
+      { readonly nodes: readonly { readonly navigateTo?: string }[] }
+    >
+  >
+}
+
+const repositoryRoot = fileURLToPath(new URL('../', import.meta.url))
+
+/** The browser's own model factory, as a standalone module. */
+const BROWSER_FACTORY_PROBE = [
+  "import { readFileSync } from 'node:fs'",
+  "import { LikeC4Model } from '@likec4/core/model'",
+  "LikeC4Model.create(JSON.parse(readFileSync(process.argv[1], 'utf8')))",
+].join('\n')
+
+/**
+ * Reads an exported document through the very factory the browser draws with,
+ * and answers with the failure it reported, or the empty string.
+ *
+ * It runs out of process because `@likec4/core` belongs to the browser program:
+ * `tsconfig.visual.json` owns it and skips its library check, while this
+ * program deliberately checks the declarations of everything it imports.
+ */
+const browserFactoryFailure = async (exportPath: string) => {
+  try {
+    await promisify(execFile)(
+      process.execPath,
+      ['--input-type=module', '-e', BROWSER_FACTORY_PROBE, exportPath],
+      { cwd: repositoryRoot },
+    )
+    return ''
+  } catch (cause) {
+    if (cause instanceof Error && 'stderr' in cause) return String(cause.stderr)
+    return String(cause)
+  }
 }
 
 /**
@@ -114,7 +157,7 @@ describe('trusted LikeC4 compiler adapter', () => {
           initialView: 'choices',
           authority: 'ad-hoc',
           candidate: '000001',
-          views: ['choices'],
+          views: ['choices', 'detailNightly', 'detailStreaming', 'index'],
         },
       })
       expect(
@@ -125,6 +168,32 @@ describe('trusted LikeC4 compiler adapter', () => {
         authority: 'ad-hoc',
         promotedAt: '2026-08-08T00:00:05.000Z',
       })
+    })
+
+    it('promotes a comparison the browser can render and navigate', async () => {
+      const session = await startSession()
+
+      const result = await compile(session.paths)
+
+      expect(result).toMatchObject({ ok: true })
+      if (!result.ok) return
+      // The overview the reviewer lands on, and one detail view per option.
+      expect(result.compiled.views).toEqual(
+        expect.arrayContaining(['choices', 'detailNightly', 'detailStreaming']),
+      )
+      const exported = JSON.parse(
+        await readFile(result.compiled.exportPath, 'utf8'),
+      ) as ExportedProject
+      // The browser draws through this factory and swallows what it cannot
+      // read, so an unreadable export is a session with a blank canvas.
+      expect(await browserFactoryFailure(result.compiled.exportPath)).toBe('')
+      // The overview is the way into both details.
+      const overview = exported.views[result.compiled.initialView]
+      expect(
+        (overview?.nodes ?? [])
+          .flatMap((node) => node.navigateTo ?? [])
+          .toSorted(),
+      ).toEqual(['detailNightly', 'detailStreaming'])
     })
 
     it('runs validate before export with a deterministic argument vector', async () => {
@@ -287,7 +356,9 @@ describe('trusted LikeC4 compiler adapter', () => {
 
       expect(result).toMatchObject({
         ok: true,
-        compiled: { views: ['choices'] },
+        compiled: {
+          views: ['choices', 'detailNightly', 'detailStreaming', 'index'],
+        },
       })
       // What is promoted is the project document itself, because that is what
       // the browser's model factory reads.
@@ -309,7 +380,9 @@ describe('trusted LikeC4 compiler adapter', () => {
 
       expect(result).toMatchObject({
         ok: true,
-        compiled: { views: ['choices'] },
+        compiled: {
+          views: ['choices', 'detailNightly', 'detailStreaming', 'index'],
+        },
       })
     })
 

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -1,0 +1,563 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseVisualBrowserInput,
+  parseVisualDiagnosticResult,
+  parseVisualEvent,
+  parseVisualHandoff,
+  parseVisualModel,
+  parseVisualResponse,
+  parseVisualSessionDescriptor,
+  parseVisualSessionRequest,
+  parseVisualSessionStarted,
+  parseVisualStatus,
+  VISUAL_LIMITS,
+  VISUAL_PROTOCOL_VERSION,
+} from '../src/adapters/visual/protocol.js'
+
+const model = {
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    'model.likec4': 'model { system = system "System" }',
+    'views.likec4': 'views { view choices { include * } }',
+  },
+} as const
+
+const sessionId = '0123456789abcdef0123456789abcdef'
+const eventId = 'aaaaaaaabbbbbbbbccccccccdddddddd'
+const responseId = 'ddddddddccccccccbbbbbbbbaaaaaaaa'
+const timestamp = '2026-08-08T00:00:00.000Z'
+
+const sessionRequest = {
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler: { command: '/usr/bin/node', args: ['fake-likec4.mjs'] },
+  initialModel: model,
+} as const
+
+const capabilities = {
+  chat: true,
+  choices: true,
+  navigation: true,
+  modelReplacement: true,
+  transcript: true,
+} as const
+
+const sessionStarted = {
+  format: 'yarramate/visual-session-started/v1',
+  protocolVersion: VISUAL_PROTOCOL_VERSION,
+  sessionId,
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  chatEnabled: true,
+  browserUrl: 'http://127.0.0.1:51234/bootstrap?key=0123456789abcdef',
+  webSocketUrl: 'ws://127.0.0.1:51234/socket',
+  origin: 'http://127.0.0.1:51234',
+  descriptorPath: '/tmp/yarramate-visual/session/descriptor.json',
+  sessionRoot: '/tmp/yarramate-visual/session',
+  capabilities,
+  startedAt: timestamp,
+} as const
+
+const sessionDescriptor = {
+  format: 'yarramate/visual-session-descriptor/v1',
+  protocolVersion: VISUAL_PROTOCOL_VERSION,
+  sessionId,
+  origin: 'http://127.0.0.1:51234',
+  agentCapability:
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+  sessionRoot: '/tmp/yarramate-visual/session',
+  journalPath: '/tmp/yarramate-visual/session/journal.jsonl',
+  createdAt: timestamp,
+} as const
+
+const visualEvent = (type: string, payload: unknown) => ({
+  format: 'yarramate/visual-event/v1',
+  sessionId,
+  sequence: 1,
+  eventId,
+  type,
+  timestamp,
+  payload,
+})
+
+const visualResponse = (type: string, payload: unknown) => ({
+  format: 'yarramate/visual-response/v1',
+  sessionId,
+  responseId,
+  eventId,
+  type,
+  timestamp,
+  payload,
+})
+
+const eventPayloads: Readonly<Record<string, unknown>> = {
+  'chat.message': { text: 'Why is option B cheaper?' },
+  'choice.selected': { choiceId: 'delivery', optionId: 'option-b' },
+  'view.navigate': { viewId: 'option-b', requiresAttention: false },
+  'session.end': { reason: 'user-ended' },
+  'browser.connected': { connectionId: 'c1' },
+  'browser.disconnected': { connectionId: 'c1', code: 1001 },
+}
+
+const handoffSummary = {
+  summary: 'Selected option B.',
+  confirmedDecisions: ['option-b'],
+  requestedChanges: [],
+  unresolvedQuestions: [],
+  finalViews: ['choices', 'option-b'],
+} as const
+
+const diagnostic = {
+  severity: 'error',
+  code: 'YMVS201',
+  message: 'Unknown element',
+  path: 'model.likec4',
+  pointer: '/files/model.likec4',
+  line: 1,
+  column: 1,
+} as const
+
+const responsePayloads: Readonly<Record<string, unknown>> = {
+  'chat.response': { text: 'Option B isolates rendering.' },
+  'agent.status': { state: 'thinking' },
+  'choice.present': {
+    choiceId: 'delivery',
+    question: 'Which delivery design?',
+    options: [
+      { id: 'option-a', label: 'Bundled' },
+      { id: 'option-b', label: 'Isolated', description: 'Separate process' },
+    ],
+  },
+  'model.replace': { model },
+  'handoff.complete': handoffSummary,
+  diagnostic: { diagnostics: [diagnostic] },
+}
+
+const handoff = {
+  format: 'yarramate/visual-handoff/v1',
+  sessionId,
+  authority: 'ad-hoc',
+  decision: 'completed',
+  terminationReason: 'user-ended',
+  lastSequence: 3,
+  transcriptPath: '/tmp/yarramate-visual/session/journal.jsonl',
+  completedAt: timestamp,
+  ...handoffSummary,
+} as const
+
+const status = {
+  format: 'yarramate/visual-status/v1',
+  protocolVersion: VISUAL_PROTOCOL_VERSION,
+  sessionId,
+  lifecycle: 'running',
+  alreadyStopped: false,
+  server: { listening: true, origin: 'http://127.0.0.1:51234' },
+  browser: { connected: true, connections: 1, lastSeenAt: timestamp },
+  agent: { attached: true, inFlightEventId: null },
+  queue: { pendingEvents: 0, lastSequence: 3, frozen: false },
+  capabilities,
+  transcriptBytes: 1024,
+  updatedAt: timestamp,
+} as const
+
+const diagnosticResult = {
+  format: 'yarramate/visual-diagnostic-result/v1',
+  diagnostics: [diagnostic],
+} as const
+
+describe('visual protocol', () => {
+  it('accepts a complete safe session request', () => {
+    expect(
+      parseVisualSessionRequest({
+        format: 'yarramate/visual-session-request/v1',
+        authority: 'ad-hoc',
+        title: 'Choose a delivery design',
+        description: 'Temporary non-canonical comparison',
+        chatEnabled: true,
+        compiler: { command: '/usr/bin/node', args: ['fake-likec4.mjs'] },
+        initialModel: model,
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it.each(['../secret.likec4', '/tmp/secret.likec4', 'asset.js'])(
+    'rejects unsafe model file %s',
+    (path) => {
+      expect(
+        parseVisualModel({ ...model, files: { [path]: 'x' } }),
+      ).toMatchObject({
+        ok: false,
+      })
+    },
+  )
+
+  it('rejects messages over the exact limit', () => {
+    expect(VISUAL_LIMITS.messageBytes).toBe(64 * 1024)
+  })
+
+  it('pins every protocol limit', () => {
+    expect(VISUAL_LIMITS).toEqual({
+      messageBytes: 65536,
+      modelBytes: 5242880,
+      transcriptBytes: 5242880,
+      pendingEvents: 32,
+      reconnectMs: 300000,
+      staleSessionMs: 86400000,
+    })
+  })
+
+  it('accepts one valid document of every format', () => {
+    expect(parseVisualModel(model)).toMatchObject({ ok: true })
+    expect(parseVisualSessionRequest(sessionRequest)).toMatchObject({ ok: true })
+    expect(parseVisualSessionStarted(sessionStarted)).toMatchObject({ ok: true })
+    expect(parseVisualSessionDescriptor(sessionDescriptor)).toMatchObject({
+      ok: true,
+    })
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: 'Hello' },
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualEvent(
+        visualEvent('chat.message', eventPayloads['chat.message']),
+      ),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualResponse(
+        visualResponse('chat.response', responsePayloads['chat.response']),
+      ),
+    ).toMatchObject({ ok: true })
+    expect(parseVisualHandoff(handoff)).toMatchObject({ ok: true })
+    expect(parseVisualStatus(status)).toMatchObject({ ok: true })
+    expect(parseVisualDiagnosticResult(diagnosticResult)).toMatchObject({
+      ok: true,
+    })
+  })
+
+  it.each(Object.keys(eventPayloads))('accepts the %s event', (type) => {
+    expect(
+      parseVisualEvent(visualEvent(type, eventPayloads[type])),
+    ).toMatchObject({ ok: true })
+  })
+
+  it.each(Object.keys(responsePayloads))('accepts the %s response', (type) => {
+    expect(
+      parseVisualResponse(visualResponse(type, responsePayloads[type])),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('rejects an unknown event discriminant and mismatched payloads', () => {
+    expect(
+      parseVisualEvent(visualEvent('chat.shout', { text: 'x' })),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualEvent(visualEvent('chat.message', { viewId: 'choices' })),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('rejects an unknown response discriminant and mismatched payloads', () => {
+    expect(
+      parseVisualResponse(visualResponse('model.patch', { model })),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualResponse(visualResponse('model.replace', { text: 'x' })),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('rejects unknown properties on every document', () => {
+    expect(parseVisualModel({ ...model, extra: 1 })).toMatchObject({ ok: false })
+    expect(
+      parseVisualSessionRequest({ ...sessionRequest, extra: 1 }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualSessionStarted({ ...sessionStarted, extra: 1 }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualSessionDescriptor({ ...sessionDescriptor, extra: 1 }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualEvent({
+        ...visualEvent('session.end', { reason: 'user-ended' }),
+        extra: 1,
+      }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualResponse({
+        ...visualResponse('agent.status', { state: 'idle' }),
+        extra: 1,
+      }),
+    ).toMatchObject({ ok: false })
+    expect(parseVisualHandoff({ ...handoff, extra: 1 })).toMatchObject({
+      ok: false,
+    })
+    expect(parseVisualStatus({ ...status, extra: 1 })).toMatchObject({
+      ok: false,
+    })
+    expect(
+      parseVisualDiagnosticResult({ ...diagnosticResult, extra: 1 }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('never lets the browser supply runtime-owned identifiers', () => {
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: 'Hello' },
+        sessionId,
+      }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualBrowserInput({
+        type: 'browser.connected',
+        payload: { connectionId: 'c1' },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('requires the request authority to match the initial model authority', () => {
+    expect(
+      parseVisualSessionRequest({ ...sessionRequest, authority: 'canonical' }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('ties model authority to source digests', () => {
+    const digests = { 'model.likec4': '9'.repeat(64) }
+    expect(
+      parseVisualModel({
+        ...model,
+        authority: 'canonical',
+        sourceDigests: digests,
+      }),
+    ).toMatchObject({ ok: true })
+    expect(parseVisualModel({ ...model, authority: 'canonical' })).toMatchObject(
+      { ok: false },
+    )
+    expect(parseVisualModel({ ...model, sourceDigests: digests })).toMatchObject(
+      { ok: false },
+    )
+  })
+
+  it('requires at least one LikeC4 source file', () => {
+    expect(
+      parseVisualModel({
+        ...model,
+        files: { 'likec4.config.json': '{"name":"visual"}' },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it.each([
+    'nested/likec4.config.json',
+    '.hidden.likec4',
+    'a/../b.likec4',
+    './model.likec4',
+    'a//b.likec4',
+    'sub\\model.likec4',
+  ])('rejects the additional unsafe model file %s', (path) => {
+    expect(parseVisualModel({ ...model, files: { [path]: 'x' } })).toMatchObject(
+      { ok: false },
+    )
+  })
+
+  it('accepts nested LikeC4 sources inside the candidate root', () => {
+    expect(
+      parseVisualModel({
+        ...model,
+        files: {
+          'likec4.config.json': '{"name":"visual"}',
+          'views/choices.likec4': 'views { view choices { include * } }',
+          'model/system.c4': 'model { system = system "System" }',
+        },
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('measures chat message limits in bytes, not characters', () => {
+    const exact = 'a'.repeat(VISUAL_LIMITS.messageBytes)
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: exact },
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: `${exact}a` },
+      }),
+    ).toMatchObject({ ok: false })
+
+    const multiByte = '€'.repeat(VISUAL_LIMITS.messageBytes / 3 + 1)
+    expect(multiByte.length).toBeLessThan(VISUAL_LIMITS.messageBytes)
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: multiByte },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('rejects a candidate model over the byte limit', () => {
+    expect(
+      parseVisualModel({
+        ...model,
+        files: {
+          ...model.files,
+          'huge.likec4': 'x'.repeat(VISUAL_LIMITS.modelBytes),
+        },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('caps the pending event queue at the exact limit', () => {
+    expect(
+      parseVisualStatus({
+        ...status,
+        queue: {
+          pendingEvents: VISUAL_LIMITS.pendingEvents,
+          lastSequence: 3,
+          frozen: true,
+          frozenReason: 'pending-events',
+        },
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualStatus({
+        ...status,
+        queue: {
+          pendingEvents: VISUAL_LIMITS.pendingEvents + 1,
+          lastSequence: 3,
+          frozen: true,
+        },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('rejects a transcript over the byte limit', () => {
+    const bulky = visualEvent('chat.message', { text: 'x'.repeat(60000) })
+    expect(
+      parseVisualHandoff({
+        ...handoff,
+        transcript: Array.from({ length: 100 }, (_unused, index) => ({
+          ...bulky,
+          sequence: index + 1,
+        })),
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('exposes the transcript only when it is supplied', () => {
+    const parsed = parseVisualHandoff(handoff)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.value.transcript).toBeUndefined()
+
+    expect(
+      parseVisualHandoff({
+        ...handoff,
+        transcript: [
+          visualEvent('chat.message', eventPayloads['chat.message']),
+          visualResponse('chat.response', responsePayloads['chat.response']),
+        ],
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('ties the handoff decision to the termination reason', () => {
+    expect(parseVisualHandoff({ ...handoff, decision: 'failed' })).toMatchObject(
+      { ok: false },
+    )
+    expect(
+      parseVisualHandoff({
+        ...handoff,
+        decision: 'failed',
+        terminationReason: 'child-failed',
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualHandoff({ ...handoff, terminationReason: 'child-failed' }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('keeps the agent capability out of the public started result', () => {
+    expect(
+      parseVisualSessionStarted({
+        ...sessionStarted,
+        agentCapability: 'f'.repeat(64),
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('forces diagram-only capabilities when chat is disabled', () => {
+    expect(
+      parseVisualSessionStarted({ ...sessionStarted, chatEnabled: false }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualSessionStarted({
+        ...sessionStarted,
+        chatEnabled: false,
+        capabilities: { ...capabilities, chat: false },
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('requires an absolute compiler executable and rejects hostile arguments', () => {
+    expect(
+      parseVisualSessionRequest({
+        ...sessionRequest,
+        compiler: { command: 'node', args: [] },
+      }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualSessionRequest({
+        ...sessionRequest,
+        compiler: { command: '/usr/bin/node', args: ['a\u0000b'] },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('reports source-located diagnostics for invalid documents', () => {
+    const parsed = parseVisualSessionRequest({ ...sessionRequest, title: '' })
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) return
+    expect(parsed.diagnostics[0]).toMatchObject({
+      severity: 'error',
+      code: 'YMVS101',
+      path: 'visual-session-request/v1',
+      pointer: '/title',
+      line: 1,
+      column: 1,
+    })
+    expect(parsed.diagnostics[0]?.message).toMatch(/\S/)
+    expect(
+      parseVisualDiagnosticResult({
+        format: 'yarramate/visual-diagnostic-result/v1',
+        diagnostics: parsed.diagnostics,
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('points unsafe file diagnostics at the offending escaped key', () => {
+    const parsed = parseVisualModel({
+      ...model,
+      files: { ...model.files, 'evil/../escape.likec4': 'x' },
+    })
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) return
+    expect(parsed.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'YMVS113',
+        pointer: '/files/evil~1..~1escape.likec4',
+      }),
+    )
+  })
+})

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -223,6 +223,7 @@ describe('visual protocol', () => {
     expect(
       parseVisualBrowserInput({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: 'Hello' },
       }),
     ).toMatchObject({ ok: true })
@@ -311,6 +312,7 @@ describe('visual protocol', () => {
     expect(
       parseVisualBrowserInput({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: 'Hello' },
         sessionId,
       }),
@@ -318,10 +320,39 @@ describe('visual protocol', () => {
     expect(
       parseVisualBrowserInput({
         type: 'browser.connected',
+        lastAcknowledgedSequence: 0,
         payload: { connectionId: 'c1' },
       }),
     ).toMatchObject({ ok: false })
   })
+
+  it('requires every browser frame to carry its last acknowledged sequence', () => {
+    expect(
+      parseVisualBrowserInput({
+        type: 'chat.message',
+        payload: { text: 'Hello' },
+      }),
+    ).toMatchObject({ ok: false })
+    expect(
+      parseVisualBrowserInput({
+        type: 'session.end',
+        payload: { reason: 'user-ended' },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it.each([-1, 1.5, '1', null])(
+    'rejects %s as a last acknowledged sequence',
+    (lastAcknowledgedSequence) => {
+      expect(
+        parseVisualBrowserInput({
+          type: 'chat.message',
+          lastAcknowledgedSequence,
+          payload: { text: 'Hello' },
+        }),
+      ).toMatchObject({ ok: false })
+    },
+  )
 
   it('requires the request authority to match the initial model authority', () => {
     expect(
@@ -386,12 +417,14 @@ describe('visual protocol', () => {
     expect(
       parseVisualBrowserInput({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: exact },
       }),
     ).toMatchObject({ ok: true })
     expect(
       parseVisualBrowserInput({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: `${exact}a` },
       }),
     ).toMatchObject({ ok: false })
@@ -401,6 +434,7 @@ describe('visual protocol', () => {
     expect(
       parseVisualBrowserInput({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: multiByte },
       }),
     ).toMatchObject({ ok: false })

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -506,6 +506,34 @@ describe('visual protocol', () => {
     ).toMatchObject({ ok: true })
   })
 
+  it('refuses a transcript entry belonging to another session', () => {
+    const foreign = {
+      ...visualEvent('chat.message', eventPayloads['chat.message']),
+      sessionId: '00000000000000000000000000000000',
+    }
+    expect(
+      parseVisualHandoff({ ...handoff, transcript: [foreign] }),
+    ).toMatchObject({
+      ok: false,
+      diagnostics: [{ code: 'YMVS116', pointer: '/transcript/0/sessionId' }],
+    })
+    expect(
+      parseVisualHandoff({
+        ...handoff,
+        transcript: [
+          visualEvent('chat.message', eventPayloads['chat.message']),
+          {
+            ...visualResponse('chat.response', responsePayloads['chat.response']),
+            sessionId: '00000000000000000000000000000000',
+          },
+        ],
+      }),
+    ).toMatchObject({
+      ok: false,
+      diagnostics: [{ code: 'YMVS116', pointer: '/transcript/1/sessionId' }],
+    })
+  })
+
   it('ties the handoff decision to the termination reason', () => {
     expect(parseVisualHandoff({ ...handoff, decision: 'failed' })).toMatchObject(
       { ok: false },

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -187,6 +187,48 @@ describe('visual protocol', () => {
     ).toMatchObject({ ok: true })
   })
 
+  it('accepts pinned npm package arguments without weakening NUL rejection', () => {
+    expect(
+      parseVisualSessionRequest({
+        ...sessionRequest,
+        compiler: {
+          command: '/usr/bin/npx',
+          args: ['--yes', 'likec4@1.59.2'],
+        },
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualSessionRequest({
+        ...sessionRequest,
+        compiler: {
+          command: '/usr/bin/npx',
+          args: ['likec4@1.59.2\u0000--project=other'],
+        },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
+  it('accepts LikeC4 source text containing @ and rejects NUL', () => {
+    expect(
+      parseVisualModel({
+        ...model,
+        files: {
+          ...model.files,
+          'model.likec4': 'model { system = system "ops@example.com" }',
+        },
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualModel({
+        ...model,
+        files: {
+          ...model.files,
+          'model.likec4': 'model\u0000hidden',
+        },
+      }),
+    ).toMatchObject({ ok: false })
+  })
+
   it.each(['../secret.likec4', '/tmp/secret.likec4', 'asset.js'])(
     'rejects unsafe model file %s',
     (path) => {

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -445,6 +445,22 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     expect(cookie).not.toContain(token as string)
   })
 
+  it('stores only a derived browser authenticator in the cookie', async () => {
+    const generatedSecrets: string[] = []
+    let draw = 0
+    const server = await start({
+      randomBytes: (size) => {
+        draw += 1
+        const secret = Buffer.alloc(size, draw)
+        generatedSecrets.push(secret.toString('hex'))
+        return secret
+      },
+    })
+    const { cookie } = await bootstrap(server)
+    const value = cookie.slice('ym_visual='.length)
+    expect(generatedSecrets).not.toContain(value)
+  })
+
   it('refuses a replayed bootstrap token', async () => {
     const server = await start()
     await bootstrap(server)

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -452,6 +452,35 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     expect(session.lastSequence).toBe(1)
   })
 
+  it('tells a reconnecting browser whether the agent still owes an answer', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const snapshotNow = async () => {
+      const body = (await (
+        await fetch(`${server.started.origin}/api/session`, {
+          headers: { Cookie: cookie },
+        })
+      ).json()) as { readonly agentTurnOpen: boolean }
+      return body.agentTurnOpen
+    }
+
+    expect(await snapshotNow()).toBe(false)
+    const asked = await sendChat(socket, 'Why is option B cheaper?')
+    expect(await snapshotNow()).toBe(true)
+
+    await postResponse(
+      server,
+      capability,
+      chatResponse(server, asked.eventId, 5, 'It reuses the intake path.'),
+    )
+    // The turn the browser opened is closed, whether or not it was connected to
+    // see the answer land.
+    expect(await snapshotNow()).toBe(false)
+    socket.close()
+  })
+
   it('restores a selected choice by the label the reviewer read', async () => {
     const server = await start()
     const capability = await capabilityOf(server)

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1123,6 +1123,30 @@ describe('startVisualServer agent responses', () => {
     expect(await journalOf(server)).toHaveLength(0)
   })
 
+  it('rejects a response that answers an event this session never journaled', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'first')
+
+    // The capability is this session's, and so is the session id; the event
+    // being answered is not.
+    const response = await postResponse(
+      server,
+      capability,
+      chatResponse(server, identifier(0xbad), 1),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      accepted: false,
+      diagnostics: [{ code: 'YMVS131', pointer: '#/eventId' }],
+    })
+    expect(await journalOf(server)).toHaveLength(1)
+    socket.close()
+  })
+
   it('promotes a valid model replacement and tells the browser', async () => {
     const server = await start()
     const capability = await capabilityOf(server)

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -318,6 +318,58 @@ const journalOf = async (handle: VisualServerHandle) =>
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as VisualEvent | VisualResponse)
 
+/** One event-loop turn, so an observed in-process condition can be re-read. */
+const tick = async () => {
+  const turn = Promise.withResolvers<void>()
+  setImmediate(turn.resolve)
+  await turn.promise
+}
+
+/**
+ * Resolves once the session has admitted an agent request. Authenticating the
+ * capability and registering the long poll are one synchronous step, so an
+ * attached agent is exactly a poll the server is already holding: an observed
+ * condition in this process rather than a guessed delay, and nothing the
+ * runtime carries for the test.
+ */
+const waitForAttachedAgent = async (handle: VisualServerHandle) => {
+  while (!handle.status().agent.attached) await tick()
+}
+
+/**
+ * Resolves once the session has journaled up to `sequence`. The runtime moves
+ * its own queue cursor as each append lands, so this observes the server that
+ * did the writing rather than racing a watch on the file it wrote.
+ */
+const waitForSequence = async (
+  handle: VisualServerHandle,
+  sequence: number,
+) => {
+  while (handle.status().queue.lastSequence < sequence) await tick()
+}
+
+/**
+ * Rejections raised by fire-and-forget socket work never reach a test's
+ * `await`, so they are collected from the process the way Node would see
+ * them: an empty list is the assertion that nothing crashed the runtime.
+ */
+const collectRejections = () => {
+  const seen: unknown[] = []
+  const observe = (reason: unknown) => seen.push(reason)
+  process.on('unhandledRejection', observe)
+  return {
+    seen,
+    settled: async () => {
+      // A rejection is reported a macrotask after it is raised, so give the
+      // loop two turns before deciding nothing was left unobserved.
+      await tick()
+      await tick()
+      process.off('unhandledRejection', observe)
+      return seen
+    },
+  }
+}
+
 /** Raw request/response text, so Host and unnormalised paths stay verbatim. */
 const rawRequest = (origin: string, lines: readonly string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -363,8 +415,9 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     )
     socket.send(JSON.stringify(chatEventInput))
     await expect(
-      waitForVisualEvent(server.started.descriptorPath, 0),
-    ).resolves.toMatchObject({ type: 'chat.message', sequence: 1 })
+      // Sequence 1 is the connection the runtime journaled for this socket.
+      waitForVisualEvent(server.started.descriptorPath, 1),
+    ).resolves.toMatchObject({ type: 'chat.message', sequence: 2 })
     socket.close()
   })
 
@@ -478,6 +531,9 @@ describe('startVisualServer bootstrap and browser authentication', () => {
       chatResponse(server, asked.eventId, 3, 'It reuses the intake path.'),
     )
     socket.close()
+    // The reload is read after the socket it replaces is journaled as gone, so
+    // the sequence the snapshot reports is settled rather than raced.
+    await waitForSequence(server, 3)
 
     const session = (await (
       await fetch(`${server.started.origin}/api/session`, {
@@ -500,7 +556,7 @@ describe('startVisualServer bootstrap and browser authentication', () => {
         text: 'It reuses the intake path.',
       },
     ])
-    expect(session.lastSequence).toBe(1)
+    expect(session.lastSequence).toBe(3)
   })
 
   it('tells a reconnecting browser whether the agent still owes an answer', async () => {
@@ -906,7 +962,7 @@ describe('startVisualServer event queue and long polling', () => {
     expect(body.waiting).toBe(false)
     expect(body.event).toMatchObject({
       type: 'chat.message',
-      sequence: 1,
+      sequence: 2,
       sessionId: server.started.sessionId,
       payload: { text: 'Compare the two delivery designs' },
     })
@@ -942,9 +998,9 @@ describe('startVisualServer event queue and long polling', () => {
     const first = (await (
       await agentFetch(server, capability, '/api/agent/events?after=0')
     ).json()) as { readonly event: VisualEvent }
-    expect(first.event.sequence).toBe(1)
+    expect(first.event.sequence).toBe(2)
     await expect(
-      (await agentFetch(server, capability, '/api/agent/events?after=1')).json(),
+      (await agentFetch(server, capability, '/api/agent/events?after=2')).json(),
     ).resolves.toMatchObject({ waiting: true })
     expect(server.status().queue.pendingEvents).toBe(2)
     socket.close()
@@ -969,10 +1025,10 @@ describe('startVisualServer event queue and long polling', () => {
     expect(answered.status).toBe(200)
 
     const second = (await (
-      await agentFetch(server, capability, '/api/agent/events?after=1')
+      await agentFetch(server, capability, '/api/agent/events?after=2')
     ).json()) as { readonly waiting: boolean; readonly event: VisualEvent }
     expect(second.waiting).toBe(false)
-    expect(second.event.sequence).toBe(2)
+    expect(second.event.sequence).toBe(3)
     expect(second.event.payload).toEqual({ text: 'second' })
     socket.close()
   })
@@ -994,7 +1050,7 @@ describe('startVisualServer event queue and long polling', () => {
 
     await expect(
       (await agentFetch(server, capability, '/api/agent/events?after=0')).json(),
-    ).resolves.toMatchObject({ waiting: true, lastSequence: 1 })
+    ).resolves.toMatchObject({ waiting: true, lastSequence: 2 })
     const journal = await journalOf(server)
     expect(journal.at(-1)).toMatchObject({ type: 'view.navigate' })
     socket.close()
@@ -1043,7 +1099,7 @@ describe('startVisualServer event queue and long polling', () => {
 
     expect(server.status().queue).toMatchObject({
       pendingEvents: VISUAL_LIMITS.pendingEvents,
-      lastSequence: VISUAL_LIMITS.pendingEvents,
+      lastSequence: VISUAL_LIMITS.pendingEvents + 1,
       frozen: true,
       frozenReason: 'pending-events',
     })
@@ -1108,6 +1164,8 @@ describe('startVisualServer event queue and long polling', () => {
     const server = await start()
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
+    // The connection is journaled before the frame that forges one arrives.
+    await nextFrame(socket, 'ready')
     const rejected = nextFrame(socket, 'rejected')
     socket.send(
       JSON.stringify({
@@ -1116,6 +1174,11 @@ describe('startVisualServer event queue and long polling', () => {
       }),
     )
     expect((await rejected).diagnostics[0]?.code).toBe('YMVS109')
+    // The one connection record this session has is the one the runtime wrote.
+    expect(await journalOf(server)).toMatchObject([
+      { type: 'browser.connected' },
+    ])
+    expect(server.status().queue.lastSequence).toBe(1)
     socket.close()
   })
 
@@ -1123,15 +1186,17 @@ describe('startVisualServer event queue and long polling', () => {
     let narrow = 0
     let wide = 0
     const server = await start({
-      // 16-byte draws mint the session id first and every event id after it;
-      // freezing those after the session id forces an identifier collision.
+      // 16-byte draws mint the session id, the style nonce, the connection id,
+      // the record the runtime writes for that connection, and then every
+      // browser event id; pinning the draws from the first browser event
+      // forces an identifier collision.
       randomBytes: (size: number) => {
         if (size !== 16) {
           wide += 1
           return Buffer.alloc(size, wide)
         }
         narrow += 1
-        return Buffer.alloc(16, narrow === 1 ? 0xa1 : 0xb2)
+        return Buffer.alloc(16, Math.min(narrow, 5))
       },
     })
     const { cookie } = await bootstrap(server)
@@ -1167,8 +1232,10 @@ describe('startVisualServer event queue and long polling', () => {
       }),
     )
     expect((await rejected).diagnostics[0]?.code).toBe('YMVS308')
-    expect(await journalOf(server)).toHaveLength(0)
-    expect(server.status().queue.lastSequence).toBe(0)
+    expect(await journalOf(server)).toMatchObject([
+      { type: 'browser.connected' },
+    ])
+    expect(server.status().queue.lastSequence).toBe(1)
     socket.close()
   })
 
@@ -1176,7 +1243,7 @@ describe('startVisualServer event queue and long polling', () => {
     const server = await start()
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
-    expect((await sendChat(socket, 'first')).sequence).toBe(1)
+    expect((await sendChat(socket, 'first')).sequence).toBe(2)
 
     // The browser is a sequence behind, which is what a reconnect mid-turn
     // looks like; admission still owns the sequence it assigns.
@@ -1188,9 +1255,157 @@ describe('startVisualServer event queue and long polling', () => {
         payload: { text: 'second' },
       }),
     )
-    expect((await accepted).sequence).toBe(2)
+    expect((await accepted).sequence).toBe(3)
     socket.close()
   })
+})
+
+describe('startVisualServer limit failures', () => {
+  /**
+   * A limit the runtime detects for itself is a runtime that can no longer
+   * carry the conversation, so it takes the same terminal transition every
+   * other cause takes: once, under a reason that is true of it, with every
+   * record the session already accepted left standing.
+   */
+  const terminals = (records: readonly (VisualEvent | VisualResponse)[]) =>
+    records.filter(
+      (record) =>
+        record.format === 'yarramate/visual-event/v1' &&
+        record.type === 'session.end',
+    )
+
+  it('ends a session whose queue reached the pending bound', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejections = collectRejections()
+    await nextFrame(socket, 'ready')
+    for (let sent = 0; sent < VISUAL_LIMITS.pendingEvents; sent += 1) {
+      await sendChat(socket, `message ${sent}`)
+    }
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'one more' },
+      }),
+    )
+    expect(await rejected).toMatchObject({ frozen: 'pending-events' })
+
+    // Sequence 1 is the connection, so the bound is reached at 1 + 32 and the
+    // terminal record is the one past it.
+    const terminal = await waitForVisualEvent(
+      server.started.descriptorPath,
+      VISUAL_LIMITS.pendingEvents + 1,
+    )
+    expect(terminal).toMatchObject({
+      type: 'session.end',
+      sequence: VISUAL_LIMITS.pendingEvents + 2,
+      payload: { reason: 'server-failed' },
+    })
+    const journal = await journalOf(server)
+    // Nothing the session had already accepted was lost to the failure, and
+    // the transition ran exactly once.
+    expect(
+      journal.filter((record) => record.type === 'chat.message'),
+    ).toHaveLength(VISUAL_LIMITS.pendingEvents)
+    expect(terminals(journal)).toHaveLength(1)
+
+    const closed = await server.stop('server-failed')
+    expect(closed.handoff).toMatchObject({
+      decision: 'failed',
+      terminationReason: 'server-failed',
+      lastSequence: VISUAL_LIMITS.pendingEvents + 2,
+    })
+    expect(await rejections.settled()).toEqual([])
+  })
+
+  it('unblocks a waiting agent when a browser frame passes the transport ceiling', async () => {
+    // Long enough that a poll the failure never settles cannot pass by timing
+    // out on its own.
+    const server = await start({ agentPollMs: 60_000 })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejections = collectRejections()
+    await nextFrame(socket, 'ready')
+    const polled = agentFetch(server, capability, '/api/agent/events?after=0')
+    await waitForAttachedAgent(server)
+
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'x'.repeat(VISUAL_SERVER_LIMITS.browserFrameBytes) },
+      }),
+    )
+    const [code] = (await once(socket, 'close')) as [number]
+    expect(code).toBe(1009)
+
+    // The child is not left holding a turn on a session that can no longer
+    // answer it.
+    await expect((await polled).json()).resolves.toMatchObject({
+      waiting: true,
+    })
+    const terminal = await waitForVisualEvent(server.started.descriptorPath, 1)
+    expect(terminal).toMatchObject({
+      type: 'session.end',
+      sequence: 2,
+      payload: { reason: 'server-failed' },
+    })
+    expect(server.status().queue.frozenReason).toBe('message-bytes')
+    // The socket the ceiling closed is shutdown, not conversation.
+    expect(
+      (await journalOf(server)).filter(
+        (record) => record.type === 'browser.disconnected',
+      ),
+    ).toHaveLength(0)
+    expect(await rejections.settled()).toEqual([])
+  })
+
+  it('ends a session whose journal refuses another response', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejections = collectRejections()
+    const asked = await sendChat(socket, 'fill the journal')
+
+    // Responses are the only record a session can grow without bound: the
+    // pending queue stops the browser long before 5 MiB of chat.
+    const filler = 'x'.repeat(VISUAL_LIMITS.messageBytes)
+    let refused: Response | undefined
+    for (let index = 0; refused === undefined && index < 128; index += 1) {
+      const posted = await postResponse(
+        server,
+        capability,
+        chatResponse(server, asked.eventId, 1000 + index, filler),
+      )
+      if (posted.status === 200) await posted.json()
+      else refused = posted
+    }
+    expect(refused?.status).toBe(409)
+    await expect(refused?.json()).resolves.toMatchObject({
+      accepted: false,
+      diagnostics: [{ code: 'YMVS122' }],
+    })
+
+    const terminal = await waitForVisualEvent(server.started.descriptorPath, 2)
+    expect(terminal).toMatchObject({
+      type: 'session.end',
+      sequence: 3,
+      payload: { reason: 'server-failed' },
+    })
+    expect(server.status().queue.frozenReason).toBe('transcript-bytes')
+    const closed = await server.stop('server-failed')
+    expect(closed.handoff).toMatchObject({
+      decision: 'failed',
+      terminationReason: 'server-failed',
+    })
+    expect(await rejections.settled()).toEqual([])
+    socket.close()
+  }, 120_000)
 })
 
 describe('startVisualServer agent responses', () => {
@@ -1322,7 +1537,8 @@ describe('startVisualServer agent responses', () => {
       accepted: false,
       diagnostics: [{ code: 'YMVS131', pointer: '/eventId' }],
     })
-    expect(await journalOf(server)).toHaveLength(1)
+    // The connection this browser opened, and the one message it sent.
+    expect(await journalOf(server)).toHaveLength(2)
     socket.close()
   })
 
@@ -1420,7 +1636,7 @@ describe('startVisualServer agent responses', () => {
     expect(server.status().agent.inFlightEventId).toBe(null)
     await sendChat(socket, 'try the other one')
     const next = (await (
-      await agentFetch(server, capability, '/api/agent/events?after=1')
+      await agentFetch(server, capability, '/api/agent/events?after=2')
     ).json()) as { readonly waiting: boolean; readonly event: VisualEvent }
     expect(next.waiting).toBe(false)
     expect(next.event.payload).toEqual({ text: 'try the other one' })
@@ -1600,15 +1816,14 @@ describe('startVisualServer lifecycle', () => {
   })
 
   it('settles a waiting long poll when the session stops', async () => {
-    const server = await start()
+    // Long enough that a poll the stop never settles cannot pass by timing out.
+    const server = await start({ agentPollMs: 60_000 })
     const capability = await capabilityOf(server)
     const polled = agentFetch(server, capability, '/api/agent/events?after=0')
-    // A real long poll has to reach the server before the stop does, and the
-    // request is in undici's hands until then: there is no in-process signal to
-    // await, and a fake clock cannot move a socket.
-    const onTheWire = Promise.withResolvers<void>()
-    setTimeout(onTheWire.resolve, 20)
-    await onTheWire.promise
+    // The poll has to be registered before the stop reaches it. Authenticating
+    // the capability and adding the poll are one synchronous step, so an
+    // attached agent is that registration, observed in this process.
+    await waitForAttachedAgent(server)
     await server.stop('main-cancelled')
     await expect((await polled).json()).resolves.toMatchObject({
       waiting: true,
@@ -1626,56 +1841,95 @@ describe('startVisualServer lifecycle', () => {
     await ended
   })
 
-  it('reports browser attachment without spending a sequence number', async () => {
+  it('journals the browser connection the runtime admitted', async () => {
     const server = await start()
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const ready = await nextFrame(socket, 'ready')
-    expect(ready.snapshot.lastSequence).toBe(0)
+    // The record is journaled before the snapshot is handed over, so the
+    // sequence the browser starts from already counts its own arrival.
+    expect(ready.snapshot.lastSequence).toBe(1)
     expect(server.status().browser).toMatchObject({
       connected: true,
       connections: 1,
     })
+    const opened = await journalOf(server)
+    const connected = opened[0]
+    if (
+      connected?.format !== 'yarramate/visual-event/v1' ||
+      connected.type !== 'browser.connected'
+    ) {
+      throw new Error('the session journaled no browser connection')
+    }
+    expect(connected).toMatchObject({
+      sessionId: server.started.sessionId,
+      sequence: 1,
+    })
+    // Every field the browser is not allowed to choose was minted here.
+    expect(connected.eventId).toMatch(/^[0-9a-f]{32}$/)
+    expect(connected.timestamp).toMatch(
+      /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$/,
+    )
 
     socket.close(1000)
     await once(socket, 'close')
-    // Connection churn is transport state, not conversation: the first
-    // journaled event is still the browser's first message.
-    expect(await journalOf(server)).toHaveLength(0)
+    await waitForSequence(server, 2)
+
+    const journal = await journalOf(server)
+    expect(journal).toHaveLength(2)
+    // One connection, one identifier: the pair names the same socket, and the
+    // close code the transport reported is the one the record carries.
+    expect(journal[1]).toMatchObject({
+      format: 'yarramate/visual-event/v1',
+      type: 'browser.disconnected',
+      sequence: 2,
+      payload: { connectionId: connected.payload.connectionId, code: 1000 },
+    })
     const idle = server.status()
     expect(idle.browser).toMatchObject({ connected: false, connections: 0 })
     expect(idle.browser.graceExpiresAt).toMatch(
       /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$/,
     )
   })
+
+  it('never opens an agent turn for a browser lifecycle record', async () => {
+    const server = await start({ agentPollMs: 60 })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await nextFrame(socket, 'ready')
+    socket.close(1000)
+    await once(socket, 'close')
+    await waitForSequence(server, 2)
+
+    await expect(
+      (await agentFetch(server, capability, '/api/agent/events?after=0')).json(),
+    ).resolves.toEqual({ waiting: true, lastSequence: 2, pendingEvents: 0 })
+    expect(server.status()).toMatchObject({
+      agent: { attached: true, inFlightEventId: null },
+      queue: { pendingEvents: 0, lastSequence: 2, frozen: false },
+    })
+  })
+
+  it('journals no disconnection for a socket the shutdown closed', async () => {
+    const server = await start({ includeTranscript: true })
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await nextFrame(socket, 'ready')
+    const ended = once(socket, 'close')
+
+    const closed = await server.stop('user-ended')
+    await ended
+
+    // The transcript recovery read is the whole record: one arrival, then the
+    // record that closed the session, and no shutdown noise behind it.
+    expect(
+      (closed.handoff?.transcript ?? []).map((record) => record.type),
+    ).toEqual(['browser.connected', 'session.end'])
+  })
 })
 
 describe('startVisualServer shutdown and admission races', () => {
-  /**
-   * Rejections raised by fire-and-forget socket work never reach a test's
-   * `await`, so they are collected from the process the way Node would see
-   * them: an empty list is the assertion that nothing crashed the runtime.
-   */
-  const collectRejections = () => {
-    const seen: unknown[] = []
-    const observe = (reason: unknown) => seen.push(reason)
-    process.on('unhandledRejection', observe)
-    return {
-      seen,
-      settled: async () => {
-        // A rejection is reported a macrotask after it is raised, so give the
-        // loop two turns before deciding nothing was left unobserved.
-        for (let turn = 0; turn < 2; turn += 1) {
-          const tick = Promise.withResolvers<void>()
-          setImmediate(tick.resolve)
-          await tick.promise
-        }
-        process.off('unhandledRejection', observe)
-        return seen
-      },
-    }
-  }
-
   it('never journals a browser frame that raced the stop it lost', async () => {
     const server = await start({ includeTranscript: true })
     const { cookie } = await bootstrap(server)
@@ -1725,13 +1979,14 @@ describe('startVisualServer shutdown and admission races', () => {
   it('tells the browser when admitting its frame fails', async () => {
     let narrow = 0
     const server = await start({
-      // 16-byte draws mint the session id, the style nonce, then the
-      // connection id, then event identifiers; failing from the first event id
-      // makes admission throw inside the socket's own fire-and-forget handler.
+      // 16-byte draws mint the session id, the style nonce, the connection id,
+      // the record the runtime writes for that connection, then browser event
+      // identifiers; failing from the first of those makes admission throw
+      // inside the socket's own fire-and-forget handler.
       randomBytes: (size: number) => {
         if (size !== 16) return randomBytes(size)
         narrow += 1
-        if (narrow >= 4) throw new Error('random source unavailable')
+        if (narrow >= 5) throw new Error('random source unavailable')
         return randomBytes(16)
       },
     })
@@ -1749,7 +2004,10 @@ describe('startVisualServer shutdown and admission races', () => {
     )
 
     expect((await rejected).diagnostics[0]?.code).toBe('YMVS307')
-    expect(await journalOf(server)).toHaveLength(0)
+    // Nothing but the connection the runtime journaled for itself.
+    expect(await journalOf(server)).toMatchObject([
+      { type: 'browser.connected' },
+    ])
     // The session survives a failed admission and still answers.
     expect(server.status().lifecycle).toBe('running')
     expect(await rejections.settled()).toEqual([])

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   VISUAL_BROWSER_HEADERS,
   VISUAL_SERVER_LIMITS,
+  visualContentSecurityPolicy,
   startVisualServer,
   type VisualServerFrame,
   type VisualServerHandle,
@@ -373,6 +374,147 @@ describe('startVisualServer bootstrap and browser authentication', () => {
         expect(checked.headers.get(name)).toBe(value)
       }
     }
+  })
+
+  it('admits inline style only under this session own nonce', async () => {
+    const server = await start()
+    const { response, cookie } = await bootstrap(server)
+    const page = await fetch(`${server.started.origin}/`, {
+      headers: { Cookie: cookie },
+    })
+    const snapshot = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as { readonly styleNonce: string }
+
+    expect(snapshot.styleNonce).toMatch(/^[0-9a-f]{32}$/)
+    for (const checked of [response, page]) {
+      const policy = checked.headers.get('content-security-policy') as string
+      expect(policy).toBe(visualContentSecurityPolicy(snapshot.styleNonce))
+      expect(policy).toContain(`style-src 'self' 'nonce-${snapshot.styleNonce}'`)
+      // A nonce admits the styles this application ships and nothing else.
+      expect(policy).not.toContain('unsafe-inline')
+      expect(policy).toContain(`script-src 'self'`)
+      expect(policy).toContain(`frame-ancestors 'none'`)
+    }
+  })
+
+  it('mints a nonce no other session can use', async () => {
+    const first = await start()
+    const second = await start()
+    const nonceOf = async (server: VisualServerHandle) => {
+      const { cookie } = await bootstrap(server)
+      const snapshot = (await (
+        await fetch(`${server.started.origin}/api/session`, {
+          headers: { Cookie: cookie },
+        })
+      ).json()) as { readonly styleNonce: string }
+      return snapshot.styleNonce
+    }
+    expect(await nonceOf(first)).not.toBe(await nonceOf(second))
+  })
+
+  it('restores the conversation to a browser that reloads', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Why is option B cheaper?')
+    await postResponse(
+      server,
+      capability,
+      chatResponse(server, asked.eventId, 3, 'It reuses the intake path.'),
+    )
+    socket.close()
+
+    const session = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as {
+      readonly transcript: readonly { readonly text: string }[]
+      readonly lastSequence: number
+    }
+
+    expect(session.transcript).toEqual([
+      {
+        id: asked.eventId,
+        speaker: 'reviewer',
+        text: 'Why is option B cheaper?',
+      },
+      {
+        id: identifier(3),
+        speaker: 'agent',
+        text: 'It reuses the intake path.',
+      },
+    ])
+    expect(session.lastSequence).toBe(1)
+  })
+
+  it('restores a selected choice by the label the reviewer read', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Which option?')
+    await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(4),
+      eventId: asked.eventId,
+      type: 'choice.present',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      payload: {
+        choiceId: 'delivery',
+        question: 'Which delivery design should we keep?',
+        options: [
+          { id: 'shared-queue', label: 'Shared queue' },
+          { id: 'isolated-worker', label: 'Isolated worker' },
+        ],
+      },
+    })
+    const chosen = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'choice.selected',
+        lastAcknowledgedSequence: 1,
+        payload: { choiceId: 'delivery', optionId: 'shared-queue' },
+      }),
+    )
+    await chosen
+    socket.close()
+
+    const session = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as {
+      readonly transcript: readonly { readonly text: string }[]
+    }
+    // The record says what the reviewer chose, not the identifier they clicked.
+    expect(session.transcript.at(-1)).toMatchObject({
+      speaker: 'reviewer',
+      text: 'Shared queue',
+    })
+  })
+
+  it('never puts model sources or credentials in a restored conversation', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'anything')
+    socket.close()
+    const body = await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).text()
+    expect(body).not.toContain('model.likec4')
+    expect(body).not.toContain(await capabilityOf(server))
+    const secret = cookie.split('=')[1] ?? ''
+    expect(secret.length).toBeGreaterThan(0)
+    expect(body).not.toContain(secret)
   })
 
   it('rejects a request whose Host header is not the bound loopback authority', async () => {
@@ -1332,13 +1474,13 @@ describe('startVisualServer shutdown and admission races', () => {
   it('tells the browser when admitting its frame fails', async () => {
     let narrow = 0
     const server = await start({
-      // 16-byte draws mint the session id, then the connection id, then event
-      // identifiers; failing from the first event id makes admission throw
-      // inside the socket's own fire-and-forget handler.
+      // 16-byte draws mint the session id, the style nonce, then the
+      // connection id, then event identifiers; failing from the first event id
+      // makes admission throw inside the socket's own fire-and-forget handler.
       randomBytes: (size: number) => {
         if (size !== 16) return randomBytes(size)
         narrow += 1
-        if (narrow >= 3) throw new Error('random source unavailable')
+        if (narrow >= 4) throw new Error('random source unavailable')
         return randomBytes(16)
       },
     })

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -67,6 +67,7 @@ const request: VisualSessionRequest = {
 
 const chatEventInput = {
   type: 'chat.message',
+  lastAcknowledgedSequence: 0,
   payload: { text: 'Compare the two delivery designs' },
 } as const
 
@@ -170,7 +171,11 @@ const nextFrame = async <Kind extends VisualServerFrame['kind']>(
 
 const sendChat = (socket: WebSocket, text: string) => {
   const accepted = nextFrame(socket, 'accepted')
-  socket.send(JSON.stringify({ type: 'chat.message', payload: { text } }))
+  socket.send(JSON.stringify({
+    type: 'chat.message',
+    lastAcknowledgedSequence: 0,
+    payload: { text },
+  }))
   return accepted
 }
 
@@ -440,6 +445,23 @@ describe('startVisualServer bootstrap and browser authentication', () => {
       },
     })
   })
+
+  it('reports the compiled LikeC4 model the browser has to render', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(`${server.started.origin}/api/session`, {
+      headers: { Cookie: cookie },
+    })
+    const session = (await response.json()) as {
+      readonly model: { readonly compiled: Record<string, unknown> }
+    }
+    // The compiled export is what `createLikeC4Model` consumes: without it the
+    // browser has view identifiers and nothing to draw.
+    expect(session.model.compiled).toMatchObject({
+      _stage: 'layouted',
+      views: { choices: { id: 'choices' } },
+    })
+  })
 })
 
 describe('startVisualServer agent capability separation', () => {
@@ -614,6 +636,7 @@ describe('startVisualServer event queue and long polling', () => {
     socket.send(
       JSON.stringify({
         type: 'view.navigate',
+        lastAcknowledgedSequence: 0,
         payload: { viewId: 'choices', requiresAttention: false },
       }),
     )
@@ -636,6 +659,7 @@ describe('startVisualServer event queue and long polling', () => {
     socket.send(
       JSON.stringify({
         type: 'view.navigate',
+        lastAcknowledgedSequence: 0,
         payload: { viewId: 'choices', requiresAttention: true },
       }),
     )
@@ -659,7 +683,11 @@ describe('startVisualServer event queue and long polling', () => {
     }
     const rejected = nextFrame(socket, 'rejected')
     socket.send(
-      JSON.stringify({ type: 'chat.message', payload: { text: 'one more' } }),
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'one more' },
+      }),
     )
     expect(await rejected).toMatchObject({ frozen: 'pending-events' })
 
@@ -684,6 +712,7 @@ describe('startVisualServer event queue and long polling', () => {
     socket.send(
       JSON.stringify({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: 'x'.repeat(VISUAL_LIMITS.messageBytes + 1) },
       }),
     )
@@ -702,6 +731,7 @@ describe('startVisualServer event queue and long polling', () => {
     socket.send(
       JSON.stringify({
         type: 'chat.message',
+        lastAcknowledgedSequence: 0,
         payload: { text: 'x'.repeat(VISUAL_SERVER_LIMITS.browserFrameBytes) },
       }),
     )
@@ -759,7 +789,11 @@ describe('startVisualServer event queue and long polling', () => {
     await sendChat(socket, 'first')
     const rejected = nextFrame(socket, 'rejected')
     socket.send(
-      JSON.stringify({ type: 'chat.message', payload: { text: 'second' } }),
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'second' },
+      }),
     )
     expect((await rejected).diagnostics[0]?.code).toBe('YMVS127')
 
@@ -767,6 +801,44 @@ describe('startVisualServer event queue and long polling', () => {
       (record) => record.type === 'chat.message',
     )
     expect(events).toHaveLength(1)
+    socket.close()
+  })
+
+  it('refuses a browser frame acknowledging a sequence the journal never reached', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 4,
+        payload: { text: 'I have seen the future' },
+      }),
+    )
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS308')
+    expect(await journalOf(server)).toHaveLength(0)
+    expect(server.status().queue.lastSequence).toBe(0)
+    socket.close()
+  })
+
+  it('admits a browser frame whose acknowledgement is merely stale', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    expect((await sendChat(socket, 'first')).sequence).toBe(1)
+
+    // The browser is a sequence behind, which is what a reconnect mid-turn
+    // looks like; admission still owns the sequence it assigns.
+    const accepted = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'second' },
+      }),
+    )
+    expect((await accepted).sequence).toBe(2)
     socket.close()
   })
 })
@@ -902,7 +974,11 @@ describe('startVisualServer agent responses', () => {
       accepted: true,
       model: { candidate: '000002', initialView: 'choices' },
     })
-    expect((await rendered).model.candidate).toBe('000002')
+    const broadcast = await rendered
+    expect(broadcast.model.candidate).toBe('000002')
+    // A promoted candidate reaches the browser with its own compiled export,
+    // so the diagram it renders is never one candidate behind.
+    expect(broadcast.model.compiled).toMatchObject({ _stage: 'layouted' })
 
     const active: unknown = JSON.parse(
       await readFile(
@@ -1217,7 +1293,11 @@ describe('startVisualServer shutdown and admission races', () => {
     // already on the admission chain when the stop begins.
     for (let sent = 0; sent < 8; sent += 1) {
       socket.send(
-        JSON.stringify({ type: 'chat.message', payload: { text: `race ${sent}` } }),
+        JSON.stringify({
+          type: 'chat.message',
+          lastAcknowledgedSequence: 0,
+          payload: { text: `race ${sent}` },
+        }),
       )
     }
     const closed = await server.stop('main-cancelled')
@@ -1268,7 +1348,11 @@ describe('startVisualServer shutdown and admission races', () => {
 
     const rejected = nextFrame(socket, 'rejected')
     socket.send(
-      JSON.stringify({ type: 'chat.message', payload: { text: 'unminted' } }),
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'unminted' },
+      }),
     )
 
     expect((await rejected).diagnostics[0]?.code).toBe('YMVS307')
@@ -1290,7 +1374,11 @@ describe('startVisualServer shutdown and admission races', () => {
     // frame written now can reach a session that is already recovering.
     const stopping = server.stop('main-cancelled')
     socket.send(
-      JSON.stringify({ type: 'chat.message', payload: { text: 'too late' } }),
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'too late' },
+      }),
     )
     const closed = await stopping
 
@@ -1416,7 +1504,11 @@ describe('startVisualServer diagnostic conformance', () => {
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const rejected = nextFrame(socket, 'rejected')
-    socket.send(JSON.stringify({ type: 'chat.message', payload: {} }))
+    socket.send(JSON.stringify({
+      type: 'chat.message',
+      lastAcknowledgedSequence: 0,
+      payload: {},
+    }))
     expect(publishable((await rejected).diagnostics).length).toBeGreaterThan(0)
     socket.close()
   })
@@ -1430,7 +1522,11 @@ describe('startVisualServer diagnostic conformance', () => {
     }
     const rejected = nextFrame(socket, 'rejected')
     socket.send(
-      JSON.stringify({ type: 'chat.message', payload: { text: 'one more' } }),
+      JSON.stringify({
+        type: 'chat.message',
+        lastAcknowledgedSequence: 0,
+        payload: { text: 'one more' },
+      }),
     )
     const diagnostics = publishable((await rejected).diagnostics)
     expect(diagnostics[0]).toMatchObject({

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -853,6 +853,40 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     expect(error.message).toContain('403')
   })
 
+  it('reserves the browser connection limit before journaling admission', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const opened: WebSocket[] = []
+    const attempts = Array.from(
+      { length: VISUAL_SERVER_LIMITS.browserConnections + 4 },
+      () =>
+        new Promise<number>((resolve, reject) => {
+          const socket = new WebSocket(server.started.webSocketUrl, {
+            headers: { Cookie: cookie, Origin: server.started.origin },
+          })
+          socket.once('open', () => {
+            opened.push(socket)
+            resolve(101)
+          })
+          socket.once('unexpected-response', (_request, response) => {
+            response.resume()
+            resolve(response.statusCode ?? 0)
+          })
+          socket.once('error', reject)
+        }),
+    )
+
+    const outcomes = await Promise.all(attempts)
+    for (const socket of opened) socket.close()
+
+    expect(outcomes.filter((status) => status === 101)).toHaveLength(
+      VISUAL_SERVER_LIMITS.browserConnections,
+    )
+    expect(outcomes.filter((status) => status !== 101)).toEqual(
+      Array(4).fill(503),
+    )
+  })
+
   it('rejects a cookie minted by another session', async () => {
     const first = await start()
     const second = await start()
@@ -1851,6 +1885,57 @@ describe('startVisualServer lifecycle', () => {
     await expect(
       fetch(`${server.started.origin}/api/agent/status`),
     ).rejects.toThrow()
+  })
+
+  it('answers every concurrent agent stop request before closing sockets', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const port = Number(new URL(server.started.origin).port)
+    const sockets = Array.from({ length: 4 }, () =>
+      connect(port, '127.0.0.1'),
+    )
+    await Promise.all(sockets.map((socket) => once(socket, 'connect')))
+    const body = JSON.stringify({ reason: 'user-ended' })
+    const responses = sockets.map(
+      (socket) =>
+        new Promise<string>((resolve, reject) => {
+          let response = ''
+          socket.setEncoding('utf8')
+          socket.on('data', (chunk) => {
+            response += chunk
+          })
+          socket.on('end', () => resolve(response))
+          socket.on('error', reject)
+          socket.write(
+            [
+              'POST /api/agent/stop HTTP/1.1',
+              `Host: 127.0.0.1:${port}`,
+              `Authorization: Bearer ${capability}`,
+              'Content-Type: application/json',
+              `Content-Length: ${Buffer.byteLength(body)}`,
+              'Connection: close',
+              '',
+              body,
+            ].join('\r\n'),
+          )
+        }),
+    )
+
+    const raw = await Promise.all(responses)
+    expect(raw.map((response) => response.split('\r\n')[0])).toEqual([
+      'HTTP/1.1 200 OK',
+      'HTTP/1.1 200 OK',
+      'HTTP/1.1 200 OK',
+      'HTTP/1.1 200 OK',
+    ])
+    const results = raw.map(
+      (response) =>
+        JSON.parse(response.split('\r\n\r\n')[1] ?? '{}') as {
+          readonly alreadyStopped: boolean
+        },
+    )
+    expect(results.filter((result) => !result.alreadyStopped)).toHaveLength(1)
+    expect(results.filter((result) => result.alreadyStopped)).toHaveLength(3)
   })
 
   it('settles a waiting long poll when the session stops', async () => {

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { once } from 'node:events'
+import { watch as watchEagerly } from 'node:fs'
 import {
   chmod,
   mkdir,
@@ -272,44 +273,57 @@ const chatResponse = (
 })
 
 /**
- * Waits for the journal named by a session descriptor to carry an event past
- * `after`. The descriptor is the agent's only entry point into the session, so
+ * Waits for the next event the journal named by a session descriptor carries
+ * past `after`, and answers only if it is the `type` the caller is correlating
+ * against. The descriptor is the agent's only entry point into the session, so
  * the helper reads the journal the way an out-of-process agent would, and it
  * waits on the file's own change events rather than on a guessed delay.
+ *
+ * Naming the type is what makes the wait a correlation rather than a cursor:
+ * the runtime journals records of its own, and a wait that took whatever came
+ * next would hand one of those back as the event under test.
  */
-const waitForVisualEvent = async (
+const waitForVisualEvent = async <Type extends VisualEvent['type']>(
   descriptorPath: string,
   after: number,
-): Promise<VisualEvent> => {
+  type: Type,
+): Promise<Extract<VisualEvent, { readonly type: Type }>> => {
   const { journalPath } = await readDescriptor(descriptorPath)
-  const journaled = async () => {
-    let lines: string[] = []
-    try {
-      lines = (await readFile(journalPath, 'utf8'))
+  // The callback watcher, not `fs/promises.watch`: the promise form is an async
+  // generator that registers nothing until its first iteration, so it cannot be
+  // armed ahead of the read the way this window needs. This one is watching
+  // from the moment it is constructed, and every change it sees is counted, so
+  // an append landing during the read below is observed rather than lost.
+  let changes = 0
+  let changed = Promise.withResolvers<void>()
+  const watcher = watchEagerly(journalPath, () => {
+    changes += 1
+    changed.resolve()
+    changed = Promise.withResolvers<void>()
+  })
+  try {
+    for (;;) {
+      const seen = changes
+      const lines = (await readFile(journalPath, 'utf8'))
         .split('\n')
         .filter((line) => line.length > 0)
-    } catch {
-      return undefined
-    }
-    for (const line of lines) {
-      const event = JSON.parse(line) as VisualEvent
-      if (
-        event.format === 'yarramate/visual-event/v1' &&
-        event.sequence > after
-      ) {
-        return event
+      for (const line of lines) {
+        const record = JSON.parse(line) as VisualEvent | VisualResponse
+        if (record.format !== 'yarramate/visual-event/v1') continue
+        if (record.sequence <= after) continue
+        if (record.type !== type) {
+          throw new Error(
+            `journal holds ${record.type} at sequence ${record.sequence}, not the ${type} this wait is for`,
+          )
+        }
+        return record as Extract<VisualEvent, { readonly type: Type }>
       }
+      // Nothing since the read began, so there is a change worth waiting for.
+      if (changes === seen) await changed.promise
     }
-    return undefined
+  } finally {
+    watcher.close()
   }
-  const already = await journaled()
-  if (already !== undefined) return already
-  // The journal exists from session creation, so it can be watched directly.
-  for await (const _change of watch(journalPath)) {
-    const appended = await journaled()
-    if (appended !== undefined) return appended
-  }
-  throw new Error(`no event past ${after} in "${journalPath}"`)
 }
 
 const journalOf = async (handle: VisualServerHandle) =>
@@ -338,8 +352,10 @@ const waitForAttachedAgent = async (handle: VisualServerHandle) => {
 
 /**
  * Resolves once the session has journaled up to `sequence`. The runtime moves
- * its own queue cursor as each append lands, so this observes the server that
- * did the writing rather than racing a watch on the file it wrote.
+ * its own queue cursor one statement *after* the append resolves, so a wait on
+ * the journal file can see a record the server has not finished accounting
+ * for. This is the stronger of the two waits — it implies the file too — and it
+ * is what anything that then reads server state has to wait on.
  */
 const waitForSequence = async (
   handle: VisualServerHandle,
@@ -416,8 +432,8 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     socket.send(JSON.stringify(chatEventInput))
     await expect(
       // Sequence 1 is the connection the runtime journaled for this socket.
-      waitForVisualEvent(server.started.descriptorPath, 1),
-    ).resolves.toMatchObject({ type: 'chat.message', sequence: 2 })
+      waitForVisualEvent(server.started.descriptorPath, 1, 'chat.message'),
+    ).resolves.toMatchObject({ sequence: 2 })
     socket.close()
   })
 
@@ -531,8 +547,8 @@ describe('startVisualServer bootstrap and browser authentication', () => {
       chatResponse(server, asked.eventId, 3, 'It reuses the intake path.'),
     )
     socket.close()
-    // The reload is read after the socket it replaces is journaled as gone, so
-    // the sequence the snapshot reports is settled rather than raced.
+    // The reload is read after the runtime has accounted for the socket it
+    // replaces, so the sequence the snapshot reports is settled, not raced.
     await waitForSequence(server, 3)
 
     const session = (await (
@@ -1298,9 +1314,9 @@ describe('startVisualServer limit failures', () => {
     const terminal = await waitForVisualEvent(
       server.started.descriptorPath,
       VISUAL_LIMITS.pendingEvents + 1,
+      'session.end',
     )
     expect(terminal).toMatchObject({
-      type: 'session.end',
       sequence: VISUAL_LIMITS.pendingEvents + 2,
       payload: { reason: 'server-failed' },
     })
@@ -1348,9 +1364,12 @@ describe('startVisualServer limit failures', () => {
     await expect((await polled).json()).resolves.toMatchObject({
       waiting: true,
     })
-    const terminal = await waitForVisualEvent(server.started.descriptorPath, 1)
+    const terminal = await waitForVisualEvent(
+      server.started.descriptorPath,
+      1,
+      'session.end',
+    )
     expect(terminal).toMatchObject({
-      type: 'session.end',
       sequence: 2,
       payload: { reason: 'server-failed' },
     })
@@ -1391,9 +1410,12 @@ describe('startVisualServer limit failures', () => {
       diagnostics: [{ code: 'YMVS122' }],
     })
 
-    const terminal = await waitForVisualEvent(server.started.descriptorPath, 2)
+    const terminal = await waitForVisualEvent(
+      server.started.descriptorPath,
+      2,
+      'session.end',
+    )
     expect(terminal).toMatchObject({
-      type: 'session.end',
       sequence: 3,
       payload: { reason: 'server-failed' },
     })

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1,0 +1,1164 @@
+import { once } from 'node:events'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { connect } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WebSocket } from 'ws'
+import {
+  VISUAL_LIMITS,
+  type VisualEvent,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionRequest,
+} from '../src/adapters/visual/protocol.js'
+import {
+  VISUAL_BROWSER_HEADERS,
+  VISUAL_SERVER_LIMITS,
+  startVisualServer,
+  type VisualServerFrame,
+  type VisualServerHandle,
+  type VisualServerOptions,
+} from '../src/adapters/visual/session-server.js'
+
+const fixtures = fileURLToPath(new URL('./fixtures/visual/', import.meta.url))
+const fakeCompiler = join(fixtures, 'fake-likec4.mjs')
+const assetRoot = join(fixtures, 'browser-assets')
+
+const modelWith = (marker?: string): VisualModel => ({
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    // The fake compiler selects its behaviour from a marker comment inside a
+    // staged source file, so an invalid candidate is a property of the model.
+    'model.likec4': `model { system = system "System" }${
+      marker === undefined ? '' : `\n// fake:${marker}`
+    }`,
+    'views/choices.likec4': 'views { view choices { include * } }',
+  },
+})
+
+const request: VisualSessionRequest = {
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler: { command: process.execPath, args: [fakeCompiler] },
+  initialModel: modelWith(),
+}
+
+const chatEventInput = {
+  type: 'chat.message',
+  payload: { text: 'Compare the two delivery designs' },
+} as const
+
+const identifier = (index: number) => index.toString(16).padStart(32, '0')
+
+let baseDir = ''
+const running: VisualServerHandle[] = []
+
+const start = async (overrides: Partial<VisualServerOptions> = {}) => {
+  const handle = await startVisualServer({
+    request,
+    baseDir,
+    assetRoot,
+    // Long enough that an event racing a poll always wins; the idle tests set
+    // their own ceiling.
+    agentPollMs: 4000,
+    ...overrides,
+  })
+  running.push(handle)
+  return handle
+}
+
+/** The agent capability lives only in the mode 0600 descriptor. */
+const capabilityOf = async (handle: VisualServerHandle): Promise<string> => {
+  const descriptor: unknown = JSON.parse(
+    await readFile(handle.started.descriptorPath, 'utf8'),
+  )
+  return (descriptor as { readonly agentCapability: string }).agentCapability
+}
+
+const bootstrap = async (handle: VisualServerHandle) => {
+  const response = await fetch(handle.started.browserUrl, {
+    redirect: 'manual',
+  })
+  const header = response.headers.get('set-cookie')
+  if (header === null) throw new Error('bootstrap returned no cookie')
+  return { response, cookie: header.split(';')[0] as string }
+}
+
+/**
+ * Every frame the socket has received and no assertion has claimed yet. The
+ * server sends `ready` the moment it accepts the upgrade, which can land before
+ * the test gets a chance to listen, so frames are buffered from construction.
+ */
+const buffered = new WeakMap<WebSocket, VisualServerFrame[]>()
+
+const openBrowserSocket = async (
+  handle: VisualServerHandle,
+  cookie: string,
+) => {
+  const socket = new WebSocket(handle.started.webSocketUrl, {
+    headers: { Cookie: cookie, Origin: handle.started.origin },
+  })
+  const frames: VisualServerFrame[] = []
+  buffered.set(socket, frames)
+  socket.on('message', (data) => {
+    frames.push(JSON.parse(String(data)) as VisualServerFrame)
+  })
+  await once(socket, 'open')
+  return socket
+}
+
+const nextFrame = async <Kind extends VisualServerFrame['kind']>(
+  socket: WebSocket,
+  kind: Kind,
+  match: (frame: Extract<VisualServerFrame, { kind: Kind }>) => boolean = () =>
+    true,
+): Promise<Extract<VisualServerFrame, { kind: Kind }>> => {
+  const frames = buffered.get(socket) ?? []
+  const take = () => {
+    const index = frames.findIndex(
+      (frame) =>
+        frame.kind === kind &&
+        match(frame as Extract<VisualServerFrame, { kind: Kind }>),
+    )
+    return index < 0
+      ? undefined
+      : (frames.splice(index, 1)[0] as Extract<
+          VisualServerFrame,
+          { kind: Kind }
+        >)
+  }
+  for (;;) {
+    const found = take()
+    if (found !== undefined) return found
+    await once(socket, 'message')
+  }
+}
+
+const sendChat = (socket: WebSocket, text: string) => {
+  const accepted = nextFrame(socket, 'accepted')
+  socket.send(JSON.stringify({ type: 'chat.message', payload: { text } }))
+  return accepted
+}
+
+const agentFetch = (
+  handle: VisualServerHandle,
+  capability: string,
+  path: string,
+  init: RequestInit = {},
+) =>
+  fetch(`${handle.started.origin}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${capability}`,
+      ...(init.headers ?? {}),
+    },
+  })
+
+const postResponse = (
+  handle: VisualServerHandle,
+  capability: string,
+  response: VisualResponse,
+) =>
+  agentFetch(handle, capability, '/api/agent/responses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(response),
+  })
+
+const chatResponse = (
+  handle: VisualServerHandle,
+  eventId: string,
+  index: number,
+  text = 'Design A isolates delivery; design B shares it.',
+): VisualResponse => ({
+  format: 'yarramate/visual-response/v1',
+  sessionId: handle.started.sessionId,
+  responseId: identifier(index),
+  eventId,
+  type: 'chat.response',
+  timestamp: '2026-08-08T00:00:02.000Z',
+  payload: { text },
+})
+
+/**
+ * Waits for the journal named by a session descriptor to carry an event past
+ * `after`. The descriptor is the agent's only entry point into the session, so
+ * the helper reads the journal the way an out-of-process agent would.
+ */
+const waitForVisualEvent = async (
+  descriptorPath: string,
+  after: number,
+): Promise<VisualEvent> => {
+  const descriptor: unknown = JSON.parse(await readFile(descriptorPath, 'utf8'))
+  const journalPath = (descriptor as { readonly journalPath: string })
+    .journalPath
+  const deadline = Date.now() + 5000
+  for (;;) {
+    let lines: string[] = []
+    try {
+      lines = (await readFile(journalPath, 'utf8'))
+        .split('\n')
+        .filter((line) => line.length > 0)
+    } catch {
+      lines = []
+    }
+    for (const line of lines) {
+      const event = JSON.parse(line) as VisualEvent
+      if (
+        event.format === 'yarramate/visual-event/v1' &&
+        event.sequence > after
+      ) {
+        return event
+      }
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`no event past ${after} in "${journalPath}"`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+const journalOf = async (handle: VisualServerHandle) =>
+  (await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'))
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as VisualEvent | VisualResponse)
+
+/** Raw request/response text, so Host and unnormalised paths stay verbatim. */
+const rawRequest = (origin: string, lines: readonly string[]) =>
+  new Promise<string>((resolve, reject) => {
+    const port = Number(new URL(origin).port)
+    const socket = connect(port, '127.0.0.1', () => {
+      socket.write([...lines, '', ''].join('\r\n'))
+    })
+    let text = ''
+    socket.setEncoding('utf8')
+    socket.on('data', (chunk) => {
+      text += chunk
+    })
+    socket.on('end', () => resolve(text))
+    socket.on('error', reject)
+  })
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'yarramate-visual-server-'))
+})
+
+afterEach(async () => {
+  for (const handle of running.splice(0)) {
+    await handle.stop('main-cancelled')
+  }
+  await rm(baseDir, { recursive: true, force: true })
+})
+
+describe('startVisualServer bootstrap and browser authentication', () => {
+  it('exchanges the bootstrap token and accepts an authenticated browser socket', async () => {
+    const server = await start()
+    const response = await fetch(server.started.browserUrl, {
+      redirect: 'manual',
+    })
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('/')
+    expect(response.headers.get('set-cookie')).toMatch(
+      /^ym_visual=[^;]+; HttpOnly; SameSite=Strict; Path=\/$/,
+    )
+
+    const socket = await openBrowserSocket(
+      server,
+      (response.headers.get('set-cookie') as string).split(';')[0] as string,
+    )
+    socket.send(JSON.stringify(chatEventInput))
+    await expect(
+      waitForVisualEvent(server.started.descriptorPath, 0),
+    ).resolves.toMatchObject({ type: 'chat.message', sequence: 1 })
+    socket.close()
+  })
+
+  it('never returns the bootstrap token in the cookie it mints', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const token = new URL(server.started.browserUrl).searchParams.get('key')
+    expect(token).toMatch(/^[0-9a-f]{64}$/)
+    expect(cookie).not.toContain(token as string)
+  })
+
+  it('refuses a replayed bootstrap token', async () => {
+    const server = await start()
+    await bootstrap(server)
+    const replay = await fetch(server.started.browserUrl, {
+      redirect: 'manual',
+    })
+    expect(replay.status).toBe(403)
+    expect(replay.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('refuses a bootstrap key that is not the browser capability', async () => {
+    const server = await start()
+    const forged = new URL(server.started.browserUrl)
+    forged.searchParams.set('key', 'a'.repeat(64))
+    const response = await fetch(forged, { redirect: 'manual' })
+    expect(response.status).toBe(403)
+    expect(response.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('serves the browser application only to a cookie-bearing request', async () => {
+    const server = await start()
+    const anonymous = await fetch(`${server.started.origin}/`)
+    expect(anonymous.status).toBe(401)
+
+    const { cookie } = await bootstrap(server)
+    const page = await fetch(`${server.started.origin}/`, {
+      headers: { Cookie: cookie },
+    })
+    expect(page.status).toBe(200)
+    expect(page.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    await expect(page.text()).resolves.toContain('/assets/app-1a2b3c4d.js')
+  })
+
+  it('returns the exact browser security headers on every browser response', async () => {
+    const server = await start()
+    const { response, cookie } = await bootstrap(server)
+    const page = await fetch(`${server.started.origin}/`, {
+      headers: { Cookie: cookie },
+    })
+    const asset = await fetch(
+      `${server.started.origin}/assets/app-1a2b3c4d.js`,
+      { headers: { Cookie: cookie } },
+    )
+    const denied = await fetch(`${server.started.origin}/`)
+    for (const checked of [response, page, asset, denied]) {
+      for (const [name, value] of Object.entries(VISUAL_BROWSER_HEADERS)) {
+        expect(checked.headers.get(name)).toBe(value)
+      }
+    }
+  })
+
+  it('rejects a request whose Host header is not the bound loopback authority', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const text = await rawRequest(server.started.origin, [
+      'GET / HTTP/1.1',
+      'Host: visual.attacker.example',
+      `Cookie: ${cookie}`,
+      'Connection: close',
+    ])
+    expect(text.split('\r\n')[0]).toContain('403')
+  })
+
+  it('rejects a browser request from a foreign origin', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(`${server.started.origin}/api/session`, {
+      headers: { Cookie: cookie, Origin: 'http://attacker.example' },
+    })
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects a WebSocket upgrade without the session cookie', async () => {
+    const server = await start()
+    const socket = new WebSocket(server.started.webSocketUrl, {
+      headers: { Origin: server.started.origin },
+    })
+    const [error] = (await once(socket, 'error')) as [Error]
+    expect(error.message).toContain('401')
+  })
+
+  it('rejects a WebSocket upgrade from a foreign origin', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = new WebSocket(server.started.webSocketUrl, {
+      headers: { Cookie: cookie, Origin: 'http://attacker.example' },
+    })
+    const [error] = (await once(socket, 'error')) as [Error]
+    expect(error.message).toContain('403')
+  })
+
+  it('rejects a cookie minted by another session', async () => {
+    const first = await start()
+    const second = await start()
+    const { cookie } = await bootstrap(first)
+    const response = await fetch(`${second.started.origin}/api/session`, {
+      headers: { Cookie: cookie },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('reports the rendered session to an authenticated browser', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(`${server.started.origin}/api/session`, {
+      headers: { Cookie: cookie },
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      sessionId: server.started.sessionId,
+      title: 'Choose a delivery design',
+      chatEnabled: true,
+      lastSequence: 0,
+      frozen: false,
+      model: {
+        candidate: '000001',
+        initialView: 'choices',
+        views: ['choices'],
+      },
+    })
+  })
+})
+
+describe('startVisualServer agent capability separation', () => {
+  it('rejects an agent route without a bearer capability', async () => {
+    const server = await start()
+    const response = await fetch(`${server.started.origin}/api/agent/status`)
+    expect(response.status).toBe(401)
+  })
+
+  it('rejects the browser capability presented as an agent bearer token', async () => {
+    const server = await start()
+    const token = new URL(server.started.browserUrl).searchParams.get(
+      'key',
+    ) as string
+    const response = await agentFetch(server, token, '/api/agent/status')
+    expect(response.status).toBe(401)
+  })
+
+  it('rejects a browser cookie presented to an agent route', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(`${server.started.origin}/api/agent/status`, {
+      headers: { Cookie: cookie },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('rejects an agent request that carries a browser origin', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(server, capability, '/api/agent/status', {
+      headers: { Origin: server.started.origin },
+    })
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects an agent capability minted by another session', async () => {
+    const first = await start()
+    const second = await start()
+    const capability = await capabilityOf(first)
+    const response = await agentFetch(second, capability, '/api/agent/status')
+    expect(response.status).toBe(401)
+  })
+
+  it('reports session status to the agent', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(server, capability, '/api/agent/status')
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      format: 'yarramate/visual-status/v1',
+      sessionId: server.started.sessionId,
+      lifecycle: 'running',
+      alreadyStopped: false,
+      server: { listening: true, origin: server.started.origin },
+      agent: { attached: true, inFlightEventId: null },
+      queue: { pendingEvents: 0, lastSequence: 0, frozen: false },
+    })
+  })
+})
+
+describe('startVisualServer event queue and long polling', () => {
+  it('answers an idle long poll with a non-terminal waiting result', async () => {
+    const server = await start({ agentPollMs: 60 })
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(
+      server,
+      capability,
+      '/api/agent/events?after=0',
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      waiting: true,
+      lastSequence: 0,
+      pendingEvents: 0,
+    })
+    expect(server.status().lifecycle).toBe('running')
+  })
+
+  it('releases a waiting long poll with the event the browser just sent', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+
+    const polled = agentFetch(server, capability, '/api/agent/events?after=0')
+    await sendChat(socket, 'Compare the two delivery designs')
+    const body = (await (await polled).json()) as {
+      readonly waiting: boolean
+      readonly event: VisualEvent
+    }
+    expect(body.waiting).toBe(false)
+    expect(body.event).toMatchObject({
+      type: 'chat.message',
+      sequence: 1,
+      sessionId: server.started.sessionId,
+      payload: { text: 'Compare the two delivery designs' },
+    })
+    socket.close()
+  })
+
+  it('replays the in-flight event to a repeated poll', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'Compare the two delivery designs')
+
+    const first = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=0')
+    ).json()) as { readonly event: VisualEvent }
+    const replay = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=0')
+    ).json()) as { readonly event: VisualEvent }
+    expect(replay.event.eventId).toBe(first.event.eventId)
+    expect(server.status().agent.inFlightEventId).toBe(first.event.eventId)
+    socket.close()
+  })
+
+  it('holds a later chat event while one response is outstanding', async () => {
+    const server = await start({ agentPollMs: 60 })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'first')
+    await sendChat(socket, 'second')
+
+    const first = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=0')
+    ).json()) as { readonly event: VisualEvent }
+    expect(first.event.sequence).toBe(1)
+    await expect(
+      (await agentFetch(server, capability, '/api/agent/events?after=1')).json(),
+    ).resolves.toMatchObject({ waiting: true })
+    expect(server.status().queue.pendingEvents).toBe(2)
+    socket.close()
+  })
+
+  it('releases the queued chat event once the turn is answered', async () => {
+    const server = await start({ agentPollMs: 60 })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'first')
+    await sendChat(socket, 'second')
+
+    const first = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=0')
+    ).json()) as { readonly event: VisualEvent }
+    const answered = await postResponse(
+      server,
+      capability,
+      chatResponse(server, first.event.eventId, 1),
+    )
+    expect(answered.status).toBe(200)
+
+    const second = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=1')
+    ).json()) as { readonly waiting: boolean; readonly event: VisualEvent }
+    expect(second.waiting).toBe(false)
+    expect(second.event.sequence).toBe(2)
+    expect(second.event.payload).toEqual({ text: 'second' })
+    socket.close()
+  })
+
+  it('keeps navigation local unless the browser requests agent attention', async () => {
+    const server = await start({ agentPollMs: 60 })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'view.navigate',
+        payload: { viewId: 'choices', requiresAttention: false },
+      }),
+    )
+    await accepted
+
+    await expect(
+      (await agentFetch(server, capability, '/api/agent/events?after=0')).json(),
+    ).resolves.toMatchObject({ waiting: true, lastSequence: 1 })
+    const journal = await journalOf(server)
+    expect(journal.at(-1)).toMatchObject({ type: 'view.navigate' })
+    socket.close()
+  })
+
+  it('delivers navigation that explicitly requests agent attention', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'view.navigate',
+        payload: { viewId: 'choices', requiresAttention: true },
+      }),
+    )
+    await accepted
+
+    await expect(
+      (await agentFetch(server, capability, '/api/agent/events?after=0')).json(),
+    ).resolves.toMatchObject({
+      waiting: false,
+      event: { type: 'view.navigate' },
+    })
+    socket.close()
+  })
+
+  it('freezes the queue once the pending bound is reached', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    for (let sent = 0; sent < VISUAL_LIMITS.pendingEvents; sent += 1) {
+      await sendChat(socket, `message ${sent}`)
+    }
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({ type: 'chat.message', payload: { text: 'one more' } }),
+    )
+    expect(await rejected).toMatchObject({ frozen: 'pending-events' })
+
+    expect(server.status().queue).toMatchObject({
+      pendingEvents: VISUAL_LIMITS.pendingEvents,
+      lastSequence: VISUAL_LIMITS.pendingEvents,
+      frozen: true,
+      frozenReason: 'pending-events',
+    })
+    const events = (await journalOf(server)).filter(
+      (record) => record.type === 'chat.message',
+    )
+    expect(events).toHaveLength(VISUAL_LIMITS.pendingEvents)
+    socket.close()
+  })
+
+  it('rejects a chat message longer than the protocol ceiling', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        payload: { text: 'x'.repeat(VISUAL_LIMITS.messageBytes + 1) },
+      }),
+    )
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS109')
+    const events = (await journalOf(server)).filter(
+      (record) => record.type === 'chat.message',
+    )
+    expect(events).toHaveLength(0)
+    socket.close()
+  })
+
+  it('drops a browser frame beyond the transport ceiling and freezes on bytes', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    socket.send(
+      JSON.stringify({
+        type: 'chat.message',
+        payload: { text: 'x'.repeat(VISUAL_SERVER_LIMITS.browserFrameBytes) },
+      }),
+    )
+    const [code] = (await once(socket, 'close')) as [number]
+    expect(code).toBe(1009)
+    expect(server.status().queue.frozenReason).toBe('message-bytes')
+    const events = (await journalOf(server)).filter(
+      (record) => record.type === 'chat.message',
+    )
+    expect(events).toHaveLength(0)
+  })
+
+  it('rejects a browser frame that is not a valid browser input', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send('{"type":"chat.message"')
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS109')
+    socket.close()
+  })
+
+  it('rejects a browser input that names a runtime-only event type', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({
+        type: 'browser.connected',
+        payload: { connectionId: 'forged' },
+      }),
+    )
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS109')
+    socket.close()
+  })
+
+  it('rejects a browser event whose minted identifier repeats', async () => {
+    let narrow = 0
+    let wide = 0
+    const server = await start({
+      // 16-byte draws mint the session id first and every event id after it;
+      // freezing those after the session id forces an identifier collision.
+      randomBytes: (size: number) => {
+        if (size !== 16) {
+          wide += 1
+          return Buffer.alloc(size, wide)
+        }
+        narrow += 1
+        return Buffer.alloc(16, narrow === 1 ? 0xa1 : 0xb2)
+      },
+    })
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'first')
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({ type: 'chat.message', payload: { text: 'second' } }),
+    )
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS127')
+
+    const events = (await journalOf(server)).filter(
+      (record) => record.type === 'chat.message',
+    )
+    expect(events).toHaveLength(1)
+    socket.close()
+  })
+})
+
+describe('startVisualServer agent responses', () => {
+  it('journals and broadcasts an agent response to the browser', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'first')
+
+    const broadcast = nextFrame(socket, 'response')
+    const posted = await postResponse(
+      server,
+      capability,
+      chatResponse(server, accepted.eventId, 1),
+    )
+    expect(posted.status).toBe(200)
+    await expect(posted.json()).resolves.toMatchObject({
+      accepted: true,
+      duplicate: false,
+    })
+    expect((await broadcast).response).toMatchObject({ type: 'chat.response' })
+    socket.close()
+  })
+
+  it('suppresses a duplicate agent response', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'first')
+    const response = chatResponse(server, accepted.eventId, 1)
+
+    await postResponse(server, capability, response)
+    const repeated = await postResponse(server, capability, response)
+    expect(repeated.status).toBe(200)
+    await expect(repeated.json()).resolves.toMatchObject({
+      accepted: true,
+      duplicate: true,
+    })
+    const journaled = (await journalOf(server)).filter(
+      (record) => record.format === 'yarramate/visual-response/v1',
+    )
+    expect(journaled).toHaveLength(1)
+    socket.close()
+  })
+
+  it('rejects a response body that is not JSON content', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(
+      server,
+      capability,
+      '/api/agent/responses',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'chat.response',
+      },
+    )
+    expect(response.status).toBe(415)
+    expect(await journalOf(server)).toHaveLength(0)
+  })
+
+  it('rejects a response body beyond the byte ceiling', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(
+      server,
+      capability,
+      '/api/agent/responses',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: `{"padding":"${'x'.repeat(VISUAL_SERVER_LIMITS.agentBodyBytes)}"}`,
+      },
+    )
+    expect(response.status).toBe(413)
+    expect(await journalOf(server)).toHaveLength(0)
+  })
+
+  it('rejects a response that violates the protocol schema', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const empty: VisualResponse = {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(1),
+      eventId: identifier(9),
+      type: 'chat.response',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      // Empty text violates the schema's minLength, which no type can catch.
+      payload: { text: '' },
+    }
+    const response = await postResponse(server, capability, empty)
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ accepted: false })
+    expect(await journalOf(server)).toHaveLength(0)
+  })
+
+  it('rejects a response belonging to another session', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await postResponse(server, capability, {
+      ...chatResponse(server, identifier(9), 1),
+      sessionId: identifier(7),
+    })
+    expect(response.status).toBe(409)
+    expect(await journalOf(server)).toHaveLength(0)
+  })
+
+  it('promotes a valid model replacement and tells the browser', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'redraw it')
+
+    const rendered = nextFrame(socket, 'model')
+    const posted = await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(3),
+      eventId: accepted.eventId,
+      type: 'model.replace',
+      timestamp: '2026-08-08T00:00:03.000Z',
+      payload: { model: modelWith() },
+    })
+    expect(posted.status).toBe(200)
+    await expect(posted.json()).resolves.toMatchObject({
+      accepted: true,
+      model: { candidate: '000002', initialView: 'choices' },
+    })
+    expect((await rendered).model.candidate).toBe('000002')
+
+    const active: unknown = JSON.parse(
+      await readFile(
+        join(server.started.sessionRoot, 'active-model.json'),
+        'utf8',
+      ),
+    )
+    expect(active).toMatchObject({ candidate: '000002' })
+    socket.close()
+  })
+
+  it('keeps the last good rendering when a replacement fails to compile', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'redraw it badly')
+
+    const diagnosed = nextFrame(
+      socket,
+      'response',
+      (frame) => frame.response.type === 'diagnostic',
+    )
+    const posted = await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(4),
+      eventId: accepted.eventId,
+      type: 'model.replace',
+      timestamp: '2026-08-08T00:00:04.000Z',
+      payload: { model: modelWith('invalid') },
+    })
+    expect(posted.status).toBe(200)
+    const body = (await posted.json()) as {
+      readonly model?: unknown
+      readonly diagnostics: readonly { readonly code: string }[]
+    }
+    expect(body.model).toBeUndefined()
+    expect(body.diagnostics[0]?.code).toBe('YMVS201')
+    expect((await diagnosed).response).toMatchObject({ type: 'diagnostic' })
+
+    const active: unknown = JSON.parse(
+      await readFile(
+        join(server.started.sessionRoot, 'active-model.json'),
+        'utf8',
+      ),
+    )
+    expect(active).toMatchObject({ candidate: '000001' })
+    const session = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as { readonly model: { readonly candidate: string } }
+    expect(session.model.candidate).toBe('000001')
+    socket.close()
+  })
+})
+
+describe('startVisualServer static asset confinement', () => {
+  it('denies a percent-encoded traversal out of the asset root', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(
+      `${server.started.origin}/assets/%2e%2e%2f%2e%2e%2ffake-likec4.mjs`,
+      { headers: { Cookie: cookie } },
+    )
+    expect(response.status).toBe(404)
+  })
+
+  it('denies a traversal that lands back inside the asset root', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    // The resolved path is a served file and its extension is whitelisted, so
+    // only the flat-name rule can refuse this one.
+    const response = await fetch(
+      `${server.started.origin}/assets/%2e%2e%2findex.html`,
+      { headers: { Cookie: cookie } },
+    )
+    expect(response.status).toBe(404)
+  })
+
+  it('denies an unnormalised traversal sent on the wire', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const text = await rawRequest(server.started.origin, [
+      'GET /assets/../../fake-likec4.mjs HTTP/1.1',
+      `Host: 127.0.0.1:${new URL(server.started.origin).port}`,
+      `Cookie: ${cookie}`,
+      'Connection: close',
+    ])
+    expect(text.split('\r\n')[0]).toContain('404')
+    expect(text).not.toContain('fake-likec4:')
+  })
+
+  it('denies a symlinked asset', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'yarramate-visual-assets-'))
+    const outside = join(root, 'secret.txt')
+    await writeFile(outside, 'agent capability', { mode: 0o600 })
+    const served = join(root, 'browser-assets')
+    await mkdir(join(served, 'assets'), { recursive: true })
+    await writeFile(join(served, 'index.html'), '<!doctype html>')
+    await symlink(outside, join(served, 'assets', 'leak-0000.js'))
+
+    const server = await start({ assetRoot: served })
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(
+      `${server.started.origin}/assets/leak-0000.js`,
+      { headers: { Cookie: cookie } },
+    )
+    expect(response.status).toBe(404)
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('denies an unknown route', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const response = await fetch(`${server.started.origin}/admin`, {
+      headers: { Cookie: cookie },
+    })
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('startVisualServer lifecycle', () => {
+  it('writes a private descriptor carrying only the agent capability', async () => {
+    const server = await start()
+    const descriptor: unknown = JSON.parse(
+      await readFile(server.started.descriptorPath, 'utf8'),
+    )
+    expect(descriptor).toMatchObject({
+      format: 'yarramate/visual-session-descriptor/v1',
+      protocolVersion: 'yarramate/visual-protocol/v1',
+      sessionId: server.started.sessionId,
+      origin: server.started.origin,
+      sessionRoot: server.started.sessionRoot,
+    })
+    const token = new URL(server.started.browserUrl).searchParams.get(
+      'key',
+    ) as string
+    expect(JSON.stringify(descriptor)).not.toContain(token)
+    if (process.platform !== 'win32') {
+      expect((await stat(server.started.descriptorPath)).mode & 0o777).toBe(
+        0o600,
+      )
+    }
+  })
+
+  it('binds only the loopback interface on an ephemeral port', async () => {
+    const server = await start()
+    expect(server.started.origin).toMatch(/^http:\/\/127\.0\.0\.1:[0-9]{1,5}$/)
+    expect(server.started.webSocketUrl).toMatch(
+      /^ws:\/\/127\.0\.0\.1:[0-9]{1,5}\/socket$/,
+    )
+    expect(Number(new URL(server.started.origin).port)).toBeGreaterThan(0)
+  })
+
+  it('refuses to start when the initial model does not compile', async () => {
+    await expect(
+      startVisualServer({
+        request: { ...request, initialModel: modelWith('invalid') },
+        baseDir,
+        assetRoot,
+      }),
+    ).rejects.toThrow(/YMVS201/)
+  })
+
+  it('recovers the handoff before deleting the session', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'first')
+    await postResponse(
+      server,
+      capability,
+      chatResponse(server, accepted.eventId, 1),
+    )
+    const root = server.started.sessionRoot
+
+    const closed = await server.stop('user-ended')
+    expect(closed).toMatchObject({
+      reason: 'user-ended',
+      alreadyStopped: false,
+    })
+    expect(closed.handoff).toMatchObject({
+      format: 'yarramate/visual-handoff/v1',
+      sessionId: server.started.sessionId,
+      lastSequence: accepted.sequence,
+    })
+    await expect(stat(root)).rejects.toThrow()
+    await expect(server.closed).resolves.toMatchObject({ reason: 'user-ended' })
+  })
+
+  it('answers a repeated stop idempotently', async () => {
+    const server = await start()
+    const first = await server.stop('user-ended')
+    const second = await server.stop('main-cancelled')
+    expect(second.alreadyStopped).toBe(true)
+    expect(second.reason).toBe('user-ended')
+    expect(second.handoff?.sessionId).toBe(first.handoff?.sessionId)
+    expect(server.status()).toMatchObject({
+      lifecycle: 'stopped',
+      alreadyStopped: true,
+      server: { listening: false },
+    })
+  })
+
+  it('stops on the agent stop route and closes the listener', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await agentFetch(server, capability, '/api/agent/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'user-ended' }),
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      reason: 'user-ended',
+      alreadyStopped: false,
+      handoff: { format: 'yarramate/visual-handoff/v1' },
+    })
+    await server.closed
+    await expect(
+      fetch(`${server.started.origin}/api/agent/status`),
+    ).rejects.toThrow()
+  })
+
+  it('settles a waiting long poll when the session stops', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const polled = agentFetch(server, capability, '/api/agent/events?after=0')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await server.stop('main-cancelled')
+    await expect((await polled).json()).resolves.toMatchObject({
+      waiting: true,
+    })
+  })
+
+  it('closes browser sockets with a closing frame', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const closing = nextFrame(socket, 'closing')
+    const ended = once(socket, 'close')
+    await server.stop('main-cancelled')
+    expect(await closing).toMatchObject({ reason: 'main-cancelled' })
+    await ended
+  })
+
+  it('reports browser attachment without spending a sequence number', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const ready = await nextFrame(socket, 'ready')
+    expect(ready.snapshot.lastSequence).toBe(0)
+    expect(server.status().browser).toMatchObject({
+      connected: true,
+      connections: 1,
+    })
+
+    socket.close(1000)
+    await once(socket, 'close')
+    // Connection churn is transport state, not conversation: the first
+    // journaled event is still the browser's first message.
+    expect(await journalOf(server)).toHaveLength(0)
+    const idle = server.status()
+    expect(idle.browser).toMatchObject({ connected: false, connections: 0 })
+    expect(idle.browser.graceExpiresAt).toMatch(
+      /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$/,
+    )
+  })
+})
+
+it('keeps the fixture asset root free of anything the server must not serve', async () => {
+  expect(dirname(assetRoot)).toBe(fixtures.replace(/\/$/, ''))
+  const page = await readFile(join(assetRoot, 'index.html'), 'utf8')
+  expect(page).not.toMatch(/https?:\/\//)
+  expect(page).not.toMatch(/<script(?![^>]*\ssrc=)/)
+})

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -18,7 +18,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { WebSocket } from 'ws'
 import {
   VISUAL_LIMITS,
+  parseVisualDiagnosticResult,
   parseVisualSessionDescriptor,
+  type VisualDiagnostic,
   type VisualEvent,
   type VisualModel,
   type VisualResponse,
@@ -1340,6 +1342,102 @@ describe('startVisualServer shutdown and admission races', () => {
     })
     await expect(stat(server.started.sessionRoot)).rejects.toThrow()
     expect(await rejections.settled()).toEqual([])
+  })
+})
+
+describe('startVisualServer diagnostic conformance', () => {
+  /**
+   * Every diagnostic the runtime publishes is read back by the one-shot agent
+   * clients inside a `visual-diagnostic-result/v1` document, so each refusal
+   * surface has to emit diagnostics that document already accepts — including
+   * the RFC 6901 pointers it requires.
+   */
+  const publishable = (diagnostics: unknown): readonly VisualDiagnostic[] => {
+    const parsed = parseVisualDiagnosticResult({
+      format: 'yarramate/visual-diagnostic-result/v1',
+      diagnostics,
+    })
+    if (!parsed.ok) {
+      throw new Error(
+        `diagnostics are not publishable: ${JSON.stringify(diagnostics)} (${parsed.diagnostics[0]?.message})`,
+      )
+    }
+    return parsed.value.diagnostics
+  }
+
+  const diagnosticsOf = (document: unknown): unknown => {
+    if (
+      typeof document === 'object' &&
+      document !== null &&
+      'diagnostics' in document
+    ) {
+      return document.diagnostics
+    }
+    throw new Error(`answer carries no diagnostics: ${JSON.stringify(document)}`)
+  }
+
+  it('publishes a schema refusal as a diagnostic result', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const empty: VisualResponse = {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(1),
+      eventId: identifier(9),
+      type: 'chat.response',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      // Empty text violates the schema's minLength, which no type can catch.
+      payload: { text: '' },
+    }
+    const response = await postResponse(server, capability, empty)
+    expect(response.status).toBe(400)
+    expect(
+      publishable(diagnosticsOf(await response.json())).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('publishes a foreign-session refusal as a diagnostic result', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const response = await postResponse(server, capability, {
+      ...chatResponse(server, identifier(9), 1),
+      sessionId: identifier(7),
+    })
+    expect(response.status).toBe(409)
+    const diagnostics = publishable(diagnosticsOf(await response.json()))
+    expect(diagnostics[0]).toMatchObject({
+      code: 'YMVS126',
+      pointer: '/sessionId',
+    })
+  })
+
+  it('publishes a rejected browser frame as a diagnostic result', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(JSON.stringify({ type: 'chat.message', payload: {} }))
+    expect(publishable((await rejected).diagnostics).length).toBeGreaterThan(0)
+    socket.close()
+  })
+
+  it('publishes a frozen-queue refusal as a diagnostic result', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    for (let sent = 0; sent < VISUAL_LIMITS.pendingEvents; sent += 1) {
+      await sendChat(socket, `message ${sent}`)
+    }
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({ type: 'chat.message', payload: { text: 'one more' } }),
+    )
+    const diagnostics = publishable((await rejected).diagnostics)
+    expect(diagnostics[0]).toMatchObject({
+      code: 'YMVS305',
+      pointer: '/sequence',
+    })
+    socket.close()
   })
 })
 

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -528,6 +528,135 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     })
   })
 
+  it('restores a choice the agent is still waiting on', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Which option?')
+    const question = {
+      choiceId: 'delivery',
+      question: 'Which delivery design should we keep?',
+      options: [
+        { id: 'shared-queue', label: 'Shared queue' },
+        { id: 'isolated-worker', label: 'Isolated worker' },
+      ],
+    }
+    const pendingChoice = async () =>
+      (
+        (await (
+          await fetch(`${server.started.origin}/api/session`, {
+            headers: { Cookie: cookie },
+          })
+        ).json()) as { readonly pendingChoice: unknown }
+      ).pendingChoice
+
+    expect(await pendingChoice()).toBe(null)
+    await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(4),
+      eventId: asked.eventId,
+      type: 'choice.present',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      payload: question,
+    })
+    // The question lives in the agent's response, never in the transcript, so
+    // a browser that reloads reads it here or cannot answer at all.
+    expect(await pendingChoice()).toEqual(question)
+
+    const chosen = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'choice.selected',
+        lastAcknowledgedSequence: 1,
+        payload: { choiceId: 'delivery', optionId: 'shared-queue' },
+      }),
+    )
+    await chosen
+    expect(await pendingChoice()).toBe(null)
+    socket.close()
+  })
+
+  it('drops a waiting choice the reviewer asked past', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Which option?')
+    await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(4),
+      eventId: asked.eventId,
+      type: 'choice.present',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      payload: {
+        choiceId: 'delivery',
+        question: 'Which delivery design should we keep?',
+        options: [
+          { id: 'shared-queue', label: 'Shared queue' },
+          { id: 'isolated-worker', label: 'Isolated worker' },
+        ],
+      },
+    })
+    // Asking something else is how a reviewer declines to choose, and the
+    // browser closes the buttons on itself when it sends one.
+    await sendChat(socket, 'What does the queue cost?')
+
+    const session = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as { readonly pendingChoice: unknown }
+    expect(session.pendingChoice).toBe(null)
+    socket.close()
+  })
+
+  it('waits on nothing once the reviewer has ended the session', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Which option?')
+    await postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(4),
+      eventId: asked.eventId,
+      type: 'choice.present',
+      timestamp: '2026-08-08T00:00:02.000Z',
+      payload: {
+        choiceId: 'delivery',
+        question: 'Which delivery design should we keep?',
+        options: [
+          { id: 'shared-queue', label: 'Shared queue' },
+          { id: 'isolated-worker', label: 'Isolated worker' },
+        ],
+      },
+    })
+
+    const ended = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'session.end',
+        lastAcknowledgedSequence: 1,
+        payload: { reason: 'user-ended' },
+      }),
+    )
+    await ended
+
+    // A session on its way out is waiting on nobody, so a browser that comes
+    // back to it is not asked a question again.
+    const session = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as { readonly pendingChoice: unknown }
+    expect(session.pendingChoice).toBe(null)
+    socket.close()
+  })
+
   it('never puts model sources or credentials in a restored conversation', async () => {
     const server = await start()
     const { cookie } = await bootstrap(server)
@@ -612,7 +741,7 @@ describe('startVisualServer bootstrap and browser authentication', () => {
       model: {
         candidate: '000001',
         initialView: 'choices',
-        views: ['choices'],
+        views: ['choices', 'detailNightly', 'detailStreaming', 'index'],
       },
     })
   })

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1337,7 +1337,9 @@ describe('startVisualServer lifecycle', () => {
     expect(closed.handoff).toMatchObject({
       format: 'yarramate/visual-handoff/v1',
       sessionId: server.started.sessionId,
-      lastSequence: accepted.sequence,
+      // The reviewer's own End was never journaled here, so the shutdown's
+      // terminal event is the record past the chat it recovered.
+      lastSequence: accepted.sequence + 1,
     })
     await expect(stat(root)).rejects.toThrow()
     await expect(server.closed).resolves.toMatchObject({ reason: 'user-ended' })
@@ -1562,21 +1564,20 @@ describe('startVisualServer shutdown and admission races', () => {
   })
 
   it('finishes admitted work before recovering the session', async () => {
+    const compilerLog = join(baseDir, 'compiler.log')
+    await writeFile(compilerLog, '')
     const server = await start({ includeTranscript: true })
     const capability = await capabilityOf(server)
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
-    const accepted = await sendChat(socket, 'redraw it badly')
+    const accepted = await sendChat(socket, 'redraw it slowly')
     const rejections = collectRejections()
 
-    // A model replacement is journaled and broadcast before its candidate is
-    // compiled, so this frame is the signal that admitted work is genuinely
-    // in flight — the compile, and the diagnostic it will journal, are not.
-    const inFlight = nextFrame(
-      socket,
-      'response',
-      (frame) => frame.response.type === 'model.replace',
-    )
+    // The barrier: the fake compiler records every execution before it does
+    // anything else, and this candidate's validate stage never returns, so a
+    // logged run means a compile is provably still in flight when stop begins.
+    process.env.YARRAMATE_FAKE_LIKEC4_LOG = compilerLog
+    const running = watch(compilerLog)
     const posted = postResponse(server, capability, {
       format: 'yarramate/visual-response/v1',
       sessionId: server.started.sessionId,
@@ -1584,24 +1585,28 @@ describe('startVisualServer shutdown and admission races', () => {
       eventId: accepted.eventId,
       type: 'model.replace',
       timestamp: '2026-08-08T00:00:06.000Z',
-      payload: { model: modelWith('invalid') },
+      payload: { model: modelWith('hang') },
     })
-    await inFlight
+    for await (const _change of running) {
+      if ((await readFile(compilerLog, 'utf8')).includes('validate')) break
+    }
+    delete process.env.YARRAMATE_FAKE_LIKEC4_LOG
 
     const closed = await server.stop('main-cancelled')
 
-    // Shutdown waited for the compile to fail and for its diagnostic to be
+    // Shutdown cancelled the compile rather than waiting out its budget, and
+    // still waited for the diagnostic that cancellation produced to be
     // journaled, so recovery reports work the server had already accepted.
     const types = (closed.handoff?.transcript ?? []).map((record) => record.type)
     expect(types).toContain('model.replace')
     expect(types).toContain('diagnostic')
     await expect((await posted).json()).resolves.toMatchObject({
       accepted: true,
-      diagnostics: [{ code: 'YMVS201' }],
+      diagnostics: [{ code: 'YMVS204' }],
     })
     await expect(stat(server.started.sessionRoot)).rejects.toThrow()
     expect(await rejections.settled()).toEqual([])
-  })
+  }, 30_000)
 })
 
 describe('startVisualServer diagnostic conformance', () => {

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -422,7 +422,7 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe('/')
     expect(response.headers.get('set-cookie')).toMatch(
-      /^ym_visual=[^;]+; HttpOnly; SameSite=Strict; Path=\/$/,
+      /^ym_visual=[^;]+; HttpOnly; SameSite=Strict; Secure; Path=\/$/,
     )
 
     const socket = await openBrowserSocket(

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { once } from 'node:events'
 import {
+  chmod,
   mkdir,
   mkdtemp,
   readFile,
@@ -204,6 +205,56 @@ const postResponse = (
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(response),
   })
+
+/**
+ * The success path of `postResponse`. A refusal is never what a test that goes
+ * on to read session state meant to exercise, so a vacuous POST is caught here
+ * rather than surviving as a silently skipped transition.
+ */
+const postAcceptedResponse = async (
+  handle: VisualServerHandle,
+  capability: string,
+  response: VisualResponse,
+) => {
+  const posted = await postResponse(handle, capability, response)
+  expect(posted.status).toBe(200)
+  const body = (await posted.json()) as { readonly accepted: boolean }
+  expect(body.accepted).toBe(true)
+  return body
+}
+
+/** The question this session is still holding, as a reloading browser reads it. */
+const pendingChoiceOf = async (handle: VisualServerHandle, cookie: string) => {
+  const session = (await (
+    await fetch(`${handle.started.origin}/api/session`, {
+      headers: { Cookie: cookie },
+    })
+  ).json()) as { readonly pendingChoice: unknown }
+  return session.pendingChoice
+}
+
+const deliveryQuestion = {
+  choiceId: 'delivery',
+  question: 'Which delivery design should we keep?',
+  options: [
+    { id: 'shared-queue', label: 'Shared queue' },
+    { id: 'isolated-worker', label: 'Isolated worker' },
+  ],
+} as const
+
+const choicePresent = (
+  handle: VisualServerHandle,
+  eventId: string,
+  index: number,
+): VisualResponse => ({
+  format: 'yarramate/visual-response/v1',
+  sessionId: handle.started.sessionId,
+  responseId: identifier(index),
+  eventId,
+  type: 'choice.present',
+  timestamp: '2026-08-08T00:00:02.000Z',
+  payload: deliveryQuestion,
+})
 
 const chatResponse = (
   handle: VisualServerHandle,
@@ -534,36 +585,16 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const asked = await sendChat(socket, 'Which option?')
-    const question = {
-      choiceId: 'delivery',
-      question: 'Which delivery design should we keep?',
-      options: [
-        { id: 'shared-queue', label: 'Shared queue' },
-        { id: 'isolated-worker', label: 'Isolated worker' },
-      ],
-    }
-    const pendingChoice = async () =>
-      (
-        (await (
-          await fetch(`${server.started.origin}/api/session`, {
-            headers: { Cookie: cookie },
-          })
-        ).json()) as { readonly pendingChoice: unknown }
-      ).pendingChoice
 
-    expect(await pendingChoice()).toBe(null)
-    await postResponse(server, capability, {
-      format: 'yarramate/visual-response/v1',
-      sessionId: server.started.sessionId,
-      responseId: identifier(4),
-      eventId: asked.eventId,
-      type: 'choice.present',
-      timestamp: '2026-08-08T00:00:02.000Z',
-      payload: question,
-    })
+    expect(await pendingChoiceOf(server, cookie)).toBe(null)
+    await postAcceptedResponse(
+      server,
+      capability,
+      choicePresent(server, asked.eventId, 4),
+    )
     // The question lives in the agent's response, never in the transcript, so
     // a browser that reloads reads it here or cannot answer at all.
-    expect(await pendingChoice()).toEqual(question)
+    expect(await pendingChoiceOf(server, cookie)).toEqual(deliveryQuestion)
 
     const chosen = nextFrame(socket, 'accepted')
     socket.send(
@@ -574,7 +605,7 @@ describe('startVisualServer bootstrap and browser authentication', () => {
       }),
     )
     await chosen
-    expect(await pendingChoice()).toBe(null)
+    expect(await pendingChoiceOf(server, cookie)).toBe(null)
     socket.close()
   })
 
@@ -584,32 +615,18 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const asked = await sendChat(socket, 'Which option?')
-    await postResponse(server, capability, {
-      format: 'yarramate/visual-response/v1',
-      sessionId: server.started.sessionId,
-      responseId: identifier(4),
-      eventId: asked.eventId,
-      type: 'choice.present',
-      timestamp: '2026-08-08T00:00:02.000Z',
-      payload: {
-        choiceId: 'delivery',
-        question: 'Which delivery design should we keep?',
-        options: [
-          { id: 'shared-queue', label: 'Shared queue' },
-          { id: 'isolated-worker', label: 'Isolated worker' },
-        ],
-      },
-    })
+    await postAcceptedResponse(
+      server,
+      capability,
+      choicePresent(server, asked.eventId, 4),
+    )
+    expect(await pendingChoiceOf(server, cookie)).toEqual(deliveryQuestion)
+
     // Asking something else is how a reviewer declines to choose, and the
     // browser closes the buttons on itself when it sends one.
     await sendChat(socket, 'What does the queue cost?')
 
-    const session = (await (
-      await fetch(`${server.started.origin}/api/session`, {
-        headers: { Cookie: cookie },
-      })
-    ).json()) as { readonly pendingChoice: unknown }
-    expect(session.pendingChoice).toBe(null)
+    expect(await pendingChoiceOf(server, cookie)).toBe(null)
     socket.close()
   })
 
@@ -619,22 +636,12 @@ describe('startVisualServer bootstrap and browser authentication', () => {
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const asked = await sendChat(socket, 'Which option?')
-    await postResponse(server, capability, {
-      format: 'yarramate/visual-response/v1',
-      sessionId: server.started.sessionId,
-      responseId: identifier(4),
-      eventId: asked.eventId,
-      type: 'choice.present',
-      timestamp: '2026-08-08T00:00:02.000Z',
-      payload: {
-        choiceId: 'delivery',
-        question: 'Which delivery design should we keep?',
-        options: [
-          { id: 'shared-queue', label: 'Shared queue' },
-          { id: 'isolated-worker', label: 'Isolated worker' },
-        ],
-      },
-    })
+    await postAcceptedResponse(
+      server,
+      capability,
+      choicePresent(server, asked.eventId, 4),
+    )
+    expect(await pendingChoiceOf(server, cookie)).toEqual(deliveryQuestion)
 
     const ended = nextFrame(socket, 'accepted')
     socket.send(
@@ -648,12 +655,55 @@ describe('startVisualServer bootstrap and browser authentication', () => {
 
     // A session on its way out is waiting on nobody, so a browser that comes
     // back to it is not asked a question again.
-    const session = (await (
-      await fetch(`${server.started.origin}/api/session`, {
-        headers: { Cookie: cookie },
-      })
-    ).json()) as { readonly pendingChoice: unknown }
-    expect(session.pendingChoice).toBe(null)
+    expect(await pendingChoiceOf(server, cookie)).toBe(null)
+    socket.close()
+  })
+
+  it('holds no question the agent presented after the reviewer ended', async () => {
+    const server = await start()
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const asked = await sendChat(socket, 'Which option?')
+
+    const ended = nextFrame(socket, 'accepted')
+    socket.send(
+      JSON.stringify({
+        type: 'session.end',
+        lastAcknowledgedSequence: 1,
+        payload: { reason: 'user-ended' },
+      }),
+    )
+    const end = await ended
+
+    // The agent was still composing when the End landed, so its question
+    // answers an event whose reviewer has already walked away.
+    await postAcceptedResponse(
+      server,
+      capability,
+      choicePresent(server, asked.eventId, 4),
+    )
+    // The handoff a terminating session waits for is still the agent's to
+    // send, so a response after an End stays admissible.
+    await postAcceptedResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(5),
+      eventId: end.eventId,
+      type: 'handoff.complete',
+      timestamp: '2026-08-08T00:00:05.000Z',
+      payload: {
+        summary: 'The reviewer ended before choosing a delivery design.',
+        confirmedDecisions: [],
+        requestedChanges: [],
+        unresolvedQuestions: ['Which delivery design should we keep?'],
+        finalViews: ['choices'],
+      },
+    })
+
+    // A browser that reloads into an ended session is never handed buttons it
+    // can no longer press.
+    expect(await pendingChoiceOf(server, cookie)).toBe(null)
     socket.close()
   })
 
@@ -1270,7 +1320,7 @@ describe('startVisualServer agent responses', () => {
     expect(response.status).toBe(409)
     await expect(response.json()).resolves.toMatchObject({
       accepted: false,
-      diagnostics: [{ code: 'YMVS131', pointer: '#/eventId' }],
+      diagnostics: [{ code: 'YMVS131', pointer: '/eventId' }],
     })
     expect(await journalOf(server)).toHaveLength(1)
     socket.close()
@@ -1315,11 +1365,17 @@ describe('startVisualServer agent responses', () => {
   })
 
   it('keeps the last good rendering when a replacement fails to compile', async () => {
-    const server = await start()
+    const server = await start({ agentPollMs: 60 })
     const capability = await capabilityOf(server)
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
     const accepted = await sendChat(socket, 'redraw it badly')
+    // The replacement has to answer a turn the agent is actually holding, or
+    // the failed compile has nothing to finish.
+    const turn = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=0')
+    ).json()) as { readonly event: VisualEvent }
+    expect(turn.event.eventId).toBe(accepted.eventId)
 
     const diagnosed = nextFrame(
       socket,
@@ -1357,6 +1413,17 @@ describe('startVisualServer agent responses', () => {
       })
     ).json()) as { readonly model: { readonly candidate: string } }
     expect(session.model.candidate).toBe('000001')
+
+    // A compile that failed still ends the turn its response answered, so the
+    // reviewer's next message reaches the agent instead of queueing behind a
+    // turn nobody owns any more.
+    expect(server.status().agent.inFlightEventId).toBe(null)
+    await sendChat(socket, 'try the other one')
+    const next = (await (
+      await agentFetch(server, capability, '/api/agent/events?after=1')
+    ).json()) as { readonly waiting: boolean; readonly event: VisualEvent }
+    expect(next.waiting).toBe(false)
+    expect(next.event.payload).toEqual({ text: 'try the other one' })
     socket.close()
   })
 })
@@ -1864,6 +1931,53 @@ describe('startVisualServer diagnostic conformance', () => {
     })
     socket.close()
   })
+})
+
+describe('startVisualServer teardown retries', () => {
+  /**
+   * The teardown is failed through the filesystem rather than the clock: a
+   * session root nothing may unlink from refuses the removal a stop ends with,
+   * refuses it on every attempt, and stops refusing the moment the permission
+   * comes back. A process the permission does not bind cannot see any of it.
+   */
+  const enforcesPermissions =
+    process.platform !== 'win32' && process.getuid?.() !== 0
+
+  it.skipIf(!enforcesPermissions)(
+    'retries a teardown the first stop failed to finish',
+    async () => {
+      const server = await start()
+      const root = server.started.sessionRoot
+      // Readable and traversable, so the recovery the stop reads still
+      // succeeds; not writable, so the removal that follows it cannot.
+      await chmod(root, 0o500)
+
+      await expect(server.stop('user-ended')).rejects.toThrow()
+      // Nothing was lost to the failure: the journal the retry recovers from
+      // is still the one this session wrote.
+      await expect(stat(join(root, 'journal.jsonl'))).resolves.toBeDefined()
+
+      await chmod(root, 0o700)
+      const closed = await server.stop('user-ended')
+
+      expect(closed).toMatchObject({
+        reason: 'user-ended',
+        alreadyStopped: false,
+      })
+      expect(closed.handoff).toMatchObject({
+        format: 'yarramate/visual-handoff/v1',
+        sessionId: server.started.sessionId,
+      })
+      await expect(stat(root)).rejects.toThrow()
+      await expect(server.closed).resolves.toMatchObject({
+        reason: 'user-ended',
+      })
+      expect(server.status()).toMatchObject({
+        lifecycle: 'stopped',
+        server: { listening: false },
+      })
+    },
+  )
 })
 
 it('keeps the fixture asset root free of anything the server must not serve', async () => {

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1872,6 +1872,7 @@ describe('startVisualServer lifecycle', () => {
     const server = await start()
     const { cookie } = await bootstrap(server)
     const socket = await openBrowserSocket(server, cookie)
+    await nextFrame(socket, 'ready')
     const closing = nextFrame(socket, 'closing')
     const ended = once(socket, 'close')
     await server.stop('main-cancelled')
@@ -1928,6 +1929,21 @@ describe('startVisualServer lifecycle', () => {
     expect(idle.browser.graceExpiresAt).toMatch(
       /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$/,
     )
+  })
+
+  it('does not admit a browser whose connected event cannot be journaled', async () => {
+    const server = await start()
+    const { cookie } = await bootstrap(server)
+    await chmod(join(server.started.sessionRoot, 'journal.jsonl'), 0o400)
+
+    const socket = await openBrowserSocket(server, cookie)
+    await once(socket, 'close')
+
+    expect(server.status()).toMatchObject({
+      browser: { connected: false, connections: 0 },
+      queue: { lastSequence: 0 },
+    })
+    expect(await journalOf(server)).toEqual([])
   })
 
   it('never opens an agent turn for a browser lifecycle record', async () => {

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { once } from 'node:events'
 import {
   mkdir,
@@ -6,6 +7,7 @@ import {
   rm,
   stat,
   symlink,
+  watch,
   writeFile,
 } from 'node:fs/promises'
 import { connect } from 'node:net'
@@ -16,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { WebSocket } from 'ws'
 import {
   VISUAL_LIMITS,
+  parseVisualSessionDescriptor,
   type VisualEvent,
   type VisualModel,
   type VisualResponse,
@@ -84,13 +87,25 @@ const start = async (overrides: Partial<VisualServerOptions> = {}) => {
   return handle
 }
 
-/** The agent capability lives only in the mode 0600 descriptor. */
-const capabilityOf = async (handle: VisualServerHandle): Promise<string> => {
-  const descriptor: unknown = JSON.parse(
-    await readFile(handle.started.descriptorPath, 'utf8'),
+/**
+ * Reads the private descriptor through the protocol parser, so a test that
+ * depends on one of its fields also asserts the document is valid.
+ */
+const readDescriptor = async (descriptorPath: string) => {
+  const parsed = parseVisualSessionDescriptor(
+    JSON.parse(await readFile(descriptorPath, 'utf8')),
   )
-  return (descriptor as { readonly agentCapability: string }).agentCapability
+  if (!parsed.ok) {
+    throw new Error(
+      `descriptor "${descriptorPath}" is invalid: ${parsed.diagnostics[0]?.message}`,
+    )
+  }
+  return parsed.value
 }
+
+/** The agent capability lives only in the mode 0600 descriptor. */
+const capabilityOf = async (handle: VisualServerHandle) =>
+  (await readDescriptor(handle.started.descriptorPath)).agentCapability
 
 const bootstrap = async (handle: VisualServerHandle) => {
   const response = await fetch(handle.started.browserUrl, {
@@ -200,24 +215,22 @@ const chatResponse = (
 /**
  * Waits for the journal named by a session descriptor to carry an event past
  * `after`. The descriptor is the agent's only entry point into the session, so
- * the helper reads the journal the way an out-of-process agent would.
+ * the helper reads the journal the way an out-of-process agent would, and it
+ * waits on the file's own change events rather than on a guessed delay.
  */
 const waitForVisualEvent = async (
   descriptorPath: string,
   after: number,
 ): Promise<VisualEvent> => {
-  const descriptor: unknown = JSON.parse(await readFile(descriptorPath, 'utf8'))
-  const journalPath = (descriptor as { readonly journalPath: string })
-    .journalPath
-  const deadline = Date.now() + 5000
-  for (;;) {
+  const { journalPath } = await readDescriptor(descriptorPath)
+  const journaled = async () => {
     let lines: string[] = []
     try {
       lines = (await readFile(journalPath, 'utf8'))
         .split('\n')
         .filter((line) => line.length > 0)
     } catch {
-      lines = []
+      return undefined
     }
     for (const line of lines) {
       const event = JSON.parse(line) as VisualEvent
@@ -228,11 +241,16 @@ const waitForVisualEvent = async (
         return event
       }
     }
-    if (Date.now() > deadline) {
-      throw new Error(`no event past ${after} in "${journalPath}"`)
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    return undefined
   }
+  const already = await journaled()
+  if (already !== undefined) return already
+  // The journal exists from session creation, so it can be watched directly.
+  for await (const _change of watch(journalPath)) {
+    const appended = await journaled()
+    if (appended !== undefined) return appended
+  }
+  throw new Error(`no event past ${after} in "${journalPath}"`)
 }
 
 const journalOf = async (handle: VisualServerHandle) =>
@@ -1114,7 +1132,12 @@ describe('startVisualServer lifecycle', () => {
     const server = await start()
     const capability = await capabilityOf(server)
     const polled = agentFetch(server, capability, '/api/agent/events?after=0')
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    // A real long poll has to reach the server before the stop does, and the
+    // request is in undici's hands until then: there is no in-process signal to
+    // await, and a fake clock cannot move a socket.
+    const onTheWire = Promise.withResolvers<void>()
+    setTimeout(onTheWire.resolve, 20)
+    await onTheWire.promise
     await server.stop('main-cancelled')
     await expect((await polled).json()).resolves.toMatchObject({
       waiting: true,
@@ -1153,6 +1176,170 @@ describe('startVisualServer lifecycle', () => {
     expect(idle.browser.graceExpiresAt).toMatch(
       /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$/,
     )
+  })
+})
+
+describe('startVisualServer shutdown and admission races', () => {
+  /**
+   * Rejections raised by fire-and-forget socket work never reach a test's
+   * `await`, so they are collected from the process the way Node would see
+   * them: an empty list is the assertion that nothing crashed the runtime.
+   */
+  const collectRejections = () => {
+    const seen: unknown[] = []
+    const observe = (reason: unknown) => seen.push(reason)
+    process.on('unhandledRejection', observe)
+    return {
+      seen,
+      settled: async () => {
+        // A rejection is reported a macrotask after it is raised, so give the
+        // loop two turns before deciding nothing was left unobserved.
+        for (let turn = 0; turn < 2; turn += 1) {
+          const tick = Promise.withResolvers<void>()
+          setImmediate(tick.resolve)
+          await tick.promise
+        }
+        process.off('unhandledRejection', observe)
+        return seen
+      },
+    }
+  }
+
+  it('never journals a browser frame that raced the stop it lost', async () => {
+    const server = await start({ includeTranscript: true })
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejections = collectRejections()
+
+    // Enqueued, unacknowledged, and deliberately not awaited: every frame is
+    // already on the admission chain when the stop begins.
+    for (let sent = 0; sent < 8; sent += 1) {
+      socket.send(
+        JSON.stringify({ type: 'chat.message', payload: { text: `race ${sent}` } }),
+      )
+    }
+    const closed = await server.stop('main-cancelled')
+
+    expect(closed).toMatchObject({
+      reason: 'main-cancelled',
+      alreadyStopped: false,
+    })
+    expect(closed.handoff).toBeDefined()
+    // Recovery must observe a settled journal: every sequence it counted is a
+    // record it could actually read.
+    const events = (closed.handoff?.transcript ?? []).filter(
+      (record) => record.format === 'yarramate/visual-event/v1',
+    )
+    expect(events).toHaveLength(closed.handoff?.lastSequence ?? -1)
+    await expect(server.closed).resolves.toMatchObject({
+      reason: 'main-cancelled',
+    })
+    await expect(server.stop('user-ended')).resolves.toMatchObject({
+      alreadyStopped: true,
+      reason: 'main-cancelled',
+    })
+    expect(server.status()).toMatchObject({
+      lifecycle: 'stopped',
+      alreadyStopped: true,
+    })
+    // Nothing may recreate the session directory after recovery deleted it.
+    await expect(stat(server.started.sessionRoot)).rejects.toThrow()
+    expect(await rejections.settled()).toEqual([])
+  })
+
+  it('tells the browser when admitting its frame fails', async () => {
+    let narrow = 0
+    const server = await start({
+      // 16-byte draws mint the session id, then the connection id, then event
+      // identifiers; failing from the first event id makes admission throw
+      // inside the socket's own fire-and-forget handler.
+      randomBytes: (size: number) => {
+        if (size !== 16) return randomBytes(size)
+        narrow += 1
+        if (narrow >= 3) throw new Error('random source unavailable')
+        return randomBytes(16)
+      },
+    })
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const rejections = collectRejections()
+
+    const rejected = nextFrame(socket, 'rejected')
+    socket.send(
+      JSON.stringify({ type: 'chat.message', payload: { text: 'unminted' } }),
+    )
+
+    expect((await rejected).diagnostics[0]?.code).toBe('YMVS307')
+    expect(await journalOf(server)).toHaveLength(0)
+    // The session survives a failed admission and still answers.
+    expect(server.status().lifecycle).toBe('running')
+    expect(await rejections.settled()).toEqual([])
+  })
+
+  it('never journals a frame sent after the drain began', async () => {
+    const server = await start({ includeTranscript: true })
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    await sendChat(socket, 'in time')
+    const rejections = collectRejections()
+
+    // The stop marks the session draining and starts the socket's closing
+    // handshake synchronously, but the client is still OPEN for a moment: a
+    // frame written now can reach a session that is already recovering.
+    const stopping = server.stop('main-cancelled')
+    socket.send(
+      JSON.stringify({ type: 'chat.message', payload: { text: 'too late' } }),
+    )
+    const closed = await stopping
+
+    const texts = (closed.handoff?.transcript ?? [])
+      .filter((record) => record.type === 'chat.message')
+      .map((record) => JSON.stringify(record.payload))
+    expect(texts).toEqual([JSON.stringify({ text: 'in time' })])
+    await expect(stat(server.started.sessionRoot)).rejects.toThrow()
+    expect(await rejections.settled()).toEqual([])
+  })
+
+  it('finishes admitted work before recovering the session', async () => {
+    const server = await start({ includeTranscript: true })
+    const capability = await capabilityOf(server)
+    const { cookie } = await bootstrap(server)
+    const socket = await openBrowserSocket(server, cookie)
+    const accepted = await sendChat(socket, 'redraw it badly')
+    const rejections = collectRejections()
+
+    // A model replacement is journaled and broadcast before its candidate is
+    // compiled, so this frame is the signal that admitted work is genuinely
+    // in flight — the compile, and the diagnostic it will journal, are not.
+    const inFlight = nextFrame(
+      socket,
+      'response',
+      (frame) => frame.response.type === 'model.replace',
+    )
+    const posted = postResponse(server, capability, {
+      format: 'yarramate/visual-response/v1',
+      sessionId: server.started.sessionId,
+      responseId: identifier(6),
+      eventId: accepted.eventId,
+      type: 'model.replace',
+      timestamp: '2026-08-08T00:00:06.000Z',
+      payload: { model: modelWith('invalid') },
+    })
+    await inFlight
+
+    const closed = await server.stop('main-cancelled')
+
+    // Shutdown waited for the compile to fail and for its diagnostic to be
+    // journaled, so recovery reports work the server had already accepted.
+    const types = (closed.handoff?.transcript ?? []).map((record) => record.type)
+    expect(types).toContain('model.replace')
+    expect(types).toContain('diagnostic')
+    await expect((await posted).json()).resolves.toMatchObject({
+      accepted: true,
+      diagnostics: [{ code: 'YMVS201' }],
+    })
+    await expect(stat(server.started.sessionRoot)).rejects.toThrow()
+    expect(await rejections.settled()).toEqual([])
   })
 })
 

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -402,6 +402,36 @@ describe('visual session store', () => {
       expect(await journalLines(session.paths.journal)).toHaveLength(0)
     })
 
+    it('rejects a response whose triggering event was never journaled', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+
+      const fabricated = await appendVisualResponse(session.paths, {
+        ...chatResponse,
+        eventId: identifier(0xbad),
+      })
+
+      expect(fabricated.ok).toBe(false)
+      expect(
+        fabricated.ok === false && fabricated.diagnostics[0],
+      ).toMatchObject({ code: 'YMVS131', pointer: '#/eventId' })
+      expect(await journalLines(session.paths.journal)).toHaveLength(1)
+    })
+
+    it('accepts the handoff that answers a journaled End', async () => {
+      const session = await startSession()
+      const end = endEvent(1, 'user-ended')
+      await appendVisualEvent(session.paths, end)
+
+      expect(
+        await appendVisualResponse(session.paths, {
+          ...handoffResponse,
+          eventId: end.eventId,
+        }),
+      ).toMatchObject({ ok: true, duplicate: false })
+      expect(await journalLines(session.paths.journal)).toHaveLength(2)
+    })
+
     it('treats a duplicate response as an accepted no-op', async () => {
       const session = await startSession()
       await appendVisualEvent(session.paths, chatEvent)
@@ -436,6 +466,10 @@ describe('visual session store', () => {
 
     it('freezes the session at exactly the 5 MiB transcript limit', async () => {
       const session = await startSession()
+      // Every response answers a journaled event, so the event this session
+      // opens with is part of the budget the responses then fill.
+      await appendVisualEvent(session.paths, chatEvent)
+      const opening = Buffer.byteLength(JSON.stringify(chatEvent), 'utf8') + 1
       const filler = 'x'.repeat(32768)
       const overhead =
         Buffer.byteLength(
@@ -444,8 +478,9 @@ describe('visual session store', () => {
         ) + 1
       const fullLine = overhead + filler.length
 
-      let count = Math.floor(VISUAL_LIMITS.transcriptBytes / fullLine)
-      let finalText = VISUAL_LIMITS.transcriptBytes - count * fullLine - overhead
+      const budget = VISUAL_LIMITS.transcriptBytes - opening
+      let count = Math.floor(budget / fullLine)
+      let finalText = budget - count * fullLine - overhead
       if (finalText < 1) {
         count -= 1
         finalText += fullLine

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -15,6 +15,7 @@ import { basename, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   VISUAL_LIMITS,
+  parseVisualDiagnosticResult,
   type VisualDiagnostic,
   type VisualEvent,
   type VisualModel,
@@ -414,8 +415,63 @@ describe('visual session store', () => {
       expect(fabricated.ok).toBe(false)
       expect(
         fabricated.ok === false && fabricated.diagnostics[0],
-      ).toMatchObject({ code: 'YMVS131', pointer: '#/eventId' })
+      ).toMatchObject({ code: 'YMVS131', pointer: '/eventId' })
       expect(await journalLines(session.paths.journal)).toHaveLength(1)
+    })
+
+    /**
+     * Every refusal is read back by the one-shot agent clients out of a
+     * `visual-diagnostic-result/v1` document, and whatever that document
+     * refuses is dropped rather than repaired — so a pointer that is not the
+     * RFC 6901 the schema requires costs the caller the code that explains
+     * the refusal, and buys a transport error in its place.
+     */
+    it('mints refusals the one-shot client keeps rather than drops', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+
+      const refused = [
+        await appendVisualEvent(session.paths, {
+          ...chatEvent,
+          sessionId: 'ab'.repeat(16),
+        }),
+        await appendVisualEvent(session.paths, { ...chatEvent, sequence: 2 }),
+        await appendVisualEvent(session.paths, {
+          ...chatEvent,
+          eventId: identifier(0x5e),
+        }),
+        await appendVisualResponse(session.paths, {
+          ...chatResponse,
+          eventId: identifier(0xbad),
+        }),
+      ]
+      await appendVisualEvent(session.paths, endEvent(2, 'user-ended'))
+      refused.push(
+        await appendVisualEvent(session.paths, {
+          ...chatEvent,
+          sequence: 3,
+          eventId: identifier(0x5f),
+        }),
+      )
+      const diagnostics = refused.flatMap((result) =>
+        result.ok ? [] : result.diagnostics,
+      )
+
+      expect(
+        diagnostics.map(({ code, pointer }) => [code, pointer]),
+      ).toEqual([
+        ['YMVS126', '/sessionId'],
+        ['YMVS127', '/eventId'],
+        ['YMVS121', '/sequence'],
+        ['YMVS131', '/eventId'],
+        ['YMVS130', '/type'],
+      ])
+      expect(
+        parseVisualDiagnosticResult({
+          format: 'yarramate/visual-diagnostic-result/v1',
+          diagnostics,
+        }),
+      ).toMatchObject({ ok: true })
     })
 
     it('accepts the handoff that answers a journaled End', async () => {
@@ -517,7 +573,19 @@ describe('visual session store', () => {
       })
 
       expect(frozen).toMatchObject({ ok: false, freeze: 'transcript-bytes' })
-      expect(frozen.ok === false && frozen.diagnostics[0]?.code).toBe('YMVS122')
+      const overflow = frozen.ok === false ? frozen.diagnostics : []
+      expect(overflow[0]).toMatchObject({
+        code: 'YMVS122',
+        pointer: '/payload',
+      })
+      // The freeze reaches the agent only through the one-shot client's strict
+      // read of a diagnostic result, which keeps nothing that document refuses.
+      expect(
+        parseVisualDiagnosticResult({
+          format: 'yarramate/visual-diagnostic-result/v1',
+          diagnostics: overflow,
+        }),
+      ).toMatchObject({ ok: true })
       expect((await stat(session.paths.journal)).size).toBe(
         VISUAL_LIMITS.transcriptBytes,
       )
@@ -735,7 +803,7 @@ describe('visual session store', () => {
         code: 'YMVS201',
         message: 'Unknown element',
         path: 'model.likec4',
-        pointer: '#/files/model.likec4',
+        pointer: '/files/model.likec4',
         line: 1,
         column: 1,
       }

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -1,0 +1,878 @@
+import { existsSync } from 'node:fs'
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  VISUAL_LIMITS,
+  type VisualDiagnostic,
+  type VisualEvent,
+  type VisualModel,
+  type VisualResponse,
+  type VisualSessionRequest,
+} from '../src/adapters/visual/protocol.js'
+import {
+  VISUAL_SESSION_MARKER_FORMAT,
+  VISUAL_SESSION_PRUNE_LIMIT,
+  appendVisualEvent,
+  appendVisualResponse,
+  createVisualSession,
+  promoteCompiledModel,
+  pruneStaleVisualSessions,
+  readActionableEventsAfter,
+  readActiveVisualModel,
+  recoverVisualSession,
+  removeVisualSession,
+  visualSessionPaths,
+} from '../src/adapters/visual/session-store.js'
+
+const model: VisualModel = {
+  format: 'yarramate/visual-model/v1',
+  authority: 'ad-hoc',
+  initialView: 'choices',
+  sourceDigests: {},
+  files: {
+    'likec4.config.json': '{"name":"visual"}',
+    'model.likec4': 'model { system = system "System" }',
+    'views/choices.likec4': 'views { view choices { include * } }',
+  },
+}
+
+const request: VisualSessionRequest = {
+  format: 'yarramate/visual-session-request/v1',
+  authority: 'ad-hoc',
+  title: 'Choose a delivery design',
+  description: 'Temporary non-canonical comparison',
+  chatEnabled: true,
+  compiler: { command: '/usr/bin/node', args: ['fake-likec4.mjs'] },
+  initialModel: model,
+}
+
+// Buffer.alloc(32, 7) is the brief's random source; the store must honour the
+// requested width, so the 16-byte session id is '07' sixteen times over.
+const sessionId = '07'.repeat(16)
+const browserSecret = '07'.repeat(32)
+
+const identifier = (index: number) => index.toString(16).padStart(32, '0')
+
+const posixOnly = process.platform !== 'win32'
+const modeOf = async (path: string) => (await stat(path)).mode & 0o777
+const journalLines = async (path: string) =>
+  (await readFile(path, 'utf8')).split('\n').filter((line) => line.length > 0)
+
+const chatEvent: VisualEvent = {
+  format: 'yarramate/visual-event/v1',
+  sessionId,
+  sequence: 1,
+  eventId: identifier(1),
+  type: 'chat.message',
+  timestamp: '2026-08-08T00:00:01.000Z',
+  payload: { text: 'Compare the two delivery designs' },
+}
+
+const chatResponse: VisualResponse = {
+  format: 'yarramate/visual-response/v1',
+  sessionId,
+  responseId: identifier(2),
+  eventId: identifier(1),
+  type: 'chat.response',
+  timestamp: '2026-08-08T00:00:02.000Z',
+  payload: { text: 'Design A isolates delivery; design B shares it.' },
+}
+
+const handoffResponse = {
+  format: 'yarramate/visual-response/v1',
+  sessionId,
+  responseId: identifier(3),
+  eventId: identifier(1),
+  type: 'handoff.complete',
+  timestamp: '2026-08-08T00:00:03.000Z',
+  payload: {
+    summary: 'The user chose the isolated delivery design.',
+    confirmedDecisions: ['Isolate delivery behind its own boundary'],
+    requestedChanges: [],
+    unresolvedQuestions: ['Does billing still need synchronous delivery?'],
+    finalViews: ['choices'],
+  },
+} satisfies VisualResponse
+
+const endEvent = (sequence: number, reason: 'user-ended' | 'browser-timeout') =>
+  ({
+    format: 'yarramate/visual-event/v1',
+    sessionId,
+    sequence,
+    eventId: identifier(900 + sequence),
+    type: 'session.end',
+    timestamp: '2026-08-08T00:01:00.000Z',
+    payload: { reason },
+  }) satisfies VisualEvent
+
+const navigateEvent = (
+  sequence: number,
+  viewId: string,
+  requiresAttention: boolean,
+) =>
+  ({
+    format: 'yarramate/visual-event/v1',
+    sessionId,
+    sequence,
+    eventId: identifier(500 + sequence),
+    type: 'view.navigate',
+    timestamp: '2026-08-08T00:00:10.000Z',
+    payload: { viewId, requiresAttention },
+  }) satisfies VisualEvent
+
+const sessionDeps = (
+  baseDir: string,
+  createdAt = '2026-08-08T00:00:00.000Z',
+) => ({
+  baseDir,
+  now: () => new Date(createdAt),
+  randomBytes: () => Buffer.alloc(32, 7),
+})
+
+const compilesCleanly = async () => []
+
+describe('visual session store', () => {
+  let parent = ''
+
+  beforeEach(async () => {
+    parent = await mkdtemp(join(tmpdir(), 'yarramate-visual-store-'))
+  })
+
+  afterEach(async () => {
+    await rm(parent, { recursive: true, force: true })
+  })
+
+  const startSession = async (createdAt?: string) =>
+    createVisualSession(request, sessionDeps(parent, createdAt))
+
+  describe('session creation', () => {
+    it('places every session artefact inside one private directory', async () => {
+      const session = await startSession()
+
+      expect(session.paths).toEqual(visualSessionPaths(join(parent, sessionId)))
+      expect(session.paths.root).toBe(join(parent, sessionId))
+      expect(session.paths.marker).toBe(join(parent, sessionId, 'session.json'))
+      expect(session.paths.journal).toBe(
+        join(parent, sessionId, 'journal.jsonl'),
+      )
+      expect(await readFile(session.paths.journal, 'utf8')).toBe('')
+    })
+
+    it('writes a versioned session marker naming its own directory', async () => {
+      const session = await startSession()
+
+      expect(JSON.parse(await readFile(session.paths.marker, 'utf8'))).toEqual({
+        format: VISUAL_SESSION_MARKER_FORMAT,
+        id: sessionId,
+        createdAt: '2026-08-08T00:00:00.000Z',
+        authority: 'ad-hoc',
+      })
+    })
+
+    it('records the authority label recovery has to report', async () => {
+      const canonicalModel: VisualModel = {
+        ...model,
+        authority: 'canonical',
+        sourceDigests: { 'model.likec4': 'a'.repeat(64) },
+      }
+      const session = await createVisualSession(
+        {
+          ...request,
+          authority: 'canonical',
+          initialModel: canonicalModel,
+        },
+        sessionDeps(parent),
+      )
+
+      expect(await recoverVisualSession(session.paths)).toMatchObject({
+        authority: 'canonical',
+      })
+    })
+
+    it('rejects a session request that fails protocol validation', async () => {
+      const broken = { ...request, authority: 'canonical' } as const
+
+      await expect(
+        createVisualSession(
+          broken as unknown as VisualSessionRequest,
+          sessionDeps(parent),
+        ),
+      ).rejects.toThrow(/YMVS1/)
+      expect(existsSync(join(parent, sessionId))).toBe(false)
+    })
+
+    it('draws the browser and agent capabilities independently', async () => {
+      let draw = 0
+      const session = await createVisualSession(request, {
+        baseDir: parent,
+        now: () => new Date('2026-08-08T00:00:00.000Z'),
+        randomBytes: (size) => Buffer.alloc(size, (draw += 1)),
+      })
+
+      expect(session.browserToken).toHaveLength(64)
+      expect(session.agentToken).toHaveLength(64)
+      expect(session.browserToken).not.toBe(session.agentToken)
+      expect(session.paths.root).toBe(join(parent, '01'.repeat(16)))
+    })
+
+    it('never reuses an existing session directory', async () => {
+      await startSession()
+
+      await expect(startSession()).rejects.toThrow()
+    })
+
+    it.skipIf(!posixOnly)(
+      'creates directories 0700 and sensitive files 0600',
+      async () => {
+        const session = await startSession()
+
+        expect(await modeOf(session.paths.root)).toBe(0o700)
+        expect(await modeOf(session.paths.candidates)).toBe(0o700)
+        expect(await modeOf(session.paths.marker)).toBe(0o600)
+        expect(await modeOf(session.paths.journal)).toBe(0o600)
+      },
+    )
+  })
+
+  describe('append-only journal', () => {
+    it('appends one UTF-8 JSON line per record in call order', async () => {
+      const session = await startSession()
+
+      expect(await appendVisualEvent(session.paths, chatEvent)).toMatchObject({
+        ok: true,
+        lastSequence: 1,
+      })
+      expect(
+        await appendVisualResponse(session.paths, chatResponse),
+      ).toMatchObject({ ok: true, lastSequence: 1 })
+
+      expect(
+        (await journalLines(session.paths.journal)).map(
+          (line) => JSON.parse(line) as unknown,
+        ),
+      ).toEqual([chatEvent, chatResponse])
+    })
+
+    it('rejects an event whose sequence does not advance', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, { ...chatEvent, sequence: 4 })
+
+      const replay = await appendVisualEvent(session.paths, {
+        ...chatEvent,
+        sequence: 4,
+        eventId: identifier(11),
+      })
+
+      expect(replay.ok).toBe(false)
+      expect(replay.ok === false && replay.diagnostics[0]?.code).toBe('YMVS121')
+      expect(await journalLines(session.paths.journal)).toHaveLength(1)
+    })
+
+    it('rejects a replayed event identifier', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+
+      const replay = await appendVisualEvent(session.paths, {
+        ...chatEvent,
+        sequence: 2,
+      })
+
+      expect(replay.ok).toBe(false)
+      expect(replay.ok === false && replay.diagnostics[0]?.code).toBe('YMVS127')
+      expect(await journalLines(session.paths.journal)).toHaveLength(1)
+    })
+
+    it('rejects a record belonging to another session', async () => {
+      const session = await startSession()
+
+      const foreign = await appendVisualEvent(session.paths, {
+        ...chatEvent,
+        sessionId: 'ab'.repeat(16),
+      })
+
+      expect(foreign.ok).toBe(false)
+      expect(foreign.ok === false && foreign.diagnostics[0]?.code).toBe(
+        'YMVS126',
+      )
+      expect(await journalLines(session.paths.journal)).toHaveLength(0)
+    })
+
+    it('rejects a malformed record before it reaches the journal', async () => {
+      const session = await startSession()
+
+      const rejected = await appendVisualEvent(session.paths, {
+        ...chatEvent,
+        payload: { text: '' },
+      } as unknown as VisualEvent)
+
+      expect(rejected.ok).toBe(false)
+      expect(await journalLines(session.paths.journal)).toHaveLength(0)
+    })
+
+    it('treats a duplicate response as an accepted no-op', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendVisualResponse(session.paths, chatResponse)
+
+      const again = await appendVisualResponse(session.paths, chatResponse)
+
+      expect(again).toMatchObject({ ok: true, duplicate: true })
+      expect(await journalLines(session.paths.journal)).toHaveLength(2)
+    })
+
+    it('serialises concurrent appends without interleaving lines', async () => {
+      const session = await startSession()
+
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          appendVisualEvent(session.paths, {
+            ...chatEvent,
+            sequence: index + 1,
+            eventId: identifier(index + 20),
+          }),
+        ),
+      )
+
+      expect(results.every((result) => result.ok)).toBe(true)
+      const lines = await journalLines(session.paths.journal)
+      expect(lines).toHaveLength(8)
+      expect(
+        lines.map((line) => (JSON.parse(line) as VisualEvent).sequence),
+      ).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    })
+
+    it('freezes the session at exactly the 5 MiB transcript limit', async () => {
+      const session = await startSession()
+      const filler = 'x'.repeat(32768)
+      const overhead =
+        Buffer.byteLength(
+          JSON.stringify({ ...chatResponse, payload: { text: '' } }),
+          'utf8',
+        ) + 1
+      const fullLine = overhead + filler.length
+
+      let count = Math.floor(VISUAL_LIMITS.transcriptBytes / fullLine)
+      let finalText = VISUAL_LIMITS.transcriptBytes - count * fullLine - overhead
+      if (finalText < 1) {
+        count -= 1
+        finalText += fullLine
+      }
+      expect(finalText).toBeGreaterThan(0)
+      expect(finalText).toBeLessThanOrEqual(VISUAL_LIMITS.messageBytes)
+
+      for (let index = 0; index < count; index += 1) {
+        const accepted = await appendVisualResponse(session.paths, {
+          ...chatResponse,
+          responseId: identifier(1000 + index),
+          payload: { text: filler },
+        })
+        expect(accepted.ok).toBe(true)
+      }
+      const last = await appendVisualResponse(session.paths, {
+        ...chatResponse,
+        responseId: identifier(2000),
+        payload: { text: 'y'.repeat(finalText) },
+      })
+
+      expect(last).toMatchObject({
+        ok: true,
+        transcriptBytes: VISUAL_LIMITS.transcriptBytes,
+      })
+      expect((await stat(session.paths.journal)).size).toBe(
+        VISUAL_LIMITS.transcriptBytes,
+      )
+
+      const frozen = await appendVisualResponse(session.paths, {
+        ...chatResponse,
+        responseId: identifier(2001),
+        payload: { text: 'z' },
+      })
+
+      expect(frozen).toMatchObject({ ok: false, freeze: 'transcript-bytes' })
+      expect(frozen.ok === false && frozen.diagnostics[0]?.code).toBe('YMVS122')
+      expect((await stat(session.paths.journal)).size).toBe(
+        VISUAL_LIMITS.transcriptBytes,
+      )
+    })
+  })
+
+  describe('actionable events', () => {
+    it('returns only events after a sequence that need an agent turn', async () => {
+      const session = await startSession()
+      const records: readonly VisualEvent[] = [
+        {
+          format: 'yarramate/visual-event/v1',
+          sessionId,
+          sequence: 1,
+          eventId: identifier(31),
+          type: 'browser.connected',
+          timestamp: '2026-08-08T00:00:00.500Z',
+          payload: { connectionId: 'c1' },
+        },
+        { ...chatEvent, sequence: 2 },
+        navigateEvent(3, 'choices', false),
+        navigateEvent(4, 'detail', true),
+        {
+          format: 'yarramate/visual-event/v1',
+          sessionId,
+          sequence: 5,
+          eventId: identifier(35),
+          type: 'choice.selected',
+          timestamp: '2026-08-08T00:00:20.000Z',
+          payload: { choiceId: 'delivery', optionId: 'isolated' },
+        },
+        endEvent(6, 'user-ended'),
+      ]
+      for (const record of records) {
+        expect(await appendVisualEvent(session.paths, record)).toMatchObject({
+          ok: true,
+        })
+      }
+
+      expect(
+        (await readActionableEventsAfter(session.paths, 0)).map(
+          (event) => event.sequence,
+        ),
+      ).toEqual([2, 4, 5, 6])
+      expect(
+        (await readActionableEventsAfter(session.paths, 4)).map(
+          (event) => event.type,
+        ),
+      ).toEqual(['choice.selected', 'session.end'])
+      expect(await readActionableEventsAfter(session.paths, 6)).toEqual([])
+    })
+  })
+
+  describe('recovery', () => {
+    it('recovers accepted events and the summary without exposing the transcript', async () => {
+      const session = await createVisualSession(request, {
+        baseDir: parent,
+        now: () => new Date('2026-08-08T00:00:00.000Z'),
+        randomBytes: () => Buffer.alloc(32, 7),
+      })
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendVisualResponse(session.paths, chatResponse)
+      await appendVisualResponse(session.paths, handoffResponse)
+
+      expect(await recoverVisualSession(session.paths, false)).toMatchObject({
+        format: 'yarramate/visual-handoff/v1',
+        summary: handoffResponse.payload.summary,
+        transcript: undefined,
+        lastSequence: 1,
+      })
+      expect(await recoverVisualSession(session.paths, true)).toMatchObject({
+        transcript: [chatEvent, chatResponse],
+      })
+    })
+
+    it('reports a completed handoff only when the user ended the session', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendVisualResponse(session.paths, handoffResponse)
+      await appendVisualEvent(session.paths, endEvent(2, 'user-ended'))
+
+      expect(await recoverVisualSession(session.paths)).toMatchObject({
+        sessionId,
+        authority: 'ad-hoc',
+        decision: 'completed',
+        terminationReason: 'user-ended',
+        lastSequence: 2,
+        transcriptPath: session.paths.journal,
+        completedAt: '2026-08-08T00:01:00.000Z',
+        confirmedDecisions: handoffResponse.payload.confirmedDecisions,
+        unresolvedQuestions: handoffResponse.payload.unresolvedQuestions,
+        finalViews: ['choices'],
+      })
+    })
+
+    it('blames the child when the user ended without a submitted handoff', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendVisualEvent(session.paths, endEvent(2, 'user-ended'))
+
+      expect(await recoverVisualSession(session.paths)).toMatchObject({
+        decision: 'failed',
+        terminationReason: 'child-failed',
+        lastSequence: 2,
+      })
+    })
+
+    it('reports a server failure when nothing terminated the session', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, navigateEvent(1, 'choices', false))
+      await appendVisualEvent(session.paths, navigateEvent(2, 'detail', true))
+
+      expect(await recoverVisualSession(session.paths)).toMatchObject({
+        decision: 'failed',
+        terminationReason: 'server-failed',
+        finalViews: ['choices', 'detail'],
+        lastSequence: 2,
+      })
+    })
+
+    it('recovers an empty journal without inventing a summary', async () => {
+      const session = await startSession()
+
+      expect(await recoverVisualSession(session.paths)).toMatchObject({
+        decision: 'failed',
+        terminationReason: 'server-failed',
+        lastSequence: 0,
+        completedAt: '2026-08-08T00:00:00.000Z',
+        finalViews: [],
+      })
+    })
+
+    it('ignores a torn final line and resumes the journal after a restart', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendFile(
+        session.paths.journal,
+        '{"format":"yarramate/visual-event/v1","sessi',
+      )
+
+      expect(await recoverVisualSession(session.paths, true)).toMatchObject({
+        lastSequence: 1,
+        transcript: [chatEvent],
+      })
+
+      const resumed = await appendVisualEvent(session.paths, {
+        ...chatEvent,
+        sequence: 2,
+        eventId: identifier(41),
+      })
+
+      expect(resumed).toMatchObject({ ok: true, lastSequence: 2 })
+      expect(
+        (await journalLines(session.paths.journal)).map(
+          (line) => (JSON.parse(line) as VisualEvent).sequence,
+        ),
+      ).toEqual([1, 2])
+    })
+
+    it('rejects a malformed complete journal line', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendFile(session.paths.journal, '{"format":"nope"}\n')
+
+      await expect(recoverVisualSession(session.paths)).rejects.toThrow(
+        /YMVS123/,
+      )
+    })
+
+    it('rejects a session directory without a valid marker', async () => {
+      const unmarked = join(parent, 'not-a-session')
+      await mkdir(unmarked, { mode: 0o700 })
+      await writeFile(join(unmarked, 'journal.jsonl'), '', { mode: 0o600 })
+
+      await expect(
+        recoverVisualSession(visualSessionPaths(unmarked)),
+      ).rejects.toThrow(/YMVS124/)
+    })
+  })
+
+  describe('model promotion', () => {
+    it('advances the active pointer only after compilation succeeds', async () => {
+      const session = await startSession()
+
+      const first = await promoteCompiledModel(session.paths, {
+        model,
+        now: () => new Date('2026-08-08T00:00:05.000Z'),
+        compile: compilesCleanly,
+      })
+
+      expect(first).toMatchObject({ promoted: true, candidate: '000001' })
+      expect(await readActiveVisualModel(session.paths)).toMatchObject({
+        candidate: '000001',
+        authority: 'ad-hoc',
+        initialView: 'choices',
+        promotedAt: '2026-08-08T00:00:05.000Z',
+      })
+      expect(
+        await readFile(
+          join(first.candidateDir, 'views/choices.likec4'),
+          'utf8',
+        ),
+      ).toBe(model.files['views/choices.likec4'])
+    })
+
+    it('keeps the last good pointer when a candidate fails to compile', async () => {
+      const session = await startSession()
+      await promoteCompiledModel(session.paths, {
+        model,
+        now: () => new Date('2026-08-08T00:00:05.000Z'),
+        compile: compilesCleanly,
+      })
+      const diagnostic: VisualDiagnostic = {
+        severity: 'error',
+        code: 'YMVS201',
+        message: 'Unknown element',
+        path: 'model.likec4',
+        pointer: '#/files/model.likec4',
+        line: 1,
+        column: 1,
+      }
+
+      const rejected = await promoteCompiledModel(session.paths, {
+        model: { ...model, initialView: 'detail' },
+        now: () => new Date('2026-08-08T00:00:09.000Z'),
+        compile: async () => [diagnostic],
+      })
+
+      expect(rejected).toMatchObject({
+        promoted: false,
+        candidate: '000002',
+        diagnostics: [diagnostic],
+      })
+      expect(existsSync(join(rejected.candidateDir, 'model.likec4'))).toBe(true)
+      expect(await readActiveVisualModel(session.paths)).toMatchObject({
+        candidate: '000001',
+        initialView: 'choices',
+      })
+    })
+
+    it('stages each candidate under a fresh monotonic directory', async () => {
+      const session = await startSession()
+      const promote = (iso: string) =>
+        promoteCompiledModel(session.paths, {
+          model,
+          now: () => new Date(iso),
+          compile: compilesCleanly,
+        })
+
+      await promote('2026-08-08T00:00:05.000Z')
+      await promote('2026-08-08T00:00:06.000Z')
+      const third = await promote('2026-08-08T00:00:07.000Z')
+
+      expect(third.candidate).toBe('000003')
+      expect((await readdir(session.paths.candidates)).sort()).toEqual([
+        '000001',
+        '000002',
+        '000003',
+      ])
+      expect(await readActiveVisualModel(session.paths)).toMatchObject({
+        candidate: '000003',
+      })
+    })
+
+    it('refuses to stage a model that fails protocol validation', async () => {
+      const session = await startSession()
+
+      await expect(
+        promoteCompiledModel(session.paths, {
+          model: {
+            ...model,
+            files: { ...model.files, '../escape.c4': 'model {}' },
+          },
+          now: () => new Date('2026-08-08T00:00:05.000Z'),
+          compile: async () => {
+            throw new Error('compiler must not run for an invalid candidate')
+          },
+        }),
+      ).rejects.toThrow(/YMVS1/)
+      expect(await readdir(session.paths.candidates)).toEqual([])
+      expect(existsSync(join(parent, 'escape.c4'))).toBe(false)
+    })
+
+    it('reports no active model before the first promotion', async () => {
+      const session = await startSession()
+
+      expect(await readActiveVisualModel(session.paths)).toBeUndefined()
+    })
+
+    it('replaces the pointer without leaving a temporary file behind', async () => {
+      const session = await startSession()
+      await promoteCompiledModel(session.paths, {
+        model,
+        now: () => new Date('2026-08-08T00:00:05.000Z'),
+        compile: compilesCleanly,
+      })
+      await promoteCompiledModel(session.paths, {
+        model,
+        now: () => new Date('2026-08-08T00:00:06.000Z'),
+        compile: compilesCleanly,
+      })
+
+      expect(
+        (await readdir(session.paths.root)).filter((entry) =>
+          entry.includes('.tmp'),
+        ),
+      ).toEqual([])
+    })
+
+    it.skipIf(!posixOnly)(
+      'swaps the pointer by rename rather than rewriting it in place',
+      async () => {
+        const session = await startSession()
+        await promoteCompiledModel(session.paths, {
+          model,
+          now: () => new Date('2026-08-08T00:00:05.000Z'),
+          compile: compilesCleanly,
+        })
+        const before = await stat(session.paths.activeModel)
+
+        await promoteCompiledModel(session.paths, {
+          model,
+          now: () => new Date('2026-08-08T00:00:06.000Z'),
+          compile: compilesCleanly,
+        })
+
+        // A truncate-and-rewrite keeps the inode and is therefore observable as
+        // a partial pointer; a write-then-rename replaces it.
+        expect((await stat(session.paths.activeModel)).ino).not.toBe(before.ino)
+      },
+    )
+
+    it.skipIf(!posixOnly)(
+      'stages candidate directories 0700 and candidate files 0600',
+      async () => {
+        const session = await startSession()
+
+        const promoted = await promoteCompiledModel(session.paths, {
+          model,
+          now: () => new Date('2026-08-08T00:00:05.000Z'),
+          compile: compilesCleanly,
+        })
+
+        expect(await modeOf(promoted.candidateDir)).toBe(0o700)
+        expect(await modeOf(join(promoted.candidateDir, 'views'))).toBe(0o700)
+        expect(await modeOf(join(promoted.candidateDir, 'model.likec4'))).toBe(
+          0o600,
+        )
+        expect(await modeOf(session.paths.activeModel)).toBe(0o600)
+      },
+    )
+  })
+
+  describe('cleanup', () => {
+    it('recovers the handoff before deleting the session', async () => {
+      const session = await startSession()
+      await appendVisualEvent(session.paths, chatEvent)
+      await appendVisualResponse(session.paths, handoffResponse)
+
+      const handoff = await removeVisualSession(session.paths, true)
+
+      expect(handoff).toMatchObject({
+        summary: handoffResponse.payload.summary,
+        transcript: [chatEvent],
+      })
+      expect(existsSync(session.paths.root)).toBe(false)
+    })
+
+    it('reports an already-removed session instead of failing', async () => {
+      const session = await startSession()
+      await removeVisualSession(session.paths)
+
+      expect(await removeVisualSession(session.paths)).toBeUndefined()
+    })
+
+    it('refuses to delete a directory that is not a marked session', async () => {
+      const unmarked = join(parent, 'precious')
+      await mkdir(unmarked, { mode: 0o700 })
+      await writeFile(join(unmarked, 'notes.md'), 'keep me', { mode: 0o600 })
+
+      await expect(
+        removeVisualSession(visualSessionPaths(unmarked)),
+      ).rejects.toThrow(/YMVS124/)
+      expect(existsSync(join(unmarked, 'notes.md'))).toBe(true)
+    })
+
+    it('refuses to delete a session whose marker names another directory', async () => {
+      const session = await startSession()
+      await writeFile(
+        session.paths.marker,
+        JSON.stringify({
+          format: VISUAL_SESSION_MARKER_FORMAT,
+          id: 'cd'.repeat(16),
+          createdAt: '2026-08-08T00:00:00.000Z',
+          authority: 'ad-hoc',
+        }),
+      )
+
+      await expect(removeVisualSession(session.paths)).rejects.toThrow(
+        /YMVS125/,
+      )
+      expect(existsSync(session.paths.marker)).toBe(true)
+    })
+  })
+
+  describe('stale pruning', () => {
+    const staleNow = new Date('2026-08-09T00:00:00.001Z')
+
+    it('prunes only marked sessions older than 24 hours', async () => {
+      const session = await startSession()
+      const unmarkedDirectory = join(parent, 'unmarked')
+      await mkdir(unmarkedDirectory, { mode: 0o700 })
+
+      const removed = await pruneStaleVisualSessions(parent, staleNow)
+
+      expect(removed).toEqual([session.paths.root])
+      expect(existsSync(unmarkedDirectory)).toBe(true)
+      expect(existsSync(session.paths.root)).toBe(false)
+    })
+
+    it('keeps a session that is exactly 24 hours old', async () => {
+      const session = await startSession()
+
+      expect(
+        await pruneStaleVisualSessions(
+          parent,
+          new Date('2026-08-09T00:00:00.000Z'),
+        ),
+      ).toEqual([])
+      expect(existsSync(session.paths.root)).toBe(true)
+    })
+
+    it('never follows a symlink out of the base directory', async () => {
+      const outside = await mkdtemp(join(tmpdir(), 'yarramate-visual-outside-'))
+      try {
+        // A genuinely stale, correctly marked session, reachable from the base
+        // directory only through a symlink: nothing but the lstat check keeps
+        // pruning away from it.
+        const real = await createVisualSession(request, {
+          baseDir: outside,
+          now: () => new Date('2026-08-01T00:00:00.000Z'),
+          randomBytes: (size) => Buffer.alloc(size, 0xab),
+        })
+        const link = join(parent, basename(real.paths.root))
+        await symlink(real.paths.root, link)
+        await writeFile(join(parent, 'stray.json'), 'ignored')
+
+        expect(await pruneStaleVisualSessions(parent, staleNow)).toEqual([])
+        expect(existsSync(link)).toBe(true)
+        expect(existsSync(real.paths.marker)).toBe(true)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
+    })
+
+    it('bounds how many stale sessions one pass removes', async () => {
+      const roots: string[] = []
+      for (let index = 1; index <= 3; index += 1) {
+        const created = await createVisualSession(request, {
+          baseDir: parent,
+          now: () => new Date(`2026-08-0${index}T00:00:00.000Z`),
+          randomBytes: (size) => Buffer.alloc(size, index),
+        })
+        roots.push(created.paths.root)
+      }
+
+      const removed = await pruneStaleVisualSessions(parent, staleNow, 2)
+
+      expect(removed).toEqual([roots[0], roots[1]])
+      expect(existsSync(roots[2] as string)).toBe(true)
+      expect(VISUAL_SESSION_PRUNE_LIMIT).toBeGreaterThan(0)
+    })
+  })
+})

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -8,6 +8,7 @@ import {
   rm,
   stat,
   symlink,
+  utimes,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -993,11 +994,41 @@ describe('visual session store', () => {
 
   describe('stale pruning', () => {
     const staleNow = new Date('2026-08-09T00:00:00.001Z')
+    const longAgo = '2026-08-01T00:00:00.000Z'
+    const withinBudget = '2026-08-08T12:00:00.000Z'
 
-    it('prunes only marked sessions older than 24 hours', async () => {
+    /**
+     * Pins every artefact of a session to one modification time. Staleness is
+     * a property of the filesystem rather than of the immutable marker, so a
+     * test states activity the same way a live runtime leaves it behind.
+     */
+    const touchSession = async (paths: VisualSessionPaths, when: string) => {
+      const at = new Date(when)
+      for (const path of [
+        paths.root,
+        paths.marker,
+        paths.descriptor,
+        paths.journal,
+        paths.candidates,
+        paths.activeModel,
+      ]) {
+        if (existsSync(path)) await utimes(path, at, at)
+      }
+    }
+
+    const promote = (paths: VisualSessionPaths) =>
+      promoteCompiledModel(paths, {
+        model,
+        now: () => new Date(withinBudget),
+        compile: compilesCleanly,
+      })
+
+    it('prunes only marked sessions untouched for longer than 24 hours', async () => {
       const session = await startSession()
+      await touchSession(session.paths, longAgo)
       const unmarkedDirectory = join(parent, 'unmarked')
       await mkdir(unmarkedDirectory, { mode: 0o700 })
+      await utimes(unmarkedDirectory, new Date(longAgo), new Date(longAgo))
 
       const removed = await pruneStaleVisualSessions(parent, staleNow)
 
@@ -1006,8 +1037,59 @@ describe('visual session store', () => {
       expect(existsSync(session.paths.root)).toBe(false)
     })
 
-    it('keeps a session that is exactly 24 hours old', async () => {
+    it('keeps a long-lived session whose journal was appended within the budget', async () => {
+      const session = await startSession(longAgo)
+      await appendVisualEvent(session.paths, chatEvent)
+      await touchSession(session.paths, longAgo)
+      const active = new Date(withinBudget)
+      await utimes(session.paths.journal, active, active)
+
+      expect(await pruneStaleVisualSessions(parent, staleNow)).toEqual([])
+      expect(existsSync(session.paths.root)).toBe(true)
+    })
+
+    it('keeps a long-lived session whose model was promoted within the budget', async () => {
+      const session = await startSession(longAgo)
+      await promote(session.paths)
+      await touchSession(session.paths, longAgo)
+      const active = new Date(withinBudget)
+      await utimes(session.paths.activeModel, active, active)
+
+      expect(await pruneStaleVisualSessions(parent, staleNow)).toEqual([])
+      expect(existsSync(session.paths.root)).toBe(true)
+    })
+
+    it('keeps a long-lived session that staged a candidate within the budget', async () => {
+      const session = await startSession(longAgo)
+      await promote(session.paths)
+      await touchSession(session.paths, longAgo)
+      // Staging a candidate changes the directory that gains the entry and
+      // nothing above it: POSIX propagates a modification no further, so the
+      // session root alone would report this session as untouched.
+      const active = new Date(withinBudget)
+      await utimes(session.paths.candidates, active, active)
+
+      expect(await pruneStaleVisualSessions(parent, staleNow)).toEqual([])
+      expect(existsSync(session.paths.root)).toBe(true)
+    })
+
+    it('removes a session no artefact has touched for longer than 24 hours', async () => {
       const session = await startSession()
+      await promote(session.paths)
+      await touchSession(session.paths, '2026-08-07T23:59:59.999Z')
+
+      expect(
+        await pruneStaleVisualSessions(
+          parent,
+          new Date('2026-08-09T00:00:00.000Z'),
+        ),
+      ).toEqual([session.paths.root])
+      expect(existsSync(session.paths.root)).toBe(false)
+    })
+
+    it('keeps a session whose newest artefact is exactly 24 hours old', async () => {
+      const session = await startSession(longAgo)
+      await touchSession(session.paths, '2026-08-08T00:00:00.000Z')
 
       expect(
         await pruneStaleVisualSessions(
@@ -1026,9 +1108,10 @@ describe('visual session store', () => {
         // pruning away from it.
         const real = await createVisualSession(request, {
           baseDir: outside,
-          now: () => new Date('2026-08-01T00:00:00.000Z'),
+          now: () => new Date(longAgo),
           randomBytes: (size) => Buffer.alloc(size, 0xab),
         })
+        await touchSession(real.paths, longAgo)
         const link = join(parent, basename(real.paths.root))
         await symlink(real.paths.root, link)
         await writeFile(join(parent, 'stray.json'), 'ignored')
@@ -1041,7 +1124,7 @@ describe('visual session store', () => {
       }
     })
 
-    it('bounds how many stale sessions one pass removes', async () => {
+    it('bounds how many stale sessions one pass removes, oldest activity first', async () => {
       const roots: string[] = []
       for (let index = 1; index <= 3; index += 1) {
         const created = await createVisualSession(request, {
@@ -1049,6 +1132,7 @@ describe('visual session store', () => {
           now: () => new Date(`2026-08-0${index}T00:00:00.000Z`),
           randomBytes: (size) => Buffer.alloc(size, index),
         })
+        await touchSession(created.paths, `2026-08-0${index}T00:00:00.000Z`)
         roots.push(created.paths.root)
       }
 

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -19,6 +19,7 @@ import {
   type VisualEvent,
   type VisualModel,
   type VisualResponse,
+  type VisualSessionDescriptor,
   type VisualSessionRequest,
 } from '../src/adapters/visual/protocol.js'
 import {
@@ -34,6 +35,8 @@ import {
   recoverVisualSession,
   removeVisualSession,
   visualSessionPaths,
+  writeVisualSessionDescriptor,
+  type VisualSessionPaths,
 } from '../src/adapters/visual/session-store.js'
 
 const model: VisualModel = {
@@ -244,6 +247,84 @@ describe('visual session store', () => {
         expect(await modeOf(session.paths.journal)).toBe(0o600)
       },
     )
+  })
+
+  describe('agent descriptor', () => {
+    const descriptorFor = (
+      paths: VisualSessionPaths,
+      overrides: Partial<VisualSessionDescriptor> = {},
+    ): VisualSessionDescriptor => ({
+      format: 'yarramate/visual-session-descriptor/v1',
+      protocolVersion: 'yarramate/visual-protocol/v1',
+      sessionId,
+      origin: 'http://127.0.0.1:49152',
+      agentCapability: '5c'.repeat(32),
+      sessionRoot: paths.root,
+      journalPath: paths.journal,
+      createdAt: '2026-08-08T00:00:00.000Z',
+      ...overrides,
+    })
+
+    it('writes the agent descriptor as a private document of this session', async () => {
+      const session = await startSession()
+      const descriptor = descriptorFor(session.paths)
+
+      await writeVisualSessionDescriptor(session.paths, descriptor)
+
+      expect(
+        JSON.parse(await readFile(session.paths.descriptor, 'utf8')),
+      ).toEqual(descriptor)
+    })
+
+    it.skipIf(!posixOnly)(
+      'keeps the capability-carrying descriptor readable only by its owner',
+      async () => {
+        const session = await startSession()
+
+        await writeVisualSessionDescriptor(
+          session.paths,
+          descriptorFor(session.paths),
+        )
+
+        expect(await modeOf(session.paths.descriptor)).toBe(0o600)
+      },
+    )
+
+    it('refuses a descriptor that names another session', async () => {
+      const session = await startSession()
+
+      await expect(
+        writeVisualSessionDescriptor(
+          session.paths,
+          descriptorFor(session.paths, { sessionId: identifier(3) }),
+        ),
+      ).rejects.toThrow(/YMVS126/)
+      expect(existsSync(session.paths.descriptor)).toBe(false)
+    })
+
+    it('refuses a descriptor that names another session directory', async () => {
+      const session = await startSession()
+
+      await expect(
+        writeVisualSessionDescriptor(
+          session.paths,
+          descriptorFor(session.paths, { journalPath: join(parent, 'x.jsonl') }),
+        ),
+      ).rejects.toThrow(/YMVS125/)
+      expect(existsSync(session.paths.descriptor)).toBe(false)
+    })
+
+    it('refuses a descriptor that fails protocol validation', async () => {
+      const session = await startSession()
+
+      await expect(
+        writeVisualSessionDescriptor(
+          session.paths,
+          descriptorFor(session.paths, { agentCapability: 'short' }),
+        ),
+      ).rejects.toThrow(/YMVS103/)
+      expect(existsSync(session.paths.descriptor)).toBe(false)
+    })
   })
 
   describe('append-only journal', () => {

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+import {
+  conversationWidthBounds,
+  createVisualWorkspaceState,
+  formatContextualQuestion,
+  normalizeSelectedElement,
+  normalizeSelectedRelationship,
+  visualDescriptionText,
+  visualWorkspaceReducer,
+  type SelectedDiagramSubject,
+} from '../src/visual-app/workspace-state.js'
+
+const elementSubject: SelectedDiagramSubject = {
+  type: 'element',
+  id: 'node-1',
+  modelRef: 'system.api',
+  deploymentRef: null,
+  identity: 'system.api',
+  title: 'API',
+  kind: 'service',
+  description: 'Handles requests.',
+  technology: 'TypeScript',
+  tags: ['public'],
+  navigateTo: 'api-detail',
+  metadata: null,
+}
+
+describe('visual workspace state', () => {
+  it('starts collapsed at the responsive default width', () => {
+    const state = createVisualWorkspaceState(1568)
+    expect(state.conversation).toEqual({
+      mode: 'auto',
+      width: 439.04,
+      unread: 0,
+    })
+  })
+
+  it('opens automatically for first activity but respects a manual close', () => {
+    const initial = createVisualWorkspaceState(1568)
+    const opened = visualWorkspaceReducer(initial, {
+      type: 'attention.received',
+    })
+    expect(opened.conversation.mode).toBe('open')
+
+    const closed = visualWorkspaceReducer(opened, {
+      type: 'conversation.toggled',
+    })
+    const waiting = visualWorkspaceReducer(closed, {
+      type: 'attention.received',
+    })
+    expect(waiting.conversation).toMatchObject({ mode: 'closed', unread: 1 })
+
+    const reopened = visualWorkspaceReducer(waiting, {
+      type: 'conversation.toggled',
+    })
+    expect(reopened.conversation).toMatchObject({ mode: 'open', unread: 0 })
+  })
+
+  it('opens for a direct selection and clears only on model replacement', () => {
+    const selected = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
+      type: 'subject.selected',
+      subject: elementSubject,
+    })
+    expect(selected.conversation.mode).toBe('open')
+    expect(selected.selectedSubject).toEqual(elementSubject)
+
+    const replaced = visualWorkspaceReducer(selected, {
+      type: 'model.replaced',
+    })
+    expect(replaced.selectedSubject).toBeNull()
+    expect(replaced.conversation.mode).toBe('open')
+  })
+
+  it('clamps width to both the panel maximum and the canvas floor', () => {
+    expect(conversationWidthBounds(1568)).toEqual({ min: 320, max: 640 })
+    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 370 })
+
+    const widened = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
+      type: 'conversation.resized',
+      width: 900,
+      viewportWidth: 1568,
+    })
+    expect(widened.conversation.width).toBe(640)
+
+    const narrowedViewport = visualWorkspaceReducer(widened, {
+      type: 'viewport.resized',
+      viewportWidth: 900,
+    })
+    expect(narrowedViewport.conversation.width).toBe(370)
+  })
+})
+
+describe('selected diagram subjects', () => {
+  it('prefers model identity and flattens element descriptions', () => {
+    const selected = normalizeSelectedElement({
+      id: 'rendered-node',
+      modelRef: 'system.api',
+      deploymentRef: 'prod.api',
+      title: 'API',
+      kind: 'service',
+      description: { txt: '  Handles requests.  ' },
+      technology: 'TypeScript',
+      tags: ['public'],
+      navigateTo: 'api-detail',
+      metadata: { owner: 'platform' },
+    })
+    expect(selected).toMatchObject({
+      identity: 'system.api',
+      description: 'Handles requests.',
+      modelRef: 'system.api',
+      deploymentRef: 'prod.api',
+    })
+  })
+
+  it('falls back through deployment identity to rendered node identity', () => {
+    expect(
+      normalizeSelectedElement({
+        id: 'deployment-node',
+        deploymentRef: 'prod.api',
+        title: 'Production API',
+      }).identity,
+    ).toBe('prod.api')
+    expect(
+      normalizeSelectedElement({ id: 'group-1', title: 'Services' }).identity,
+    ).toBe('group-1')
+  })
+
+  it('preserves edge endpoints, rendered description, and aggregate count', () => {
+    const selected = normalizeSelectedRelationship(
+      {
+        id: 'edge-1',
+        source: 'missing-source',
+        target: 'api',
+        label: 'routes to',
+        description: { txt: 'Requests cross this boundary.' },
+        kind: 'sync',
+        technology: 'HTTPS',
+        notation: 'request',
+        relations: ['relation-1', 'relation-2'],
+      },
+      new Map([['api', 'API']]),
+    )
+    expect(selected).toMatchObject({
+      sourceId: 'missing-source',
+      sourceTitle: 'missing-source',
+      targetTitle: 'API',
+      description: 'Requests cross this boundary.',
+      aggregateCount: 2,
+      relationshipIds: ['relation-1', 'relation-2'],
+    })
+  })
+
+  it('treats absent or blank descriptions as missing', () => {
+    expect(visualDescriptionText(undefined)).toBeNull()
+    expect(visualDescriptionText({ txt: '   ' })).toBeNull()
+  })
+
+  it('formats the exact visible text sent through the existing chat seam', () => {
+    expect(formatContextualQuestion('What owns this?', elementSubject)).toBe(
+      'About “API” (system.api): What owns this?',
+    )
+
+    const relationship = normalizeSelectedRelationship(
+      {
+        id: 'edge-1',
+        source: 'web',
+        target: 'api',
+        label: 'calls',
+        relations: ['one', 'two'],
+      },
+      new Map([
+        ['web', 'Web'],
+        ['api', 'API'],
+      ]),
+    )
+    expect(formatContextualQuestion('Why synchronous?', relationship)).toBe(
+      'About relationship “Web → API — calls” (2 model relationships): Why synchronous?',
+    )
+    expect(formatContextualQuestion('  General question  ', null)).toBe(
+      'General question',
+    )
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -121,7 +121,7 @@ describe('visual workspace state', () => {
 })
 
 describe('selected diagram subjects', () => {
-  it('prefers model identity and flattens element descriptions', () => {
+  it('prefers deployment identity for deployment nodes and flattens descriptions', () => {
     const selected = normalizeSelectedElement({
       id: 'rendered-node',
       modelRef: 'system.api',
@@ -135,7 +135,7 @@ describe('selected diagram subjects', () => {
       metadata: { owner: 'platform' },
     })
     expect(selected).toMatchObject({
-      identity: 'system.api',
+      identity: 'prod.api',
       description: 'Handles requests.',
       modelRef: 'system.api',
       deploymentRef: 'prod.api',

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -30,7 +30,16 @@ describe('visual workspace state', () => {
     const state = createVisualWorkspaceState(1568)
     expect(state.conversation).toEqual({
       mode: 'auto',
-      width: 439.04,
+      width: expect.closeTo(439.04, 2),
+      unread: 0,
+    })
+  })
+
+  it('caps the default width at 480px on wide viewports', () => {
+    const state = createVisualWorkspaceState(1920)
+    expect(state.conversation).toEqual({
+      mode: 'auto',
+      width: 480,
       unread: 0,
     })
   })

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -121,7 +121,7 @@ describe('visual workspace state', () => {
 })
 
 describe('selected diagram subjects', () => {
-  it('prefers deployment identity for deployment nodes and flattens descriptions', () => {
+  it('prefers model identity for deployment nodes and flattens descriptions', () => {
     const selected = normalizeSelectedElement({
       id: 'rendered-node',
       modelRef: 'system.api',
@@ -135,7 +135,7 @@ describe('selected diagram subjects', () => {
       metadata: { owner: 'platform' },
     })
     expect(selected).toMatchObject({
-      identity: 'prod.api',
+      identity: 'system.api',
       description: 'Handles requests.',
       modelRef: 'system.api',
       deploymentRef: 'prod.api',

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -80,14 +80,14 @@ describe('visual workspace state', () => {
     expect(replaced.conversation.mode).toBe('open')
   })
 
-  it('clamps width to both the panel maximum and the canvas floor', () => {
+  it('clamps width to the design maximum of min(45vw, 640px)', () => {
     expect(conversationWidthBounds(1568)).toEqual({ min: 320, max: 640 })
-    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 370 })
+    expect(conversationWidthBounds(900)).toEqual({ min: 320, max: 405 })
+    expect(conversationWidthBounds(600)).toEqual({ min: 320, max: 320 })
 
     const widened = visualWorkspaceReducer(createVisualWorkspaceState(1568), {
       type: 'conversation.resized',
       width: 900,
-      viewportWidth: 1568,
     })
     expect(widened.conversation.width).toBe(640)
 
@@ -95,7 +95,28 @@ describe('visual workspace state', () => {
       type: 'viewport.resized',
       viewportWidth: 900,
     })
-    expect(narrowedViewport.conversation.width).toBe(370)
+    expect(narrowedViewport.conversation.width).toBe(405)
+  })
+
+  // The separator reads its aria bounds from this state, so a viewport change
+  // that leaves the panel width alone must still be observable.
+  it('tracks the viewport width even when the clamped panel width is unchanged', () => {
+    const initial = createVisualWorkspaceState(1568)
+    expect(initial.viewportWidth).toBe(1568)
+
+    const wider = visualWorkspaceReducer(initial, {
+      type: 'viewport.resized',
+      viewportWidth: 1600,
+    })
+    expect(wider.conversation.width).toBe(initial.conversation.width)
+    expect(wider.viewportWidth).toBe(1600)
+
+    // A drag clamps against the viewport the state already knows.
+    const dragged = visualWorkspaceReducer(
+      visualWorkspaceReducer(wider, { type: 'viewport.resized', viewportWidth: 900 }),
+      { type: 'conversation.resized', width: 900 },
+    )
+    expect(dragged.conversation.width).toBe(405)
   })
 })
 
@@ -166,7 +187,7 @@ describe('selected diagram subjects', () => {
 
   it('formats the exact visible text sent through the existing chat seam', () => {
     expect(formatContextualQuestion('What owns this?', elementSubject)).toBe(
-      'About “API” (system.api): What owns this?',
+      'About element “API” (system.api): What owns this?',
     )
 
     const relationship = normalizeSelectedRelationship(

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -301,6 +301,7 @@ describe('workspace manifests', () => {
         '.yarramate/projections/state-engine-change.yaml',
         '.yarramate/projections/state-engine-target.yaml',
         '.yarramate/projections/state-foundation.yaml',
+        '.yarramate/projections/visual-conversation-path.yaml',
       ],
       adapterMappings: [
         '.yarramate/integrations/likec4/subject-mapping.yaml',

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["test"]
+  "exclude": ["test", "src/visual-app"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2024"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
   "include": ["src/**/*.ts", "test/**/*.ts"],
   // The browser application is a separate program with its own libs and
   // its own build: `tsconfig.visual.json` owns it.
-  "exclude": ["src/visual-app"]
+  "exclude": [
+    "src/visual-app",
+    "test/visual-workspace-state.test.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,8 @@
     "resolveJsonModule": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  // The browser application is a separate program with its own libs and
+  // its own build: `tsconfig.visual.json` owns it.
+  "exclude": ["src/visual-app"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   // its own build: `tsconfig.visual.json` owns it.
   "exclude": [
     "src/visual-app",
-    "test/visual-workspace-state.test.ts"
+    "test/visual-workspace-state.test.ts",
+    "test/visual-app-render.test.ts"
   ]
 }

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -17,6 +17,7 @@
   "include": [
     "src/visual-app/**/*.ts",
     "src/visual-app/**/*.tsx",
-    "vite.visual.config.ts"
+    "vite.visual.config.ts",
+    "test/visual-workspace-state.test.ts"
   ]
 }

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -18,6 +18,7 @@
     "src/visual-app/**/*.ts",
     "src/visual-app/**/*.tsx",
     "vite.visual.config.ts",
-    "test/visual-workspace-state.test.ts"
+    "test/visual-workspace-state.test.ts",
+    "test/visual-app-render.test.ts"
   ]
 }

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": [
+    "src/visual-app/**/*.ts",
+    "src/visual-app/**/*.tsx",
+    "vite.visual.config.ts"
+  ]
+}

--- a/vite.visual.config.ts
+++ b/vite.visual.config.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+/**
+ * Builds the browser application the session server serves, and nothing else.
+ *
+ * The output is self-contained by construction: relative asset URLs, flat
+ * hashed file names the server's asset route admits, and no external origin,
+ * because the page runs under a policy that allows only `'self'`.
+ */
+export default defineConfig({
+  root: fileURLToPath(new URL('./src/visual-app/', import.meta.url)),
+  base: './',
+  build: {
+    outDir: fileURLToPath(new URL('./dist/visual-app/', import.meta.url)),
+    // Only this directory: `build:node` writes the rest of `dist`.
+    emptyOutDir: true,
+    assetsDir: 'assets',
+    assetsInlineLimit: 0,
+    modulePreload: { polyfill: false },
+    target: 'es2022',
+    sourcemap: false,
+    reportCompressedSize: false,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Add a `yarramate-visual` sibling runtime for visual architecture conversations without widening Core semantics:

- publish nine closed `yarramate/visual-*/v1` JSON contracts and the packaged CLI;
- compile checked canonical or explicitly ad-hoc temporary LikeC4 models behind an authenticated loopback server;
- render a diagram-first React/LikeC4 workspace with a compact command strip, collapsible/resizable desktop conversation, and accessible mobile bottom sheet;
- let users inspect elements and relationships, progressively reveal descriptions, navigate related views, and send exact selected-subject context with a question;
- render descriptions, choices, chat, status, diagnostics, navigation, and End while keeping ephemeral workspace state browser-local;
- persist an append-only journal for reconnect, recovery, opt-in transcripts, deterministic handoff, idempotent stop, and cleanup;
- teach the canonical `yarramate-architecture` skill to select embedded chat, diagram-only, or semantic fallback from observed harness capabilities;
- declare the runtime, browser, protocol, repository evidence, and focused journey in YarraMate's self-model;
- record the stable adapter/protocol decision in ADR 0081.

The completed browser smoke and review cycles also fixed invalid fixture rendering, pending-choice reconnect loss, incomplete self-model placement, limit recovery, browser lifecycle journaling, stale-session pruning, fault/turn-state edge cases, non-idempotent CLI stop, Details-panel reflow, stale separator ARIA bounds, cross-session handoff transcript records, TypeScript project ownership for browser-state tests, and clear-text storage of the loopback browser credential.

## Validation

Fresh on head `0ce9f01`:

- `pnpm verify` — passed end to end:
  - TypeScript: root Node/test project and browser project passed with zero diagnostics.
  - Build: Node declarations and visual Vite bundle completed; existing chunk-size warning only.
  - Tests: 49 files, 798 tests passed.
  - Self-check: 234 concepts, 325 relationships, 4 states; no errors.
  - LikeC4 validation: valid (2 files).
- Real Chromium smoke at 1568×924 and 390×844 — zero-reflow Details overlay, labelled close action, resize bounds across a bail-out viewport change, exact selected-element transcript context, mobile bottom sheet, no horizontal overflow, empty console, loopback-only requests, and hostile description markup inert.
- Focused credential smoke on current Chromium at `http://127.0.0.1:<random-port>` — bootstrap redirected successfully, the authenticated page reached `Live`, all resources stayed loopback-only, and the `ym_visual` cookie was observed as `Secure`, `HttpOnly`, and `SameSite=Strict`.
- Credential TDD proves the cookie stores only an HMAC-SHA256-derived authenticator; the 256-bit signing key remains in the server closure and never reaches browser state, descriptors, journal, or handoff.
- Whole-branch senior review followed by one fix wave and scoped re-review — no critical, important, or release-blocking defect remains.
- Post-review TypeScript ownership fix received a clean scoped review; both cookie changes received clean specialist security reviews.

## Review notes

Residual non-blocking local-hardening tradeoffs for human review:

- `O_NOFOLLOW` descriptor opening can block on a same-user FIFO unless `O_NONBLOCK` is also used.
- Platforms without `O_NOFOLLOW` fall back to the repository's existing POSIX trust assumptions.
- Repeating `stop` after cleanup treats an absent descriptor parent as already stopped; a mistyped absent session directory has the same silent result.
- Symlink refusal remains `YMVS401`, but its message is now `cannot be read` rather than `is not a regular file`.

## Related issue

None. Both accepted designs and implementation plans are committed under `docs/superpowers/`; ADR 0081 records the stable contract decision.

## Contract impact

Adds a sibling adapter boundary: `yarramate-visual`, nine closed versioned schema exports, and browser/agent session documents. It does not add a Core semantic verb or change native YarraMate meaning. Incompatible visual protocol changes require a version beside v1.

## Checklist

- [x] Tests and documentation cover the changed behavior.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic and stable-interface changes have approved designs and an ADR where required.
- [x] Browser behavior was exercised at desktop and mobile sizes.
- [x] The loopback browser credential is derived and marked `Secure`, `HttpOnly`, and `SameSite=Strict`.
