### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.0
+
+- Add the `yarramate-visual` adapter (beta): a sibling runtime that renders
+  LikeC4 diagrams of a bounded slice in a local, authenticated browser
+  session and delegates a chat conversation about what is on screen to a
+  visual agent, over a published, closed `yarramate/visual-*/v1` contract.
+  Git review remains responsible for accepting any resulting architecture
+  proposal; the runtime never becomes canonical architecture by itself.
+
 ## 0.16.0
 
 - Add optional profile concept-kind layers and layer-aware projections.

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,10 +1,11 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.15.0
+v0.17.0
 a design interview any agent can resume.
 the map your coding agents share.
 architecture your CI can check.
 a model that knows what's missing.
 intent your code can contradict.
 the handover between your agents.
+a diagram you can talk to.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Release preparation per docs/RELEASING.md, following #181 (yarramate-visual adapter, beta).

- `package.json`: 0.16.0 -> 0.17.0
- `CHANGELOG.md`: document the visual conversation adapter
- `assets/taglines.txt`: bump released version (was stale at v0.15.0 since the 0.16.0 release), add a tagline for the new capability

## Verification
- `pnpm run verify`: typecheck, build, 826/826 tests, self-check clean, LikeC4 valid
- `npm pack --dry-run`: 139 files, 855.8 kB — runtime, schemas, consumer guide, canonical skill, README, LICENSE; no source/tests/fixtures/dogfooding inputs

## Next
Merge, tag `v0.17.0` on the merge commit, `npm publish --access public`, then a GitHub release from the tag.