### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.18.0
+
+- Resolve `attestations[].by` as a subject reference, reusing `YM304` when it
+  does not resolve, instead of accepting free text: an authority has to be
+  someone the model already knows (ADR 0082). Documents whose `by` is a name
+  rather than a reference no longer compile.
+- Add optional `attestations[].recordedBy` naming whoever held the pen.
+  `apply` requires it on every attestation an operations batch writes, since a
+  batch is by construction a machine's transcription of someone's judgment.
+- Report `unconfirmed-attestation` from `reconcile`, with a matching
+  `summary.unconfirmedAttestations` counter, when a record names a recorder
+  other than its attesting authority. Advisory like `stale-attestation`:
+  `check --strict` is unaffected.
+- Render the recorder beside the authority in `export rtm` attestation cells.
+
 ## 0.17.0
 
 - Add the `yarramate-visual` adapter (beta): a sibling runtime that renders

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,7 +1,7 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.17.0
+v0.18.0
 a design interview any agent can resume.
 the map your coding agents share.
 architecture your CI can check.
@@ -9,3 +9,4 @@ a model that knows what's missing.
 intent your code can contradict.
 the handover between your agents.
 a diagram you can talk to.
+who signed off, and who held the pen.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Release preparation per docs/RELEASING.md, following #185 (attestation authority as a subject reference).

- `package.json`: 0.17.0 -> 0.18.0
- `CHANGELOG.md`: document the attestation identity contract change
- `assets/taglines.txt`: bump released version, add a tagline for the new provenance surface ("who signed off, and who held the pen.")

## Contract impact
Stable-interface change shipped by #185, versioned here:

- `yarramate/document/v1`: `attestations[].by` is a subject reference; `recordedBy` added (optional)
- `yarramate/operations/v1`: `by` is a subject reference; `recordedBy` required on every attestation a batch writes
- `yarramate/reconciliation-report/v1`, `yarramate/ask-result/v1`: `unconfirmed-attestation` finding and `unconfirmedAttestations` counter

Documents that named an authority as free text now fail with `YM304` until the name becomes a reference - the same failure an unresolved `owner` already produces.

## Verification
- `pnpm run verify`: typecheck, build, 832/832 tests (50 files), self-check clean (234 concepts, 325 relationships, 4 states), LikeC4 valid
- `npm pack --dry-run`: 139 files, 857.7 kB - runtime, schemas, consumer guide, canonical skill, README, LICENSE; no source/tests/fixtures/dogfooding inputs

## Next
Merge, tag `v0.18.0` on the merge commit, `npm publish --access public`, then a GitHub release from the tag.
