### PR TITLE
feat: export visual-graph projector and ArchiMate notation vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.22.0
 
 - Export a Workers-safe visual-graph projector as
   `yarramate/adapter/visual-graph` (`projectGraphForCanvas`) and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Export a Workers-safe visual-graph projector as
+  `yarramate/adapter/visual-graph` (`projectGraphForCanvas`) and a
+  renderer-neutral ArchiMate notation vocabulary as
+  `yarramate/notation/archimate` (layer colours, aspect shapes, kind glyphs,
+  relationship line styles). The local visual app consumes the same
+  vocabulary. `canvasNode.layer` / `aspect` in
+  `yarramate/visual-graph/v1` are closed on the profile enums (plus null).
+  No session-protocol or apply changes (#201).
+
 - Correct the conservative-extension property in `docs/PROFILES.md` and ADR
   0079. It was published as one statement — loading a profile extension adds
   subjects and never changes verdicts — quantified over the profile together

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,7 +1,7 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.21.0
+v0.22.0
 a design interview any agent can resume.
 the map your coding agents share.
 architecture your CI can check.
@@ -13,3 +13,4 @@ a diagram that writes back.
 who signed off, and who held the pen.
 a rename every reference follows.
 two reviewers, no lost write.
+the same canvas another app can share.

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -206,6 +206,31 @@ Consumers validating the protocol can import the versioned documents directly,
 for example `yarramate/schema/visual-handoff` or
 `yarramate/schema/visual-session-request`.
 
+## Hosted or browser rendering of the visual graph
+
+Consumers that compile a workspace themselves (or receive a compiled
+`SemanticGraph` and profile context) and render with their own cytoscape (or
+other) host can import the pure projection and notation surfaces — without
+starting `yarramate-visual`:
+
+```ts
+import { projectGraphForCanvas } from 'yarramate/adapter/visual-graph'
+import {
+  conceptNotationOf,
+  relationshipNotationOf,
+  kindGlyphDataUriOf,
+  LAYER_COLORS,
+} from 'yarramate/notation/archimate'
+```
+
+These subpaths are Workers/browser-safe: no Node built-ins, no `ws`, and no
+visual session server. The local `yarramate-visual` runtime remains the
+optional loopback conversation product and is not required for projection.
+`presentation.notation: 'archimate'` is still a rendering mode only
+([ADR 0087](adr/0087-archimate-notation-is-a-rendering-mode-not-a-vocabulary.md));
+the notation module is descriptive vocabulary for that mode, not an ArchiMate
+conformance package.
+
 ## MCP server for agent harnesses
 
 Harnesses that load MCP servers can connect the bundled read-only adapter:

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -102,6 +102,10 @@ None of these toggle a projection query or compose a `filter.query` event; toggl
 
 Under `notation === 'archimate'`, the stylesheet swaps node shapes by aspect (resolved from each concept kind's inheritance), applies line-notation conventions by core relationship kind (derived kinds resolve through lineage), and forces `layered` direction to `DOWN` with the direction toggle disabled and a reason shown (`"ArchiMate notation fixes direction to Top-Down."`). The direction pin is applied only at layout-config build time; nothing is overwritten in state, so switching back to `native` restores the projection's declared direction on the next layout.
 
+The kind colours, aspect shapes, glyphs, and relationship line styles are
+defined once in the published `yarramate/notation/archimate` module; this app
+imports that module rather than keeping a parallel table.
+
 Node shapes by aspect: `active-structure` → `rectangle`, `behavior` → `round-rectangle`, `passive-structure` → `rectangle` + top accent, `motivation` → `octagon`, `composite` → `rectangle` + dashed border.
 
 Line notation (element-line convention pairs) covers all 11 core relationship kinds: `composition` (solid, filled diamond → none), `aggregation` (solid, hollow diamond → none), `assignment` (solid, filled circle → filled triangle), `realization` (dotted, none → hollow triangle), `specialization` (solid, none → hollow triangle), `serving` (solid, none → vee), `access` (dotted, none → vee), `influence` (dashed, none → vee), `triggering` (solid, none → filled triangle), `flow` (dashed, none → filled triangle), `association` (solid, none → none). Derived kinds like `implements` (inherits `realization`) resolve to their core ancestor and render with the core kind's notation.

--- a/docs/superpowers/plans/2026-08-18-visual-graph-and-archimate-notation-exports.md
+++ b/docs/superpowers/plans/2026-08-18-visual-graph-and-archimate-notation-exports.md
@@ -1,0 +1,1009 @@
+# Visual-graph and ArchiMate notation exports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish Workers-safe `yarramate/adapter/visual-graph` and `yarramate/notation/archimate` package subpaths, and tighten `canvasNode.layer` / `aspect` to profile enums ∪ null.
+
+**Architecture:** Extract pure claim-value helpers so `projectGraphForCanvas` no longer runtime-imports `compiler.ts`. Export the projector through a thin adapter barrel. Lift canvas ArchiMate colours, shapes, glyphs, and edge styles into `src/notation/archimate.ts` as the single source of truth; point the visual app at it. Schema enums close free strings without changing projector output.
+
+**Tech Stack:** TypeScript (NodeNext package build + Bundler visual app), Vitest, Ajv 2020 JSON Schema, existing `src/profile.ts` core vocabulary.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-visual-graph-and-archimate-notation-exports-design.md`  
+**Issue:** [#201](https://github.com/yarrasys/yarramate/issues/201)
+
+## Global Constraints
+
+- Purity: `./adapter/visual-graph` and `./notation/archimate` import graphs MUST NOT include `node:*`, `ws`, or `src/adapters/visual/*`.
+- No apply / operations / compiler semantic changes; no session protocol changes.
+- Layer colours = visual-app canvas palette (not LikeC4 DSL).
+- Full core `conceptKinds` + all 11 `relationshipKinds`; missing glyphs are `null`.
+- Profile aliases (`compiler-module`, `repository-file`) stay app-local, not in core vocabulary export.
+- No main-entry re-exports; subpaths only.
+- No ArchiMate conformance claim (ADR 0087).
+- Prefer TDD; do not run full `pnpm verify` every task — focused tests per task; full verify once at the end.
+- Skip formatters/linters beyond what the task needs; no drive-by refactors.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `src/graph-claims.ts` | Pure attestation/constraint claim encode/decode + predicate prefix |
+| `src/graph-projection.ts` | Canvas projector; runtime-imports only pure modules + type-only compiler types |
+| `src/compiler.ts` | Re-export claim helpers for in-repo callers (`reconciliation`, `rtm`) |
+| `src/adapters/visual-graph-entry.ts` | Public barrel for `yarramate/adapter/visual-graph` |
+| `src/notation/archimate.ts` | Renderer-neutral ArchiMate notation vocabulary |
+| `src/visual-app/kind-icons.ts` | Thin wrapper: core glyphs via notation + local profile aliases |
+| `src/visual-app/graph-canvas.tsx` | Consume shared colours/shapes/edge notation |
+| `schema/yarramate-visual-graph.schema.json` | `layer` / `aspect` enum ∪ null |
+| `package.json` | Two new `exports` entries |
+| `tsconfig.visual.json` | Include `src/notation/**/*.ts` (and `src/profile.ts` if imported) |
+| `test/graph-claims.test.ts` | Parser round-trip / reject cases |
+| `test/export-purity.test.ts` | Import-graph purity for the two subpath entries |
+| `test/archimate-notation.test.ts` | Vocabulary completeness + colour/glyph contracts |
+| `test/visual-graph-schema.test.ts` | Enum accept/reject cases |
+| `test/kind-icons.test.ts` | Unchanged expectations (aliases still work) |
+| `test/badges.test.ts` | Still imports `LAYER_COLORS` from graph-canvas re-export or notation |
+| `docs/CONSUMING-YARRAMATE.md` | Consumer note for the two subpaths |
+| `docs/VISUAL-ADAPTER.md` | Point ArchiMate mode at shared vocabulary |
+| `CHANGELOG.md` | Unreleased bullets |
+
+---
+
+### Task 1: Extract pure `graph-claims` module
+
+**Files:**
+- Create: `src/graph-claims.ts`
+- Modify: `src/compiler.ts` (move bodies out; re-export)
+- Modify: `src/graph-projection.ts` (import claims from `graph-claims`, types-only from compiler)
+- Create: `test/graph-claims.test.ts`
+- Test: `test/graph-claims.test.ts`, `test/graph-projection.test.ts`
+
+**Interfaces:**
+- Consumes: existing parser implementations currently at `src/compiler.ts` ~310–366
+- Produces:
+  - `ATTESTATION_PREDICATE_PREFIX: 'yarramate/attestation/'`
+  - `attestationClaimValue(attestation): string`
+  - `parseAttestationClaimValue(value): AttestationClaimParts | undefined`
+  - `parseConstraintExpectsValue(value): ConstraintExpectsParts | undefined`
+  - types `AttestationClaimParts`, `ConstraintExpectsParts`
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `test/graph-claims.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  ATTESTATION_PREDICATE_PREFIX,
+  attestationClaimValue,
+  parseAttestationClaimValue,
+  parseConstraintExpectsValue,
+} from '../src/graph-claims.js'
+
+describe('graph-claims', () => {
+  it('exposes the attestation predicate prefix', () => {
+    expect(ATTESTATION_PREDICATE_PREFIX).toBe('yarramate/attestation/')
+  })
+
+  it('round-trips attestation values with and without recordedBy', () => {
+    expect(parseAttestationClaimValue(attestationClaimValue({ by: 'a', on: '2026-08-01' }))).toEqual({
+      by: 'a',
+      on: '2026-08-01',
+    })
+    expect(
+      parseAttestationClaimValue(
+        attestationClaimValue({ by: 'a', on: '2026-08-01', recordedBy: 'bot' }),
+      ),
+    ).toEqual({ by: 'a', on: '2026-08-01', recordedBy: 'bot' })
+  })
+
+  it('rejects malformed attestation values', () => {
+    expect(parseAttestationClaimValue('only-one-token')).toBeUndefined()
+    expect(parseAttestationClaimValue('a not-a-date')).toBeUndefined()
+  })
+
+  it('parses constraint expects with spaces in the value', () => {
+    expect(parseConstraintExpectsValue('terraform-scan region ap-southeast-2')).toEqual({
+      provider: 'terraform-scan',
+      key: 'region',
+      value: 'ap-southeast-2',
+    })
+    expect(parseConstraintExpectsValue('p k value with spaces')).toEqual({
+      provider: 'p',
+      key: 'k',
+      value: 'value with spaces',
+    })
+  })
+
+  it('rejects malformed constraint expects', () => {
+    expect(parseConstraintExpectsValue('only-one')).toBeUndefined()
+    expect(parseConstraintExpectsValue('one two')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run test/graph-claims.test.ts`  
+Expected: FAIL — cannot resolve `../src/graph-claims.js`
+
+- [ ] **Step 3: Create `src/graph-claims.ts` with the moved implementations**
+
+Move these symbols **verbatim** from `compiler.ts` (keep comments):
+
+- `ATTESTATION_PREDICATE_PREFIX`
+- `attestationClaimValue`
+- `AttestationClaimParts`
+- `parseAttestationClaimValue`
+- `ConstraintExpectsParts`
+- `parseConstraintExpectsValue`
+
+File must have **zero** imports (pure strings only).
+
+- [ ] **Step 4: Point `compiler.ts` at the module and re-export**
+
+At top of `compiler.ts` (or beside previous definitions):
+
+```ts
+export {
+  ATTESTATION_PREDICATE_PREFIX,
+  attestationClaimValue,
+  parseAttestationClaimValue,
+  parseConstraintExpectsValue,
+  type AttestationClaimParts,
+  type ConstraintExpectsParts,
+} from './graph-claims.js'
+```
+
+Delete the original bodies from `compiler.ts` so there is a single definition.
+
+Leave `reconciliation.ts` and `rtm.ts` importing from `./compiler.js` — re-exports preserve them.
+
+- [ ] **Step 5: Point `graph-projection.ts` at pure modules**
+
+Replace the compiler value import with:
+
+```ts
+import {
+  ATTESTATION_PREDICATE_PREFIX,
+  parseAttestationClaimValue,
+  parseConstraintExpectsValue,
+} from './graph-claims.js'
+import type {
+  GraphClaim,
+  ResolvedProfileContext,
+  SemanticGraph,
+} from './compiler.js'
+import { kindLabelOf } from './kind-label.js'
+```
+
+Also narrow `CanvasNode.layer` / `aspect` types now or in Task 5 — **prefer Task 5** so this task stays extraction-only. Keep `string | null` until Task 5.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+```bash
+pnpm exec vitest run test/graph-claims.test.ts test/graph-projection.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/graph-claims.ts src/compiler.ts src/graph-projection.ts test/graph-claims.test.ts
+git commit -m "$(cat <<'EOF'
+refactor: extract pure graph claim value helpers
+
+Move attestation/constraint claim encode/decode out of compiler.ts so
+the visual-graph projector can import them without node:module/Ajv.
+EOF
+)"
+```
+
+---
+
+### Task 2: Publish `yarramate/adapter/visual-graph` + purity test
+
+**Files:**
+- Create: `src/adapters/visual-graph-entry.ts`
+- Modify: `package.json` (`exports`)
+- Create: `test/export-purity.test.ts`
+- Test: `test/export-purity.test.ts`
+
+**Interfaces:**
+- Consumes: `projectGraphForCanvas`, `CanvasGraph`, `CanvasNode`, `CanvasEdge` from `src/graph-projection.ts`
+- Produces: package subpath `yarramate/adapter/visual-graph`
+
+- [ ] **Step 1: Write the failing purity + export smoke tests**
+
+Create `test/export-purity.test.ts`:
+
+```ts
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, join, normalize } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createRequire } from 'node:module'
+
+const root = join(process.cwd(), 'src')
+
+const FORBIDDEN = /^(node:|ws$|fs$|path$|os$|child_process$|crypto$|net$|http$|https$)/
+
+function runtimeImportGraph(entryRelative: string): { files: string[]; hits: string[] } {
+  const seen = new Set<string>()
+  const queue = [entryRelative]
+  const hits: string[] = []
+  while (queue.length > 0) {
+    const rel = queue.shift()!
+    if (seen.has(rel)) continue
+    seen.add(rel)
+    const full = join(root, rel)
+    if (!existsSync(full)) continue
+    const text = readFileSync(full, 'utf8')
+    // Strip type-only imports so `import type` from compiler.js is allowed.
+    const withoutTypeImports = text.replace(
+      /^\s*import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?\s*$/gm,
+      '',
+    )
+    for (const match of withoutTypeImports.matchAll(/from\s+['"]([^'"]+)['"]/g)) {
+      const spec = match[1]!
+      if (FORBIDDEN.test(spec) || spec === 'ws') {
+        hits.push(`${rel} -> ${spec}`)
+        continue
+      }
+      if (spec.includes('adapters/visual/') || spec.endsWith('/visual/session-server.js')) {
+        hits.push(`${rel} -> ${spec}`)
+        continue
+      }
+      // Disallow runtime import of compiler.js (Node/Ajv).
+      if (spec.endsWith('/compiler.js') || spec === './compiler.js' || spec === '../compiler.js') {
+        hits.push(`${rel} -> ${spec} (runtime)`)
+        continue
+      }
+      if (spec.startsWith('.')) {
+        let p = spec
+        if (!p.endsWith('.ts') && !p.endsWith('.js') && !p.endsWith('.json')) p += '.ts'
+        p = p.replace(/\.js$/, '.ts')
+        const target = normalize(join(dirname(rel), p)).replace(/\\/g, '/')
+        if (!seen.has(target)) queue.push(target)
+      }
+    }
+  }
+  return { files: [...seen].sort(), hits }
+}
+
+describe('package export purity', () => {
+  it('adapter/visual-graph import graph stays free of Node, ws, session, and compiler runtime', () => {
+    const { hits } = runtimeImportGraph('adapters/visual-graph-entry.ts')
+    expect(hits).toEqual([])
+  })
+
+  it('notation/archimate import graph stays free of Node, ws, session, and compiler runtime', () => {
+    // Task 3 creates the module; until then this may fail — implement Task 3
+    // before expecting green, or gate with existsSync.
+    const entry = 'notation/archimate.ts'
+    if (!existsSync(join(root, entry))) {
+      expect(existsSync(join(root, entry))).toBe(true)
+      return
+    }
+    const { hits } = runtimeImportGraph(entry)
+    expect(hits).toEqual([])
+  })
+})
+
+describe('adapter/visual-graph barrel', () => {
+  it('re-exports projectGraphForCanvas', async () => {
+    const mod = await import('../src/adapters/visual-graph-entry.js')
+    expect(typeof mod.projectGraphForCanvas).toBe('function')
+  })
+})
+```
+
+**Note for implementer:** Prefer splitting the notation purity assertion into Task 3’s commit if Task 2 would stay red. Minimal approach for Task 2: only assert `visual-graph-entry` purity + barrel export; add notation purity case in Task 3.
+
+Recommended Task 2 test body — **visual-graph only**:
+
+```ts
+it('adapter/visual-graph import graph stays free of Node, ws, session, and compiler runtime', () => {
+  const { hits } = runtimeImportGraph('adapters/visual-graph-entry.ts')
+  expect(hits).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run test/export-purity.test.ts`  
+Expected: FAIL — missing entry module and/or forbidden compiler runtime edge
+
+- [ ] **Step 3: Add barrel**
+
+Create `src/adapters/visual-graph-entry.ts`:
+
+```ts
+export {
+  projectGraphForCanvas,
+  type CanvasGraph,
+  type CanvasNode,
+  type CanvasEdge,
+} from '../graph-projection.js'
+```
+
+- [ ] **Step 4: Add package export**
+
+In `package.json` `exports`, immediately after `./adapter/graphify`:
+
+```json
+"./adapter/visual-graph": {
+  "types": "./dist/adapters/visual-graph-entry.d.ts",
+  "import": "./dist/adapters/visual-graph-entry.js"
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+```bash
+pnpm exec vitest run test/export-purity.test.ts test/graph-projection.test.ts
+pnpm exec tsc -p tsconfig.build.json --pretty false
+```
+Expected: PASS; `dist/adapters/visual-graph-entry.js` and `.d.ts` exist
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adapters/visual-graph-entry.ts package.json test/export-purity.test.ts
+git commit -m "$(cat <<'EOF'
+feat: export pure visual-graph projector subpath
+
+Add yarramate/adapter/visual-graph barrel and an import-graph purity
+test so hosted/browser consumers can project without Node session code.
+EOF
+)"
+```
+
+---
+
+### Task 3: ArchiMate notation vocabulary module
+
+**Files:**
+- Create: `src/notation/archimate.ts`
+- Create: `test/archimate-notation.test.ts`
+- Modify: `package.json` (`exports`)
+- Modify: `test/export-purity.test.ts` (add notation purity case)
+- Modify: `tsconfig.visual.json` (include notation + profile for app consumers)
+- Test: `test/archimate-notation.test.ts`, `test/export-purity.test.ts`
+
+**Interfaces:**
+- Consumes: `conceptKinds`, `layers`, `aspects`, `relationshipKinds`, types from `src/profile.ts`
+- Produces:
+  - `LAYER_COLORS: Record<Layer, { fill: string; border: string }>`
+  - `ASPECT_SHAPES` / concept + relationship notation tables
+  - `conceptNotationOf(kindLabel: string): ConceptNotation | null`
+  - `relationshipNotationOf(kindLabel: string): RelationshipNotation | null`
+  - `kindGlyphDataUriOf(kindLabel: string): string | null`
+  - `ICON_SIZE = 14` (same as today’s kind-icons)
+  - package subpath `yarramate/notation/archimate`
+
+- [ ] **Step 1: Write failing completeness tests**
+
+Create `test/archimate-notation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { conceptKinds, layers, relationshipKinds } from '../src/profile.js'
+import {
+  CONCEPT_NOTATION,
+  LAYER_COLORS,
+  RELATIONSHIP_NOTATION,
+  conceptNotationOf,
+  kindGlyphDataUriOf,
+  relationshipNotationOf,
+} from '../src/notation/archimate.js'
+
+const KNOWN_GLYPHS = [
+  'applicationComponent',
+  'applicationFunction',
+  'applicationService',
+  'artifact',
+  'businessActor',
+  'businessFunction',
+  'capability',
+  'dataObject',
+  'deliverable',
+  'driver',
+  'goal',
+  'node',
+  'plateau',
+  'representation',
+  'requirement',
+  'systemSoftware',
+  'technologyFunction',
+] as const
+
+describe('archimate notation vocabulary', () => {
+  it('covers every core concept kind exactly once', () => {
+    const ids = CONCEPT_NOTATION.map((row) => row.id).sort()
+    const expected = conceptKinds.map((k) => k.id).sort()
+    expect(ids).toEqual(expected)
+  })
+
+  it('covers every core relationship kind exactly once', () => {
+    const ids = RELATIONSHIP_NOTATION.map((row) => row.id).sort()
+    const expected = [...relationshipKinds].sort()
+    expect(ids).toEqual(expected)
+  })
+
+  it('uses the locked canvas layer palette', () => {
+    expect(LAYER_COLORS.motivation).toEqual({ fill: '#CCCCFF', border: '#8F8FE0' })
+    expect(LAYER_COLORS.strategy).toEqual({ fill: '#F5DEAA', border: '#C9A355' })
+    expect(LAYER_COLORS.business).toEqual({ fill: '#FFFF99', border: '#C9C355' })
+    expect(LAYER_COLORS.application).toEqual({ fill: '#CCFFFF', border: '#4FB8B8' })
+    expect(LAYER_COLORS.technology).toEqual({ fill: '#CCFFCC', border: '#5FAE5F' })
+    expect(LAYER_COLORS.implementation).toEqual({ fill: '#FFE0E0', border: '#D89999' })
+    expect(LAYER_COLORS.physical).toEqual({ fill: '#F0F0F0', border: '#999999' })
+    expect(LAYER_COLORS.composite).toEqual({ fill: '#F0F0F0', border: '#999999' })
+    for (const layer of layers) {
+      expect(LAYER_COLORS[layer]).toEqual(
+        expect.objectContaining({ fill: expect.any(String), border: expect.any(String) }),
+      )
+    }
+  })
+
+  it('derives shape tokens from aspect', () => {
+    expect(conceptNotationOf('applicationComponent')).toMatchObject({
+      aspect: 'active-structure',
+      shape: 'rectangle',
+    })
+    expect(conceptNotationOf('applicationFunction')).toMatchObject({
+      aspect: 'behavior',
+      shape: 'round-rectangle',
+    })
+    expect(conceptNotationOf('dataObject')).toMatchObject({
+      aspect: 'passive-structure',
+      shape: 'rectangle',
+      accent: 'top-band',
+    })
+    expect(conceptNotationOf('goal')).toMatchObject({
+      aspect: 'motivation',
+      shape: 'octagon',
+    })
+    expect(conceptNotationOf('grouping')).toMatchObject({
+      aspect: 'composite',
+      shape: 'rectangle',
+      borderStyle: 'dashed',
+    })
+  })
+
+  it('ships glyphs for the 17 kinds the canvas already drew; null otherwise is allowed', () => {
+    for (const id of KNOWN_GLYPHS) {
+      expect(conceptNotationOf(id)?.glyph).toEqual(expect.any(String))
+      expect(kindGlyphDataUriOf(id)).toMatch(/^data:image\/svg\+xml;utf8,/)
+    }
+    // A core kind never drawn before may be null — stakeholder is one.
+    const stakeholder = conceptNotationOf('stakeholder')
+    expect(stakeholder).not.toBeNull()
+    // glyph may be null or string; lookup still works
+    expect(conceptNotationOf('notAKind')).toBeNull()
+    expect(kindGlyphDataUriOf('notAKind')).toBeNull()
+  })
+
+  it('maps composition and realization edge notation', () => {
+    expect(relationshipNotationOf('composition')).toEqual({
+      id: 'composition',
+      lineStyle: 'solid',
+      sourceArrow: { shape: 'diamond', fill: 'filled' },
+      targetArrow: { shape: 'none' },
+    })
+    expect(relationshipNotationOf('realization')).toEqual({
+      id: 'realization',
+      lineStyle: 'dotted',
+      sourceArrow: { shape: 'none' },
+      targetArrow: { shape: 'triangle', fill: 'hollow' },
+    })
+  })
+
+  it('does not publish profile-extended aliases', () => {
+    expect(conceptNotationOf('compiler-module')).toBeNull()
+    expect(conceptNotationOf('repository-file')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run test/archimate-notation.test.ts`  
+Expected: FAIL — module missing
+
+- [ ] **Step 3: Implement `src/notation/archimate.ts`**
+
+Structure (implement fully — no placeholders):
+
+```ts
+import {
+  conceptKinds,
+  layers,
+  relationshipKinds,
+  type Aspect,
+  type Layer,
+  type RelationshipKind,
+} from '../profile.js'
+
+export const ICON_SIZE = 14
+const INK = '#182228'
+
+export const LAYER_COLORS = {
+  motivation: { fill: '#CCCCFF', border: '#8F8FE0' },
+  strategy: { fill: '#F5DEAA', border: '#C9A355' },
+  business: { fill: '#FFFF99', border: '#C9C355' },
+  application: { fill: '#CCFFFF', border: '#4FB8B8' },
+  technology: { fill: '#CCFFCC', border: '#5FAE5F' },
+  implementation: { fill: '#FFE0E0', border: '#D89999' },
+  physical: { fill: '#F0F0F0', border: '#999999' },
+  composite: { fill: '#F0F0F0', border: '#999999' },
+} as const satisfies Record<Layer, { readonly fill: string; readonly border: string }>
+
+// Aspect → shape/accent/borderStyle tables from the design.
+// BASE_KIND_SVG: copy the 17 bodies from src/visual-app/kind-icons.ts verbatim.
+// CONCEPT_NOTATION = conceptKinds.map(...)
+// RELATIONSHIP_NOTATION = the 11 rows from graph-canvas ArchiMate edge styles.
+// Lookups: Map by id; conceptNotationOf / relationshipNotationOf / kindGlyphDataUriOf
+```
+
+**Relationship table (authoritative — copy into code):**
+
+| id | lineStyle | source | target |
+|---|---|---|---|
+| composition | solid | diamond filled | none |
+| aggregation | solid | diamond hollow | none |
+| assignment | solid | circle filled | triangle filled |
+| realization | dotted | none | triangle hollow |
+| specialization | solid | none | triangle hollow |
+| serving | solid | none | vee |
+| access | dotted | none | vee |
+| influence | dashed | none | vee |
+| triggering | solid | none | triangle filled |
+| flow | dashed | none | triangle filled |
+| association | solid | none | none |
+
+**Glyph bodies:** copy exactly from `src/visual-app/kind-icons.ts` `BASE_KIND_SVG` (lines 42–89). Wrapper for data URI must match current chrome:
+
+```ts
+function svg(body: string): string {
+  // same attributes as kind-icons.ts svg()
+}
+function toDataUri(svgMarkup: string): string {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svgMarkup)}`
+}
+```
+
+Build `CONCEPT_NOTATION` from `conceptKinds` so coverage cannot drift:
+
+```ts
+export const CONCEPT_NOTATION: readonly ConceptNotation[] = conceptKinds.map((kind) => {
+  const shapeMeta = aspectShapeOf(kind.aspect)
+  return {
+    id: kind.id,
+    notation: kind.name,
+    layer: kind.layer,
+    aspect: kind.aspect,
+    ...shapeMeta,
+    glyph: BASE_KIND_SVG[kind.id] ?? null,
+    colors: LAYER_COLORS[kind.layer],
+  }
+})
+```
+
+- [ ] **Step 4: Wire package export + visual tsconfig include**
+
+`package.json` exports:
+
+```json
+"./notation/archimate": {
+  "types": "./dist/notation/archimate.d.ts",
+  "import": "./dist/notation/archimate.js"
+}
+```
+
+`tsconfig.visual.json` `include` add:
+
+```json
+"src/notation/**/*.ts",
+"src/profile.ts"
+```
+
+(`profile.ts` is imported by notation; visual typecheck must see it.)
+
+Extend `test/export-purity.test.ts` with the notation purity case from Task 2 notes.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+```bash
+pnpm exec vitest run test/archimate-notation.test.ts test/export-purity.test.ts
+pnpm exec tsc -p tsconfig.build.json --pretty false
+```
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/notation/archimate.ts test/archimate-notation.test.ts test/export-purity.test.ts package.json tsconfig.visual.json
+git commit -m "$(cat <<'EOF'
+feat: publish ArchiMate notation vocabulary export
+
+Add yarramate/notation/archimate with full core kind coverage, canvas
+layer colours, aspect shapes, glyphs, and relationship line styles.
+EOF
+)"
+```
+
+---
+
+### Task 4: Point visual app at shared notation
+
+**Files:**
+- Modify: `src/visual-app/kind-icons.ts`
+- Modify: `src/visual-app/graph-canvas.tsx`
+- Test: `test/kind-icons.test.ts`, `test/badges.test.ts`, `test/graph-canvas.test.ts` (if present), `test/graph-canvas-layout.test.ts`
+
+**Interfaces:**
+- Consumes: `LAYER_COLORS`, `kindGlyphDataUriOf`, `ICON_SIZE`, `RELATIONSHIP_NOTATION`, aspect shape helpers from `src/notation/archimate.ts`
+- Produces: unchanged browser behavior for existing glyphs/colours/edge styles
+
+- [ ] **Step 1: Confirm existing app tests are the regression net**
+
+Run:
+```bash
+pnpm exec vitest run test/kind-icons.test.ts test/badges.test.ts test/graph-canvas.test.ts test/graph-canvas-layout.test.ts
+```
+Expected: PASS on current main (baseline before edits)
+
+- [ ] **Step 2: Rewrite `kind-icons.ts` as a thin wrapper**
+
+```ts
+import {
+  ICON_SIZE,
+  kindGlyphDataUriOf as coreKindGlyphDataUriOf,
+} from '../notation/archimate.js'
+
+export { ICON_SIZE }
+
+const PROFILE_ALIAS_GLYPH: Record<string, string> = {
+  'compiler-module': 'applicationComponent',
+  'repository-file': 'artifact',
+}
+
+export function kindIconUriOf(kindLabel: string): string | null {
+  const aliased = PROFILE_ALIAS_GLYPH[kindLabel]
+  if (aliased !== undefined) return coreKindGlyphDataUriOf(aliased)
+  return coreKindGlyphDataUriOf(kindLabel)
+}
+```
+
+Remove local `BASE_KIND_SVG` / URI tables.
+
+- [ ] **Step 3: Rewrite graph-canvas colour + ArchiMate stylesheet sources**
+
+1. Delete local `LAYER_COLORS` definition; re-export from notation so `badges.test.ts` keeps working:
+
+```ts
+export { LAYER_COLORS } from '../notation/archimate.js'
+import { LAYER_COLORS, RELATIONSHIP_NOTATION, conceptNotationOf } from '../notation/archimate.js'
+```
+
+2. Build layer colour rules by iterating `Object.entries(LAYER_COLORS)` (or fixed layer list) instead of six hand-written blocks — include physical/composite now that they have explicit neutrals (behavior: same fill as previous default for those layers).
+
+3. Replace hard-coded `archimateNodeShapes` / `archimateEdgeStyles` arrays with generators from notation:
+
+```ts
+// Node shapes: one rule per aspect token used by ASPECT_SHAPES /
+// conceptNotation aspect fields — keep the passive-structure gradient and
+// composite dashed border exactly as today (DEFAULT_BORDER / DEFAULT_FILL).
+
+// Edges:
+for (const rel of RELATIONSHIP_NOTATION) {
+  // selector: `edge[coreKindLabel = "${rel.id}"]`
+  // map lineStyle / sourceArrow / targetArrow to cytoscape style keys
+}
+```
+
+Do **not** change arrow mappings; only the source of the table moves.
+
+- [ ] **Step 4: Run visual regression tests + visual typecheck**
+
+Run:
+```bash
+pnpm exec vitest run test/kind-icons.test.ts test/badges.test.ts test/graph-canvas.test.ts test/graph-canvas-layout.test.ts test/archimate-notation.test.ts
+pnpm exec tsc -p tsconfig.visual.json --pretty false
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/visual-app/kind-icons.ts src/visual-app/graph-canvas.tsx
+git commit -m "$(cat <<'EOF'
+refactor: drive visual app ArchiMate rendering from shared notation
+
+Point kind-icons and graph-canvas at yarramate notation vocabulary so
+the local app and package consumers share one source of truth.
+EOF
+)"
+```
+
+---
+
+### Task 5: Tighten `canvasNode.layer` / `aspect` enums
+
+**Files:**
+- Modify: `schema/yarramate-visual-graph.schema.json`
+- Modify: `src/graph-projection.ts` (`CanvasNode` types)
+- Modify: `test/visual-graph-schema.test.ts`
+- Test: `test/visual-graph-schema.test.ts`, `test/graph-projection.test.ts`
+
+**Interfaces:**
+- Consumes: `Layer`, `Aspect` from `src/profile.ts`
+- Produces: schema + types that accept enum values ∪ null only
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append to `test/visual-graph-schema.test.ts` a minimal valid node factory used by new cases, then:
+
+```ts
+const baseNode = {
+  id: 'main#service',
+  localId: 'service',
+  document: 'main.yaml',
+  kind: 'yarramate/core@0.1#applicationComponent',
+  kindLabel: 'applicationComponent',
+  layer: 'application',
+  aspect: 'active-structure',
+  name: 'Service',
+  description: null,
+  aka: [],
+  status: null,
+  owner: null,
+  distinctFrom: [],
+  supersedes: [],
+  constraints: [],
+  references: [],
+  presentIn: [],
+  attestations: [],
+}
+
+it('accepts every profile layer and aspect enum value and null', () => {
+  const layers = [
+    'motivation', 'strategy', 'business', 'application',
+    'technology', 'physical', 'implementation', 'composite', null,
+  ]
+  const aspects = [
+    'motivation', 'active-structure', 'behavior',
+    'passive-structure', 'composite', null,
+  ]
+  for (const layer of layers) {
+    expect(validateVisualGraph({ nodes: [{ ...baseNode, layer }], edges: [] })).toBe(true)
+  }
+  for (const aspect of aspects) {
+    expect(validateVisualGraph({ nodes: [{ ...baseNode, aspect }], edges: [] })).toBe(true)
+  }
+})
+
+it('rejects free-string layer and aspect values', () => {
+  expect(
+    validateVisualGraph({ nodes: [{ ...baseNode, layer: 'not-a-layer' }], edges: [] }),
+  ).toBe(false)
+  expect(
+    validateVisualGraph({ nodes: [{ ...baseNode, aspect: 'not-an-aspect' }], edges: [] }),
+  ).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run test to verify reject case fails open (still accepts free strings)**
+
+Run: `pnpm exec vitest run test/visual-graph-schema.test.ts`  
+Expected: new reject test FAIL (free strings still valid) or accept test may already pass
+
+- [ ] **Step 3: Update schema**
+
+Replace `layer` / `aspect` property schemas under `canvasNode` with:
+
+```json
+"layer": {
+  "anyOf": [
+    {
+      "enum": [
+        "motivation",
+        "strategy",
+        "business",
+        "application",
+        "technology",
+        "physical",
+        "implementation",
+        "composite"
+      ]
+    },
+    { "type": "null" }
+  ]
+},
+"aspect": {
+  "anyOf": [
+    {
+      "enum": [
+        "motivation",
+        "active-structure",
+        "behavior",
+        "passive-structure",
+        "composite"
+      ]
+    },
+    { "type": "null" }
+  ]
+}
+```
+
+- [ ] **Step 4: Narrow TypeScript types**
+
+In `graph-projection.ts`:
+
+```ts
+import type { Aspect, Layer } from './profile.js'
+
+export interface CanvasNode {
+  // ...
+  readonly layer: Layer | null
+  readonly aspect: Aspect | null
+  // ...
+}
+```
+
+Runtime assignment unchanged (`profileContext.conceptKindLayers.get(kind) ?? null`). If Map values are typed `string`, assert/narrow via `as Layer` only if necessary — prefer typing the maps later; a local helper is fine:
+
+```ts
+layer: (profileContext.conceptKindLayers.get(kind) as Layer | undefined) ?? null,
+aspect: (profileContext.conceptKindAspects.get(kind) as Aspect | undefined) ?? null,
+```
+
+(Only if tsc requires it; avoid if inference already works.)
+
+- [ ] **Step 5: Run tests**
+
+Run:
+```bash
+pnpm exec vitest run test/visual-graph-schema.test.ts test/graph-projection.test.ts
+pnpm exec tsc -p tsconfig.build.json --pretty false
+```
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add schema/yarramate-visual-graph.schema.json src/graph-projection.ts test/visual-graph-schema.test.ts
+git commit -m "$(cat <<'EOF'
+fix: enum-constrain visual-graph layer and aspect
+
+Close canvasNode.layer/aspect to the profile vocabulary (plus null) so
+swimlane placement is not free-string.
+EOF
+)"
+```
+
+---
+
+### Task 6: Docs, changelog, full verification
+
+**Files:**
+- Modify: `docs/CONSUMING-YARRAMATE.md`
+- Modify: `docs/VISUAL-ADAPTER.md`
+- Modify: `CHANGELOG.md`
+- Test: full focused suite + build
+
+- [ ] **Step 1: Consumer docs**
+
+In `docs/CONSUMING-YARRAMATE.md`, after the visual conversations section (before MCP), add a short subsection:
+
+```markdown
+## Hosted or browser rendering of the visual graph
+
+Consumers that compile a workspace themselves (or receive a compiled
+`SemanticGraph` and profile context) and render with their own cytoscape (or
+other) host can import the pure projection and notation surfaces — without
+starting `yarramate-visual`:
+
+```ts
+import { projectGraphForCanvas } from 'yarramate/adapter/visual-graph'
+import {
+  conceptNotationOf,
+  relationshipNotationOf,
+  kindGlyphDataUriOf,
+  LAYER_COLORS,
+} from 'yarramate/notation/archimate'
+```
+
+These subpaths are Workers/browser-safe: no Node built-ins, no `ws`, and no
+visual session server. The local `yarramate-visual` runtime remains the
+optional loopback conversation product and is not required for projection.
+`presentation.notation: 'archimate'` is still a rendering mode only
+([ADR 0087](adr/0087-archimate-notation-is-a-rendering-mode-not-a-vocabulary.md));
+the notation module is descriptive vocabulary for that mode, not an ArchiMate
+conformance package.
+```
+
+(Fix nested fence if markdown requires indent/ alternate fencing.)
+
+- [ ] **Step 2: Visual adapter docs**
+
+In `docs/VISUAL-ADAPTER.md` ArchiMate notation mode section (~line 101), add one sentence after the opening paragraph:
+
+```markdown
+The kind colours, aspect shapes, glyphs, and relationship line styles are
+defined once in the published `yarramate/notation/archimate` module; this app
+imports that module rather than keeping a parallel table.
+```
+
+- [ ] **Step 3: CHANGELOG**
+
+Under `## Unreleased` prepend:
+
+```markdown
+- Export a Workers-safe visual-graph projector as
+  `yarramate/adapter/visual-graph` (`projectGraphForCanvas`) and a
+  renderer-neutral ArchiMate notation vocabulary as
+  `yarramate/notation/archimate` (layer colours, aspect shapes, kind glyphs,
+  relationship line styles). The local visual app consumes the same
+  vocabulary. `canvasNode.layer` / `aspect` in
+  `yarramate/visual-graph/v1` are closed on the profile enums (plus null).
+  No session-protocol or apply changes (#201).
+```
+
+- [ ] **Step 4: Full verification**
+
+Run:
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p tsconfig.visual.json --pretty false
+pnpm exec tsc -p tsconfig.build.json --pretty false
+pnpm exec vitest run test/graph-claims.test.ts test/export-purity.test.ts test/archimate-notation.test.ts test/graph-projection.test.ts test/visual-graph-schema.test.ts test/kind-icons.test.ts test/badges.test.ts test/graph-canvas.test.ts test/graph-canvas-layout.test.ts
+pnpm build
+```
+Expected: all PASS; `dist/adapters/visual-graph-entry.js` and `dist/notation/archimate.js` present
+
+Optional broader: `pnpm test` if time allows.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/CONSUMING-YARRAMATE.md docs/VISUAL-ADAPTER.md CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: document visual-graph and ArchiMate notation package exports
+
+Describe the new subpaths for hosted/browser renderers and note the
+shared notation source in the visual adapter guide (#201).
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| Pure claim-helper extract | Task 1 |
+| `yarramate/adapter/visual-graph` export | Task 2 |
+| Purity: no node/ws/session/compiler runtime | Tasks 2–3 |
+| `yarramate/notation/archimate` full core coverage | Task 3 |
+| Canvas palette locked colours | Task 3 |
+| Glyphs for 17 existing; null elsewhere; no profile aliases in export | Task 3 |
+| 11 relationship notations | Task 3 |
+| visual-app cutover | Task 4 |
+| Schema layer/aspect enums ∪ null | Task 5 |
+| CanvasNode TS narrowing | Task 5 |
+| CONSUMING + VISUAL-ADAPTER + CHANGELOG | Task 6 |
+| Non-goals (no apply/session/LikeC4 sync/main re-export) | Honoured throughout |
+
+## Plan self-review
+
+- **Placeholders:** none; relationship table and colour values inlined.
+- **Type names:** `ConceptNotation` / `RelationshipNotation` defined in Task 3 implementation; tests use exported values only.
+- **tsconfig.visual gap:** Task 3 includes `src/notation/**/*.ts` and `src/profile.ts`.
+- **Purity test vs Task 3 ordering:** Task 2 purity is visual-graph-only; notation purity lands in Task 3.
+- **badges.test.ts:** continues importing `LAYER_COLORS` from `graph-canvas` via re-export.

--- a/docs/superpowers/specs/2026-08-18-visual-graph-and-archimate-notation-exports-design.md
+++ b/docs/superpowers/specs/2026-08-18-visual-graph-and-archimate-notation-exports-design.md
@@ -1,0 +1,397 @@
+# Design: Export visual-graph projector and ArchiMate notation vocabulary
+
+Issue: [#201](https://github.com/yarrasys/yarramate/issues/201) — export the
+visual-graph projector and ArchiMate notation vocabulary as supported package
+surfaces.
+
+## Problem
+
+Hosted and browser-side consumers want to render a compiled YarraMate model with
+the same contracts the local visual app uses (cytoscape.js + cytoscape-elk),
+without reimplementing projection or ArchiMate-inspired notation.
+
+`yarramate@0.21.0` already publishes `./schema/visual-graph` and types
+`presentation.notation: 'native' | 'archimate'`, but three gaps block supported
+consumption:
+
+1. **Visual-graph projector is not a public export.**  
+   `projectGraphForCanvas` (`src/graph-projection.ts`) produces a
+   `yarramate/visual-graph/v1` document from a `SemanticGraph` +
+   `ResolvedProfileContext`. It is only reached through the visual session path
+   under `dist/adapters/visual/*`. Deep-importing is unsupported and risks
+   pulling Node-only session code (`ws`, `node:path`, session-server) into a
+   Workers/browser bundle. The projector logic itself is pure, but it
+   value-imports claim helpers from `compiler.ts`, which loads `node:module` +
+   Ajv at init — the same seam `src/kind-label.ts` already documents.
+
+2. **ArchiMate notation vocabulary is not available as data.**  
+   Notation mode is a public presentation contract (ADR 0087), but the per-kind
+   glyph/shape mapping and relationship line styles live only inside the
+   prebuilt visual app (`src/visual-app/kind-icons.ts`,
+   `src/visual-app/graph-canvas.tsx`). The nearest shipped asset is
+   `assets/likec4/specification.likec4`, which expresses layer tags and notation
+   labels in LikeC4 DSL for a different renderer and a different palette.
+
+3. **`layer` and `aspect` are untyped on `canvasNode`.**  
+   Both are `string | null` in `schema/yarramate-visual-graph.schema.json`,
+   while profile already defines closed enums
+   (`schema/yarramate-profile.schema.json`, `src/profile.ts`). Swimlane and
+   aspect placement should not depend on free strings.
+
+## Goals
+
+1. Publish a **Workers-safe** `SemanticGraph + ResolvedProfileContext →
+   visual-graph/v1` function as a supported package export.
+2. Publish a **renderer-neutral ArchiMate notation vocabulary** (concept kind →
+   label/shape/glyph/layer colours; relationship kind → line notation) as a
+   supported export, sourced from the visual-app tables + core
+   `conceptKinds` / `relationshipKinds`.
+3. Tighten `canvasNode.layer` / `aspect` to the existing profile enums (still
+   nullable).
+
+## Non-goals
+
+- No `apply` / operations / compiler semantic changes.
+- No visual session protocol or `yarramate-visual` runtime changes as a product
+  surface. Local-only assumptions (loopback bind, Git working tree,
+  `.yarramate-out/`) stay out of the supported consumer contract.
+- No ArchiMate conformance claim; no kind → ArchiMate-element-type metamodel
+  mapping. Standing remains ADR 0087: notation is a rendering mode, not a
+  vocabulary fork.
+- No LikeC4 palette sync. `assets/likec4/specification.likec4` stays
+  adapter-owned.
+- No requirement that every core kind ship a glyph on day one (`glyph: null` is
+  valid).
+- No main-entry (`yarramate`) purity rewrite. Main stays Node-capable; purity is
+  a **subpath** guarantee.
+- No profile-extended kind aliases in the core vocabulary export
+  (`compiler-module`, `repository-file` remain app/consumer-local).
+
+## Decisions locked in design review
+
+| Topic | Choice |
+|---|---|
+| Packaging | Dedicated pure subpaths (Approach B), not main-entry-only and not a fat `./adapter/visual` barrel |
+| Layer colours | Visual-app canvas `LAYER_COLORS`, not LikeC4 DSL colours |
+| Kind coverage | Full core `conceptKinds` + all 11 `relationshipKinds` |
+| Missing glyphs | Allowed (`null`) |
+| JSON twin of vocabulary | Not required for v1; TypeScript module is the source of truth |
+| Main-entry re-exports | None by default; subpaths are the supported surface |
+
+## Grounding — verified in this repo
+
+| Fact | Where |
+|---|---|
+| Projector symbol | `projectGraphForCanvas` in `src/graph-projection.ts` |
+| Call sites | `src/adapters/visual/session-server.ts`, `session-store.ts` (`buildVisualModelGraph`) |
+| Schema already exported | `package.json` → `./schema/visual-graph` |
+| Adapter export pattern | `./adapter/likec4`, `./adapter/graphify` barrels under `src/adapters/` |
+| Build includes projector | `tsconfig.build.json` includes `src/**/*.ts`, excludes `src/visual-app` |
+| Node leak path | `graph-projection.ts` value-imports parsers from `compiler.ts` → `node:module` |
+| Kind label already pure | `src/kind-label.ts` (comment documents the Ajv/`node:module` problem) |
+| Layer/aspect enums | `src/profile.ts` `layers` / `aspects`; mirrored in profile + projection schemas |
+| Canvas colours | `src/visual-app/graph-canvas.tsx` `LAYER_COLORS` (6 coloured + neutral default) |
+| Aspect shapes + edge styles | `buildStylesheet` ArchiMate branch in `graph-canvas.tsx` |
+| Glyphs today | 17 base bodies + 2 profile aliases in `kind-icons.ts` |
+| Notation is rendering-only | ADR 0087 |
+
+## Public export surface
+
+### New package exports
+
+| Subpath | Built module | Publishes |
+|---|---|---|
+| `yarramate/adapter/visual-graph` | `dist/adapters/visual-graph-entry.js` | `projectGraphForCanvas`, `CanvasGraph`, `CanvasNode`, `CanvasEdge` |
+| `yarramate/notation/archimate` | `dist/notation/archimate.js` | notation tables + lookup helpers |
+| `yarramate/schema/visual-graph` | *(existing)* | schema; `layer` / `aspect` enums tightened in place |
+
+`package.json` `exports` gains the two code subpaths using the same
+`types` + `import` shape as `./adapter/likec4`. `files` is unchanged (`dist`
+already ships).
+
+### Consumer shape
+
+```ts
+import {
+  projectGraphForCanvas,
+  type CanvasGraph,
+} from 'yarramate/adapter/visual-graph'
+
+import {
+  LAYER_COLORS,
+  conceptNotationOf,
+  relationshipNotationOf,
+  kindGlyphDataUriOf,
+} from 'yarramate/notation/archimate'
+```
+
+### Purity contract (normative)
+
+The import graphs of `./adapter/visual-graph` and `./notation/archimate` MUST
+NOT include:
+
+- `node:*` built-ins
+- `ws`
+- `src/adapters/visual/*` (session server, protocol wire, client)
+- filesystem loaders
+
+Enforced by a focused test over the source (or emitted) import graph for those
+entry modules.
+
+## Purity cut and module layout
+
+### New / changed modules
+
+```
+src/graph-claims.ts                 # NEW — pure predicate constants + claim value parsers
+src/graph-projection.ts             # runtime: graph-claims + kind-label; type-only from compiler
+src/compiler.ts                     # imports graph-claims (behavior unchanged; may re-export)
+src/adapters/visual-graph-entry.ts  # NEW — public barrel for ./adapter/visual-graph
+src/notation/archimate.ts           # NEW — vocabulary for ./notation/archimate
+src/visual-app/kind-icons.ts        # thin wrapper over notation module
+src/visual-app/graph-canvas.tsx     # import LAYER_COLORS / shapes / edge styles from notation
+schema/yarramate-visual-graph.schema.json  # layer/aspect enum ∪ null
+package.json                        # exports map
+```
+
+### `graph-claims.ts`
+
+Move these value exports out of `compiler.ts` without behavior change:
+
+- `ATTESTATION_PREDICATE_PREFIX`
+- `parseAttestationClaimValue`
+- `parseConstraintExpectsValue`
+- any tiny types those parsers need (`AttestationClaimParts`,
+  `ConstraintExpectsParts`)
+
+`compiler.ts` continues to expose them if anything external already imported
+them from the compiler surface (prefer re-export for compatibility inside the
+repo). No public package API change is required for these helpers.
+
+### `graph-projection.ts` after the cut
+
+Runtime imports only:
+
+- `./graph-claims.js`
+- `./kind-label.js`
+- `import type { GraphClaim, ResolvedProfileContext, SemanticGraph }` from
+  `./compiler.js` (type-only; erased at emit)
+
+### `visual-graph-entry.ts`
+
+```ts
+export {
+  projectGraphForCanvas,
+  type CanvasGraph,
+  type CanvasNode,
+  type CanvasEdge,
+} from '../graph-projection.js'
+```
+
+### Compatibility
+
+- Session path keeps importing `projectGraphForCanvas` from
+  `../../graph-projection.js` — same symbol, same behavior.
+- Existing tests keep importing from `src/graph-projection.js`.
+- No wire/format version bump: document format remains
+  `yarramate/visual-graph/v1`. Schema enum tightening accepts every value the
+  projector already emits.
+
+## Notation vocabulary shape
+
+### Module
+
+`src/notation/archimate.ts` → `yarramate/notation/archimate`
+
+Renderer-neutral data + small lookups. No cytoscape, no DOM, no Node.
+
+### Layer colours (canvas palette)
+
+```ts
+export const LAYER_COLORS: Record<Layer, { readonly fill: string; readonly border: string }>
+```
+
+| Layer | fill | border |
+|---|---|---|
+| motivation | `#CCCCFF` | `#8F8FE0` |
+| strategy | `#F5DEAA` | `#C9A355` |
+| business | `#FFFF99` | `#C9C355` |
+| application | `#CCFFFF` | `#4FB8B8` |
+| technology | `#CCFFCC` | `#5FAE5F` |
+| implementation | `#FFE0E0` | `#D89999` |
+| physical | `#F0F0F0` | `#999999` (today’s neutral default) |
+| composite | `#F0F0F0` | `#999999` (today’s neutral default) |
+
+### Aspect → shape
+
+| Aspect | shape | extra |
+|---|---|---|
+| active-structure | `rectangle` | — |
+| behavior | `round-rectangle` | — |
+| passive-structure | `rectangle` | `accent: 'top-band'` |
+| motivation | `octagon` | — |
+| composite | `rectangle` | `borderStyle: 'dashed'` |
+
+`accent` and `borderStyle` are renderer-neutral tokens. The local app keeps
+mapping `top-band` to the existing cytoscape gradient and `dashed` to
+`border-style: dashed`.
+
+### Concept kind entry
+
+One row per core `conceptKinds` entry in `src/profile.ts`:
+
+```ts
+interface ConceptNotation {
+  readonly id: string                 // local kind id
+  readonly notation: string           // profile human name
+  readonly layer: Layer
+  readonly aspect: Aspect
+  readonly shape: 'rectangle' | 'round-rectangle' | 'octagon'
+  readonly accent?: 'top-band'
+  readonly borderStyle?: 'dashed'
+  readonly glyph: string | null       // bare SVG body, or null
+  readonly colors: { readonly fill: string; readonly border: string }
+}
+```
+
+- **Coverage:** every core concept kind.
+- **Glyphs:** lift the 17 existing bodies from `kind-icons.ts`; all other core
+  kinds ship `glyph: null`.
+- **Profile aliases** (`compiler-module`, `repository-file`) are **not** in this
+  table. The visual app keeps a local alias → parent glyph map (as today).
+
+### Relationship kind entry
+
+One row per core relationship kind (all 11), matching the ArchiMate branch of
+`buildStylesheet` in `graph-canvas.tsx`:
+
+```ts
+interface RelationshipNotation {
+  readonly id: RelationshipKind
+  readonly lineStyle: 'solid' | 'dotted' | 'dashed'
+  readonly sourceArrow: {
+    readonly shape: 'none' | 'triangle' | 'circle' | 'diamond' | 'vee'
+    readonly fill?: 'filled' | 'hollow'
+  }
+  readonly targetArrow: {
+    readonly shape: 'none' | 'triangle' | 'circle' | 'diamond' | 'vee'
+    readonly fill?: 'filled' | 'hollow'
+  }
+}
+```
+
+### Public API
+
+```ts
+export const LAYER_COLORS
+export const ASPECT_SHAPES
+export const CONCEPT_NOTATION: readonly ConceptNotation[]
+export const RELATIONSHIP_NOTATION: readonly RelationshipNotation[]
+
+export function conceptNotationOf(kindLabel: string): ConceptNotation | null
+export function relationshipNotationOf(kindLabel: string): RelationshipNotation | null
+export function kindGlyphDataUriOf(kindLabel: string): string | null
+// wraps glyph body with the same stroke chrome kind-icons uses today (INK, 14px)
+```
+
+Optional convenience bag `archimateNotation` may group the tables; not required
+if named exports are clearer. No separate JSON asset in v1.
+
+### App cutover
+
+- `kind-icons.ts` becomes a thin wrapper over `kindGlyphDataUriOf` (and may keep
+  `ICON_SIZE` + the two profile aliases).
+- `graph-canvas.tsx` imports `LAYER_COLORS`, aspect shape table, and relationship
+  notation from the shared module and builds cytoscape selectors from that data.
+- Pixels and behavior for kinds that already had glyphs/colours stay unchanged.
+
+## Schema enums
+
+In `schema/yarramate-visual-graph.schema.json`, replace free strings using the
+same `anyOf: [enum, null]` pattern already used elsewhere in this package's
+schemas (e.g. visual-graph attestation fields, visual-status):
+
+```json
+"layer": {
+  "anyOf": [
+    {
+      "enum": [
+        "motivation", "strategy", "business", "application",
+        "technology", "physical", "implementation", "composite"
+      ]
+    },
+    { "type": "null" }
+  ]
+},
+"aspect": {
+  "anyOf": [
+    {
+      "enum": [
+        "motivation", "active-structure", "behavior",
+        "passive-structure", "composite"
+      ]
+    },
+    { "type": "null" }
+  ]
+}
+```
+
+TypeScript `CanvasNode` in `graph-projection.ts` narrows to
+`Layer | null` and `Aspect | null` (import types from `profile.ts` — pure,
+already Workers-safe).
+
+Projector output is unchanged: values already come from
+`profileContext.conceptKindLayers` / `conceptKindAspects`, which are populated
+from those enums.
+
+## Documentation touchpoints
+
+Minimal, only where consumers look today:
+
+- `docs/CONSUMING-YARRAMATE.md` — short note that hosted/browser renderers can
+  import `yarramate/adapter/visual-graph` and `yarramate/notation/archimate`,
+  and that the local visual runtime remains optional/local-only.
+- `docs/VISUAL-ADAPTER.md` — point ArchiMate notation mode at the shared
+  vocabulary module as source of truth (still ADR 0087 standing).
+- `CHANGELOG.md` — under Unreleased: two new export subpaths + schema enum
+  tighten.
+
+No new ADR required unless implementation discovers a decision that contradicts
+0087; this work implements 0087’s packaging consequence rather than replacing it.
+
+## Verification
+
+| Check | Evidence |
+|---|---|
+| Projector behavior preserved | Existing `test/graph-projection.test.ts` green |
+| Schema enums | Extend `test/visual-graph-schema.test.ts`: accept each enum value + `null`; reject free strings |
+| Notation completeness | New unit test: every `conceptKinds` id present; every `relationshipKinds` id present; colours match the locked table; 17 known glyphs non-null |
+| Purity | New test walks import graph from `visual-graph-entry.ts` and `notation/archimate.ts`; fails on `node:`, `ws`, or `adapters/visual/` |
+| App still builds | `pnpm` visual build / existing visual-app unit tests (`graph-canvas*.test.ts`, kind-icon tests if any) |
+| Package exports | `package.json` exports resolve; `tsc` build emits `dist/adapters/visual-graph-entry.*` and `dist/notation/archimate.*` |
+
+## Implementation order
+
+1. Extract `src/graph-claims.ts`; point `compiler.ts` + `graph-projection.ts` at it.
+2. Add `src/adapters/visual-graph-entry.ts` + package export; purity test.
+3. Add `src/notation/archimate.ts` with full core tables; unit tests; package export.
+4. Point `kind-icons.ts` + `graph-canvas.tsx` at the notation module; keep profile aliases local.
+5. Tighten visual-graph schema + `CanvasNode` types; schema tests.
+6. Docs + CHANGELOG.
+7. Full focused verification pass above.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Draft-2020-12 `enum` with `null` quirks in Ajv | Prefer the formulation already used elsewhere in-repo if one exists; cover with schema tests |
+| Glyph SVG chrome drift (wrapper attributes) | `kindGlyphDataUriOf` owns the wrapper; app stops duplicating it |
+| Accidental session import into pure subpath | Purity test on CI path for those entries |
+| Consumers expecting profile aliases in core vocabulary | Document that aliases are consumer-local; only core kinds are exported |
+
+## Out of scope follow-ups (not this change)
+
+- Syncing LikeC4 specification colours to the canvas palette.
+- Generating glyphs for every core kind.
+- Exporting visual session protocol helpers for non-local hosts.
+- Re-exporting the projector from the main `yarramate` entry.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/adapters/visual-graph-entry.d.ts",
       "import": "./dist/adapters/visual-graph-entry.js"
     },
+    "./notation/archimate": {
+      "types": "./dist/notation/archimate.d.ts",
+      "import": "./dist/notation/archimate.js"
+    },
     "./schema/document": "./schema/yarramate-document.schema.json",
     "./schema/profile": "./schema/yarramate-profile.schema.json",
     "./schema/projection": "./schema/yarramate-projection.schema.json",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/adapters/graphify-entry.d.ts",
       "import": "./dist/adapters/graphify-entry.js"
     },
+    "./adapter/visual-graph": {
+      "types": "./dist/adapters/visual-graph-entry.d.ts",
+      "import": "./dist/adapters/visual-graph-entry.js"
+    },
     "./schema/document": "./schema/yarramate-document.schema.json",
     "./schema/profile": "./schema/yarramate-profile.schema.json",
     "./schema/projection": "./schema/yarramate-projection.schema.json",

--- a/schema/yarramate-visual-graph.schema.json
+++ b/schema/yarramate-visual-graph.schema.json
@@ -63,10 +63,35 @@
           "type": "string"
         },
         "layer": {
-          "type": ["string", "null"]
+          "anyOf": [
+            {
+              "enum": [
+                "motivation",
+                "strategy",
+                "business",
+                "application",
+                "technology",
+                "physical",
+                "implementation",
+                "composite"
+              ]
+            },
+            { "type": "null" }
+          ]
         },
         "aspect": {
-          "type": ["string", "null"]
+          "anyOf": [
+            {
+              "enum": [
+                "motivation",
+                "active-structure",
+                "behavior",
+                "passive-structure",
+                "composite"
+              ]
+            },
+            { "type": "null" }
+          ]
         },
         "name": {
           "type": "string"

--- a/src/adapters/visual-graph-entry.ts
+++ b/src/adapters/visual-graph-entry.ts
@@ -1,0 +1,6 @@
+export {
+  projectGraphForCanvas,
+  type CanvasGraph,
+  type CanvasNode,
+  type CanvasEdge,
+} from '../graph-projection.js'

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -18,6 +18,7 @@ import documentSchema from '../schema/yarramate-document.schema.json' with {
 import profileSchema from '../schema/yarramate-profile.schema.json' with {
   type: 'json',
 }
+import { ATTESTATION_PREDICATE_PREFIX, attestationClaimValue } from './graph-claims.js'
 
 const coreProfile = 'yarramate/core@0.1'
 // `ajv/dist/2020.js` is CJS. Its default-export shape is resolved
@@ -307,63 +308,14 @@ const distinctFromClaimId = (subject: string, other: string) =>
 const supersedesClaimId = (subject: string, predecessor: string) =>
   `${subject}~supersedes-${Buffer.from(predecessor, 'utf8').toString('hex')}`
 
-export const ATTESTATION_PREDICATE_PREFIX = 'yarramate/attestation/'
-
-// An attestation claim packs the authority, the date it was given, and
-// the recorder when a machine held the pen. A reference carries no
-// spaces and the date is fixed width, so the three parse back out of one
-// value unambiguously wherever a reader needs them.
-export const attestationClaimValue = (attestation: {
-  readonly by: string
-  readonly on: string
-  readonly recordedBy?: string
-}): string =>
-  attestation.recordedBy === undefined
-    ? `${attestation.by} ${attestation.on}`
-    : `${attestation.by} ${attestation.on} ${attestation.recordedBy}`
-
-export interface AttestationClaimParts {
-  readonly by: string
-  readonly on: string
-  readonly recordedBy?: string
-}
-
-export const parseAttestationClaimValue = (
-  value: string,
-): AttestationClaimParts | undefined => {
-  const match = /^(\S+) ([0-9]{4}-[0-9]{2}-[0-9]{2})(?: (.+))?$/.exec(value)
-  if (match === null) return undefined
-  const recordedBy = match[3]
-  return {
-    by: match[1]!,
-    on: match[2]!,
-    ...(recordedBy === undefined ? {} : { recordedBy }),
-  }
-}
-
-export interface ConstraintExpectsParts {
-  readonly provider: string
-  readonly key: string
-  readonly value: string
-}
-
-// Mirrors the compiler's own write-side encoding (ADR 0075): provider and
-// key admit no whitespace, so the first two spaces delimit them and
-// everything after the second space is the expected value verbatim, spaces
-// included. This is the sole authority for decoding the value written at
-// the constraint's `expects` claim — reconciliation.ts delegates here
-// rather than mirroring the regex itself.
-export const parseConstraintExpectsValue = (
-  value: string,
-): ConstraintExpectsParts | undefined => {
-  const match = /^(\S+) (\S+) ([\s\S]+)$/.exec(value)
-  if (match === null) return undefined
-  return {
-    provider: match[1]!,
-    key: match[2]!,
-    value: match[3]!,
-  }
-}
+export {
+  ATTESTATION_PREDICATE_PREFIX,
+  attestationClaimValue,
+  parseAttestationClaimValue,
+  parseConstraintExpectsValue,
+  type AttestationClaimParts,
+  type ConstraintExpectsParts,
+} from './graph-claims.js'
 
 const describeAspect = (aspect: (typeof conceptKinds)[number]['aspect']) =>
   aspect.replace('-', ' ')

--- a/src/graph-claims.ts
+++ b/src/graph-claims.ts
@@ -1,0 +1,57 @@
+export const ATTESTATION_PREDICATE_PREFIX = 'yarramate/attestation/'
+
+// An attestation claim packs the authority, the date it was given, and
+// the recorder when a machine held the pen. A reference carries no
+// spaces and the date is fixed width, so the three parse back out of one
+// value unambiguously wherever a reader needs them.
+export const attestationClaimValue = (attestation: {
+  readonly by: string
+  readonly on: string
+  readonly recordedBy?: string
+}): string =>
+  attestation.recordedBy === undefined
+    ? `${attestation.by} ${attestation.on}`
+    : `${attestation.by} ${attestation.on} ${attestation.recordedBy}`
+
+export interface AttestationClaimParts {
+  readonly by: string
+  readonly on: string
+  readonly recordedBy?: string
+}
+
+export const parseAttestationClaimValue = (
+  value: string,
+): AttestationClaimParts | undefined => {
+  const match = /^(\S+) ([0-9]{4}-[0-9]{2}-[0-9]{2})(?: (.+))?$/.exec(value)
+  if (match === null) return undefined
+  const recordedBy = match[3]
+  return {
+    by: match[1]!,
+    on: match[2]!,
+    ...(recordedBy === undefined ? {} : { recordedBy }),
+  }
+}
+
+export interface ConstraintExpectsParts {
+  readonly provider: string
+  readonly key: string
+  readonly value: string
+}
+
+// Mirrors the compiler's own write-side encoding (ADR 0075): provider and
+// key admit no whitespace, so the first two spaces delimit them and
+// everything after the second space is the expected value verbatim, spaces
+// included. This is the sole authority for decoding the value written at
+// the constraint's `expects` claim — reconciliation.ts delegates here
+// rather than mirroring the regex itself.
+export const parseConstraintExpectsValue = (
+  value: string,
+): ConstraintExpectsParts | undefined => {
+  const match = /^(\S+) (\S+) ([\s\S]+)$/.exec(value)
+  if (match === null) return undefined
+  return {
+    provider: match[1]!,
+    key: match[2]!,
+    value: match[3]!,
+  }
+}

--- a/src/graph-projection.ts
+++ b/src/graph-projection.ts
@@ -1,10 +1,12 @@
 import {
   ATTESTATION_PREDICATE_PREFIX,
-  type GraphClaim,
-  type ResolvedProfileContext,
-  type SemanticGraph,
   parseAttestationClaimValue,
   parseConstraintExpectsValue,
+} from './graph-claims.js'
+import type {
+  GraphClaim,
+  ResolvedProfileContext,
+  SemanticGraph,
 } from './compiler.js'
 import { kindLabelOf } from './kind-label.js'
 export interface CanvasNode {

--- a/src/graph-projection.ts
+++ b/src/graph-projection.ts
@@ -9,14 +9,15 @@ import type {
   SemanticGraph,
 } from './compiler.js'
 import { kindLabelOf } from './kind-label.js'
+import type { Aspect, Layer } from './profile.js'
 export interface CanvasNode {
   readonly id: string // qualified subject id, e.g. "yarramate-engine#compiler-module"
   readonly localId: string // authored id inside its document, e.g. "compiler-module"
   readonly document: string // manifest-relative path, from the subject's kind claim source
   readonly kind: string // resolved kind identity, e.g. "yarramate/core@0.1#applicationComponent"
   readonly kindLabel: string // local id stripped of profile prefix, e.g. "applicationComponent"
-  readonly layer: string | null // from profileContext.conceptKindLayers, null if unresolved
-  readonly aspect: string | null // from profileContext.conceptKindAspects, null if unresolved
+  readonly layer: Layer | null // from profileContext.conceptKindLayers, null if unresolved
+  readonly aspect: Aspect | null // from profileContext.conceptKindAspects, null if unresolved
   readonly name: string
   readonly description: string | null
   readonly aka: readonly string[]
@@ -218,8 +219,8 @@ const projectConcept = (
     document: kindClaim.source.path,
     kind,
     kindLabel: kindLabelOf(kind),
-    layer: profileContext.conceptKindLayers.get(kind) ?? null,
-    aspect: profileContext.conceptKindAspects.get(kind) ?? null,
+    layer: (profileContext.conceptKindLayers.get(kind) as Layer | undefined) ?? null,
+    aspect: (profileContext.conceptKindAspects.get(kind) as Aspect | undefined) ?? null,
     name: claimValue(nameClaim),
     description: descriptionClaim === undefined ? null : claimValue(descriptionClaim),
     aka: claims

--- a/src/notation/archimate.ts
+++ b/src/notation/archimate.ts
@@ -1,0 +1,238 @@
+// Single source of truth for ArchiMate-inspired rendering data: layer
+// palette, aspect-driven shape tokens, per-concept-kind glyphs, and
+// per-relationship-kind line/arrow styles. Pure data + lookups, no
+// cytoscape/DOM dependency - the same zero-import discipline as
+// `src/visual-app/kind-icons.ts` and `badges.ts`, so this module can be
+// published standalone (`yarramate/notation/archimate`) and consumed by
+// non-canvas renderers. Not wired into `graph-canvas.tsx` yet (Task 4
+// switches the canvas to read from here instead of its own inline tables).
+import { conceptKinds, layers, relationshipKinds, type Aspect, type Layer, type RelationshipKind } from '../profile.js'
+
+export const ICON_SIZE = 14
+const INK = '#182228' // --ink (src/visual-app/styles.css:12)
+
+// The locked canvas layer palette (`graph-canvas.tsx`'s `LAYER_COLORS`
+// selectors) - `physical` and `composite` deliberately share the same
+// neutral grey since neither carries a distinct layer identity of its own.
+export const LAYER_COLORS = {
+  motivation: { fill: '#CCCCFF', border: '#8F8FE0' },
+  strategy: { fill: '#F5DEAA', border: '#C9A355' },
+  business: { fill: '#FFFF99', border: '#C9C355' },
+  application: { fill: '#CCFFFF', border: '#4FB8B8' },
+  technology: { fill: '#CCFFCC', border: '#5FAE5F' },
+  implementation: { fill: '#FFE0E0', border: '#D89999' },
+  physical: { fill: '#F0F0F0', border: '#999999' },
+  composite: { fill: '#F0F0F0', border: '#999999' },
+} as const satisfies Record<Layer, { readonly fill: string; readonly border: string }>
+
+export interface ShapeMeta {
+  readonly shape: 'rectangle' | 'round-rectangle' | 'octagon'
+  /** Passive-structure's ArchiMate header-stripe convention. */
+  readonly accent?: 'top-band'
+  /** Composite (grouping/location/junction) convention. */
+  readonly borderStyle?: 'dashed'
+}
+
+// Aspect -> shape/accent/borderStyle, mirroring `graph-canvas.tsx`'s
+// `node[aspect = "…"]` selectors (Task 8/11 ArchiMate notation mode).
+export const ASPECT_SHAPES: Record<Aspect, ShapeMeta> = {
+  motivation: { shape: 'octagon' },
+  'active-structure': { shape: 'rectangle' },
+  behavior: { shape: 'round-rectangle' },
+  'passive-structure': { shape: 'rectangle', accent: 'top-band' },
+  composite: { shape: 'rectangle', borderStyle: 'dashed' },
+}
+
+function svg(body: string): string {
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${ICON_SIZE}" height="${ICON_SIZE}" ` +
+    `viewBox="0 0 ${ICON_SIZE} ${ICON_SIZE}">` +
+    `<g fill="none" stroke="${INK}" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">${body}</g>` +
+    `</svg>`
+  )
+}
+
+function toDataUri(svgMarkup: string): string {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svgMarkup)}`
+}
+
+// The 17 kinds the canvas already draws a glyph for (`src/visual-app/
+// kind-icons.ts` `BASE_KIND_SVG`), copied verbatim. Every other core kind
+// (e.g. `stakeholder`) has no glyph body and resolves to `null` below -
+// that's an allowed gap, not a coverage failure: `CONCEPT_NOTATION` still
+// carries a row for it, just with `glyph: null`.
+const BASE_KIND_SVG: Record<string, string> = {
+  // Component: UML/ArchiMate component box with two connector notches on
+  // its left edge.
+  applicationComponent:
+    '<rect x="3" y="2" width="9" height="10"/>' +
+    '<rect x="1" y="4" width="2.5" height="1.5"/>' +
+    '<rect x="1" y="8" width="2.5" height="1.5"/>',
+  // Function: rounded process box with a right-pointing chevron.
+  applicationFunction: '<rect x="2" y="3" width="10" height="8" rx="2"/><path d="M5.5 5 L8 7 L5.5 9"/>',
+  // Service: a pill/oval, ArchiMate's rounded-rectangle service shape.
+  applicationService: '<rect x="1.5" y="4" width="11" height="6" rx="3"/>',
+  // Artifact: a document with a folded top-right corner.
+  artifact: '<path d="M3 1.5 H9 L11 3.5 V12.5 H3 Z"/><path d="M9 1.5 V3.5 H11"/>',
+  // Actor: a stick figure - head, torso, arms, legs.
+  businessActor: '<circle cx="7" cy="3.5" r="1.8"/><path d="M7 5.3 V9 M4 7 H10 M7 9 L4.5 12.5 M7 9 L9.5 12.5"/>',
+  // Function: same process-box convention as applicationFunction, an
+  // upward chevron distinguishes the business layer.
+  businessFunction: '<rect x="2" y="3" width="10" height="8" rx="2"/><path d="M5 8 L7 5.5 L9 8"/>',
+  // Capability: a box with a compass-style arrow toward its top-right
+  // corner (capability-as-direction motif).
+  capability: '<rect x="2" y="2" width="10" height="10" rx="1"/><path d="M5 9 L9 5 M9 5 H6.5 M9 5 V7.5"/>',
+  // Data object: a record box with a header divider.
+  dataObject: '<rect x="2" y="2" width="10" height="10"/><path d="M2 5.5 H12"/>',
+  // Deliverable: a folded-corner document (like artifact) with a ribbon
+  // check-mark distinguishing it as a completed output.
+  deliverable:
+    '<path d="M3 1.5 H8 L11 4.5 V12.5 H3 Z"/><path d="M8 1.5 V4.5 H11"/><path d="M5 9.5 L7 12.5 L9 9.5"/>',
+  // Driver: a steering-wheel motif - a circle with four radiating spokes.
+  driver: '<circle cx="7" cy="7" r="5"/><path d="M7 2 V5 M7 9 V12 M2 7 H5 M9 7 H12"/>',
+  // Goal: a target - two concentric circles.
+  goal: '<circle cx="7" cy="7" r="5"/><circle cx="7" cy="7" r="2.2"/>',
+  // Node: a 3D cuboid, ArchiMate's technology-node glyph.
+  node: '<path d="M2 5 L7 2.5 L12 5 L12 10 L7 12.5 L2 10 Z"/><path d="M2 5 L7 7.5 L12 5 M7 7.5 V12.5"/>',
+  // Plateau: a flat-topped trapezoid.
+  plateau: '<path d="M2 11 L4.5 4 H9.5 L12 11 Z"/><path d="M2 11 H12"/>',
+  // Representation: a document with a wavy bottom edge (curled paper).
+  representation: '<path d="M3 2 H11 V9 Q9.5 11 8 9.5 Q6.5 8 5 9.5 Q3.5 11 3 9 Z"/>',
+  // Requirement: a pointed banner/shield shape with a header divider.
+  requirement: '<path d="M3 2.5 H11 V9 L7 11.5 L3 9 Z"/><path d="M3 5 H11"/>',
+  // System software: a nested box, a smaller box docked inside the larger.
+  systemSoftware: '<rect x="2" y="2" width="10" height="10"/><rect x="4" y="4" width="4" height="3"/>',
+  // Function: same process convention again, technology layer gets a gear
+  // motif - a circle with radiating teeth.
+  technologyFunction:
+    '<circle cx="7" cy="7" r="4"/>' +
+    '<path d="M7 2 V3.2 M7 10.8 V12 M2 7 H3.2 M10.8 7 H12 ' +
+    'M3.5 3.5 L4.3 4.3 M9.7 9.7 L10.5 10.5 M3.5 10.5 L4.3 9.7 M9.7 4.3 L10.5 3.5"/>',
+}
+
+export interface ConceptNotation extends ShapeMeta {
+  readonly id: string
+  readonly notation: string
+  readonly layer: Layer
+  readonly aspect: Aspect
+  readonly glyph: string | null
+  readonly colors: { readonly fill: string; readonly border: string }
+}
+
+// Built from `conceptKinds` (not enumerated by hand) so coverage cannot
+// drift from the core vocabulary - a new kind added to `profile.ts` gets a
+// notation row automatically, and a removed one disappears automatically.
+export const CONCEPT_NOTATION: readonly ConceptNotation[] = conceptKinds.map((kind) => ({
+  id: kind.id,
+  notation: kind.name,
+  layer: kind.layer,
+  aspect: kind.aspect,
+  ...ASPECT_SHAPES[kind.aspect],
+  glyph: BASE_KIND_SVG[kind.id] ?? null,
+  colors: LAYER_COLORS[kind.layer],
+}))
+
+const CONCEPT_NOTATION_BY_ID: Record<string, ConceptNotation> = Object.fromEntries(
+  CONCEPT_NOTATION.map((row) => [row.id, row]),
+)
+
+export function conceptNotationOf(kindLabel: string): ConceptNotation | null {
+  return CONCEPT_NOTATION_BY_ID[kindLabel] ?? null
+}
+
+export function kindGlyphDataUriOf(kindLabel: string): string | null {
+  const glyph = CONCEPT_NOTATION_BY_ID[kindLabel]?.glyph
+  return glyph == null ? null : toDataUri(svg(glyph))
+}
+
+export interface ArrowNotation {
+  readonly shape: 'none' | 'diamond' | 'triangle' | 'circle' | 'vee'
+  readonly fill?: 'filled' | 'hollow'
+}
+
+export interface RelationshipNotation {
+  readonly id: RelationshipKind
+  readonly lineStyle: 'solid' | 'dotted' | 'dashed'
+  readonly sourceArrow: ArrowNotation
+  readonly targetArrow: ArrowNotation
+}
+
+type RelationshipStyle = Omit<RelationshipNotation, 'id'>
+
+// The 11 rows from `graph-canvas.tsx`'s ArchiMate edge selectors (Task 11).
+const RELATIONSHIP_STYLE: Record<RelationshipKind, RelationshipStyle> = {
+  composition: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'diamond', fill: 'filled' },
+    targetArrow: { shape: 'none' },
+  },
+  aggregation: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'diamond', fill: 'hollow' },
+    targetArrow: { shape: 'none' },
+  },
+  assignment: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'circle', fill: 'filled' },
+    targetArrow: { shape: 'triangle', fill: 'filled' },
+  },
+  realization: {
+    lineStyle: 'dotted',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'triangle', fill: 'hollow' },
+  },
+  specialization: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'triangle', fill: 'hollow' },
+  },
+  serving: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'vee' },
+  },
+  access: {
+    lineStyle: 'dotted',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'vee' },
+  },
+  influence: {
+    lineStyle: 'dashed',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'vee' },
+  },
+  triggering: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'triangle', fill: 'filled' },
+  },
+  flow: {
+    lineStyle: 'dashed',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'triangle', fill: 'filled' },
+  },
+  association: {
+    lineStyle: 'solid',
+    sourceArrow: { shape: 'none' },
+    targetArrow: { shape: 'none' },
+  },
+}
+
+// Built from `relationshipKinds` so coverage cannot drift, same discipline
+// as `CONCEPT_NOTATION` above.
+export const RELATIONSHIP_NOTATION: readonly RelationshipNotation[] = relationshipKinds.map((id) => ({
+  id,
+  ...RELATIONSHIP_STYLE[id],
+}))
+
+const RELATIONSHIP_NOTATION_BY_ID: Record<string, RelationshipNotation> = Object.fromEntries(
+  RELATIONSHIP_NOTATION.map((row) => [row.id, row]),
+)
+
+export function relationshipNotationOf(kindLabel: string): RelationshipNotation | null {
+  return RELATIONSHIP_NOTATION_BY_ID[kindLabel] ?? null
+}
+
+// `layers` is re-exported so consumers of this subpath don't need a second
+// import from `../profile.js` just to iterate the palette.
+export { layers }

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -20,6 +20,7 @@ import {
   ownerInitialsOf,
 } from './badges.js'
 import { ICON_SIZE, kindIconUriOf } from './kind-icons.js'
+import { ASPECT_SHAPES, LAYER_COLORS, RELATIONSHIP_NOTATION } from '../notation/archimate.js'
 
 // Register elk extension once at module load, guarded against re-registration
 let elkRegistered = false
@@ -28,20 +29,17 @@ if (!elkRegistered) {
   elkRegistered = true
 }
 
-// Layer → color palette from approved ArchiMate mockups (6 of 8 union values used)
-export const LAYER_COLORS = {
-  motivation: { fill: '#CCCCFF', border: '#8F8FE0' },
-  strategy: { fill: '#F5DEAA', border: '#C9A355' },
-  business: { fill: '#FFFF99', border: '#C9C355' },
-  application: { fill: '#CCFFFF', border: '#4FB8B8' },
-  technology: { fill: '#CCFFCC', border: '#5FAE5F' },
-  implementation: { fill: '#FFE0E0', border: '#D89999' },
-} as const satisfies Record<
-  'motivation' | 'strategy' | 'business' | 'application' | 'technology' | 'implementation',
-  { readonly fill: string; readonly border: string }
->
+// Re-exported so `badges.test.ts` (and any other existing consumer of this
+// module's `LAYER_COLORS`) keeps working - the palette itself now lives in
+// `src/notation/archimate.ts`, the single source of truth shared with any
+// future standalone notation consumer.
+export { LAYER_COLORS }
 
-// Default neutral style for uncolored layers (physical, composite, or null)
+// Base node fill/border, used when a node has no `layer` attribute at all
+// (falls through every `node[layer = "…"]` rule below) and reused as the
+// passive-structure gradient's two stop colors further down. `physical` and
+// `composite` resolve through `LAYER_COLORS` to these same values now, not
+// through this fallback - they carry an explicit neutral row of their own.
 const DEFAULT_FILL = '#F0F0F0'
 const DEFAULT_BORDER = '#999999'
 
@@ -399,48 +397,18 @@ export function buildStylesheet(
         'background-clip': (ele: NodeSingular) => badgeStyleFor(ele).clips,
       },
     },
-    {
-      selector: 'node[layer = "motivation"]',
-      style: {
-        'background-color': LAYER_COLORS.motivation.fill,
-        'border-color': LAYER_COLORS.motivation.border,
-      },
-    },
-    {
-      selector: 'node[layer = "strategy"]',
-      style: {
-        'background-color': LAYER_COLORS.strategy.fill,
-        'border-color': LAYER_COLORS.strategy.border,
-      },
-    },
-    {
-      selector: 'node[layer = "business"]',
-      style: {
-        'background-color': LAYER_COLORS.business.fill,
-        'border-color': LAYER_COLORS.business.border,
-      },
-    },
-    {
-      selector: 'node[layer = "application"]',
-      style: {
-        'background-color': LAYER_COLORS.application.fill,
-        'border-color': LAYER_COLORS.application.border,
-      },
-    },
-    {
-      selector: 'node[layer = "technology"]',
-      style: {
-        'background-color': LAYER_COLORS.technology.fill,
-        'border-color': LAYER_COLORS.technology.border,
-      },
-    },
-    {
-      selector: 'node[layer = "implementation"]',
-      style: {
-        'background-color': LAYER_COLORS.implementation.fill,
-        'border-color': LAYER_COLORS.implementation.border,
-      },
-    },
+    // One rule per `LAYER_COLORS` entry (8, including `physical` and
+    // `composite`'s explicit neutral row) instead of six hand-written
+    // blocks - coverage tracks the notation module's palette automatically.
+    ...Object.entries(LAYER_COLORS).map(
+      ([layer, colors]): cytoscape.StylesheetJsonBlock => ({
+        selector: `node[layer = "${layer}"]`,
+        style: {
+          'background-color': colors.fill,
+          'border-color': colors.border,
+        },
+      }),
+    ),
     {
       // Compound container (see resolveCompositionParents below): keeps its own
       // layer fill/border from the rules above but at low opacity with a dashed
@@ -514,136 +482,44 @@ export function buildStylesheet(
   // lineage identically to the core kind it inherits from. Appended after
   // `baseStylesheet` rather than folded in, so `notation === 'native'`
   // returns the exact same array untouched.
-  const archimateNodeShapes: cytoscape.StylesheetJsonBlock[] = [
-    {
-      selector: 'node[aspect = "active-structure"]',
-      style: { shape: 'rectangle' },
+  // Node shapes: one rule per `ASPECT_SHAPES` entry, translating the
+  // notation module's ShapeMeta into cytoscape node style. Passive
+  // structure's top accent band and composite's dashed border are decoded
+  // from `accent`/`borderStyle` here, using the same DEFAULT_BORDER /
+  // DEFAULT_FILL gradient stops as before - only the table's source moved.
+  const archimateNodeShapes: cytoscape.StylesheetJsonBlock[] = Object.entries(ASPECT_SHAPES).map(
+    ([aspect, meta]): cytoscape.StylesheetJsonBlock => {
+      const style: cytoscape.Css.Node = { shape: meta.shape }
+      if (meta.accent === 'top-band') {
+        style['background-fill'] = 'linear-gradient'
+        style['background-gradient-direction'] = 'to-bottom'
+        style['background-gradient-stop-colors'] = [DEFAULT_BORDER, DEFAULT_FILL]
+        style['background-gradient-stop-positions'] = ['0%', '20%']
+      }
+      if (meta.borderStyle === 'dashed') {
+        style['border-style'] = 'dashed'
+      }
+      return { selector: `node[aspect = "${aspect}"]`, style }
     },
-    {
-      selector: 'node[aspect = "behavior"]',
-      style: { shape: 'round-rectangle' },
-    },
-    {
-      // Rectangle with a top accent band: a short gradient from the neutral
-      // border color into the neutral fill stands in for ArchiMate's passive
-      // structure header stripe without a second stacked shape.
-      selector: 'node[aspect = "passive-structure"]',
-      style: {
-        shape: 'rectangle',
-        'background-fill': 'linear-gradient',
-        'background-gradient-direction': 'to-bottom',
-        'background-gradient-stop-colors': [DEFAULT_BORDER, DEFAULT_FILL],
-        'background-gradient-stop-positions': ['0%', '20%'],
-      },
-    },
-    {
-      selector: 'node[aspect = "motivation"]',
-      style: { shape: 'octagon' },
-    },
-    {
-      selector: 'node[aspect = "composite"]',
-      style: { shape: 'rectangle', 'border-style': 'dashed' },
-    },
-  ]
+  )
 
-  const archimateEdgeStyles: cytoscape.StylesheetJsonBlock[] = [
-    {
-      selector: 'edge[coreKindLabel = "composition"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'diamond',
-        'source-arrow-fill': 'filled',
-        'target-arrow-shape': 'none',
-      },
+  // Edges: one rule per `RELATIONSHIP_NOTATION` row, translating
+  // lineStyle/sourceArrow/targetArrow into cytoscape's edge style keys. An
+  // arrow fill is only emitted when the notation row declares one (a
+  // `'none'` shape never carries a fill), matching the arrow mappings
+  // exactly - only the table's source moved, arrows unchanged.
+  const archimateEdgeStyles: cytoscape.StylesheetJsonBlock[] = RELATIONSHIP_NOTATION.map(
+    (rel): cytoscape.StylesheetJsonBlock => {
+      const style: cytoscape.Css.Edge = {
+        'line-style': rel.lineStyle,
+        'source-arrow-shape': rel.sourceArrow.shape,
+        'target-arrow-shape': rel.targetArrow.shape,
+      }
+      if (rel.sourceArrow.fill !== undefined) style['source-arrow-fill'] = rel.sourceArrow.fill
+      if (rel.targetArrow.fill !== undefined) style['target-arrow-fill'] = rel.targetArrow.fill
+      return { selector: `edge[coreKindLabel = "${rel.id}"]`, style }
     },
-    {
-      selector: 'edge[coreKindLabel = "aggregation"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'diamond',
-        'source-arrow-fill': 'hollow',
-        'target-arrow-shape': 'none',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "assignment"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'circle',
-        'source-arrow-fill': 'filled',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-fill': 'filled',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "realization"]',
-      style: {
-        'line-style': 'dotted',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-fill': 'hollow',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "specialization"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-fill': 'hollow',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "serving"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'vee',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "access"]',
-      style: {
-        'line-style': 'dotted',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'vee',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "influence"]',
-      style: {
-        'line-style': 'dashed',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'vee',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "triggering"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-fill': 'filled',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "flow"]',
-      style: {
-        'line-style': 'dashed',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-fill': 'filled',
-      },
-    },
-    {
-      selector: 'edge[coreKindLabel = "association"]',
-      style: {
-        'line-style': 'solid',
-        'source-arrow-shape': 'none',
-        'target-arrow-shape': 'none',
-      },
-    },
-  ]
+  )
 
   return [...baseStylesheet, ...archimateNodeShapes, ...archimateEdgeStyles]
 }

--- a/src/visual-app/kind-icons.ts
+++ b/src/visual-app/kind-icons.ts
@@ -1,111 +1,29 @@
-// Pure kind-icon generation: a 14x14 ArchiMate-glyph SVG (as an inline
-// `data:` URI) per element kind this repo's graph actually uses. No
-// cytoscape/DOM dependency here, same isolation as `badges.ts` (the sibling
-// module for the same stylesheet) - this stays testable as a plain
-// string-in/string-out lookup. `graph-canvas.tsx` consumes it from the
-// stylesheet as one `background-image` layer on the node's top-left corner,
-// under `notation === 'archimate'` only.
+// Thin wrapper around the shared `src/notation/archimate.ts` glyph catalogue:
+// resolves a graph node's kind label to its `data:image/svg+xml` icon URI.
+// The 17 core-vocabulary glyphs and their SVG rendering live in the notation
+// module now (the single source of truth for both this canvas and any future
+// standalone consumer); this file only adds the two local profile aliases
+// that inherit their parent's glyph verbatim.
+import { ICON_SIZE, kindGlyphDataUriOf as coreKindGlyphDataUriOf } from '../notation/archimate.js'
 
-// An SVG `data:` URI can't read `var(--token)`, so the stroke colour below
-// is `--ink` (`src/visual-app/styles.css:11-21`), resolved once to its
-// literal rendered hex - same value `badges.ts` uses for `INK`, redeclared
-// here rather than imported so this module keeps its own zero-import,
-// zero-dependency footprint.
-const INK = '#182228' // --ink (styles.css:12)
-
-// 14px: the brief's fixed icon size. `graph-canvas.tsx` reads it for the
-// background-image layer's `background-width`/`background-height`, so the
-// drawn glyph and the SVG's own viewport stay the same size.
-export const ICON_SIZE = 14
-
-function toDataUri(svg: string): string {
-  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
-}
-
-// Stroke colour/width/cap/join are declared once on the wrapping `<g>`
-// rather than repeated per shape - every glyph body below is bare
-// `rect`/`circle`/`path` markup with no fill or stroke attributes of its
-// own, which is what keeps these icons single-stroke by construction.
-function svg(body: string): string {
-  return (
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${ICON_SIZE}" height="${ICON_SIZE}" ` +
-    `viewBox="0 0 ${ICON_SIZE} ${ICON_SIZE}">` +
-    `<g fill="none" stroke="${INK}" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">${body}</g>` +
-    `</svg>`
-  )
-}
-
-// The 17 kinds `yarramate/core@0.1` and `.yarramate/profiles/
-// yarramate-development.yaml` (the two that don't inherit) declare, each
-// rendered as a simplified single-stroke take on its ArchiMate element
-// glyph. Descriptive notation only - no trademark or conformance claim.
-const BASE_KIND_SVG: Record<string, string> = {
-  // Component: UML/ArchiMate component box with two connector notches on
-  // its left edge.
-  applicationComponent:
-    '<rect x="3" y="2" width="9" height="10"/>' +
-    '<rect x="1" y="4" width="2.5" height="1.5"/>' +
-    '<rect x="1" y="8" width="2.5" height="1.5"/>',
-  // Function: rounded process box with a right-pointing chevron.
-  applicationFunction: '<rect x="2" y="3" width="10" height="8" rx="2"/><path d="M5.5 5 L8 7 L5.5 9"/>',
-  // Service: a pill/oval, ArchiMate's rounded-rectangle service shape.
-  applicationService: '<rect x="1.5" y="4" width="11" height="6" rx="3"/>',
-  // Artifact: a document with a folded top-right corner.
-  artifact: '<path d="M3 1.5 H9 L11 3.5 V12.5 H3 Z"/><path d="M9 1.5 V3.5 H11"/>',
-  // Actor: a stick figure - head, torso, arms, legs.
-  businessActor: '<circle cx="7" cy="3.5" r="1.8"/><path d="M7 5.3 V9 M4 7 H10 M7 9 L4.5 12.5 M7 9 L9.5 12.5"/>',
-  // Function: same process-box convention as applicationFunction, an
-  // upward chevron distinguishes the business layer.
-  businessFunction: '<rect x="2" y="3" width="10" height="8" rx="2"/><path d="M5 8 L7 5.5 L9 8"/>',
-  // Capability: a box with a compass-style arrow toward its top-right
-  // corner (capability-as-direction motif).
-  capability: '<rect x="2" y="2" width="10" height="10" rx="1"/><path d="M5 9 L9 5 M9 5 H6.5 M9 5 V7.5"/>',
-  // Data object: a record box with a header divider.
-  dataObject: '<rect x="2" y="2" width="10" height="10"/><path d="M2 5.5 H12"/>',
-  // Deliverable: a folded-corner document (like artifact) with a ribbon
-  // check-mark distinguishing it as a completed output.
-  deliverable:
-    '<path d="M3 1.5 H8 L11 4.5 V12.5 H3 Z"/><path d="M8 1.5 V4.5 H11"/><path d="M5 9.5 L7 12.5 L9 9.5"/>',
-  // Driver: a steering-wheel motif - a circle with four radiating spokes.
-  driver: '<circle cx="7" cy="7" r="5"/><path d="M7 2 V5 M7 9 V12 M2 7 H5 M9 7 H12"/>',
-  // Goal: a target - two concentric circles.
-  goal: '<circle cx="7" cy="7" r="5"/><circle cx="7" cy="7" r="2.2"/>',
-  // Node: a 3D cuboid, ArchiMate's technology-node glyph.
-  node: '<path d="M2 5 L7 2.5 L12 5 L12 10 L7 12.5 L2 10 Z"/><path d="M2 5 L7 7.5 L12 5 M7 7.5 V12.5"/>',
-  // Plateau: a flat-topped trapezoid.
-  plateau: '<path d="M2 11 L4.5 4 H9.5 L12 11 Z"/><path d="M2 11 H12"/>',
-  // Representation: a document with a wavy bottom edge (curled paper).
-  representation: '<path d="M3 2 H11 V9 Q9.5 11 8 9.5 Q6.5 8 5 9.5 Q3.5 11 3 9 Z"/>',
-  // Requirement: a pointed banner/shield shape with a header divider.
-  requirement: '<path d="M3 2.5 H11 V9 L7 11.5 L3 9 Z"/><path d="M3 5 H11"/>',
-  // System software: a nested box, a smaller box docked inside the larger.
-  systemSoftware: '<rect x="2" y="2" width="10" height="10"/><rect x="4" y="4" width="4" height="3"/>',
-  // Function: same process convention again, technology layer gets a gear
-  // motif - a circle with radiating teeth.
-  technologyFunction:
-    '<circle cx="7" cy="7" r="4"/>' +
-    '<path d="M7 2 V3.2 M7 10.8 V12 M2 7 H3.2 M10.8 7 H12 ' +
-    'M3.5 3.5 L4.3 4.3 M9.7 9.7 L10.5 10.5 M3.5 10.5 L4.3 9.7 M9.7 4.3 L10.5 3.5"/>',
-}
-
-const BASE_KIND_ICON_URI: Record<string, string> = Object.fromEntries(
-  Object.entries(BASE_KIND_SVG).map(([kind, body]) => [kind, toDataUri(svg(body))]),
-)
+export { ICON_SIZE }
 
 // `compiler-module` and `repository-file` are the two kinds
 // `.yarramate/profiles/yarramate-development.yaml` adds beyond
-// `yarramate/core@0.1`'s 17. Both inherit their parent's glyph verbatim -
-// the same URI constant is reused below, not a re-serialized copy, so the
-// two pairs are byte-identical.
-const KIND_ICON_URI: Record<string, string> = {
-  ...BASE_KIND_ICON_URI,
-  'compiler-module': BASE_KIND_ICON_URI['applicationComponent']!,
-  'repository-file': BASE_KIND_ICON_URI['artifact']!,
+// `yarramate/core@0.1`'s 17. Both inherit their parent's glyph verbatim, so
+// each aliases to the parent kind's id rather than duplicating its glyph
+// body - this alias map is local because the notation module has no notion
+// of profile-specific kinds, only the core vocabulary.
+const PROFILE_ALIAS_GLYPH: Record<string, string> = {
+  'compiler-module': 'applicationComponent',
+  'repository-file': 'artifact',
 }
 
 // `kindLabel` is a kind's local id (`kindLabelOf` in `src/kind-label.ts`),
 // not the qualified `<profile>#<id>` identity. Unknown label -> no icon, no
 // crash: the top-right slot simply stays empty.
 export function kindIconUriOf(kindLabel: string): string | null {
-  return KIND_ICON_URI[kindLabel] ?? null
+  const aliased = PROFILE_ALIAS_GLYPH[kindLabel]
+  if (aliased !== undefined) return coreKindGlyphDataUriOf(aliased)
+  return coreKindGlyphDataUriOf(kindLabel)
 }

--- a/test/archimate-notation.test.ts
+++ b/test/archimate-notation.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { conceptKinds, layers, relationshipKinds } from '../src/profile.js'
+import {
+  CONCEPT_NOTATION,
+  LAYER_COLORS,
+  RELATIONSHIP_NOTATION,
+  conceptNotationOf,
+  kindGlyphDataUriOf,
+  relationshipNotationOf,
+} from '../src/notation/archimate.js'
+
+const KNOWN_GLYPHS = [
+  'applicationComponent',
+  'applicationFunction',
+  'applicationService',
+  'artifact',
+  'businessActor',
+  'businessFunction',
+  'capability',
+  'dataObject',
+  'deliverable',
+  'driver',
+  'goal',
+  'node',
+  'plateau',
+  'representation',
+  'requirement',
+  'systemSoftware',
+  'technologyFunction',
+] as const
+
+describe('archimate notation vocabulary', () => {
+  it('covers every core concept kind exactly once', () => {
+    const ids = CONCEPT_NOTATION.map((row) => row.id).sort()
+    const expected = conceptKinds.map((k) => k.id).sort()
+    expect(ids).toEqual(expected)
+  })
+
+  it('covers every core relationship kind exactly once', () => {
+    const ids = RELATIONSHIP_NOTATION.map((row) => row.id).sort()
+    const expected = [...relationshipKinds].sort()
+    expect(ids).toEqual(expected)
+  })
+
+  it('uses the locked canvas layer palette', () => {
+    expect(LAYER_COLORS.motivation).toEqual({ fill: '#CCCCFF', border: '#8F8FE0' })
+    expect(LAYER_COLORS.strategy).toEqual({ fill: '#F5DEAA', border: '#C9A355' })
+    expect(LAYER_COLORS.business).toEqual({ fill: '#FFFF99', border: '#C9C355' })
+    expect(LAYER_COLORS.application).toEqual({ fill: '#CCFFFF', border: '#4FB8B8' })
+    expect(LAYER_COLORS.technology).toEqual({ fill: '#CCFFCC', border: '#5FAE5F' })
+    expect(LAYER_COLORS.implementation).toEqual({ fill: '#FFE0E0', border: '#D89999' })
+    expect(LAYER_COLORS.physical).toEqual({ fill: '#F0F0F0', border: '#999999' })
+    expect(LAYER_COLORS.composite).toEqual({ fill: '#F0F0F0', border: '#999999' })
+    for (const layer of layers) {
+      expect(LAYER_COLORS[layer]).toEqual(
+        expect.objectContaining({ fill: expect.any(String), border: expect.any(String) }),
+      )
+    }
+  })
+
+  it('derives shape tokens from aspect', () => {
+    expect(conceptNotationOf('applicationComponent')).toMatchObject({
+      aspect: 'active-structure',
+      shape: 'rectangle',
+    })
+    expect(conceptNotationOf('applicationFunction')).toMatchObject({
+      aspect: 'behavior',
+      shape: 'round-rectangle',
+    })
+    expect(conceptNotationOf('dataObject')).toMatchObject({
+      aspect: 'passive-structure',
+      shape: 'rectangle',
+      accent: 'top-band',
+    })
+    expect(conceptNotationOf('goal')).toMatchObject({
+      aspect: 'motivation',
+      shape: 'octagon',
+    })
+    expect(conceptNotationOf('grouping')).toMatchObject({
+      aspect: 'composite',
+      shape: 'rectangle',
+      borderStyle: 'dashed',
+    })
+  })
+
+  it('ships glyphs for the 17 kinds the canvas already drew; null otherwise is allowed', () => {
+    for (const id of KNOWN_GLYPHS) {
+      expect(conceptNotationOf(id)?.glyph).toEqual(expect.any(String))
+      expect(kindGlyphDataUriOf(id)).toMatch(/^data:image\/svg\+xml;utf8,/)
+    }
+    // A core kind never drawn before may be null — stakeholder is one.
+    const stakeholder = conceptNotationOf('stakeholder')
+    expect(stakeholder).not.toBeNull()
+    // glyph may be null or string; lookup still works
+    expect(conceptNotationOf('notAKind')).toBeNull()
+    expect(kindGlyphDataUriOf('notAKind')).toBeNull()
+  })
+
+  it('maps composition and realization edge notation', () => {
+    expect(relationshipNotationOf('composition')).toEqual({
+      id: 'composition',
+      lineStyle: 'solid',
+      sourceArrow: { shape: 'diamond', fill: 'filled' },
+      targetArrow: { shape: 'none' },
+    })
+    expect(relationshipNotationOf('realization')).toEqual({
+      id: 'realization',
+      lineStyle: 'dotted',
+      sourceArrow: { shape: 'none' },
+      targetArrow: { shape: 'triangle', fill: 'hollow' },
+    })
+  })
+
+  it('does not publish profile-extended aliases', () => {
+    expect(conceptNotationOf('compiler-module')).toBeNull()
+    expect(conceptNotationOf('repository-file')).toBeNull()
+  })
+})

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -54,6 +54,11 @@ describe('package export purity', () => {
     const { hits } = runtimeImportGraph('adapters/visual-graph-entry.ts')
     expect(hits).toEqual([])
   })
+
+  it('notation/archimate import graph stays free of Node, ws, session, and compiler runtime', () => {
+    const { hits } = runtimeImportGraph('notation/archimate.ts')
+    expect(hits).toEqual([])
+  })
 })
 
 describe('adapter/visual-graph barrel', () => {

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, join, normalize } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = join(process.cwd(), 'src')
+
+const FORBIDDEN = /^(node:|ws$|fs$|path$|os$|child_process$|crypto$|net$|http$|https$)/
+
+function runtimeImportGraph(entryRelative: string): { files: string[]; hits: string[] } {
+  const seen = new Set<string>()
+  const queue = [entryRelative]
+  const hits: string[] = []
+  while (queue.length > 0) {
+    const rel = queue.shift()!
+    if (seen.has(rel)) continue
+    seen.add(rel)
+    const full = join(root, rel)
+    if (!existsSync(full)) continue
+    const text = readFileSync(full, 'utf8')
+    // Strip type-only imports so `import type` from compiler.js is allowed.
+    const withoutTypeImports = text.replace(
+      /^\s*import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?\s*$/gm,
+      '',
+    )
+    for (const match of withoutTypeImports.matchAll(/from\s+['"]([^'"]+)['"]/g)) {
+      const spec = match[1]!
+      if (FORBIDDEN.test(spec) || spec === 'ws') {
+        hits.push(`${rel} -> ${spec}`)
+        continue
+      }
+      if (spec.includes('adapters/visual/') || spec.endsWith('/visual/session-server.js')) {
+        hits.push(`${rel} -> ${spec}`)
+        continue
+      }
+      // Disallow runtime import of compiler.js (Node/Ajv).
+      if (spec.endsWith('/compiler.js') || spec === './compiler.js' || spec === '../compiler.js') {
+        hits.push(`${rel} -> ${spec} (runtime)`)
+        continue
+      }
+      if (spec.startsWith('.')) {
+        let p = spec
+        if (!p.endsWith('.ts') && !p.endsWith('.js') && !p.endsWith('.json')) p += '.ts'
+        p = p.replace(/\.js$/, '.ts')
+        const target = normalize(join(dirname(rel), p)).replace(/\\/g, '/')
+        if (!seen.has(target)) queue.push(target)
+      }
+    }
+  }
+  return { files: [...seen].sort(), hits }
+}
+
+describe('package export purity', () => {
+  it('adapter/visual-graph import graph stays free of Node, ws, session, and compiler runtime', () => {
+    const { hits } = runtimeImportGraph('adapters/visual-graph-entry.ts')
+    expect(hits).toEqual([])
+  })
+})
+
+describe('adapter/visual-graph barrel', () => {
+  it('re-exports projectGraphForCanvas', async () => {
+    // Dynamic import intentionally exercises the module-loading boundary
+    // for the published subpath entry point.
+    const mod = await import('../src/adapters/visual-graph-entry.js')
+    expect(typeof mod.projectGraphForCanvas).toBe('function')
+  })
+})

--- a/test/graph-claims.test.ts
+++ b/test/graph-claims.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ATTESTATION_PREDICATE_PREFIX,
+  attestationClaimValue,
+  parseAttestationClaimValue,
+  parseConstraintExpectsValue,
+} from '../src/graph-claims.js'
+
+describe('graph-claims', () => {
+  it('exposes the attestation predicate prefix', () => {
+    expect(ATTESTATION_PREDICATE_PREFIX).toBe('yarramate/attestation/')
+  })
+
+  it('round-trips attestation values with and without recordedBy', () => {
+    expect(parseAttestationClaimValue(attestationClaimValue({ by: 'a', on: '2026-08-01' }))).toEqual({
+      by: 'a',
+      on: '2026-08-01',
+    })
+    expect(
+      parseAttestationClaimValue(
+        attestationClaimValue({ by: 'a', on: '2026-08-01', recordedBy: 'bot' }),
+      ),
+    ).toEqual({ by: 'a', on: '2026-08-01', recordedBy: 'bot' })
+  })
+
+  it('rejects malformed attestation values', () => {
+    expect(parseAttestationClaimValue('only-one-token')).toBeUndefined()
+    expect(parseAttestationClaimValue('a not-a-date')).toBeUndefined()
+  })
+
+  it('parses constraint expects with spaces in the value', () => {
+    expect(parseConstraintExpectsValue('terraform-scan region ap-southeast-2')).toEqual({
+      provider: 'terraform-scan',
+      key: 'region',
+      value: 'ap-southeast-2',
+    })
+    expect(parseConstraintExpectsValue('p k value with spaces')).toEqual({
+      provider: 'p',
+      key: 'k',
+      value: 'value with spaces',
+    })
+  })
+
+  it('rejects malformed constraint expects', () => {
+    expect(parseConstraintExpectsValue('only-one')).toBeUndefined()
+    expect(parseConstraintExpectsValue('one two')).toBeUndefined()
+  })
+})

--- a/test/visual-graph-schema.test.ts
+++ b/test/visual-graph-schema.test.ts
@@ -151,4 +151,70 @@ relationships:
       }),
     ).toBe(false)
   })
+
+  it('accepts every profile layer and aspect enum value and null', () => {
+    const baseNode = {
+      id: 'main#service',
+      localId: 'service',
+      document: 'main.yaml',
+      kind: 'yarramate/core@0.1#applicationComponent',
+      kindLabel: 'applicationComponent',
+      layer: 'application',
+      aspect: 'active-structure',
+      name: 'Service',
+      description: null,
+      aka: [],
+      status: null,
+      owner: null,
+      distinctFrom: [],
+      supersedes: [],
+      constraints: [],
+      references: [],
+      presentIn: [],
+      attestations: [],
+    }
+    const layers = [
+      'motivation', 'strategy', 'business', 'application',
+      'technology', 'physical', 'implementation', 'composite', null,
+    ]
+    const aspects = [
+      'motivation', 'active-structure', 'behavior',
+      'passive-structure', 'composite', null,
+    ]
+    for (const layer of layers) {
+      expect(validateVisualGraph({ nodes: [{ ...baseNode, layer }], edges: [] })).toBe(true)
+    }
+    for (const aspect of aspects) {
+      expect(validateVisualGraph({ nodes: [{ ...baseNode, aspect }], edges: [] })).toBe(true)
+    }
+  })
+
+  it('rejects free-string layer and aspect values', () => {
+    const baseNode = {
+      id: 'main#service',
+      localId: 'service',
+      document: 'main.yaml',
+      kind: 'yarramate/core@0.1#applicationComponent',
+      kindLabel: 'applicationComponent',
+      layer: 'application',
+      aspect: 'active-structure',
+      name: 'Service',
+      description: null,
+      aka: [],
+      status: null,
+      owner: null,
+      distinctFrom: [],
+      supersedes: [],
+      constraints: [],
+      references: [],
+      presentIn: [],
+      attestations: [],
+    }
+    expect(
+      validateVisualGraph({ nodes: [{ ...baseNode, layer: 'not-a-layer' }], edges: [] }),
+    ).toBe(false)
+    expect(
+      validateVisualGraph({ nodes: [{ ...baseNode, aspect: 'not-an-aspect' }], edges: [] }),
+    ).toBe(false)
+  })
 })

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -17,6 +17,8 @@
   "include": [
     "src/visual-app/**/*.ts",
     "src/visual-app/**/*.tsx",
+    "src/notation/**/*.ts",
+    "src/profile.ts",
     "vite.visual.config.ts",
     "test/badges.test.ts",
     "test/kind-icons.test.ts",
@@ -27,6 +29,7 @@
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",
     "test/changeset-tray.test.ts",
-    "test/subject-form.test.ts"
+    "test/subject-form.test.ts",
+    "test/archimate-notation.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Expose the existing visual-graph projector and ArchiMate notation vocabulary as supported package subpaths so hosted/browser consumers (ApertureX) can render from YarraMate's projection instead of a parallel reimplementation.

- `yarramate/adapter/visual-graph` — `projectGraphForCanvas` + canvas types. Import graph is Workers-safe (no `node:*`, `ws`, visual session, or runtime `compiler.js`).
- `yarramate/notation/archimate` — renderer-neutral kind/relationship vocabulary (label, shape, glyph, layer colour, arrows). Full core `conceptKinds` / `relationshipKinds` coverage.
- Visual app now consumes that shared notation module (profile aliases stay local).
- `canvasNode.layer` / `aspect` tightened to profile enums + `null`.
- Docs and Unreleased changelog entry.

No apply, operations/v1, compiler semantics, or visual session protocol changes.

## Validation

- `pnpm exec tsc --noEmit` — exit 0
- `pnpm exec tsc -p tsconfig.visual.json` — exit 0
- `pnpm exec tsc -p tsconfig.build.json` — exit 0
- Focused vitest (`graph-claims`, `export-purity`, `archimate-notation`, `graph-projection`, `visual-graph-schema`, `kind-icons`, `badges`, `graph-canvas`, `graph-canvas-layout`) — 9 files / 92 tests passed
- `pnpm build` — exit 0; emits `dist/adapters/visual-graph-entry.js` and `dist/notation/archimate.js`
- Full `pnpm test` in the worktree: 66/67 files. The one failure is a worktree `node_modules` symlink path artifact in `package-consumer.test.ts`. Same test on a normal checkout: 3/3 passed.

## Related issue

Closes #201

## Contract impact

- New package subpaths: `./adapter/visual-graph`, `./notation/archimate`.
- `schema/yarramate-visual-graph.schema.json`: `canvasNode.layer` / `aspect` change from free `string|null` to profile enums + `null`. Existing valid graphs that already emit profile vocabulary continue to validate; free strings now fail schema validation.
- No change to native document semantics, apply, compiler, diagnostics, or the visual session protocol.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.