### PR TITLE
chore: ignore agent scratch space and explain the ES2024 library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ graphify-out/
 .env.*
 !.env.example
 
-# Agent worktrees are ephemeral checkouts of this repository
-.claude/worktrees/
+# Agent scratch space: ephemeral worktrees, harness settings, skill state
+.claude/
+.superpowers/
 .worktrees/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    // Emit stays ES2022; the library surface is what the engines field already
+    // requires (Node >= 22), which is where Promise.withResolvers lives.
     "lib": ["ES2024"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary

Repository hygiene, no runtime or contract change.

- `.gitignore`: `.claude/` and `.superpowers/` join `.worktrees/` under one "agent scratch space" heading. The old rule only covered `.claude/worktrees/`, so harness settings and skill state kept showing up as untracked noise in `git status`.
- `tsconfig.json`: comment explaining why `target` (ES2022) and `lib` (ES2024) differ. The library setting shipped in #181 for `Promise.withResolvers` in `src/adapters/visual/session-server.ts`; without the note it reads as a mistake and invites a "fix".

## Verification

- `npx tsc -p tsconfig.json --noEmit`: clean.
- `npx tsc -p tsconfig.build.json --noEmit`: clean.
- `git check-ignore -v` confirms `.claude/settings.json` and `.superpowers` now resolve to the new rules; working tree is clean afterwards.
- Deleting the `lib` line reproduces `TS2550: Property 'withResolvers' does not exist` in both configs, so the setting the comment describes is load-bearing.
