### PR TITLE
fix: name the catalogue authority "agent", not "evidence"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.0
+
+- Rename the question catalogue's `authority: evidence` to `agent`, matching
+  the runtime, `yarramate-interrogation-report/v1`, and `docs/INTERROGATION.md`.
+  A catalogue that declared `evidence` passed catalogue validation and then
+  produced a report that failed its own schema; the shipped catalogue never
+  used the value, so no interview changes.
+
 ## 0.18.0
 
 - Resolve `attestations[].by` as a subject reference, reusing `YM304` when it

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -399,9 +399,9 @@
           "$ref": "#/$defs/nonEmptyText"
         },
         "authority": {
-          "description": "Who may answer. evidence: an agent may propose the answer from repository evidence (still lands as a reviewable diff). human: a genuine design decision that must be escalated. either: evidence may propose, human confirms.",
+          "description": "Who may answer. A label carried into reports, never a gate (ADR 0082). agent: an agent may propose the answer from repository evidence (still lands as a reviewable diff). human: a genuine design decision that must be escalated. either: an agent may propose, a human confirms.",
           "enum": [
-            "evidence",
+            "agent",
             "human",
             "either"
           ]

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -20,6 +20,13 @@ const reportSchema = JSON.parse(
   ),
 ) as object
 
+const catalogueSchema = JSON.parse(
+  readFileSync(
+    join(repositoryRoot, 'schema/yarramate-question-catalogue.schema.json'),
+    'utf8',
+  ),
+) as { readonly $defs: { readonly question: { readonly properties: { readonly authority: { readonly enum: readonly string[] } } } } }
+
 const catalogue =
   'format: yarramate/question-catalogue/v1\n' +
   'id: fixture\n' +
@@ -131,6 +138,42 @@ describe('ask --open interrogation', () => {
     expect(after.exitCode).toBe(0)
     expect(after.stdout).toContain('closed goal-missing')
   })
+
+  it.each(catalogueSchema.$defs.question.properties.authority.enum)(
+    'renders a "%s" authority into a schema-valid report',
+    (authority) => {
+      // The catalogue is an input contract and the report is an output one.
+      // An authority a catalogue may legally declare that the report cannot
+      // carry is a vocabulary split that only shows up once someone writes
+      // the catalogue - so every admitted value round-trips here.
+      writeFileSync(
+        join(workspace, 'catalogue.yaml'),
+        catalogue.replace('    authority: human\n', `    authority: ${authority}\n`),
+        'utf8',
+      )
+      const result = runCli(
+        [
+          'ask',
+          'workspace.yaml',
+          '--open',
+          '--catalogue',
+          'catalogue.yaml',
+          '--json',
+        ],
+        workspace,
+      )
+      expect(result.exitCode).toBe(0)
+      const payload = JSON.parse(result.stdout) as {
+        readonly report: unknown
+      }
+      const validate = new Ajv2020({ allErrors: true }).compile(reportSchema)
+      expect({ authority, valid: validate(payload.report), errors: validate.errors }).toEqual({
+        authority,
+        valid: true,
+        errors: null,
+      })
+    },
+  )
 
   it('matches subject selectors through profile lineage by default', () => {
     // platform-team descends from businessActor, so the selector written


### PR DESCRIPTION
## Summary

`schema/yarramate-question-catalogue.schema.json` admitted `authority: evidence`.
Everything downstream says `agent`:

| Surface | Vocabulary |
|---|---|
| `schema/yarramate-question-catalogue.schema.json` | `evidence`, `human`, `either` |
| `src/interrogate-command.ts:69,99` | `human`, `agent`, `either` |
| `schema/yarramate-interrogation-report.schema.json` | `human`, `agent`, `either` |
| `docs/INTERROGATION.md:51` | `human`, `agent`, `either` |

A catalogue declaring `evidence` passes catalogue validation, runs, and emits a
report that fails `yarramate-interrogation-report/v1`. Reproduced before the fix
with a one-question catalogue: `ask --open --json` exited 0 and the payload
failed report-schema validation at `/waves/0/questions/0/authority`.

Only reachable by authoring a catalogue - `catalogues/core-enrichment.yaml` uses
`either` (26) and `human` (13), never `evidence` - so no shipped interview changes.

## Change

- Rename the enum value to `agent` and rewrite the description to match the
  ADR 0082 framing already in `docs/INTERROGATION.md`: a label carried into
  reports, never a gate.
- `test/interrogate-command.test.ts` parametrises over the enum the catalogue
  schema admits and asserts each value round-trips into a schema-valid report.
  Guard proven: restoring `evidence` fails the new case (1 failed | 13 passed).
- `docs/research/question-catalogue/` holds a research snapshot that already
  diverges from the shipped schema; left alone.

## Verification

- `npx tsc -p tsconfig.json --noEmit`: clean.
- Full suite: 50 files, 835 tests passed (832 before; +3 parametrised cases).
- `node dist/cli.js ask .yarramate/workspace.yaml --open --json`: 39 questions,
  0 open - unchanged.
