### PR TITLE
feat: ask what pins a kind's aspect

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -22,12 +22,6 @@ concepts:
     constraints:
       - id: stable-interface
         ref: yarramate-product#stable-cli
-  - id: profile-catalogue
-    kind: compiler-module
-    name: Native profile catalogue
-    description: Supplies known concept kinds and broad relationship policies.
-    owner: yarramate-product#yarramate-maintainers
-    status: current
   - id: workspace-loader
     kind: compiler-module
     name: Workspace manifest loader
@@ -334,6 +328,18 @@ concepts:
     owner: yarramate-product#yarramate-maintainers
     name: Concept kind catalogue
     description: Resolved concept kinds with aspects, lineage, and the optional rigidity meta-property available to a compilation. A rigid kind may not specialize an anti-rigid one, so a profile author who parents a service under a role is told at resolution time instead of inheriting a distinction that cannot hold.
+    status: current
+  - id: profile-catalogue
+    kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
+    name: Native profile catalogue
+    description: The shipped core vocabulary - concept kinds with their aspects and rigidity, and the relationship policies that constrain endpoints. It is data a compilation resolves, not a component that runs.
+    status: current
+  - id: question-catalogue
+    kind: dataObject
+    owner: yarramate-product#yarramate-maintainers
+    name: Shipped question catalogue
+    description: The versioned design-question catalogue evaluated against the compiled graph. It resolves from the installed package by default, so orientation needs no argument, and `--catalogue` substitutes an authored one.
     status: current
   - id: relationship-policy-catalogue
     kind: dataObject
@@ -653,6 +659,16 @@ concepts:
     description: The reviewer's own browser on the consumer host. It is the only place the visual conversation presentation runs, and that presentation page reaches nothing but the one authenticated loopback origin its session serves.
     owner: yarramate-product#yarramate-maintainers
     status: current
+  - id: execute-shipped-binaries
+    kind: technologyFunction
+    name: Execute the shipped binaries
+    description: Runs the CLI, the adapters, and the visual session server as ordinary Node processes on the consumer host.
+    status: current
+  - id: render-visual-session-page
+    kind: technologyFunction
+    name: Render the visual session page
+    description: Loads the session bundle from its authenticated loopback origin and runs the presentation, transport included, as an ordinary web page.
+    status: current
   - id: npm-package
     kind: artifact
     name: npm package
@@ -752,6 +768,11 @@ concepts:
     kind: applicationFunction
     name: Present the visual conversation
     description: Draws the promoted views, the authority and connection state, the transcript, the structured choices, and End, and turns what the reviewer does with them into session events.
+    status: current
+  - id: expose-cli-over-mcp
+    kind: applicationFunction
+    name: Expose the CLI over MCP
+    description: Advertises the read-only CLI verbs as stdio Model Context Protocol tools and forwards each call to the same command surface a human runs.
     status: current
 relationships:
   - id: core-contract-checker-loads-contract
@@ -1181,15 +1202,13 @@ relationships:
     to: adapter-mapping-schema
     mode: read
   - id: profile-supplies-kinds
-    kind: access
+    kind: composition
     from: profile-catalogue
     to: kind-catalogue
-    mode: write
   - id: profile-supplies-policies
-    kind: access
+    kind: composition
     from: profile-catalogue
     to: relationship-policy-catalogue
-    mode: write
   - id: init-command-serves-agent-harness
     kind: serving
     from: init-command
@@ -1288,6 +1307,10 @@ relationships:
     kind: serving
     from: mcp-adapter
     to: yarramate-product#agent-harness
+  - id: mcp-adapter-exposes-cli-surface
+    kind: assignment
+    from: mcp-adapter
+    to: expose-cli-over-mcp
   - id: mcp-adapter-uses-cli
     kind: serving
     from: cli
@@ -1387,10 +1410,17 @@ relationships:
     to: design-step-schema
     mode: read
   - id: design-command-reads-profile-catalogue
-    kind: association
+    kind: access
     from: design-command
     to: profile-catalogue
-    description: The shipped question catalogue is internal data resolved from the installed package, never a harness argument.
+    mode: read
+    description: The interview resolves kinds and relationship policies from the same shipped vocabulary the compiler resolved.
+  - id: design-command-reads-question-catalogue
+    kind: access
+    from: design-command
+    to: question-catalogue
+    mode: read
+    description: The catalogue the interview asks from is internal data resolved from the installed package unless --catalogue names another.
   - id: cli-provides-ask
     kind: implements
     from: cli
@@ -1410,10 +1440,17 @@ relationships:
     to: ask-result-schema
     mode: read
   - id: ask-command-reads-profile-catalogue
-    kind: association
+    kind: access
     from: ask-command
     to: profile-catalogue
-    description: The same internal question catalogue design interviews from - ask reads what design asks, so orientation counts, --open, and --advise see identical open questions.
+    mode: read
+    description: Catalogue subject selectors resolve through profile lineage, so ask reads the same kinds the compiler resolved.
+  - id: ask-command-reads-question-catalogue
+    kind: access
+    from: ask-command
+    to: question-catalogue
+    mode: read
+    description: The same catalogue design interviews from - ask reads what design asks, so orientation counts, --open, and --advise see identical open questions.
   - id: cli-provides-export
     kind: implements
     from: cli
@@ -1451,6 +1488,10 @@ relationships:
     kind: realization
     from: npm-package
     to: cli
+  - id: runtime-executes-binaries
+    kind: assignment
+    from: nodejs-runtime
+    to: execute-shipped-binaries
   - id: runtime-serves-cli
     kind: serving
     from: nodejs-runtime
@@ -1476,6 +1517,10 @@ relationships:
     from: local-web-browser
     to: visual-browser
     description: The presentation runs in the reviewer's own browser on the same host; nothing about it is deployed anywhere else.
+  - id: web-browser-renders-session-page
+    kind: assignment
+    from: local-web-browser
+    to: render-visual-session-page
   - id: export-command-serves-traceability-matrix
     kind: serving
     from: export-command

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -325,6 +325,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/adapters/mcp-cli.ts
+  - subject: yarramate-engine#expose-cli-over-mcp
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/mcp-cli.ts
   - subject: yarramate-engine#native-document
     result: confirmed
     evidence:
@@ -333,10 +337,18 @@ observations:
     result: confirmed
     evidence:
       uri: repo:package.json
+  - subject: yarramate-engine#execute-shipped-binaries
+    result: confirmed
+    evidence:
+      uri: repo:package.json
   - subject: yarramate-engine#local-web-browser
     result: confirmed
     evidence:
       uri: repo:src/visual-app/index.html
+  - subject: yarramate-engine#render-visual-session-page
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/App.tsx
   - subject: yarramate-engine#npm-package
     result: confirmed
     evidence:
@@ -349,6 +361,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/profile.ts
+  - subject: yarramate-engine#question-catalogue
+    result: confirmed
+    evidence:
+      uri: repo:catalogues/core-enrichment.yaml
   - subject: yarramate-engine#projection-result
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -267,6 +267,9 @@ mappings:
   - native: yarramate-engine#profile-catalogue
     external: engineProfileCatalogue
     type: concept
+  - native: yarramate-engine#question-catalogue
+    external: engineQuestionCatalogue
+    type: concept
   - native: yarramate-engine#projection-definition
     external: engineProjectionDefinition
     type: concept
@@ -1197,6 +1200,12 @@ mappings:
   - native: yarramate-engine#mcp-adapter-uses-cli
     external: mcpAdapterUsesCli
     type: relationship
+  - native: yarramate-engine#expose-cli-over-mcp
+    external: exposeCliOverMcp
+    type: concept
+  - native: yarramate-engine#mcp-adapter-exposes-cli-surface
+    external: mcpAdapterExposesCliSurface
+    type: relationship
   - native: yarramate-engine#new-command
     external: newCommand
     type: concept
@@ -1332,6 +1341,9 @@ mappings:
   - native: yarramate-engine#design-command-reads-profile-catalogue
     external: designCommandReadsProfileCatalogue
     type: relationship
+  - native: yarramate-engine#design-command-reads-question-catalogue
+    external: designCommandReadsQuestionCatalogue
+    type: relationship
   - native: yarramate-engine#design-command-reads-step-schema
     external: designCommandReadsStepSchema
     type: relationship
@@ -1352,6 +1364,9 @@ mappings:
     type: concept
   - native: yarramate-engine#ask-command-reads-profile-catalogue
     external: askCommandReadsProfileCatalogue
+    type: relationship
+  - native: yarramate-engine#ask-command-reads-question-catalogue
+    external: askCommandReadsQuestionCatalogue
     type: relationship
   - native: yarramate-engine#ask-command-reads-result-schema
     external: askCommandReadsResultSchema
@@ -1404,6 +1419,18 @@ mappings:
   - native: yarramate-engine#local-web-browser
     external: localWebBrowser
     type: concept
+  - native: yarramate-engine#execute-shipped-binaries
+    external: executeShippedBinaries
+    type: concept
+  - native: yarramate-engine#render-visual-session-page
+    external: renderVisualSessionPage
+    type: concept
+  - native: yarramate-engine#runtime-executes-binaries
+    external: runtimeExecutesBinaries
+    type: relationship
+  - native: yarramate-engine#web-browser-renders-session-page
+    external: webBrowserRendersSessionPage
+    type: relationship
   - native: yarramate-engine#web-browser-serves-visual-browser
     external: webBrowserServesVisualBrowser
     type: relationship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
   A catalogue that declared `evidence` passed catalogue validation and then
   produced a report that failed its own schema; the shipped catalogue never
   used the value, so no interview changes.
+- Add the `unconstrained-kind` trigger condition and a `kind-untested` hygiene
+  question (core-enrichment 0.7 → 0.8): a subject whose kind is pinned by no
+  relationship claim could be reclassified freely and still compile, so the
+  interview asks rather than the engine inferring (ADR 0083). 153 of the
+  repository's own 238 concepts carry such a kind; the shipped question is
+  scoped to active-structure, where it opens 4.
+- Publish `relationshipKindEndpointAspects` on `ResolvedProfileContext`, the
+  lineage-resolved table of which endpoints each relationship kind constrains.
 
 ## 0.18.0
 

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.7"
+version: "0.8"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -1075,3 +1075,54 @@ questions:
     resolution: >-
       Declare architecture states and mark presence with present-in where the
       distinction carries decisions; explicitly decline states otherwise.
+
+  - id: kind-untested
+    wave: hygiene
+    since: "0.8"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#resource
+        - yarramate/core@0.1#businessActor
+        - yarramate/core@0.1#businessRole
+        - yarramate/core@0.1#businessCollaboration
+        - yarramate/core@0.1#businessInterface
+        - yarramate/core@0.1#applicationComponent
+        - yarramate/core@0.1#applicationCollaboration
+        - yarramate/core@0.1#applicationInterface
+        - yarramate/core@0.1#node
+        - yarramate/core@0.1#device
+        - yarramate/core@0.1#systemSoftware
+        - yarramate/core@0.1#technologyCollaboration
+        - yarramate/core@0.1#technologyInterface
+        - yarramate/core@0.1#path
+        - yarramate/core@0.1#communicationNetwork
+        - yarramate/core@0.1#equipment
+        - yarramate/core@0.1#facility
+        - yarramate/core@0.1#distributionNetwork
+    trigger:
+      - condition: unconstrained-kind
+    question: >-
+      Nothing in the model tests that {subject.name} is a structural element
+      at all: no behaviour is assigned to it, so reclassifying it as a
+      service, an object, or a goal would compile exactly the same. What
+      does it run, host, or perform?
+    askPlain: >-
+      What does {subject.name} actually do, or what runs on it? The model
+      says what it is but nothing says what it takes part in.
+    materiality: >-
+      A structural kind is a promise that something behaves through this
+      element. Only four relationship kinds constrain the aspect of an
+      endpoint, so where none of them touches the subject the kind is a
+      label no check can contradict — the choice between a node, a piece of
+      system software, and an application component stops carrying
+      information, and diagrams inherit a distinction the model never made.
+    authority: either
+    resolution: >-
+      Assign {subject.name} to the behaviour it performs — the process,
+      function, service, or capability it carries. Assignment is the one
+      claim whose source endpoint must be an active structure, so recording
+      it makes the classification falsifiable. If nothing in scope is
+      assigned to it, reclassify it to a kind that does carry a claim, or
+      retire it with a description saying why it sits outside this
+      architecture.

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -35,11 +35,15 @@ questions. Each question binds:
   direction, whose counterpart is of a given kind — the linkage-depth
   primitive), `missing-reference` (no reference-bearing claim such as a
   constraint binding, by direction), `missing-attestation` (no
-  recorded `yarramate/attestation/<topic>` claim; see ADR 0056), or
+  recorded `yarramate/attestation/<topic>` claim; see ADR 0056),
   `near-duplicate` (the subject resembles another subject of the same
   kind closely enough to be the same thing under two names, and no
   `yarramate/identity/distinct-from` claim dismisses the pair; the
-  algorithm and its thresholds are stated in ADR 0077).
+  algorithm and its thresholds are stated in ADR 0077), or
+  `unconstrained-kind` (no relationship claim pins the aspect at this
+  subject's end, so its kind is a label no check can contradict — only
+  `assignment`, `access`, `triggering`, and `influence` constrain an
+  endpoint's aspect; see ADR 0083).
   Relationship kinds in conditions resolve through profile lineage by
   default, the same rule as subject selectors;
 - a **scope** — `workspace` (asked once) or `subject` (asked per matching

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -30,6 +30,16 @@ inherits its parent's aspect. A relationship kind inherits its parent's
 endpoint constraints and may narrow them with `sourceAspects` or
 `targetAspects`; it cannot broaden an existing restriction.
 
+Those endpoint constraints are the only thing that makes a concept kind
+checkable. In the core profile just four relationship kinds pin an aspect —
+`assignment` (source: active-structure), `access` (target: passive-structure),
+`triggering` (both ends: behavior), and `influence` (target: motivation) — so
+a subject touched by none of them could be reclassified to almost any other
+kind and the workspace would still compile. `ask` reports that gap through
+the `unconstrained-kind` trigger condition rather than guessing a kind
+(ADR 0083); narrowing aspects on an extension relationship kind, as `owns`
+does above, extends the set of claims that can falsify a classification.
+
 Local kind names may not shadow inherited names. Profiles may extend other
 explicit profiles, and resolution is independent of CLI/source order.
 

--- a/docs/adr/0083-a-kind-nothing-constrains-is-a-label.md
+++ b/docs/adr/0083-a-kind-nothing-constrains-is-a-label.md
@@ -1,0 +1,159 @@
+# A kind nothing constrains is a label
+
+Status: accepted
+
+From a MuleSoft modelling probe (2026-08-13): model a public API over
+Salesforce, built on Anypoint CloudHub 2.0, and ask what the engine can
+actually adjudicate about the vendor stack. The honest answer at the time
+was the documented boundary — the engine is blind to requirement words and
+vendor names (`docs/AGENT-INTERFACE.md`), and no catalogue question asks
+about the vendor choice at all. The follow-up question is the interesting
+one: what happens if the engine *does* try to categorise, and what happens
+if it refuses?
+
+Measurement first. A two-concept probe — CloudHub, an Experience API —
+swept concept kind against relationship kind:
+
+| CloudHub kind | `assignment` | `serving` |
+| --- | --- | --- |
+| `node` | OK | OK |
+| `systemSoftware` | OK | OK |
+| `applicationComponent` | OK | OK |
+| `capability` | YM404 | OK |
+
+The engine draws exactly one line here, and it is not the line a modeller
+cares about. It cannot distinguish a node from system software from an
+application component — the choice that carries the meaning — and only
+notices when a *behavior* kind is asked to be the source of an
+`assignment`. Every candidate passes as long as nothing is assigned.
+
+That generalises. The core profile has 62 concept kinds across eight
+layers and five aspects, and eleven relationship kinds. Only four
+relationship kinds constrain the aspect of an endpoint:
+
+| relationship kind | pinned endpoint |
+| --- | --- |
+| `assignment` | source: active-structure |
+| `access` | target: passive-structure |
+| `triggering` | source and target: behavior |
+| `influence` | target: motivation |
+
+Against the repository's own model — 238 concepts, 325 relationships —
+153 concepts carry a kind that nothing in the graph tests. Reclassify any
+of them to any other kind of the same or another aspect and the workspace
+compiles identically.
+
+## Rejected: infer the kind
+
+The engine could map `cloudhub-worker` to `node` from the word, or derive
+a kind from a subject's relationships. Three reasons not to, all of them
+already load-bearing elsewhere:
+
+- The Graphify adapter settled this exact question for evidence and chose
+  explicit mapping only: it "does not infer this correspondence from
+  labels, paths, communities, or similarity"
+  (`docs/GRAPHIFY-ADAPTER.md`). Kind inference is the same inference at
+  the classification layer.
+- `evidence-intent-separation` in `.yarramate/architecture/product.yaml`:
+  observations may support or challenge a proposal but cannot silently
+  author declared intent. An inferred kind is declared intent nobody
+  declared.
+- `deterministic-correctness`: an inferred kind shifts with the lookup
+  table, so `check` stops being reproducible across engine versions —
+  which is `architecture-drift`, the founding driver, reintroduced by the
+  tool. ADR 0082 spent a release removing a record of a judgment nobody
+  made; a guessed kind is that forgery one level down.
+
+## Rejected: make it a `check` error
+
+A model that assigns nothing to its runtimes is thin, not contradictory.
+`check` reports contradictions; thinness is what the interview is for —
+the same split as ADR 0056 (attestation) and ADR 0077 (near-duplicate).
+A rule that fires 153 times on the repository's own model is a warning
+nobody reads, and it would fail every existing repository on upgrade.
+
+## Decided
+
+A deterministic trigger condition, `unconstrained-kind`, plus one hygiene
+question, `kind-untested`, in `catalogues/core-enrichment.yaml` (version
+0.7 → 0.8). The engine gains no opinion about any kind; it reports where
+its own rules cannot reach.
+
+## The rule, exactly
+
+A subject's kind is *tested* when the subject participates in at least one
+relationship claim whose kind pins an aspect at that subject's end of the
+claim: a source-end claim counts when the kind pins `source`, a target-end
+claim counts when it pins `target`. Nothing else counts — not descriptions,
+ownership, states, constraint references, or relationships whose kind pins
+neither side.
+
+Three consequences follow from taking that literally:
+
+- **An absent side is permissive, not unknown.** `serving` pins neither
+  endpoint, so a hundred `serving` claims still test nothing about the
+  kinds at either end. The condition says so.
+- **Endpoint aspects resolve through profile lineage**, the same rule as
+  subject selectors and relationship kinds in every other condition. An
+  extension relationship kind inherits its parent's pins; an extension
+  concept kind is answerable exactly when its parent is, so
+  `cloudhub-worker` parented under `applicationComponent` is interrogated
+  as an application component without the catalogue knowing the word.
+- **No profile context, no finding.** When the caller supplies no resolved
+  profile the rules are unknown rather than absent, and the condition
+  reports nothing instead of inventing a gap.
+
+`relationshipKindEndpointAspects` is published on `ResolvedProfileContext`
+for this, alongside the existing kind lineages: the compiler already
+resolves the constraint to enforce YM404, and the interview now reads the
+same table rather than re-deriving it.
+
+## Why the shipped question is scoped to active-structure
+
+The condition is general; the scoping is a catalogue decision, and it was
+made by measurement, not taste. Untested subjects in the repository's own
+model, by aspect:
+
+| aspect | untested | subjects |
+| --- | --- | --- |
+| active-structure | 4 | 21 |
+| motivation | 8 | 9 |
+| behavior | 43 | 58 |
+| passive-structure | 98 | 150 |
+
+Where the untested share is the majority the question is a background hum.
+A `repository-file` artifact nobody has modelled a reader for is ordinary
+(86 of them here); a service that is realized and serves but is never
+sequenced by a `triggering` claim is ordinary. Active-structure is the one
+aspect where the missing claim is `assignment` — the claim that says this
+element performs something — and where absence is rare enough to read as
+an omission rather than as the shape of the model.
+
+Widening to the other aspects is a catalogue edit under a later version,
+not an engine change. It is deferred until a model exists where the ratio
+inverts.
+
+## Rejected on measurement: a `layers` selector
+
+The first cut added a `layers` filter to the catalogue subject selector,
+on the theory that the discriminating axis was layer — ask about
+technology and application elements, skip motivation. Scoping by layer
+opens 153 questions; scoping by aspect opens 4. Layer is a presentation
+grouping, aspect is what the relationship rules actually key on. The
+filter was reverted before it shipped, and the selector keeps the two
+narrowing dimensions it already had.
+
+## What it catches
+
+Four subjects in the repository's own model: `local-web-browser` and
+`nodejs-runtime` (`systemSoftware`), `mcp-adapter` and `profile-catalogue`
+(`applicationComponent`). All four are declared runtimes and components
+with nothing assigned to them and nothing running on them — the model
+names the browser that renders visual sessions without ever saying what
+runs in it.
+
+And the MuleSoft case in miniature, which is where the question came from.
+The engine still will not choose between `node`, `systemSoftware`, and
+`applicationComponent` for CloudHub. It now says out loud that the choice
+is currently unfalsifiable, and `authority: either` lets an agent propose
+the assignment while a human confirms it.

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -346,6 +346,19 @@
               "const": "near-duplicate"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject's kind is never tested by anything the compiler can check: it participates in no relationship whose kind pins the aspect at the subject's end, so reclassifying it to any other kind of any other aspect would still compile. The kind is a label rather than a constraint (ADR 0083).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unconstrained-kind"
+            }
+          }
         }
       ]
     },

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,6 +3,7 @@ import { LineCounter, parseDocument } from 'yaml'
 import {
   conceptKinds,
   relationshipPolicies,
+  type Aspect,
   type Layer,
   type Rigidity,
 } from './profile.js'
@@ -183,10 +184,23 @@ export interface SemanticGraph {
   readonly claims: readonly GraphClaim[]
 }
 
+// Which endpoint aspects a relationship kind pins, resolved through profile
+// lineage. An absent side is the honest reading: that endpoint accepts any
+// aspect, so a claim of this kind tests nothing about how its subject was
+// classified (ADR 0083).
+export interface RelationshipEndpointAspects {
+  readonly source?: readonly Aspect[]
+  readonly target?: readonly Aspect[]
+}
+
 export interface ResolvedProfileContext {
   readonly conceptKindLineages: ReadonlyMap<string, readonly string[]>
   readonly relationshipKindLineages: ReadonlyMap<string, readonly string[]>
   readonly conceptKindLayers: ReadonlyMap<string, string>
+  readonly relationshipKindEndpointAspects: ReadonlyMap<
+    string,
+    RelationshipEndpointAspects
+  >
 }
 
 export type CompilationResult =
@@ -1937,6 +1951,21 @@ function compileWorkspaceResolved(
         [...conceptKindByIdentity]
           .sort(([left], [right]) => left.localeCompare(right))
           .map(([identity, kind]) => [identity, kind.layer] as const),
+      ),
+      relationshipKindEndpointAspects: immutableMap(
+        [...relationshipKindByIdentity]
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([identity, kind]) => [
+            identity,
+            Object.freeze({
+              ...(kind.sourceAspects === undefined
+                ? {}
+                : { source: Object.freeze([...kind.sourceAspects]) }),
+              ...(kind.targetAspects === undefined
+                ? {}
+                : { target: Object.freeze([...kind.targetAspects]) }),
+            }) as RelationshipEndpointAspects,
+          ] as const),
       ),
     },
     graph: {

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -55,6 +55,7 @@ type CatalogueCondition =
     }
   | { readonly condition: 'missing-attestation'; readonly topic: string }
   | { readonly condition: 'near-duplicate' }
+  | { readonly condition: 'unconstrained-kind' }
 
 export interface CatalogueQuestion {
   readonly id: string
@@ -421,6 +422,30 @@ const conditionHolds = (
       // index, so this reads exactly like every other condition: the claim's
       // existence is the whole signal (ADR 0056).
       return (index.nearDuplicates().get(subjectId!) ?? []).length > 0
+    case 'unconstrained-kind': {
+      // A compiled graph already satisfies every aspect rule it is subject to
+      // (YM404), so participation in a kind that pins the aspect at this
+      // subject's end is the whole test: reclassify the subject to another
+      // aspect and the workspace stops compiling. Where no such claim exists
+      // the kind is a label the engine can never contradict (ADR 0083).
+      // Without a profile context the rules are unknown, not absent, so the
+      // condition reports nothing rather than inventing a finding.
+      if (profileContext === undefined) return false
+      return !index.relationshipClaims.some((claim) => {
+        const endpoints = profileContext.relationshipKindEndpointAspects.get(
+          claim.predicate,
+        )
+        if (endpoints === undefined) return false
+        if (endpoints.source !== undefined && claim.subject === subjectId) {
+          return true
+        }
+        return (
+          endpoints.target !== undefined &&
+          'ref' in claim.object &&
+          claim.object.ref === subjectId
+        )
+      })
+    }
   }
 }
 

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -470,6 +470,94 @@ describe('ask --open interrogation', () => {
     })
   })
 
+  it('opens a kind nothing constrains and closes it through an inherited endpoint aspect', () => {
+    // ADR 0083: a kind is falsifiable only where some relationship kind pins
+    // the aspect at that subject's end. The fixture's `owns` declares no
+    // `sourceAspects` - it inherits `active-structure` from core
+    // `assignment` - so the pin is only visible through profile lineage.
+    // `association` pins neither end, which is the control: participating in
+    // a relationship is not the test, being constrained by one is.
+    const hygiene =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: kind-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: hygiene\n' +
+      '    name: Hygiene\n' +
+      'questions:\n' +
+      '  - id: kind-untested\n' +
+      '    wave: hygiene\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#businessActor"]\n' +
+      '    trigger:\n' +
+      '      - condition: unconstrained-kind\n' +
+      '    question: Nothing tests that {subject.name} is what its kind says.\n' +
+      '    materiality: A kind no rule can contradict is a label.\n' +
+      '    authority: either\n' +
+      '    resolution: Assign it to the behaviour it performs.\n'
+    const kinded =
+      'format: yarramate/v1\n' +
+      'id: main\n' +
+      'profile: example/platform@1.0\n' +
+      'concepts:\n' +
+      '  - id: platform\n' +
+      '    kind: platform-team\n' +
+      '    name: Platform team\n' +
+      '  - id: customer\n' +
+      '    kind: businessActor\n' +
+      '    name: Customer\n' +
+      '  - id: rollout\n' +
+      '    kind: businessProcess\n' +
+      '    name: Rollout\n' +
+      'relationships: []\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), hygiene, 'utf8')
+    writeFileSync(join(workspace, 'architecture/main.yaml'), kinded, 'utf8')
+
+    const before = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(before.exitCode).toBe(0)
+    const opened = JSON.parse(before.stdout).report
+    expect(opened.summary).toEqual({ questions: 1, openQuestions: 1, open: 2 })
+    expect(
+      opened.waves[0].questions[0].subjects.map(
+        (subject: { readonly id: string }) => subject.id,
+      ),
+    ).toEqual(['main#customer', 'main#platform'])
+
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      kinded.replace(
+        'relationships: []\n',
+        'relationships:\n' +
+          '  - id: platform-owns-rollout\n' +
+          '    kind: owns\n' +
+          '    from: platform\n' +
+          '    to: rollout\n' +
+          '  - id: customer-associates-rollout\n' +
+          '    kind: association\n' +
+          '    from: customer\n' +
+          '    to: rollout\n',
+      ),
+      'utf8',
+    )
+    const after = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(after.exitCode).toBe(0)
+    const remaining = JSON.parse(after.stdout).report
+    expect(remaining.summary).toEqual({ questions: 1, openQuestions: 1, open: 1 })
+    expect(
+      remaining.waves[0].questions[0].subjects.map(
+        (subject: { readonly id: string }) => subject.id,
+      ),
+    ).toEqual(['main#customer'])
+  })
+
   it('keeps the shipped catalogue fully closed on the repository self-model', () => {
     const result = runCli(
       ['ask', '.yarramate/workspace.yaml', '--open', '--json'],

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -1601,7 +1601,7 @@ views:
         "view starter-technology-deployment {\n" +
           "    title '4 · ArchiMate viewpoints / Technology and deployment'\n" +
           "    description 'Technology structure, behavior, services, networks, and deployed artifacts.'\n" +
-          '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, likec4ExportAdapter, localWebBrowser, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli, visualBrowser, visualRuntime',
+          '    include consumerHost, consumerPackage, engineCli, engineGraphifyEvidenceAdapter, executeShippedBinaries, likec4ExportAdapter, localWebBrowser, mcpAdapter, nodejsRuntime, npmPackage, packageConsumerTests, productDesignSolutionBeforeBuild, productDiscoverProjectArchitecture, productStableCli, renderVisualSessionPage, visualBrowser, visualRuntime',
       )
       const marker = JSON.parse(
         readFileSync(
@@ -2578,8 +2578,8 @@ mappings:
               'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
             subject: 'yarramate-engine#likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/124',
-            line: 1325,
+            pointer: '/relationships/125',
+            line: 1348,
             column: 5,
           },
           {
@@ -2589,8 +2589,8 @@ mappings:
               'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
             subject: 'yarramate-engine#likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/125',
-            line: 1329,
+            pointer: '/relationships/126',
+            line: 1352,
             column: 5,
           },
           {


### PR DESCRIPTION
## Summary

A concept kind was a label the engine could never contradict. `check` reads structure — cardinality, endpoints, references, aspects on the four relationship kinds that declare them — but nothing reads a subject's *kind* against how that subject actually participates. On the repository self-model, 171 of 238 subjects carried a classification no rule tests.

The MuleSoft modelling probe (2026-08-13) is the concrete case: declare `cloudhub-worker` under `node`, `systemSoftware`, or `applicationComponent` and all three compile identically. The honest answer was "the engine has no opinion", and the only reason it holds is that nothing `assignment`s to any of them.

This PR keeps the engine's refusal to infer kinds (ADR 0082: no engine-authored claims) and adds the measurement instead.

## What changed

**Engine** — `ResolvedProfileContext` now publishes two lineage-resolved tables:
- `conceptKindLayers` — every kind's ArchiMate layer;
- `relationshipKindEndpointAspects` — which endpoint aspect each relationship kind pins at each end, resolved through profile lineage so extension relationship kinds inherit their parent's constraints.

**Catalogue condition** — new `unconstrained-kind` trigger: a subject matches when no relationship claim it participates in pins an aspect at its end. Four core relationship kinds constrain an endpoint (`assignment` source: active-structure, `access` target: passive-structure, `influence` target: motivation, `triggering` both: behavior), so "unconstrained" is a statement about compiled participation, not a guess about intent.

**Question** — `kind-untested` in the hygiene wave (`core-enrichment` 0.7 → 0.8), scoped to structural kinds across `resource`, `businessActor`, `businessRole`, `businessCollaboration`, `businessInterface`, `applicationComponent`, `applicationCollaboration`, `applicationInterface`, `device`, `systemSoftware`, `technologyCollaboration`, `technologyInterface`, `path`, `communicationNetwork`, `equipment`, `facility`, `distributionNetwork`. Resolution names the two legal answers: assign it to the behaviour it performs, or retire it with a description saying why it sits outside this architecture.

**ADR 0083** — records why the pressure is a question and not an inference.

## What the self-model answered

Scoping by aspect rather than layer is what made it answerable: `active-structure` returned 4 open subjects out of 238, not 153 noise rows.

| Subject | Declared as | Nothing |
|---|---|---|
| `local-web-browser` | `systemSoftware` | ran on it |
| `nodejs-runtime` | `systemSoftware` | executed by it |
| `mcp-adapter` | `applicationComponent` | assigned to it |
| `profile-catalogue` | `applicationComponent` | assigned to it |

Fixed in the model, not suppressed: added `execute-shipped-binaries` (technologyFunction) and `render-visual-session-page` (applicationFunction), assigned them, and reclassified `profile-catalogue` and `kind-catalogue` as `dataObject` — they are resolved vocabulary the compiler reads, not components that run. LikeC4 subject mappings and evidence observations follow the new subjects.

## Contract impact

- `schema/yarramate-question-catalogue.schema.json` — additive: one new `condition` branch. Catalogues that do not use it are unaffected.
- `catalogues/core-enrichment.yaml` — internal shipped data, version 0.7 → 0.8 per ADR 0063 (a new question is an additive version bump).
- No CLI surface change. No Core document format change.

## Validation

- `pnpm verify` — typecheck, build, **836 tests / 50 files**, `self:check` (238 concepts, 330 relationships, 4 states, no errors), LikeC4 validation green.
- Guard proof: reverting the participation test in `conditionHolds` to a naive existence check fails the new test.
- `ask .yarramate/workspace.yaml --open` — 40 questions, 0 open on the self-model.
- Two positional assertions in `test/likec4-cli.test.ts` (engine.yaml relationship indices, technology-deployment include list) updated for the new self-model subjects.
