### PR TITLE
feat: land evidence observations through yarramate apply

### DIFF
--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -797,3 +797,83 @@ observations:
     result: confirmed
     evidence:
       uri: repo:test/workspace.test.ts
+  - subject: yarramate-engine#build-visual-session-request
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/request.ts
+  - subject: yarramate-engine#commit-visual-changeset
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-server.ts
+  - subject: yarramate-engine#save-visual-layout
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/session-server.ts
+  - subject: yarramate-engine#visual-layout-sidecar
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-layout.schema.json
+  - subject: yarramate-engine#render-visual-presentation-badges
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/badges.ts
+  - subject: yarramate-engine#render-archimate-kind-icons
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/kind-icons.ts
+  - subject: yarramate-repository#visual-request-source
+    result: confirmed
+    evidence:
+      uri: repo:src/adapters/visual/request.ts
+  - subject: yarramate-repository#visual-canvas-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/graph-canvas.tsx
+  - subject: yarramate-repository#visual-inspector-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/subject-form.tsx
+  - subject: yarramate-repository#visual-changeset-tray-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/changeset-tray.tsx
+  - subject: yarramate-repository#visual-badges-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/badges.ts
+  - subject: yarramate-repository#visual-kind-icons-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/kind-icons.ts
+  - subject: yarramate-repository#visual-layout-schema-source
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-layout.schema.json
+  - subject: yarramate-repository#visual-request-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/visual-request.test.ts
+  - subject: yarramate-repository#visual-canvas-layout-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/graph-canvas-layout.test.ts
+  - subject: yarramate-repository#visual-inspector-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/subject-form.test.ts
+  - subject: yarramate-repository#visual-changeset-tray-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/changeset-tray.test.ts
+  - subject: yarramate-repository#visual-badges-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/badges.test.ts
+  - subject: yarramate-repository#visual-kind-icons-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/kind-icons.test.ts
+  - subject: yarramate-repository#apply-operations-tests
+    result: confirmed
+    evidence:
+      uri: repo:test/apply-operations.test.ts

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -310,6 +310,49 @@ distinguishable from one that never had a graph to check against.
 about who wrote a record, not a contradiction between the model and
 observed reality, so it reports rather than gates.
 
+## Writing overlays
+
+An overlay is a workspace document, so `yarramate apply` writes it the way
+it writes a model document: `add-observation`, `update-observation`, and
+`delete-observation` address an evidence document declared by the manifest's
+`evidence` list (ADR 0089). Before this the only way to record what a
+provider read was to open the file, which is exactly the hand-editing the
+apply loop exists to prevent — a reviewer who adds a concept through the
+visual canvas or a batch has no path to the evidence for it.
+
+```yaml
+format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: .yarramate/evidence/repository.yaml
+    observation:
+      subject: yarramate-engine#compiler
+      result: confirmed
+      evidence:
+        uri: repo:src/compiler.ts
+```
+
+An observation is addressed by the pair (target, key) rather than by an
+`id`, because an overlay entry has none: `reconcile` already treats that
+pair as unique per document (ADR 0075, `YM803`). The target is the
+observation's `subject` or `claim`; a keyless observation is the presence
+claim for its target, so an absent `key` is itself an address rather than a
+wildcard. `update-observation` names the entry the same way and changes
+whatever else it carries — `result`, `value`, `evidence.uri`,
+`evidence.message` — scalars replacing in place. Retraction is explicit and
+narrow: `remove: [message]` is the only retraction an observation admits,
+because `message` is the only optional field it holds, and setting and
+removing it in one operation is rejected rather than ordered.
+`delete-observation` removes the whole entry.
+
+The gate is the one every batch passes. The candidate workspace compiles,
+then every touched overlay is loaded and evaluated against the compiled
+graph, before a single byte is written: an observation whose subject the
+graph does not carry rejects the batch with `YM801` and leaves every source
+unchanged. `yarramate/apply-result/v1` counts the work as
+`addedObservations`, `updatedObservations`, and `deletedObservations`
+alongside the concept and relationship counts.
+
 ## Boundary
 
 Evidence overlays do not:

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -433,9 +433,9 @@ operations:
 yarramate apply operations.yaml .yarramate/workspace.yaml
 ```
 
-The operations are `add-concept`, `add-relationship`, `update-concept`,
-`update-relationship`, `delete-concept`, and `delete-relationship`. Concept
-and relationship records accept the same
+The model operations are `add-concept`, `add-relationship`,
+`update-concept`, `update-relationship`, `delete-concept`, and
+`delete-relationship`. Concept and relationship records accept the same
 optional fields as the authoring format — for example `status`,
 `description`, `aka`, `owner`, `distinctFrom`, `supersedes`,
 `constraints`, `references`, `presentIn`, `attestations`, and the
@@ -456,6 +456,14 @@ Integrity is evaluated against the post-batch state, so a concept and its
 referring relationships can leave in one batch (ADR 0069). Retirement
 (`status: retired`) remains the descoping path; delete only when the
 history itself is noise.
+
+Three further operations — `add-observation`, `update-observation`, and
+`delete-observation` — address an evidence overlay declared by the
+manifest's `evidence` list rather than a model document. An overlay entry
+has no `id`, so an observation is addressed by the pair (target, key)
+instead (ADR 0089); `docs/EVIDENCE.md` covers the shape. They pass the same
+atomic gate: the candidate workspace compiles and every touched overlay is
+evaluated against the compiled graph before anything is written.
 
 An `attestations` entry an operation writes must carry `recordedBy`, even
 though a hand-authored document may omit it: a batch is a machine's

--- a/docs/adr/0089-an-observation-is-a-write-addressed-by-its-pair.md
+++ b/docs/adr/0089-an-observation-is-a-write-addressed-by-its-pair.md
@@ -1,0 +1,121 @@
+# An observation is a write, addressed by its pair
+
+Status: accepted
+
+`yarramate apply` compiled the whole candidate workspace before writing a
+byte, and could not write an observation. Evidence overlays were outside it,
+so the only way to record what a provider read was to open
+`.yarramate/evidence/*.yaml` and type into it — exactly the hand-authoring the
+`design` → `apply` loop exists to prevent. Issue #177 measured the cost: 20
+subjects created by the visual work carried no observation at all, and nothing
+in the gate noticed, because the write surface that could have recorded them
+did not exist.
+
+That matters more than a workflow nit. Evidence is where honesty lives: the
+atomic gate, the located diagnostic, and the splice writer's byte-identical
+untouched regions all protect concepts and relationships. An observation — the
+claim that says _this really exists and here is the artifact proving it_ — got
+none of that protection and was authored by the least validated path in the
+repository.
+
+Decided: `operations/v1` gains `add-observation`, `update-observation`, and
+`delete-observation`. They are addressed by manifest path like every other
+operation, and they land through the same batch.
+
+```yaml
+format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: .yarramate/evidence/repository.yaml
+    observation:
+      subject: yarramate-engine#commit-visual-changeset
+      key: exists
+      value: "true"
+      result: confirmed
+      evidence:
+        uri: repo:src/adapters/visual/session-server.ts
+        message: The commit handler calls applyOperations
+```
+
+## The address is the pair, not an id
+
+A concept operation names an `id`. An overlay entry has none. The pair
+`(target, key)` is what `reconcile` already treats as unique per document —
+it is the pair `YM803` rejects a duplicate of — so it is the address here too,
+and no new identity is minted. `target` is `subject` or `claim`, never both,
+which the schema enforces as a `oneOf` rather than leaving to the writer.
+
+A keyless observation is not a wildcard. It is the presence claim for its
+target, addressable in its own right, and an operation that omits `key`
+matches only the entry that also omits it.
+
+The consequence for the schema is that `add` and `update` cannot share a
+shape. `add` requires `result` and `evidence`, because an entry without them
+asserts nothing. `update` requires neither, because it names an address and
+changes whatever else it lists; `value` still depends on `key`, since `key`
+without `value` is a different address rather than a partial write. Sharing
+one `$defs` entry between them would have forced `add` to accept an
+assertionless entry or `update` to restate the whole observation on every
+edit.
+
+## The atomic gate extends, and it extends by evaluating
+
+The first of issue #177's open questions was whether the atomic gate covers
+overlays, given that the compiler never reads them. "The whole workspace must
+compile" says nothing about a file that is not a compiler input.
+
+It extends, restated: the model documents must compile, and every overlay the
+batch touched must load and evaluate against the graph that batch just proved
+compiles. An observation naming a subject that does not exist is rejected by
+`apply`, not discovered later by `reconcile`. Nothing is written until both
+pass, so a batch that adds a concept and records the observation proving it
+lands whole or not at all.
+
+Only touched overlays are evaluated. Pre-existing drift elsewhere in the
+workspace is `reconcile`'s report to make; failing an unrelated batch for it
+would make every edit hostage to a stale entry nobody in this batch read.
+
+## Retraction is deleting the entry, and `remove` is only the message
+
+The second question was whether `remove` and retraction apply to observations
+at all, since a provider re-run legitimately replaces what it wrote.
+
+An entry that no longer holds is deleted: `delete-observation` retracts it,
+and unlike a concept deletion it stages no reference-integrity check, because
+an overlay entry is nobody's reference target. A provider re-running replaces
+its entries the same way — delete and add, or update in place — and needs no
+special verb.
+
+Field-level `remove` accepts exactly one field: `evidence.message`. `result`
+and `evidence.uri` are what make the entry an observation, so removing either
+leaves a shape `add` would have refused, and `value` is half of the address.
+The prose note is the only genuinely optional thing an entry carries, and it
+is the only thing `remove` can take back. Setting and removing the same field
+in one operation is a contradiction the batch rejects rather than resolves.
+
+## Provenance is a property of the document, not the operation
+
+The third question was whether provider-authored overlays and human-authored
+ones need different treatment, since the loop should not invite hand-authoring
+of something a provider owns.
+
+They do not, because `provider` is a document-level field naming _how the
+world was read_, not _who typed the file_. An agent that uses `apply` to record
+a `repository-audit` observation is claiming it performed a repository audit —
+the identical claim the audit's own writer makes. `apply` cannot check that
+claim for either of them, and pretending to by gating on a provider allowlist
+would encode a registry this repository does not have.
+
+What follows is a convention, not a check: a provider that regenerates its
+document wholesale should own a document nobody else writes, because
+regeneration drops entries it did not author. The manifest already lets a
+workspace declare as many overlays as it needs. `apply` enforces only what it
+can see — the overlay is listed in the manifest, it loads, and it evaluates.
+
+## What this does not do
+
+It does not let the browser author evidence. The visual changeset carries
+observation operations through to `apply` unchanged, and the tray can describe
+one, but no inspector control composes one yet. A reviewer who adds a concept
+on the canvas still has no path to the evidence for it — that path is a
+surface, and this ADR is the write verb it will need.

--- a/schema/yarramate-apply-result.schema.json
+++ b/schema/yarramate-apply-result.schema.json
@@ -17,7 +17,10 @@
         "updatedConcepts",
         "updatedRelationships",
         "deletedConcepts",
-        "deletedRelationships"
+        "deletedRelationships",
+        "addedObservations",
+        "updatedObservations",
+        "deletedObservations"
       ],
       "properties": {
         "addedConcepts": { "type": "integer", "minimum": 0 },
@@ -25,7 +28,10 @@
         "updatedConcepts": { "type": "integer", "minimum": 0 },
         "updatedRelationships": { "type": "integer", "minimum": 0 },
         "deletedConcepts": { "type": "integer", "minimum": 0 },
-        "deletedRelationships": { "type": "integer", "minimum": 0 }
+        "deletedRelationships": { "type": "integer", "minimum": 0 },
+        "addedObservations": { "type": "integer", "minimum": 0 },
+        "updatedObservations": { "type": "integer", "minimum": 0 },
+        "deletedObservations": { "type": "integer", "minimum": 0 }
       }
     },
     "documents": {

--- a/schema/yarramate-operations.schema.json
+++ b/schema/yarramate-operations.schema.json
@@ -247,6 +247,137 @@
         }
       }
     },
+    "observationTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "subject": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "claim": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "key": {
+          "$ref": "#/$defs/nonEmptyText"
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["subject"],
+          "not": {
+            "required": ["claim"]
+          }
+        },
+        {
+          "required": ["claim"],
+          "not": {
+            "required": ["subject"]
+          }
+        }
+      ]
+    },
+    "observationFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": {
+        "key": ["value"],
+        "value": ["key"]
+      },
+      "properties": {
+        "subject": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "claim": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "key": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "value": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "result": {
+          "enum": ["confirmed", "contradicted", "unknown", "not-observed"]
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["uri"],
+          "properties": {
+            "uri": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "message": {
+              "$ref": "#/$defs/nonEmptyText"
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["subject"],
+          "not": {
+            "required": ["claim"]
+          }
+        },
+        {
+          "required": ["claim"],
+          "not": {
+            "required": ["subject"]
+          }
+        }
+      ]
+    },
+    "observationChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": {
+        "value": ["key"]
+      },
+      "properties": {
+        "subject": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "claim": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "key": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "value": {
+          "$ref": "#/$defs/nonEmptyText"
+        },
+        "result": {
+          "enum": ["confirmed", "contradicted", "unknown", "not-observed"]
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "uri": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "message": {
+              "$ref": "#/$defs/nonEmptyText"
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["subject"],
+          "not": {
+            "required": ["claim"]
+          }
+        },
+        {
+          "required": ["claim"],
+          "not": {
+            "required": ["subject"]
+          }
+        }
+      ]
+    },
     "operation": {
       "oneOf": [
         {
@@ -445,6 +576,69 @@
             },
             "relationship": {
               "$ref": "#/$defs/deleteTarget"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["op", "document", "observation"],
+          "properties": {
+            "op": {
+              "const": "add-observation"
+            },
+            "document": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "observation": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/observationFields"
+                },
+                {
+                  "type": "object",
+                  "required": ["result", "evidence"]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["op", "document", "observation"],
+          "properties": {
+            "op": {
+              "const": "update-observation"
+            },
+            "document": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "observation": {
+              "$ref": "#/$defs/observationChange"
+            },
+            "remove": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "enum": ["message"]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["op", "document", "observation"],
+          "properties": {
+            "op": {
+              "const": "delete-observation"
+            },
+            "document": {
+              "$ref": "#/$defs/nonEmptyText"
+            },
+            "observation": {
+              "$ref": "#/$defs/observationTarget"
             }
           }
         }

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -81,6 +81,10 @@ cite the pattern by name when explaining the resulting model.
    when states or several related declarations make that clearer.
 6. Add an evidence overlay only for existing subjects or stable claim IDs.
    Evidence supports or challenges the proposal; it is not a second model.
+   Observations land through the same `yarramate apply` batch as the model
+   they observe (`add-observation`, `update-observation`,
+   `delete-observation`) — the loop that keeps a partial edit off disk is
+   the loop that keeps an unevaluated observation off disk.
 7. Add the focused projections needed to answer the
    repository-orientation question. Add a separate projection for every
    ordered flow that needs a dynamic view, then include each intended view in

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -330,6 +330,36 @@ Evidence evaluates an existing subject or stable claim ID. Results are
 observed subject directly through evidence or mutate declared intent from an
 evidence result.
 
+Overlays are workspace documents, so write them the way you write a model
+document — through `yarramate apply`, never by hand:
+
+```yaml
+format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: .yarramate/evidence/repository.yaml
+    observation:
+      subject: delivery#delivery-api
+      result: confirmed
+      evidence: { uri: "repo:src/delivery-api.ts" }
+  - op: update-observation
+    document: .yarramate/evidence/repository.yaml
+    observation:
+      claim: delivery#api-accesses-data
+      result: confirmed
+      evidence: { message: Storage behavior is now explicit }
+  - op: delete-observation
+    document: .yarramate/evidence/repository.yaml
+    observation: { subject: delivery#retired-api }
+```
+
+An observation is addressed by its `(target, key)` pair, not by an id: the
+target is `subject` or `claim`, and `key` names a value observation. Omit
+`key` for the presence claim itself. An update enriches like `update-*` on a
+concept — scalars replace, `remove: [message]` retracts — and the whole
+batch is rejected unless the candidate workspace compiles and every touched
+overlay evaluates cleanly against it.
+
 ## LikeC4 project
 
 Keep visualization configuration outside native documents. Project `mapping`,

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -18,6 +18,7 @@ import {
   type CliResult,
 } from './cli-support.js'
 import { compileWorkspace, type Diagnostic, type WorkspaceSource } from './compiler.js'
+import { evaluateEvidence, loadEvidence } from './evidence.js'
 import {
   loadSourceDocument,
   locateSourcePath,
@@ -31,6 +32,7 @@ import type {
   ConceptFields,
   ConstraintReference,
   IdentifiedReference,
+  ObservationTarget,
   OperationsDocument,
   RelationshipFields,
   YarramateApplyResult,
@@ -49,6 +51,11 @@ const SCALAR_CONCEPT_FIELDS = ['kind', 'name', 'description', 'status', 'owner']
 const LIST_CONCEPT_FIELDS = ['aka', 'constraints', 'references', 'presentIn', 'attestations', 'distinctFrom', 'supersedes'] as const
 const SCALAR_RELATIONSHIP_FIELDS = ['kind', 'from', 'to', 'name', 'description', 'status', 'mode', 'content'] as const
 const LIST_RELATIONSHIP_FIELDS = ['references', 'presentIn'] as const
+// An overlay entry's address is the pair (target, key); everything else it
+// carries is editable. `uri` and `message` sit one level down, inside the
+// entry's own `evidence:` mapping.
+const SCALAR_OBSERVATION_FIELDS = ['result', 'value'] as const
+const EVIDENCE_FIELDS = ['uri', 'message'] as const
 
 // ---------------------------------------------------------------------------
 // The splice layer. Every operation becomes a minimal text edit against the
@@ -143,11 +150,12 @@ const itemFieldInsertAt = (source: string, map: YAMLMap): number => {
   return afterContentLine(source, anchor)
 }
 
-// Appends one item to a top-level block collection (`concepts:` or
-// `relationships:`), creating or converting the collection when needed.
+// Appends one item to a top-level block collection (`concepts:`,
+// `relationships:` or an overlay's `observations:`), creating or converting
+// the collection when needed.
 const appendCollectionItem = (
   source: string,
-  collection: 'concepts' | 'relationships',
+  collection: string,
   item: Readonly<Record<string, unknown>>,
 ): string => {
   const document = parseDocument(source)
@@ -192,10 +200,33 @@ const appendCollectionItem = (
   )
 }
 
-const itemMap = (
+type ItemFields = Readonly<Record<string, unknown>>
+type ItemMatcher = (fields: ItemFields) => boolean
+
+const byId =
+  (id: string): ItemMatcher =>
+  (fields) =>
+    fields.id === id
+
+// An overlay entry has no `id`: it is addressed by the pair (target, key) -
+// what `reconcile` already treats as unique per document (ADR 0075, and the
+// YM803 duplicate-target diagnostic). A keyless address matches the keyless
+// entry, the presence claim for that target, and never stands in for every
+// key the target carries.
+const byObservation =
+  (target: ObservationTarget): ItemMatcher =>
+  (fields) =>
+    fields.subject === target.subject &&
+    fields.claim === target.claim &&
+    fields.key === target.key
+
+const observationAddress = (target: ObservationTarget): string =>
+  `"${target.subject ?? target.claim}"${target.key === undefined ? '' : ` (${target.key})`}`
+
+const itemMatching = (
   source: string,
   collection: string,
-  id: string,
+  matches: ItemMatcher,
 ): { readonly map: YAMLMap; readonly sequence: YAMLSeq } | undefined => {
   const document = parseDocument(source)
   const root = document.contents
@@ -204,19 +235,26 @@ const itemMap = (
   if (pair === undefined || !isSeq(pair.value)) return undefined
   const sequence = pair.value as YAMLSeq
   const found = sequence.items.find(
-    (candidate) =>
-      isMap(candidate) &&
-      (candidate as YAMLMap).items.some(
-        (field) =>
-          isScalar(field.key) &&
-          field.key.value === 'id' &&
-          isScalar(field.value) &&
-          field.value.value === id,
-      ),
+    (candidate) => isMap(candidate) && matches((candidate as YAMLMap).toJSON() as ItemFields),
   )
   return found === undefined
     ? undefined
     : { map: found as YAMLMap, sequence }
+}
+
+const itemMap = (
+  source: string,
+  collection: string,
+  id: string,
+): { readonly map: YAMLMap; readonly sequence: YAMLSeq } | undefined =>
+  itemMatching(source, collection, byId(id))
+
+// An observation's locator is a mapping inside the entry; edits descend into
+// it so a changed URI splices that one line rather than re-rendering the
+// entry around it.
+const nestedMap = (map: YAMLMap, key: string): YAMLMap | undefined => {
+  const pair = pairFor(map, key)
+  return pair !== undefined && isMap(pair.value) ? (pair.value as YAMLMap) : undefined
 }
 
 // The indent item fields sit at, read off the item's own first field.
@@ -363,14 +401,14 @@ const removeField = (
 // schema requires the key.
 const removeCollectionItem = (
   source: string,
-  collection: 'concepts' | 'relationships',
-  id: string,
+  collection: string,
+  matches: ItemMatcher,
 ): string => {
-  const { map, sequence } = itemMap(source, collection, id)!
+  const { map, sequence } = itemMatching(source, collection, matches)!
   if (sequence.flow) {
-    const remaining = (
-      sequence.toJSON() as ReadonlyArray<Readonly<Record<string, unknown>>>
-    ).filter((item) => item.id !== id)
+    const remaining = (sequence.toJSON() as readonly ItemFields[]).filter(
+      (item) => !matches(item),
+    )
     const [start, valueEnd] = nodeRange(sequence)
     return splice(
       source,
@@ -444,6 +482,13 @@ export const applyOperations = (
   const workspaceDocuments = new Map(
     resolvedWorkspace.documents.map((path) => [resolve(cwd, path), path]),
   )
+  // Overlay entries live in the workspace's evidence documents, addressed the
+  // same way. The two sets stay apart: a concept operation aimed at an
+  // overlay — or an observation aimed at a compiler document — is rejected
+  // before anything is touched.
+  const workspaceEvidence = new Map(
+    resolvedWorkspace.evidence.map((path) => [resolve(cwd, path), path]),
+  )
   const candidates = new Map<string, string>()
   const counts = {
     addedConcepts: 0,
@@ -452,6 +497,9 @@ export const applyOperations = (
     updatedRelationships: 0,
     deletedConcepts: 0,
     deletedRelationships: 0,
+    addedObservations: 0,
+    updatedObservations: 0,
+    deletedObservations: 0,
   }
   const deletions: Array<{
     readonly index: number
@@ -472,13 +520,18 @@ export const applyOperations = (
   })
   for (const [index, operation] of operationList.entries()) {
     const absolute = resolve(cwd, operation.document)
-    const manifestPath = workspaceDocuments.get(absolute)
+    const overlay = operation.op.endsWith('-observation')
+    const manifestPath = overlay
+      ? workspaceEvidence.get(absolute)
+      : workspaceDocuments.get(absolute)
     const locate = (message: string): Diagnostic =>
       locateOperation(index, message)
     if (manifestPath === undefined) {
       return failed([
         locate(
-          `Operation ${index} targets "${operation.document}", which is not a document of workspace "${resolvedWorkspace.id}"`,
+          `Operation ${index} targets "${operation.document}", which is not ${
+            overlay ? 'an evidence document' : 'a document'
+          } of workspace "${resolvedWorkspace.id}"`,
         ),
       ])
     }
@@ -517,13 +570,103 @@ export const applyOperations = (
           ),
         ])
       }
-      source = removeCollectionItem(source, collection, id)
+      source = removeCollectionItem(source, collection, byId(id))
       deletions.push({ index, absolute, id })
       if (operation.op === 'delete-concept') {
         counts.deletedConcepts += 1
       } else {
         counts.deletedRelationships += 1
       }
+    } else if (operation.op === 'add-observation') {
+      const address = observationAddress(operation.observation)
+      const matches = byObservation(operation.observation)
+      if (itemMatching(source, 'observations', matches) !== undefined) {
+        return failed([
+          locate(
+            `Operation ${index} adds an observation of ${address}, which ${operation.document} already records`,
+          ),
+        ])
+      }
+      source = appendCollectionItem(
+        source,
+        'observations',
+        operation.observation as unknown as ItemFields,
+      )
+      counts.addedObservations += 1
+    } else if (operation.op === 'update-observation') {
+      const target = operation.observation
+      const address = observationAddress(target)
+      const matches = byObservation(target)
+      const removals = operation.remove ?? []
+      if (removals.includes('message') && target.evidence?.message !== undefined) {
+        return failed([
+          locate(`Operation ${index} both sets and removes "message" on ${address}`),
+        ])
+      }
+      if (itemMatching(source, 'observations', matches) === undefined) {
+        return failed([
+          locate(
+            `Operation ${index} updates an observation of ${address}, which does not exist in ${operation.document}`,
+          ),
+        ])
+      }
+      const fields = target as unknown as ItemFields
+      for (const key of SCALAR_OBSERVATION_FIELDS) {
+        if (fields[key] === undefined) continue
+        source = setScalarField(
+          source,
+          itemMatching(source, 'observations', matches)!.map,
+          key,
+          fields[key],
+        )
+      }
+      for (const key of EVIDENCE_FIELDS) {
+        const value = target.evidence?.[key]
+        if (value === undefined) continue
+        const locator = nestedMap(
+          itemMatching(source, 'observations', matches)!.map,
+          'evidence',
+        )
+        if (locator === undefined) {
+          return failed([
+            locate(
+              `Operation ${index} updates the evidence of ${address}, which ${operation.document} does not record as a mapping`,
+            ),
+          ])
+        }
+        source = setScalarField(source, locator, key, value)
+      }
+      for (const key of removals) {
+        const locator = nestedMap(
+          itemMatching(source, 'observations', matches)!.map,
+          'evidence',
+        )
+        // Annotated: without it the assignment below feeds `source` back
+        // into its own inferred type through this call.
+        const removed: string | undefined =
+          locator === undefined ? undefined : removeField(source, locator, key)
+        if (removed === undefined) {
+          return failed([
+            locate(`Operation ${index} removes "${key}", which is not set on ${address}`),
+          ])
+        }
+        source = removed
+      }
+      counts.updatedObservations += 1
+    } else if (operation.op === 'delete-observation') {
+      const address = observationAddress(operation.observation)
+      const matches = byObservation(operation.observation)
+      if (itemMatching(source, 'observations', matches) === undefined) {
+        return failed([
+          locate(
+            `Operation ${index} deletes an observation of ${address}, which does not exist in ${operation.document}`,
+          ),
+        ])
+      }
+      // An overlay entry is nobody's reference target, so unlike a concept
+      // deletion this stages no reference-integrity check.
+      source = removeCollectionItem(source, 'observations', matches)
+      counts.deletedObservations += 1
     } else {
       const collection =
         operation.op === 'update-concept' ? 'concepts' : 'relationships'
@@ -718,11 +861,29 @@ export const applyOperations = (
   )
   if (!compilation.ok) return failed(compilation.diagnostics)
 
+  // The overlay gate: an observation the batch authored must load and must
+  // evaluate against the graph the batch just proved compiles, so an entry
+  // naming a subject that does not exist is rejected here rather than
+  // discovered later by `reconcile`. Only touched overlays are evaluated —
+  // pre-existing drift elsewhere is reconcile's report to make, not this
+  // batch's failure.
+  for (const [absolute, path] of workspaceEvidence) {
+    const source = candidates.get(absolute)
+    if (source === undefined) continue
+    const loaded = loadEvidence({ path, source })
+    if (!loaded.ok) return failed(loaded.diagnostics)
+    const evaluation = evaluateEvidence(compilation.graph, loaded.evidence)
+    if (!evaluation.ok) return failed(evaluation.diagnostics)
+  }
+
   for (const [absolute, source] of candidates) {
     writeFileSync(absolute, source, 'utf8')
   }
   const touched = [...candidates.keys()]
-    .map((absolute) => workspaceDocuments.get(absolute)!)
+    .map(
+      (absolute) =>
+        workspaceDocuments.get(absolute) ?? workspaceEvidence.get(absolute)!,
+    )
     .sort()
   return {
     ok: true,
@@ -795,7 +956,10 @@ export function runApplyCommand(
       result.applied.updatedConcepts +
       result.applied.updatedRelationships +
       result.applied.deletedConcepts +
-      result.applied.deletedRelationships
+      result.applied.deletedRelationships +
+      result.applied.addedObservations +
+      result.applied.updatedObservations +
+      result.applied.deletedObservations
     return {
       exitCode: 0,
       stdout: `Applied ${applied} operation${applied === 1 ? '' : 's'} to ${result.documents.join(', ')}\n`,

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -60,9 +60,44 @@ export interface RelationshipFields {
   readonly presentIn?: readonly string[]
 }
 
+// An observation is addressed by the pair (target, key) rather than by an
+// `id`, because an overlay entry has none: the pair is what `reconcile`
+// already treats as unique per document (ADR 0075, and the YM803 duplicate
+// -target diagnostic). A keyless observation is the presence claim for its
+// target, so `key` absent is itself an address, not a wildcard.
+export interface ObservationTarget {
+  readonly subject?: string
+  readonly claim?: string
+  readonly key?: string
+}
+
+export interface ObservationFields extends ObservationTarget {
+  readonly value?: string
+  readonly result?: 'confirmed' | 'contradicted' | 'unknown' | 'not-observed'
+  readonly evidence?: { readonly uri: string; readonly message?: string }
+}
+
+// An update addresses an entry by (target, key) and changes whatever else it
+// names, so `key` here is an address rather than a field: unlike `add`, it
+// carries no obligation to restate the value read at that key, and evidence
+// can be corrected a field at a time.
+export interface ObservationChange extends ObservationTarget {
+  readonly value?: string
+  readonly result?: 'confirmed' | 'contradicted' | 'unknown' | 'not-observed'
+  readonly evidence?: { readonly uri?: string; readonly message?: string }
+}
+
 export type YarramateOperation =
-  | { readonly op: 'add-concept'; readonly document: string; readonly concept: ConceptFields }
-  | { readonly op: 'add-relationship'; readonly document: string; readonly relationship: RelationshipFields }
+  | {
+      readonly op: 'add-concept'
+      readonly document: string
+      readonly concept: ConceptFields
+    }
+  | {
+      readonly op: 'add-relationship'
+      readonly document: string
+      readonly relationship: RelationshipFields
+    }
   | {
       readonly op: 'update-concept'
       readonly document: string
@@ -85,6 +120,22 @@ export type YarramateOperation =
       readonly document: string
       readonly relationship: { readonly id: string }
     }
+  | {
+      readonly op: 'add-observation'
+      readonly document: string
+      readonly observation: ObservationFields
+    }
+  | {
+      readonly op: 'update-observation'
+      readonly document: string
+      readonly observation: ObservationChange
+      readonly remove?: readonly string[]
+    }
+  | {
+      readonly op: 'delete-observation'
+      readonly document: string
+      readonly observation: ObservationTarget
+    }
 
 export interface OperationsDocument {
   readonly format: 'yarramate/operations/v1'
@@ -101,6 +152,9 @@ export interface YarramateApplyResult {
     readonly updatedRelationships: number
     readonly deletedConcepts: number
     readonly deletedRelationships: number
+    readonly addedObservations: number
+    readonly updatedObservations: number
+    readonly deletedObservations: number
   }
   readonly documents: readonly string[]
 }

--- a/src/visual-app/changeset-tray.tsx
+++ b/src/visual-app/changeset-tray.tsx
@@ -45,14 +45,29 @@ export const describeChangesetRow = (
   operation: YarramateOperation,
   graph: CanvasGraph | null,
 ): ChangesetRowDescription => {
-  // Every union member's payload carries `id`; scalars/lists it sets or
-  // appends are whatever other keys ride alongside it.
-  const payload = 'concept' in operation ? operation.concept : operation.relationship
   // Only `update-*` members carry `remove` at all.
   const removedFields =
-    operation.op === 'update-concept' || operation.op === 'update-relationship'
+    operation.op === 'update-concept' ||
+    operation.op === 'update-relationship' ||
+    operation.op === 'update-observation'
       ? (operation.remove ?? [])
       : []
+  if ('observation' in operation) {
+    // An overlay entry has no `id`: the pair (target, key) is its address,
+    // and the target may be a claim this canvas never draws - the name
+    // lookup falls back to the identity, which is what the row should say.
+    const { subject, claim, key, ...fields } = operation.observation
+    const name = resolveSubjectName(operation.document, (subject ?? claim)!, graph)
+    return {
+      verb: operation.op,
+      subjectName: key === undefined ? name : `${name} (${key})`,
+      fields: Object.keys(fields),
+      removedFields,
+    }
+  }
+  // Every other union member's payload carries `id`; scalars/lists it sets
+  // or appends are whatever other keys ride alongside it.
+  const payload = 'concept' in operation ? operation.concept : operation.relationship
   return {
     verb: operation.op,
     subjectName: resolveSubjectName(operation.document, payload.id, graph),

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -288,26 +288,31 @@ const viewWithin = (model: VisualRenderedModel): string => model.initialView;
  */
 const turnAnswered = { awaitingAgent: false, agentStatus: null } as const;
 
-/** Derive a unique key for an operation target (subject id + changed field names).
+/** Derive a unique key for an operation target (address + changed field names).
  * Operations targeting the same subject and field should replace rather than queue.
- * Combines op type, document, subject id, and sorted field names (excluding 'id').
+ * Concepts and relationships are addressed by `id`; an overlay observation has
+ * none and is addressed by the pair (target, key) that `apply` matches on.
  */
 const changesetTargetKey = (op: YarramateOperation): string => {
+  const changedFields = (payload: object, address: readonly string[]) =>
+    Object.keys(payload)
+      .filter((k) => !address.includes(k))
+      .sort()
+      .join(":");
   if ("concept" in op) {
     const concept = op.concept;
-    const fields = Object.keys(concept)
-      .filter((k) => k !== "id")
-      .sort()
-      .join(":");
-    return `${op.op}:${op.document}:concept:${concept.id}:${fields}`;
-  } else {
-    const relationship = op.relationship;
-    const fields = Object.keys(relationship)
-      .filter((k) => k !== "id")
-      .sort()
-      .join(":");
-    return `${op.op}:${op.document}:relationship:${relationship.id}:${fields}`;
+    return `${op.op}:${op.document}:concept:${concept.id}:${changedFields(concept, ["id"])}`;
   }
+  if ("relationship" in op) {
+    const relationship = op.relationship;
+    return `${op.op}:${op.document}:relationship:${relationship.id}:${changedFields(relationship, ["id"])}`;
+  }
+  const observation = op.observation;
+  const address = `${observation.subject ?? observation.claim}:${observation.key ?? ""}`;
+  return `${op.op}:${op.document}:observation:${address}:${changedFields(
+    observation,
+    ["subject", "claim", "key"],
+  )}`;
 };
 
 const transition = (

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -105,6 +105,9 @@ describe('apply command', () => {
       updatedRelationships: 0,
       deletedConcepts: 0,
       deletedRelationships: 0,
+      addedObservations: 0,
+      updatedObservations: 0,
+      deletedObservations: 0,
     })
     const validate = new Ajv2020({ allErrors: true }).compile(resultSchema)
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
@@ -501,6 +504,9 @@ operations:
       updatedRelationships: 0,
       deletedConcepts: 1,
       deletedRelationships: 1,
+      addedObservations: 0,
+      updatedObservations: 0,
+      deletedObservations: 0,
     })
     const validate = new Ajv2020({ allErrors: true }).compile(resultSchema)
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
@@ -777,5 +783,232 @@ operations:
     expect(after).toContain('id: flow-item')
     expect(after).toContain('name: Flow item')
     expect(after).not.toContain('status: planned')
+  })
+
+  describe('observation operations', () => {
+    const overlay = `format: yarramate/evidence/v1
+id: repository-audit
+version: "1.0"
+provider: repository-audit
+observations:
+  - subject: main#user
+    result: confirmed
+    evidence:
+      uri: repo:src/user.ts
+  - subject: main#user
+    key: role
+    value: operator
+    result: confirmed
+    evidence:
+      uri: repo:src/user.ts
+      message: read off the role constant
+`
+
+    beforeEach(() => {
+      mkdirSync(join(workspace, 'evidence'))
+      writeFileSync(join(workspace, 'evidence/repository.yaml'), overlay, 'utf8')
+      writeFileSync(
+        join(workspace, 'workspace.yaml'),
+        `format: yarramate/workspace/v1
+id: apply-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence:
+  - evidence/repository.yaml
+`,
+        'utf8',
+      )
+    })
+
+    const apply = (operations: string) => {
+      writeFileSync(join(workspace, 'operations.yaml'), operations, 'utf8')
+      return runCli(
+        ['apply', 'operations.yaml', 'workspace.yaml', '--json'],
+        workspace,
+      )
+    }
+    const overlayNow = () =>
+      readFileSync(join(workspace, 'evidence/repository.yaml'), 'utf8')
+
+    it('adds, updates and deletes overlay entries in one batch', () => {
+      const result = apply(`format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#reviewer
+      result: not-observed
+      evidence:
+        uri: repo:src/reviewer.ts
+        message: no reviewer wiring found
+  - op: update-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+      key: role
+      value: administrator
+      evidence:
+        uri: repo:src/roles.ts
+  - op: delete-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+`)
+      expect(result.exitCode).toBe(0)
+      const payload = JSON.parse(result.stdout) as {
+        applied: Record<string, number>
+        documents: readonly string[]
+      }
+      expect(
+        new Ajv2020({ allErrors: true }).validate(resultSchema, payload),
+      ).toBe(true)
+      expect(payload.applied).toMatchObject({
+        addedObservations: 1,
+        updatedObservations: 1,
+        deletedObservations: 1,
+      })
+      expect(payload.documents).toEqual(['evidence/repository.yaml'])
+      const after = overlayNow()
+      expect(after).toContain('subject: main#reviewer')
+      expect(after).toContain('message: no reviewer wiring found')
+      expect(after).toContain('value: administrator')
+      expect(after).toContain('uri: repo:src/roles.ts')
+      // The keyless entry is gone; the keyed one it shares a target with
+      // survives, untouched apart from the fields the update named.
+      expect(after).not.toContain('uri: repo:src/user.ts')
+      expect(after).toContain('read off the role constant')
+      expect(after).toContain('result: confirmed')
+    })
+
+    it('refuses an entry whose target the graph does not carry', () => {
+      const result = apply(`format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#nobody
+      result: confirmed
+      evidence:
+        uri: repo:src/nobody.ts
+`)
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('YM801')
+      expect(overlayNow()).toBe(overlay)
+    })
+
+    it('keeps model documents and overlays apart', () => {
+      const atModel = apply(`format: yarramate/operations/v1
+operations:
+  - op: add-observation
+    document: architecture/main.yaml
+    observation:
+      subject: main#user
+      result: confirmed
+      evidence:
+        uri: repo:src/user.ts
+`)
+      expect(atModel.exitCode).toBe(1)
+      expect(atModel.stdout).toContain('not an evidence document')
+      const atOverlay = apply(`format: yarramate/operations/v1
+operations:
+  - op: add-concept
+    document: evidence/repository.yaml
+    concept:
+      id: intruder
+      kind: applicationService
+      name: Intruder
+`)
+      expect(atOverlay.exitCode).toBe(1)
+      expect(atOverlay.stdout).toContain('not a document')
+      expect(overlayNow()).toBe(overlay)
+    })
+
+    it('addresses a keyed entry apart from the keyless one', () => {
+      const result = apply(`format: yarramate/operations/v1
+operations:
+  - op: update-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+      result: contradicted
+`)
+      expect(result.exitCode).toBe(0)
+      const after = overlayNow()
+      // The keyless entry took the change; the keyed entry kept its own
+      // result rather than being swept up by the shared subject.
+      expect(after).toContain('result: contradicted')
+      expect(after.match(/result: confirmed/g)).toHaveLength(1)
+    })
+
+    it('refuses an update or delete of an entry that is not there', () => {
+      const missing = apply(`format: yarramate/operations/v1
+operations:
+  - op: update-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+      key: absent
+      value: nothing
+`)
+      expect(missing.exitCode).toBe(1)
+      expect(missing.stdout).toContain('does not exist')
+      const gone = apply(`format: yarramate/operations/v1
+operations:
+  - op: delete-observation
+    document: evidence/repository.yaml
+    observation:
+      claim: main#never-claimed
+`)
+      expect(gone.exitCode).toBe(1)
+      expect(gone.stdout).toContain('does not exist')
+      expect(overlayNow()).toBe(overlay)
+    })
+
+    it('retracts an evidence message without touching the locator', () => {
+      const result = apply(`format: yarramate/operations/v1
+operations:
+  - op: update-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+      key: role
+    remove: [message]
+`)
+      expect(result.exitCode).toBe(0)
+      const after = overlayNow()
+      expect(after).not.toContain('read off the role constant')
+      expect(after).toContain('uri: repo:src/user.ts')
+    })
+
+    it('writes nothing when a model edit rides with a bad observation', () => {
+      const before = readFileSync(
+        join(workspace, 'architecture/main.yaml'),
+        'utf8',
+      )
+      const result = apply(`format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: user
+      description: The person managing todo tasks.
+  - op: add-observation
+    document: evidence/repository.yaml
+    observation:
+      subject: main#user
+      result: confirmed
+      evidence:
+        uri: repo:src/user.ts
+`)
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('already records')
+      expect(
+        readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8'),
+      ).toBe(before)
+      expect(overlayNow()).toBe(overlay)
+    })
   })
 })

--- a/test/apply-operations.test.ts
+++ b/test/apply-operations.test.ts
@@ -69,6 +69,9 @@ describe('applyOperations', () => {
       updatedRelationships: 0,
       deletedConcepts: 0,
       deletedRelationships: 0,
+      addedObservations: 0,
+      updatedObservations: 0,
+      deletedObservations: 0,
     })
     expect(outcome.result.documents).toEqual(['architecture/main.yaml'])
 

--- a/test/changeset-tray.test.ts
+++ b/test/changeset-tray.test.ts
@@ -109,6 +109,25 @@ const deleteOp: YarramateOperation = {
   relationship: { id: 'checkout-db' },
 }
 
+const observeOp: YarramateOperation = {
+  op: 'add-observation',
+  document: '.yarramate/evidence/repository.yaml',
+  observation: {
+    subject: 'architecture#checkout',
+    key: 'exists',
+    value: 'true',
+    result: 'confirmed',
+    evidence: { uri: 'repo:src/checkout.ts' },
+  },
+}
+
+const retractMessageOp: YarramateOperation = {
+  op: 'update-observation',
+  document: '.yarramate/evidence/repository.yaml',
+  observation: { claim: 'architecture#checkout~expects-residency' },
+  remove: ['message'],
+}
+
 describe('resolveSubjectName', () => {
   it('names a concept from the current graph', () => {
     expect(resolveSubjectName('architecture/main.yaml', 'checkout', graph)).toBe(
@@ -167,6 +186,28 @@ describe('describeChangesetRow / changesetRowLabel', () => {
     expect(row.fields).toEqual([])
     expect(row.removedFields).toEqual([])
     expect(changesetRowLabel(row)).toBe('delete-relationship · checkout-db')
+  })
+
+  it('addresses an observation by its target and key, never by an id', () => {
+    const row = describeChangesetRow(observeOp, graph)
+    expect(row).toEqual({
+      verb: 'add-observation',
+      subjectName: 'architecture#checkout (exists)',
+      fields: ['value', 'result', 'evidence'],
+      removedFields: [],
+    })
+    expect(changesetRowLabel(row)).toBe(
+      'add-observation · architecture#checkout (exists) · value, result, evidence',
+    )
+  })
+
+  it('names a keyless observation by its target alone', () => {
+    const row = describeChangesetRow(retractMessageOp, graph)
+    expect(row.subjectName).toBe('architecture#checkout~expects-residency')
+    expect(row.fields).toEqual([])
+    expect(changesetRowLabel(row)).toBe(
+      'update-observation · architecture#checkout~expects-residency · remove: message',
+    )
   })
 })
 

--- a/test/self-model.test.ts
+++ b/test/self-model.test.ts
@@ -5,6 +5,8 @@ import { compileWorkspace } from '../src/compiler.js'
 import { compareArchitectureStates } from '../src/architecture-state.js'
 import { evaluateProjection, loadProjection } from '../src/projection.js'
 import { prepareLikeC4Export } from '../src/adapters/likec4.js'
+import { evaluateEvidenceWorkspace, loadEvidence } from '../src/evidence.js'
+import { reconcileEvidenceReports } from '../src/reconciliation.js'
 
 const model = (name: string) => ({
   path: `.yarramate/architecture/${name}.yaml`,
@@ -230,6 +232,32 @@ describe('YarraMate repository model', () => {
         'yarramate-repository#agent-skill-source',
       ]),
     )
+  })
+
+  it('leaves no current concept without an evidence observation', () => {
+    const result = compileWorkspace(selfModelSources)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const overlay = loadEvidence(repositorySource('.yarramate/evidence/repository.yaml'))
+    expect(overlay.ok).toBe(true)
+    if (!overlay.ok) return
+
+    const evaluation = evaluateEvidenceWorkspace(result.graph, [overlay.evidence])
+    expect(evaluation.ok).toBe(true)
+    if (!evaluation.ok) return
+
+    // Attestation staleness is git-derived, so the reconcile command
+    // supplies it and this dogfooding read deliberately does not: coverage
+    // is a property of the model and its overlay alone, and asserting it
+    // here keeps the honesty gate inside `pnpm test`.
+    const report = reconcileEvidenceReports('yarramate', evaluation.reports, result.graph)
+
+    expect(report.summary.subjectsWithoutEvidence).toBe(0)
+    expect(report.unobservedSubjects).toBeUndefined()
+    expect(report.summary.contradicted).toBe(0)
+    expect(report.summary.notObserved).toBe(0)
   })
 
   it('renders its architecture-state change through the optional LikeC4 adapter', () => {


### PR DESCRIPTION
## Summary

Closes the hole issue #177 named: a maintenance pass could add concepts through `yarramate apply` but had to hand-edit `.yarramate/evidence/*.yaml` to record the observations proving they exist. Evidence was the one authoring surface that could not tell the truth about itself.

`operations/v1` now carries three further operations — `add-observation`, `update-observation`, `delete-observation` — that address an evidence document declared by the manifest's `evidence:` list. They pass the same atomic gate as model operations: the candidate workspace compiles, then every touched overlay is loaded and evaluated against the compiled graph before a single byte is written. A batch that mixes a concept edit with a bad observation writes nothing.

An observation has no `id`; the pair `(target, key)` is its address — the same uniqueness `reconcile` already enforces per document (ADR 0075, `YM803`). ADR 0089 records that decision.

## What changed

- **Schema** — `yarramate-operations.schema.json` gains `observationTarget`, `observationFields`, `observationChange` and the three operation variants; `yarramate-apply-result.schema.json` gains `addedObservations` / `updatedObservations` / `deletedObservations`.
- **Apply** — `applyOperations` resolves overlay paths against the manifest's `evidence:` list (a concept operation aimed at an overlay, or an observation aimed at a compiler document, is rejected before anything is touched), routes the three ops through the existing splice primitives, and runs the overlay evaluation gate after the compile gate. `removeCollectionItem` is generalised from id-matching to a matcher so keyless entries can be addressed.
- **Backfill** — the 20 subjects the four visual plans declared without evidence now carry observations, landed through `yarramate apply` itself rather than by hand. `reconcile` reports `subjectsWithoutEvidence: 0`, 218 observations, all confirmed.
- **Honesty gate** — `test/self-model.test.ts` asserts the repo's own model leaves no current concept unobserved, so the gap cannot silently reopen inside `pnpm test`.
- **Visual tray** — `changesetTargetKey` and `describeChangesetRow` handle observation operations, so a browser-authored overlay edit stages and reads like any other row.
- **Docs** — `EVIDENCE.md`, `NATIVE-DOCUMENT.md`, the architecture skill, and the native-authoring reference all describe overlays as workspace documents written through `apply`, never by hand.

## Verification

- `pnpm verify` (typecheck, build, 1021 tests across 62 files, `self:check`, LikeC4 validate) — green.
- `node dist/cli.js reconcile .yarramate/workspace.yaml` — `subjectsWithoutEvidence: 0`, `contradicted: 0`, `notObserved: 0`.
- Red-then-green proof for the coverage test: reverting the overlay backfill fails it with `expected 20 to be +0`.

## Checklist

- [x] Tests cover the change (27 new assertions across apply, tray, and the self-model suite).
- [x] Docs and the agent skill updated.
- [x] Semantic or stable-interface changes have an ADR — `docs/adr/0089-an-observation-is-a-write-addressed-by-its-pair.md`.
