### PR TITLE
Benchmark harness v3: seven-verb surface, provenance, resume

### DIFF
--- a/docs/research/context-benchmark/runner/catalogue.mjs
+++ b/docs/research/context-benchmark/runner/catalogue.mjs
@@ -1,7 +1,16 @@
-// Shared helper: catalogue snapshot of a workspace — open questions under the
-// core-enrichment catalogue (via the reference evaluator) alongside the number
-// of concepts they were counted over. Returns null (never throws) when the
-// workspace does not compile or the evaluator output is unrecognisable.
+// Shared helper: catalogue snapshot of a workspace — open questions alongside
+// the number of concepts they were counted over. Returns null (never throws)
+// when the workspace does not compile or the output is unrecognisable; the
+// failure is reported on stderr, because the 2026-07-29 → 0.7.0 break showed
+// a silent null here erases a whole metric family without anyone noticing.
+//
+// Harness v3: the count comes from the pinned toolchain's own evaluator
+// (`design --json`, shipped catalogue by default) rather than the research
+// evaluator under docs/research/question-catalogue/. The research schema had
+// drifted behind the product catalogue (0.8 uses fields it never learned), and
+// the toolchain's evaluator is also what a condition-B/C agent actually
+// experiences. Baseline (run-benchmark.mjs) and post-run (score.mjs) snapshots
+// default to the same shipped catalogue, so the not-worse delta is coherent.
 //
 // The concept count exists because the evaluator counts subject-scoped
 // questions once per matching subject: an absolute open-question total is not
@@ -9,16 +18,11 @@
 // catalogue-density-not-worse).
 
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
-const catalogueDir = join(repoRoot, 'docs/research/question-catalogue');
-const productCatalogueDir = join(repoRoot, 'catalogues');
-
-// Enrichment targets, as evaluate-catalogue.mjs defines them: concept subjects
-// minus the architecture-state subjects, which carry no catalogue questions.
+// Enrichment targets: concept subjects minus the architecture-state subjects,
+// which carry no catalogue questions.
 const conceptCount = (graph) => {
   const states = new Set((graph.claims ?? [])
     .filter((claim) => claim.predicate === 'yarramate/state/type')
@@ -26,23 +30,30 @@ const conceptCount = (graph) => {
   return (graph.subjects ?? []).filter((subject) => subject.type === 'concept' && !states.has(subject.id)).length;
 };
 
-export const catalogueSnapshot = (toolchainDir, workspaceDir, scratchDir, cataloguePath = join(productCatalogueDir, 'core-enrichment.yaml')) => {
+export const catalogueSnapshot = (toolchainDir, workspaceDir, scratchDir, cataloguePath = null) => {
   try {
-    const compiled = execFileSync(join(toolchainDir, 'yarramate'), ['compile', join(workspaceDir, 'workspace.yaml')], {
+    const workspacePath = join(workspaceDir, 'workspace.yaml');
+    // `export graph` is the seven-verb surface's compiled-graph emitter; the
+    // pre-0.7.0 `compile` verb this helper first shipped against is gone.
+    const graphPath = join(scratchDir, 'compiled-graph.json');
+    execFileSync(join(toolchainDir, 'yarramate'), ['export', 'graph', workspacePath, '--out', graphPath], {
       encoding: 'utf8',
       maxBuffer: 512 * 1024 * 1024,
     });
-    const graphPath = join(scratchDir, 'compiled-graph.json');
-    writeFileSync(graphPath, compiled);
-    const evaluated = execFileSync('node', [
-      join(catalogueDir, 'evaluate-catalogue.mjs'),
-      join(catalogueDir, 'yarramate-question-catalogue.schema.json'),
-      cataloguePath,
-      graphPath,
-    ], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
-    const open = evaluated.match(/total open questions[^:]*:\s*(\d+)/i);
-    return open ? { open: Number(open[1]), concepts: conceptCount(JSON.parse(compiled)) } : null;
-  } catch {
+    const stepArgs = ['design', workspacePath, '--json'];
+    if (cataloguePath) stepArgs.push('--catalogue', cataloguePath);
+    const step = JSON.parse(execFileSync(join(toolchainDir, 'yarramate'), stepArgs, {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    }));
+    const open = step.progress?.open;
+    if (typeof open !== 'number') {
+      console.error('catalogue snapshot: design --json carried no progress.open; recording null baseline');
+      return null;
+    }
+    return { open, concepts: conceptCount(JSON.parse(readFileSync(graphPath, 'utf8'))) };
+  } catch (error) {
+    console.error(`catalogue snapshot failed; recording null baseline: ${error.message ?? error}`);
     return null;
   }
 };

--- a/docs/research/context-benchmark/runner/conditions.mjs
+++ b/docs/research/context-benchmark/runner/conditions.mjs
@@ -8,11 +8,16 @@ const BASE = 'Work in the repository at the current directory.';
 // `yarramate init` writes (ADR 0040): an adopted repository advertises its
 // workspace to agent harnesses, so B/C mirror an adopted repository rather
 // than a bare model drop. The pilot (2026-07-29) ran without the pointer and
-// the weak tier never discovered the workspace; the instruction text below is
-// unchanged so prompt neutrality is preserved.
+// the weak tier never discovered the workspace.
+//
+// Harness v3: the 2026-07-29 sweep's text named `status` and `context`, both
+// removed by the 0.7.0 seven-verb break (ADR 0061); an instruction telling the
+// agent to run verbs that exit with a usage dump is a harness defect, not a
+// frozen artifact. The named query surface is now the current one. B and C
+// still share the string byte for byte.
 const MODEL_AVAILABLE =
   `${BASE} It contains a committed .yarramate architecture workspace; the ` +
-  'yarramate CLI is installed and can query it (status, context, check).';
+  'yarramate CLI is installed and can query it (ask, check, reconcile).';
 
 export const CONDITIONS = {
   A: {

--- a/docs/research/context-benchmark/runner/run-benchmark.mjs
+++ b/docs/research/context-benchmark/runner/run-benchmark.mjs
@@ -12,7 +12,13 @@
 //     --toolchain <dir with yarramate bins> --out <results-dir> \
 //     [--conditions A,B,C] [--tasks id,id] [--label tier-name] \
 //     [--harness 'claude -p --output-format json'] [--keep-subject-agent-config] \
-//     [--dry-run]
+//     [--dry-run] [--resume]
+//
+// --resume skips matrix cells that already have a record in <out>/runs.jsonl
+// (same suite, label, condition, task). A killed sweep appends no record for
+// the run it died in, so rerunning with --resume picks up exactly where it
+// stopped; the 2026-07-29 sweep lost seven tail runs to a session cap and had
+// to be retried by hand.
 //
 // The harness command receives the composed prompt on stdin and runs with the
 // task workdir as cwd. Anything printed to stdout is captured as the transcript.
@@ -53,6 +59,7 @@ const label = opt('label', 'default');
 const conditionIds = opt('conditions', 'A,B,C').split(',');
 const onlyTasks = opt('tasks') ? new Set(opt('tasks').split(',')) : null;
 const dryRun = flag('dry-run');
+const resume = flag('resume');
 const agentConfigPolicy = flag('keep-subject-agent-config') ? 'keep' : 'neutralize';
 
 const modelSourceDir = () => {
@@ -90,6 +97,15 @@ if (!toolchain) {
   process.exit(2);
 }
 
+// Provenance: the 2026-07-29 sweep recorded no toolchain version anywhere in
+// runs.jsonl — the version under test lived only in the results write-up. The
+// gallery model is likewise unpinned by the suite schema (a path, not a SHA),
+// so the clone's HEAD is captured here.
+const toolchainVersion = execFileSync(join(toolchain, 'yarramate'), ['--version'], { encoding: 'utf8' }).trim();
+const galleryCommit = suite.repository.gallery
+  ? execSync('git rev-parse HEAD', { cwd: galleryDir, encoding: 'utf8' }).trim()
+  : null;
+
 mkdirSync(outDir, { recursive: true });
 const cacheDir = join(outDir, 'cache', suite.suite);
 if (!existsSync(cacheDir)) {
@@ -119,7 +135,20 @@ const pointerFiles = () => {
 };
 
 const runsPath = join(outDir, 'runs.jsonl');
+const recorded = new Set();
+if (resume && existsSync(runsPath)) {
+  for (const line of readFileSync(runsPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    const record = JSON.parse(line);
+    recorded.add(`${record.suite}|${record.label}|${record.condition}|${record.task}`);
+  }
+}
+
 for (const [index, { conditionId, condition, task }] of matrix.entries()) {
+  if (resume && recorded.has(`${suite.suite}|${label}|${conditionId}|${task.id}`)) {
+    console.log(`[${index + 1}/${matrix.length}] ${suite.suite} ${conditionId} ${task.id} — already recorded, skipped`);
+    continue;
+  }
   const runDir = join(outDir, suite.suite, label, conditionId, task.id);
   const workdir = join(runDir, 'repo');
   rmSync(runDir, { recursive: true, force: true });
@@ -186,6 +215,8 @@ for (const [index, { conditionId, condition, task }] of matrix.entries()) {
     suite: suite.suite,
     suiteType: suite.type,
     headline: suite.headline,
+    toolchainVersion,
+    galleryCommit,
     label,
     condition: conditionId,
     task: task.id,

--- a/docs/research/context-benchmark/runner/score.mjs
+++ b/docs/research/context-benchmark/runner/score.mjs
@@ -37,7 +37,10 @@ const opt = (name, fallback) => {
 const runsPath = opt('runs');
 const suitePath = opt('suite');
 const toolchain = opt('toolchain');
-const cataloguePath = opt('catalogue', join(repoRoot, 'catalogues/core-enrichment.yaml'));
+// Default null = the pinned toolchain's shipped catalogue, matching what
+// run-benchmark.mjs recorded as the baseline; --catalogue overrides both only
+// if passed to both sides.
+const cataloguePath = opt('catalogue', null);
 if (!runsPath || !suitePath || !toolchain) {
   console.error('usage: score.mjs --runs <runs.jsonl> --suite <suite.yaml> --toolchain <bin-dir> [--catalogue <catalogue.yaml>]');
   process.exit(2);

--- a/docs/research/context-benchmark/runner/validate-suite.mjs
+++ b/docs/research/context-benchmark/runner/validate-suite.mjs
@@ -1,4 +1,4 @@
-// Draft validator for yarramate/benchmark-suite/v1 task suites.
+// Draft validator for yarramate/benchmark-suite v1 and v2 task suites.
 // Schema validation plus the cross-checks the schema cannot express:
 // unique task ids, per-family minimums, and condition-neutral prompts.
 // Usage: node validate-suite.mjs <schema.json> <suite.yaml> [suite.yaml ...]


### PR DESCRIPTION
Prep for the 2026-08 re-sweep (v2 suites + kafka/keycloak at yarramate@0.22.0).

The 2026-07-29 harness predates the 0.7.0 break and could not honestly measure a modern toolchain:

- **conditions.mjs** — the B/C instruction named `status` and `context`, removed by ADR 0061; it now names the current query surface (`ask`, `check`, `reconcile`). B and C still share one byte-identical string (prompt-leakage invariant intact).
- **catalogue.mjs** — shelled to the removed `compile` verb and swallowed the failure, so every baseline in a re-sweep would have been a silent null. Now: `export graph` + the pinned toolchain's own `design --json` evaluator (the research evaluator's schema has drifted behind catalogue 0.8), and null baselines are loud on stderr. `score.mjs` defaults to the same shipped catalogue so the not-worse delta stays coherent.
- **run-benchmark.mjs** — `runs.jsonl` now records `toolchainVersion` and `galleryCommit` (the v1 sweep's version under test lived only in the write-up; the gallery model was never pinned anywhere), and `--resume` skips already-recorded cells so a session-cap kill no longer costs tail runs.

Verified: all six suites validate + dry-run (162 runs/tier); `catalogueSnapshot` returns `{open:70, concepts:20}` on the miniflux showcase with the published 0.22.0 dist; `inject-stale` self-verifies 3 contradictions on kafka and keycloak model copies; runner unit tests 4/4.

Frozen task files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)