### PR TITLE
docs: record the native visual adapter in the roadmap and backlog

### DIFF
--- a/docs/BACKLOG-DISPOSITION.md
+++ b/docs/BACKLOG-DISPOSITION.md
@@ -23,7 +23,10 @@ The current repository implements the agreed foundation for:
   logical and dynamic output;
 - non-destructive LikeC4 mapping synchronization, opt-in stale-entry pruning,
   and source-located project reference diagnostics;
-- explicit Graphify node observation producing standard evidence overlays.
+- explicit Graphify node observation producing standard evidence overlays;
+- native browser visualization and mechanical model editing through the
+  `yarramate-visual` adapter, its published `yarramate/visual-protocol/v2`
+  wire, and changeset commits that land through `yarramate apply`.
 
 There is no remaining concrete, locally actionable item in the agreed Core 0.1
 or initial journey scope.
@@ -66,6 +69,13 @@ Additional authoring, catalogue, source, runtime, visualization, or evidence
 adapters need a named tool, consumer journey, input/output contract, and
 acceptance fixture. “Additional adapters” alone is not an implementable
 requirement.
+
+This gate has been resolved once, for browser visualization and mechanical
+editing: the named tool is cytoscape.js, the consumer journey is a reviewer
+reading and correcting the model in a session, the contract is
+`yarramate/visual-protocol/v2`, and the acceptance fixtures are the visual
+session, protocol, and app suites. Further adapters in any of these
+categories still need their own four answers.
 
 When one of these gates is resolved, add a bounded roadmap item and ADR before
 implementation. Until then, the local backlog is exhausted rather than

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,6 +135,20 @@ notation.
   styling parity remain future adapter work.
   Adapter-owned deployment nodes and named instances of projected concepts
   are implemented with regression validation.**
+- Native browser visualization and mechanical editing adapter.
+  **`yarramate-visual` runs a foreground session that publishes a browser URL;
+  cytoscape.js renders the native graph v2 model directly, with no DSL and no
+  LikeC4 round-trip. Layered, radial, and force layout backends, native and
+  ArchiMate notation modes, kind icons, and lifecycle, evidence, and ownership
+  badges are implemented. Saved views persist as ordinary
+  `.yarramate/projections/*.yaml` documents and dragged positions as
+  `.yarramate/visual-layout` sidecars. Dropdown-constrained field edits
+  accumulate in a changeset that commits through `yarramate/operations/v1` and
+  `yarramate apply`, so the browser holds no private write path. The wire is
+  the published `yarramate/visual-protocol/v2` contract; see
+  `docs/VISUAL-ADAPTER.md` and ADRs 0081 and 0084 to 0088. In-app undo and
+  redo, renaming a subject identity, and concurrent-edit conflict resolution
+  across browsers remain future adapter work.**
 - Generic evidence-provider interface.
   **A provider-neutral existing-claim evidence overlay and deterministic report
   are implemented. Constraint assessment reuses that seam; the first optional


### PR DESCRIPTION
## Summary

`docs/ROADMAP.md` and `docs/BACKLOG-DISPOSITION.md` still described visualization
as LikeC4-only and as an unresolved demand gate, four merged plans after
`yarramate-visual` started rendering and editing the native model directly. This
records what shipped.

- **Roadmap 0.6** gains a `Native browser visualization and mechanical editing
  adapter` entry: cytoscape.js over the native graph v2 model with no DSL and no
  LikeC4 round-trip; layered, radial, and force backends; native and ArchiMate
  notation with kind icons; lifecycle, evidence, and ownership badges; saved views
  as ordinary `.yarramate/projections/*.yaml`; positions as
  `.yarramate/visual-layout` sidecars; dropdown-constrained field edits committing
  through `yarramate/operations/v1` and `yarramate apply`; the published
  `yarramate/visual-protocol/v2` wire. Deferred items are named: in-app undo/redo,
  renaming a subject identity, cross-browser conflict resolution.
- **Backlog `Locally complete`** gains the same adapter, stated as the write path
  it actually uses.
- **Backlog `Demand-gated`** keeps its wording for *additional* adapters and now
  records that the gate was resolved once, answering its own four questions for
  this adapter: named tool (cytoscape.js), consumer journey (a reviewer reading
  and correcting the model in a session), contract
  (`yarramate/visual-protocol/v2`), acceptance fixtures (the visual session,
  protocol, and app suites).

## Related issue

None.

## Contract impact

None. No schema, format, command, or semantic change — documentation only. Every
claim added is grounded in shipped code: `src/adapters/visual/`,
`src/visual-app/`, `docs/VISUAL-ADAPTER.md`, and ADRs 0081 and 0084 to 0088.

## Deliberately not in this PR

`docs/BACKLOG-DISPOSITION.md:31-32` still asserts there is no remaining concrete,
locally actionable item in scope. That is currently false — issue #177 (evidence
observations cannot be authored through `apply`, so the one editing surface this
repo now ships cannot record evidence) is concrete and in scope. It is corrected
by the PR that implements it rather than edited twice.

## Validation

- `npx prettier --check docs/ROADMAP.md docs/BACKLOG-DISPOSITION.md` — clean.
- Adapter claims verified against source before writing: layout backend names in
  `src/visual-app/graph-canvas.tsx`, sidecar and projection paths in
  `src/adapters/visual/session-server.ts`, wire version in
  `src/adapters/visual/protocol-contract.ts:15`, fixture files in `test/`.

## Checklist

- [x] Tests or documentation cover the change where appropriate. (Documentation
      only; nothing executable changed.)
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where
      required. (No interface change; this records ADRs 0081 and 0084 to 0088.)
