### PR TITLE
docs: make the tagged-checkout release rule checkable

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,7 +37,10 @@ either action.
 
 ## Publication
 
-From the tagged, clean checkout:
+From the tagged, clean checkout — `git checkout vX.Y.Z` in a fresh clone, never
+a branch tip. npm stamps the current `HEAD` into the package's `gitHead`, so a
+publish from `main` claims provenance the tag does not carry, even when the
+tarball bytes are identical:
 
 ```sh
 npm publish --access public
@@ -47,8 +50,9 @@ Then create a GitHub release from the same tag and verify:
 
 ```sh
 npm view yarramate version
+npm view yarramate@X.Y.Z gitHead   # must equal `git rev-parse vX.Y.Z^{commit}`
 npx --yes yarramate --help
 ```
 
 Publication is complete only when the npm package and GitHub release identify
-the same source version.
+the same source version, and the published `gitHead` is the tagged commit.


### PR DESCRIPTION
## Summary

`docs/RELEASING.md` told maintainers to publish "from the tagged, clean checkout" and to confirm the npm package and GitHub release "identify the same source version", but gave no command that could fail. v0.18.0 slipped through it.

- Publish step now names the mechanism: npm writes the current `HEAD` into the package's `gitHead`, so a publish from `main` claims provenance the tag does not carry even when the tarball bytes match.
- Verification block gains `npm view yarramate@X.Y.Z gitHead`, compared against `git rev-parse vX.Y.Z^{commit}`.

No runtime, schema, or contract change.

## Evidence

Live v0.18.0, which is published and `latest`:

```
tag commit: 3295bc332c8d745477e2d6de5c4b382b1f528825   (v0.18.0)
published : 3675c29787d884a9913fb95aefe68a2e26bd441a   (main, #187)
```

The tarball itself is sound — `dist.integrity` `sha512-QtRHsGL0xy59/...`, 139 files, byte-identical to the pack taken from a clean tag checkout during release verification. Only the provenance metadata drifted, which is exactly the failure the new comparison surfaces.