### PR TITLE
fix: gate the compiler cancellation test on a recorded invocation

### DIFF
--- a/test/visual-likec4-compiler.test.ts
+++ b/test/visual-likec4-compiler.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { existsSync, watch } from 'node:fs'
+import { existsSync, readFileSync, watch } from 'node:fs'
 import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -469,9 +469,15 @@ describe('trusted LikeC4 compiler adapter', () => {
       const controller = new AbortController()
       // Cancel only once the fixture compiler has recorded its invocation, so
       // this exercises killing a live child rather than a pre-aborted spawn.
+      // The gate is a complete record, not the log's existence: the fixture
+      // appends by creating the file and then writing the line, so a kill
+      // inside that window leaves a log that never gets its record at all.
       // `fs.watch` is not guaranteed to deliver every event on every platform
       // (see the Node docs' own "Caveats" section), so a short poll runs
       // alongside it rather than trusting the single watch callback.
+      const recorded = () =>
+        existsSync(invocations) &&
+        readFileSync(invocations, 'utf8').endsWith('\n')
       const started = new Promise<void>((resolve) => {
         let settled = false
         const settle = () => {
@@ -482,10 +488,10 @@ describe('trusted LikeC4 compiler adapter', () => {
           resolve()
         }
         const watcher = watch(parent, () => {
-          if (existsSync(invocations)) settle()
+          if (recorded()) settle()
         })
         const poll = setInterval(() => {
-          if (existsSync(invocations)) settle()
+          if (recorded()) settle()
         }, 5)
       })
 


### PR DESCRIPTION
## Summary

`test/visual-likec4-compiler.test.ts > abandons a compiler when the caller cancels the compilation` failed CI on `5933d15` ([run 31692297510](https://github.com/yarrasys/yarramate/actions/runs/31692297510)) with `[]` where `['validate']` was expected. It is a real race in the test, not in the adapter.

The test waits for the fixture compiler to record its invocation before aborting, so the abort kills a live child rather than a pre-aborted spawn. The gate was `existsSync(invocations)`. The fixture records with `appendFileSync` (`test/fixtures/visual/fake-likec4.mjs:28`), which creates the log and then writes the line, so the gate can fire on a zero-length file. The abort then kills the child inside that window, the record never lands, and `argVectors()` reads an empty log for the rest of the test.

Gate on a complete record instead - the log ending in a newline - which is exactly the invariant the later assertion reads back. `fs.watch` plus the 5 ms poll fallback are unchanged; only the predicate moved from existence to content.

## Contract impact

None. Test-only; no runtime, schema, or document contract changes. The tarball does not carry tests, so `v0.18.0` is unaffected.

## Verification

- `npx tsc -p tsconfig.json --noEmit`: clean.
- `npx vitest run test/visual-likec4-compiler.test.ts` five consecutive times: 28/28 each run.
