### PR TITLE
feat: rank hop interrogation ahead of model hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- Interrogation: `has-linkage`, `exists-linkage` (`direction` includes
+  `either`), `missing-constraint`, and `missing-flow-content` conditions.
+  Questions that name kinds from a profile no document has selected are
+  omitted from the report rather than reported closed or stuck open.
+  `no-subject-of-kind` honours `kindMatching` (default `descendants`), a
+  loosening of `outcome-missing`, `stakeholders-missing`,
+  `constraints-missing`, and `no-service-declared` for profile-derived
+  kinds.
+- Ship `yarramate/policy@0.1` as a built-in optional profile (ADR 0095):
+  `authentication-constraint`, `rate-limit-constraint`,
+  `reliability-constraint`, `mechanism-constraint`. Select it on a
+  document; do not copy a file. Catalogue `core-enrichment` 0.9 adds an
+  `interaction` wave before business so hop questions rank ahead of
+  `owner-missing`.
+
 ## 0.22.0
 
 - Export a Workers-safe visual-graph projector as

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,12 +1,13 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "0.8"
+version: "0.9"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
   description: >-
-    The guided design path: motivation, business, application, technology,
-    and implementation waves plus cross-cutting hygiene. Each question
+    The guided design path: motivation, interaction, business, application,
+    technology, and implementation waves plus cross-cutting hygiene. Each
+    question
     states the decision its answer changes; a question that cannot is
     deleted, not softened. Adequacy is enforced by linkage depth and
     attestation, never by reading words. Versioning is additive within a
@@ -18,6 +19,12 @@ waves:
   - id: motivation
     name: Motivation
     description: Why the system exists and what constrains it.
+  - id: interaction
+    name: Interaction
+    description: >-
+      Load-bearing hops: the behavior a component is assigned to, the
+      serving/triggering/flow mechanism, payload, trust, reliability, and
+      capacity. Hygiene waits.
   - id: business
     name: Business
     description: Who acts, what is served, and what information matters.
@@ -332,6 +339,398 @@ questions:
       Review the subject's description and linkage, then record an
       attestation with topic "adequacy" (revoke by deleting it; Git
       reviews both).
+
+  # ---- interaction ---------------------------------------------------------
+  - id: authn-standard-missing
+    wave: interaction
+    since: "0.9"
+    scope: workspace
+    trigger:
+      - condition: exists-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#businessActor
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/policy@0.1#authentication-constraint
+    question: >-
+      What is the default authentication mechanism for interactions in this
+      architecture?
+    askPlain: >-
+      When one system talks to another here, how do they prove who they
+      are? Pick the default now so each hop is not inventing its own.
+    materiality: >-
+      An unauthenticated hop to another system is a trust-boundary decision
+      nobody recorded. Implementers will pick a mechanism in code, and the
+      next hop will assume a different one. This question does not cover
+      authorization or transport security.
+    authority: human
+    resolution: >-
+      Add an authentication-constraint (the standard, or a not-applicable
+      subject with the reason in its description) in a document that
+      selects yarramate/policy@0.1.
+
+  - id: ratelimit-standard-missing
+    wave: interaction
+    since: "0.9"
+    scope: workspace
+    trigger:
+      - condition: exists-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/policy@0.1#rate-limit-constraint
+    question: >-
+      Where is rate limiting a requirement, and what is the default rule?
+    askPlain: >-
+      Do caller-facing APIs have a capacity cap? If yes, what is it? If
+      no, say so so we do not keep asking per hop.
+    materiality: >-
+      Caller-facing hops without a capacity rule are sized by whoever
+      implements first. An explicit none is a decision; silence is not.
+    authority: human
+    resolution: >-
+      Add a rate-limit-constraint for the default cap, or a
+      ratelimit-not-applicable subject. Bind hop-specific values with
+      expects on the binding.
+
+  - id: reliability-standard-missing
+    wave: interaction
+    since: "0.9"
+    scope: workspace
+    trigger:
+      - condition: exists-linkage
+        kinds:
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessActor
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/policy@0.1#reliability-constraint
+    question: >-
+      What is the default delivery, retry, and idempotency rule for
+      asynchronous or content-moving interactions?
+    askPlain: >-
+      When a message or payload does not arrive, do we retry, and what
+      makes a retry safe to repeat?
+    materiality: >-
+      Retry without idempotency duplicates work; no retry without a
+      recorded choice leaves timeout behaviour to each implementer.
+    authority: human
+    resolution: >-
+      Add a reliability-constraint (the standard, or not-applicable with
+      the reason in its description).
+
+  - id: hop-unrealised
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationComponent
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#businessActor
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#assignment
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#applicationInterface
+    question: >-
+      {subject.name} participates in an application interaction, but
+      nothing it is assigned to is that interaction. What process,
+      function, interaction, event, or interface is the hop?
+    askPlain: >-
+      {subject.name} talks to something else, but the model never names
+      the work it does in that talk. What is the actual step?
+    materiality: >-
+      A component-to-component edge with no assigned behavior is
+      inventory. Protocol, trust, payload, and failure have nowhere to
+      bind until the hop is a subject.
+    authority: either
+    resolution: >-
+      Add an application process, function, interaction, event, or
+      interface, assign this component to it, and relate that behavior
+      with serving, triggering, or flow to its counterpart. Do not answer
+      by deleting the component or adding a realization instead.
+
+  - id: interaction-protocol-unbound
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessActor
+      - condition: missing-constraint
+        kinds:
+          - yarramate/policy@0.1#mechanism-constraint
+    question: >-
+      {subject.name} is a serving hop. Which protocol is it — REST/HTTP,
+      SOAP, GraphQL, or something else?
+    askPlain: >-
+      When {subject.name} is called, what is the wire protocol?
+    materiality: >-
+      Serving names the pattern, not the contract. A REST hop and a SOAP
+      hop fail, version, and authenticate differently.
+    authority: either
+    resolution: >-
+      Bind a mechanism-constraint on this behavior (or a not-applicable
+      subject if the serving kind is already the whole answer).
+
+  - id: interaction-content-unknown
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: missing-flow-content
+    question: >-
+      {subject.name} sends a flow with no content. What moves?
+    askPlain: >-
+      {subject.name} sends something on. What is that something called?
+    materiality: >-
+      A flow with no content is an unnamed payload. Retry, scanning, and
+      the counterpart contract have nothing to name.
+    authority: either
+    resolution: >-
+      Set content on the flow relationship.
+
+  - id: interaction-contract-unknown
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessActor
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#access
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#dataObject
+          - yarramate/core@0.1#contract
+    question: >-
+      {subject.name} participates in a hop but accesses no contract or
+      data object. What information does it read or write?
+    askPlain: >-
+      What record or contract is {subject.name} working with?
+    materiality: >-
+      Schema ownership, identifiers, and classification have nowhere to
+      attach until the hop names the information it moves.
+    authority: either
+    resolution: >-
+      Add access from this behavior to a dataObject or contract.
+
+  - id: interaction-trust-unbound
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessActor
+      - condition: missing-constraint
+        kinds:
+          - yarramate/policy@0.1#authentication-constraint
+    question: >-
+      How is trust established for {subject.name}?
+    askPlain: >-
+      Who does {subject.name} authenticate as, and with what?
+    materiality: >-
+      An unauthenticated hop to another system is a trust-boundary
+      decision nobody recorded. This is authentication only — not
+      authorization or transport security.
+    authority: either
+    resolution: >-
+      Bind an authentication-constraint on this behavior, or a
+      not-applicable subject if this hop is deliberately unauthenticated.
+
+  - id: interaction-reliability-unbound
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#triggering
+          - yarramate/core@0.1#flow
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationProcess
+          - yarramate/core@0.1#applicationFunction
+          - yarramate/core@0.1#applicationInteraction
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessActor
+      - condition: missing-constraint
+        kinds:
+          - yarramate/policy@0.1#reliability-constraint
+    question: >-
+      What happens when {subject.name} fails — retry, idempotency,
+      dead-letter, compensation?
+    askPlain: >-
+      If {subject.name} does not finish, do we retry, and what makes a
+      retry safe?
+    materiality: >-
+      A content-moving hop without a reliability rule duplicates or
+      drops work at the first timeout.
+    authority: either
+    resolution: >-
+      Bind a reliability-constraint. A named failure process is stronger
+      and may come later; the constraint is the 0.9 closer.
+
+  - id: interaction-capacity-unbound
+    wave: interaction
+    since: "0.9"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationProcess
+        - yarramate/core@0.1#applicationFunction
+        - yarramate/core@0.1#applicationInteraction
+        - yarramate/core@0.1#applicationEvent
+        - yarramate/core@0.1#applicationInterface
+      statuses:
+        - planned
+        - current
+    trigger:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+      - condition: missing-constraint
+        kinds:
+          - yarramate/policy@0.1#rate-limit-constraint
+    question: >-
+      What is the capacity rule for {subject.name}?
+    askPlain: >-
+      How hard may callers hit {subject.name}, or is there no cap?
+    materiality: >-
+      An Experience-facing hop without a capacity rule is sized by
+      whoever implements first. Explicit none is a decision.
+    authority: either
+    resolution: >-
+      Bind a rate-limit-constraint, with expects on the binding for the
+      numeric cap, or a not-applicable subject.
 
   # ---- business ------------------------------------------------------------
   - id: service-consumer-unknown

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -42,8 +42,8 @@ guidance; the harness/LLM loops: answer arrives as prose → agent
 translates it into `apply` operations → re-invoke `design`.
 
 - **The catalogue is internal.** It ships inside the product, versioned
-  with it — the deep ArchiMate path (motivation + business +
-  application waves first, ~35–45 questions with in-wave ordering;
+  with it — the deep ArchiMate path (motivation + interaction +
+  business + application waves first, with in-wave ordering;
   technology/implementation later) plus adequacy conditions (below).
   `--catalogue <path>` exists only as an override for teams authoring
   their own. Harnesses never pass or read catalogue files.

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -33,7 +33,12 @@ questions. Each question binds:
   `isolated`, `no-subject-of-kind`, `no-state-defined`,
   `missing-linkage` (no relationship of given kinds, in a given
   direction, whose counterpart is of a given kind — the linkage-depth
-  primitive), `missing-reference` (no reference-bearing claim such as a
+  primitive), `has-linkage` (the positive of `missing-linkage`;
+  `direction` may be `either`), `exists-linkage` (workspace: some
+  concept would satisfy `has-linkage`), `missing-constraint` (no
+  `yarramate/constraint/requires` binding whose target matches the
+  given kinds), `missing-flow-content` (the subject is an endpoint of a
+  `flow` that has no `content`), `missing-reference` (no reference-bearing claim such as a
   constraint binding, by direction), `missing-attestation` (no
   recorded `yarramate/attestation/<topic>` claim; see ADR 0056),
   `near-duplicate` (the subject resembles another subject of the same
@@ -68,8 +73,11 @@ questions. Each question binds:
   (ADR 0072).
 
 The engine ships an internal core-enrichment catalogue, seed questions
-across motivation, business, application, and hygiene waves for
-`yarramate/core@0.1`, evaluated when no `--catalogue` is given.
+across motivation, interaction, business, application, technology,
+implementation, and hygiene waves for `yarramate/core@0.1`, evaluated
+when no `--catalogue` is given. Interaction questions that name
+`yarramate/policy@0.1` kinds are omitted unless a document selects that
+profile (ADR 0095).
 Catalogues are ordinary versioned data: extend the shipped one under a new
 identity or write one per organisation, then pass it with `--catalogue`.
 Composition via `extends` is deferred from v1 (ADR 0053).
@@ -77,10 +85,13 @@ Composition via `extends` is deferred from v1 (ADR 0053).
 ## Evaluation model
 
 A question is **open** iff its trigger matches, and **closed** the moment it
-no longer does. Interview state is recomputed from model plus catalogue on
-every run and never stored: no session files, no second canonical store,
-nothing to resume. Editing the model and re-running yields exactly the
-still-open questions.
+no longer does. A question is **not applicable** when any kind it names
+belongs to a profile that no document in the workspace has selected
+(`graph.profiles`). Inapplicable questions are omitted from the report and
+from `summary.questions`; they are not `open: false`. Interview state is
+recomputed from model plus catalogue on every run and never stored: no
+session files, no second canonical store, nothing to resume. Editing the
+model and re-running yields exactly the still-open questions.
 
 Open questions are not findings against anyone. `check` answers "is this
 model well-formed", `reconcile` answers "does reality agree", and

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -2,7 +2,15 @@
 
 YarraMate projects extend the bundled vocabulary through explicit profile
 documents. Their normative structure is
-`schema/yarramate-profile.schema.json`.
+`schema/yarramate-profile.schema.json`. One optional profile also ships
+inside the package: `yarramate/policy@0.1` (ADR 0095). A document may
+select `profile: yarramate/policy@0.1` without copying a file; the
+compiler injects it when selected or extended. It is not an interrogation
+switch. Webapps that call a system API need `authentication-constraint`
+too. Policy subjects belong in a document that selects this profile;
+other documents may keep an existing org profile and bind with qualified
+`constraints[].ref`. Re-basing an org profile onto policy is allowed and
+not required.
 
 ## Smallest profile
 

--- a/docs/adr/0095-policy-kinds-are-a-shipped-optional-profile.md
+++ b/docs/adr/0095-policy-kinds-are-a-shipped-optional-profile.md
@@ -1,0 +1,55 @@
+# Policy kinds are a shipped optional profile
+
+Status: accepted
+
+YarraMate Core has one `constraint` kind. An authentication rule and a
+rate-limit rule can both be stored as constraints, and the catalogue cannot
+tell them apart. Distinct NFR questions need distinct closing claims.
+
+ADR 0087 rejected adding ArchiMate as a profile because that would fork
+*notation* into a second vocabulary for the same subjects. This decision is
+the opposite case: the kinds are **new semantics** (specializations of
+`constraint`), not a competing name for an existing Core kind. Profiles are
+the extension point for that. The kinds are not added to Core, because Core
+kinds are lineage roots and every workspace would then see the NFR questions
+as applicable.
+
+## Decision
+
+Ship `yarramate/policy@0.1` as a built-in optional profile, resolved the way
+Core is resolved: a document may select `profile: yarramate/policy@0.1`
+without copying a file into the workspace. The compiler injects the shipped
+YAML when a document selects it or another profile extends it, and does not
+inject it when nobody does. A workspace file that already declares the same
+identity wins; the shipped copy is not added beside it.
+
+0.1 kinds, all parent `yarramate/core@0.1#constraint`, local ids kebab-case:
+
+- `authentication-constraint`
+- `rate-limit-constraint`
+- `reliability-constraint`
+- `mechanism-constraint`
+
+Planned 0.2 (named now, not shipped): `authorization-constraint`,
+`transport-security-constraint`. Versioning inside 0.x is additive, mirroring
+ADR 0063, so catalogue 0.10 can name 0.2 kinds and workspaces still on 0.1
+skip those questions (unknown-kind omission).
+
+The profile is named `yarramate/policy`, not `integration-architecture`.
+Webapps that call a system API need `authentication-constraint` too.
+
+Adoption is multi-document: policy subjects live in a document that selects
+this profile; components may stay on an existing org profile; hops bind with
+qualified `constraints[].ref`. Re-basing an org profile onto policy is
+allowed and not required. Multi-`extends` is out of scope.
+
+Not-applicable is a declared subject of the same kind (`<policy>-not-applicable`
+local ids) with the reason in `description`. Numeric values belong in
+`expects` on the binding (ADR 0075).
+
+## Consequences
+
+Catalogue questions written against policy kinds are applicable only when
+the profile is in `graph.profiles`. A vocabulary nobody selects still
+changes nothing (ADR 0079). Core does not become an API specification
+language.

--- a/docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design-review.md
+++ b/docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design-review.md
@@ -1,0 +1,401 @@
+# Review: Interaction-first interrogation
+
+Target: `docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design.md`
+Reviewer role: maintainer, principal-engineer pass
+Date: 2026-08-20
+Method: every checkable claim in the spec was verified against the working tree
+(`yarramate@0.22.0`, `main`), the PR #204 branch, and issue #205. Findings cite
+file and line.
+
+## Verdict
+
+**Direction accepted. Request changes.**
+
+The diagnosis is right, the evidence sections are faithful to their sources, and
+the thesis (reify hops, bind named policy subjects, hop-property triggers instead
+of an estate classifier) is the correct answer to #205 and consistent with ADR
+0053/0058/0063 and the conservative-extension contract. The alternatives analysis
+in §11 is genuinely load-bearing, not decoration.
+
+Five things must change before this is accepted, none of which threaten the
+thesis:
+
+1. Two §9.4 questions cannot be expressed under the engine's AND-only trigger
+   semantics and must be split (F1).
+2. `interaction-trust-unbound` as drafted does not fire on the spec's own
+   recommended encoding (F2).
+3. §8.4 (unknown-kind skip) needs a precise applicability definition and a
+   report-contract decision; today's engine behaviour differs by scope and one
+   half of it is a live bug the slice must fix (F3, F4).
+4. Slice 2 is not "ship a YAML file": `yarramate/policy@0.1` would be the first
+   shipped optional profile ever, there is no resolution mechanism for shipped
+   profiles, and single-`profile:`-per-document plus single-`extends` chaining
+   makes adoption impossible for estates already on their own extension profile
+   (F5).
+5. The behavior kind lists omit `applicationInteraction` and
+   `applicationCollaboration`, so the ArchiMate-idiomatic reification of a
+   two-component interaction would not close `hop-unrealised` (F6).
+
+Answers to the six §15 reviewer questions are at the end, as requested, instead
+of "looks good."
+
+---
+
+## Fact check
+
+The spec invites reviewers to attack its decisions. Its factual ground was
+checked first; it is in unusually good shape. Corrections follow the table.
+
+| Spec claim | Verdict |
+|---|---|
+| §1 numbers (16 types, 226 instances, 85% in five hygiene questions) | Confirmed against issue #205 body |
+| §2 catalogue scope is subject/workspace; `selectSubjects` iterates concepts only; relationship subjects cannot be questioned | Confirmed (`src/interrogate-command.ts:278-296`, concepts built at `:202-210`) |
+| §2 all ten condition types are absences except `near-duplicate`; no `has-linkage` / `exists-linkage` / `missing-constraint` exists | Confirmed (schema `condition` oneOf; evaluator switch `src/interrogate-command.ts:324-448`) |
+| §2 `serving` pins no aspect; only assignment/access/triggering/influence do | Confirmed (ADR 0083; `src/profile.ts:204-233`, `serving` at `:211` declares none) |
+| §2 wave placements (`owner-missing` business, `kind-untested` hygiene, etc.) | Confirmed, all five (`catalogues/core-enrichment.yaml:364`, `:1079`, `:722`, `:592`, `:695`) |
+| §2 relationships carry description/references/status/mode/content and not owner/constraints/attestations | Confirmed; also allowed: `name`, `presentIn` (`schema/yarramate-document.schema.json:237-287`, `additionalProperties: false`) |
+| §2 one `constraint`, one `requirement` kind in Core | Confirmed (`src/profile.ts:79-80`) |
+| §3.1 / §3.2 summaries of the elicitation pilot and spec-build results | Fair compressions of both source docs; the "combined-arm ranked channel above `outcome-missing`" point is from the pilot's same-day addendum, correctly so |
+| §3.3 sweep numbers (gallery opens 43/55/40/70/75/86; B−A +9.8; sonnet change 13/14 vs 8/14; comprehension flat 28/32; check-pass 24/24; no-contradicted B 6/6; change-B gap +50; zero staleInfluence; not-worse 14/20 and 13/20) | All confirmed against `RESULTS-2026-08-19.md` on the PR #204 branch |
+| §9.1 `since` field exists, additive-minor is the ADR 0063 rule | Confirmed (`schema/yarramate-question-catalogue.schema.json:426-431`; all 40 shipped questions declare `since`) |
+| §9.2 wave insertion needs no engine work | Confirmed, and stronger than the spec states: wave order is pure catalogue data ("The wave taxonomy is catalogue opinion, not engine semantics", schema `:47`; `design` top-step loop at `src/design-command.ts:65-76` walks `report.waves` in array order). No test pins catalogue `0.8`, question counts, or wave counts |
+| §9.3 `design --wave` does not exist | Confirmed; note two tests actively assert unknown options are rejected (`test/design-command.test.ts:334-341`, `test/ask-command.test.ts:506-511`), so adding it later is a deliberate CLI-surface change, which is fine |
+| §10 catalogue is internal | Confirmed verbatim (`docs/AGENT-INTERFACE.md:44-49`) |
+| Success criterion 6 shape (loaded-but-unselected profile changes nothing) | Confirmed as an existing test pattern (`test/conservative-extension.test.ts:168-190`, `:300-352`) |
+
+Corrections and nuances, none fatal:
+
+- **§2 "It will ask ownership 45 times."** Rhetorical overreach: `design`
+  serves `owner-missing` once with a 45-entry `openSubjects` roster
+  (`src/design-command.ts:117-122`). The wave-order complaint stands; the
+  "45 times" framing does not. Say "45 subjects before any interaction
+  question" instead.
+- **§3.3 "about a third of the time the interview gets worse."** The
+  catalogue-not-worse gate is secondary, not a hard gate, and the sweep doc
+  itself marks it non-comparable across sweeps (harness v3 delta 2). The
+  within-run reading the spec uses is legitimate; the sentence should carry the
+  "secondary gate" qualifier so it is not quoted later as a headline result.
+- **§5 non-goals cite #116 for `openSubjects`.** The code comment agrees
+  (`src/design-command.ts:119`), but the merge was PR #118 ("One answer, many
+  subjects"). Cite issue #116 / PR #118 if precision matters.
+- **§8.1 "`kindMatching: descendants` # default, same as `missing-linkage`".**
+  The schema declares no default on `missing-linkage` (nor
+  `missing-relationship`); the default lives only in code
+  (`src/interrogate-command.ts:373`). If `has-linkage` copies that schema
+  object, add the explicit `"default": "descendants"` to both while there.
+- **§6.2 typo:** "They do not restated Core."
+- **§9.6 `askPlain` "required".** Schema-optional by design (ADR 0072;
+  absent from the `required` list). Only 20 of 40 shipped questions author it.
+  Requiring it on the new questions is an authoring gate for slice 3, not a
+  schema property; state it that way, and enforce it in the slice 3 catalogue
+  tests so it does not erode.
+
+---
+
+## Findings
+
+Ordered by severity. F1 through F5 block acceptance; F6 blocks slice 3 as
+drafted; the rest are advisory.
+
+### F1 (blocking): trigger arrays are AND-only; two questions cannot be expressed as drafted
+
+A question's `trigger` is an array of conditions evaluated with `.every()`
+(`src/interrogate-command.ts:516`); the schema is `array of condition, minItems
+1` with no combinator. Two §9.4 rows need OR or conditional logic:
+
+- **`interaction-payload-unknown`**: "`has-linkage` flow *or* the subject is a
+  process/function with `missing-linkage` access". A cross-condition OR. Not
+  expressible. Split into two questions (`interaction-content-unknown` for
+  flow-bearing behaviors, `interaction-contract-unknown` for process/function
+  without data access), or add an `anyOf` combinator to the engine, which
+  contradicts §8.5's "no other engine work". Recommendation: split. Two precise
+  questions also satisfy ADR 0063's selector-precision rule better than one
+  clever one.
+- **`interaction-mechanism-unknown`**: the close column embeds a conditional
+  ("if still only `serving` to a component, `missing-constraint
+  mechanismConstraint` remains open"). One trigger cannot express "closed
+  unless the chosen kind was serving". Split the protocol overlay into its own
+  question (`interaction-protocol-unbound`: `has-linkage` serving to a
+  component AND `missing-constraint` `mechanismConstraint`), which also cleanly
+  resolves the spec's own worry about not demanding `mechanismConstraint` on
+  event-driven hops: the trigger simply never matches them.
+
+The spec already flags mechanism as "needs careful trigger drafting". It is not
+a drafting nicety; under AND-only semantics the current §9.4 table is not
+implementable. Redraft §9.4 with one condition-set per question id.
+
+### F2 (blocking): `interaction-trust-unbound` does not fire on the spec's own encoding
+
+§6.1 and the native-authoring skill define the idiomatic hop as behavior
+related to **behavior** (name the invoked behavior, assign the performers,
+relate behaviors). But the trust trigger reads "`has-linkage`
+serving/flow/triggering to `applicationComponent` OR to `businessActor`".
+
+After correct reification, the counterpart of the behavior's serving/flow edge
+is another behavior or interface, not a component. A fully reified chain,
+exactly what `hop-unrealised` just demanded, would make the trust question
+never open. The mechanism row gets this right ("to a behavior, component,
+interface, or actor"); trust and delivery must use the same counterpart list.
+Add the behavior and interface kinds to `counterpartKinds` on
+`interaction-trust-unbound` (and check `interaction-delivery-unbound` and
+`interaction-capacity-unbound` for the same slip; capacity's serving-to-actor
+is plausibly fine as drafted, but an interface serving the actor on the
+Experience edge should also count).
+
+The slice 0 fixture would have caught this, which is an argument for building
+slice 0 first exactly as the spec orders it. Fix the table anyway; the fixture
+is the oracle, not the editor.
+
+### F3 (blocking): §8.4 needs a contract, not a behaviour sketch
+
+Three gaps:
+
+1. **"In the workspace's resolved profile lineage" is ambiguous.** Success
+   criterion 6 (profile present in the manifest, selected by no document,
+   byte-identical output) is only satisfiable if applicability means "the kind
+   is contributed by a profile **selected by at least one document**", not
+   "loadable from the manifest". PROFILES.md's "a vocabulary nobody selects
+   changes nothing" forces the strict reading. Write it down; the two readings
+   diverge exactly on the conservative-extension test.
+2. **Not-applicable is a third state and the report contract has two.** Today a
+   question is `open: true|false`. The spec says a skipped question "does not
+   open, does not count in progress, does not appear in `ask --open`". Decide
+   how that renders in the `ask` report JSON: absent entirely, or present with
+   an explicit `applicable: false`. Absent is simpler but makes "why is the
+   authn question not being asked?" undiagnosable; an explicit marker is more
+   honest and matches ADR 0063's spirit (honest reopen implies honest
+   not-asked). Either way it is an additive report-schema change and the spec
+   should name it as slice 1 surface.
+3. **Current behaviour differs by scope and the spec describes neither.**
+   Verified: a subject-scoped question whose selector kinds are unknown
+   silently reports `open: false` (`src/interrogate-command.ts:533-535`), i.e.
+   reads as *complete*, which is the quiet-lie variant of the trap; a
+   workspace-scoped `no-subject-of-kind` with unknown kinds stays `open: true`
+   forever, the trap §8.4 describes. The spec's fix covers both, but the tests
+   in slice 1 must pin both directions, not just the open-forever one.
+
+### F4 (blocking): fix the `no-subject-of-kind` lineage bug inside slice 1
+
+Verified live bug, pre-existing: the schema promises `kindMatching` with
+default `descendants` on `no-subject-of-kind`
+(`schema/yarramate-question-catalogue.schema.json:233-238`), but the evaluator
+does a flat exact-string `includes` and never consults lineage
+(`src/interrogate-command.ts:363-366`). Every other kind-aware condition routes
+through `kindMatches` with `profileContext`.
+
+This matters to this design specifically: all three workspace policy questions
+are built on `no-subject-of-kind` over policy kinds. The moment anyone ships a
+profile specializing `authenticationConstraint` (an org profile with
+`oauthClientCredentialsConstraint`, say), the standard question reopens forever
+on a workspace that has answered it. The existing conservative-extension tests
+do not catch this because their fixtures keep core kinds on core subjects.
+Slice 1 already touches this switch statement; fix the bug there, with a test
+where the only matching subject carries a derived kind.
+
+### F5 (blocking): slice 2 understates what "shipped next to Core" means
+
+Verified: there is **no precedent**. No optional profile ships today
+(`package.json` `files` has no profiles directory; the only profile in the repo
+is the dogfooding `.yarramate/profiles/yarramate-development.yaml`). Core
+itself is built-in code (`src/profile.ts`), not a shipped file. And ADR 0087
+explicitly rejected the nearest prior candidate (ArchiMate as a profile),
+ruling notation is a rendering mode.
+
+Three consequences the spec must address:
+
+1. **Resolution.** Workspaces reference profiles by manifest glob
+   (`profiles: [profiles/*.yaml]`); documents select one by id
+   (`profile: yarramate/development@1.0`). There is no path from
+   `profile: yarramate/policy@0.1` in a document to a file the user never
+   copied. Either the engine resolves shipped profile ids built-in (the way
+   Core resolves, and the way the catalogue is "internal"), or `init` /docs
+   tell users to vendor the file. Built-in resolution is the right call and
+   matches the catalogue precedent, but it is engine work that slice 2
+   currently does not contain.
+2. **Composition.** A document selects exactly one profile and a profile has
+   exactly one `extends`. An estate already on its own extension profile (this
+   repo's own `engine.yaml` is one) cannot adopt policy without re-basing its
+   profile chain onto `yarramate/policy@0.1`. That is a real adoption wall for
+   precisely the enterprise estates #205 comes from. Options: multi-`extends`,
+   multi-profile selection per document, or explicitly accept chaining and
+   document the re-base as the adoption path. The spec must pick one; my
+   preference is to accept chaining for 0.1 and say so in the profile's docs,
+   because multi-extends drags in diamond-resolution semantics nobody has
+   asked for yet.
+3. **ADR.** "First shipped optional profile" is an architectural decision with
+   an existing contrary-adjacent ADR (0087). Write the ADR that distinguishes
+   them: notation is presentation, policy kinds are semantics, which is
+   exactly what profiles are for. Also state the profile's own versioning
+   rule (additive within 0.x mirrors ADR 0063, so catalogue 0.10 can rely on
+   policy 0.2 kinds; §8.4 then degrades gracefully for workspaces on 0.1,
+   which is a genuine strength of the skip mechanism and worth stating).
+
+### F6 (blocking for slice 3): the behavior kind lists omit `applicationInteraction` and `applicationCollaboration`
+
+Core has both (`src/profile.ts:116,121`). ArchiMate's idiomatic answer to
+"collective behavior of two components interacting" is `applicationInteraction`
+assigned from an `applicationCollaboration`. A modeler who reifies a hop that
+way satisfies the spirit of `hop-unrealised` and fails its close condition
+(assignment to process|function|event|interface). Under ADR 0063's
+selector-precision rule that is a catalogue defect on day one. Add
+`applicationInteraction` to every behavior list in §6.1 and §9.4 (selectors and
+closers), and decide whether collaboration-assigned counts for the assignment
+check.
+
+Related, cosmetic: the wave id `interaction` sits next to a Core kind named
+`applicationInteraction` that the spec never mentions. Fine to keep the name;
+mention the kind so the omission reads as a decision rather than an oversight.
+
+### F7 (should-fix): `has-linkage` needs `direction: either`, or an explicit sink waiver
+
+`missing-linkage`'s `direction` is `outgoing|incoming` only. §8.1 copies it.
+"Participates in an interaction" is direction-agnostic: a pure sink (a
+component that only *receives* `flow` or `triggering`, e.g. an audit store fed
+by events) has no outgoing edge and would dodge `hop-unrealised`. Serving
+chains mostly survive because `serving` points outward from every layer, but
+flow/triggering sinks are real in the #205 estate class. Since `has-linkage`
+is a new condition, supporting `either` at birth costs one `some()` over both
+directions; the alternative under AND-only triggers is two near-duplicate
+questions. Add `either` to `has-linkage` (and `exists-linkage`) only; leave
+`missing-linkage` untouched.
+
+### F8 (should-fix): per-hop trust authority
+
+The workspace standard question is rightly `human`. Per-hop
+`interaction-trust-unbound` is also `human`, which means an estate with 20
+reified behaviors queues 20 human-authority steps. Once a workspace standard
+exists, binding it to a hop is exactly the kind of proposal an agent can make
+and a human can veto: `either` with resolution hints that name the standard is
+the better default, and it is consistent with `authority` being "a label,
+never a gate" (ADR 0082). Keep `human` only for the workspace-level standard
+questions.
+
+### F9 (advisory): smaller items
+
+- **Design step already carries its wave.** `wave` is a required field on the
+  design-step schema. The §9.3/§10 skill stop-rule can therefore be
+  mechanical, not vibes: "when `design --json` returns a step whose `wave` is
+  not `interaction` (for the subjects in play), stop and render the brief."
+  Cite this in §9.3; it is most of the answer to reviewer question 4.
+- **ADR 0075 `expects` is an unused asset here.** Constraint subjects can
+  carry `expects` (provider/key/value) compiling to
+  `yarramate/constraint/expects`. "100 rps per client" as
+  `expects: {provider: gateway, key: rps-per-client, value: "100"}` makes the
+  rate-limit subject machine-readable for later evidence work with zero new
+  surface. Not required for 0.9; worth one line in the profile docs so authors
+  do not bury the number in prose, which §6.4 otherwise invites.
+- **Not-applicable constraints: accept, with a convention.** A constraint
+  subject asserting "no rate limit, and why" is an ontological wart, but the
+  alternative (absence means both "decided no" and "never asked") is the exact
+  ambiguity this design exists to kill. Document a naming convention
+  (`<policy>-not-applicable` local ids) and require the *why* in the
+  description; consider whether the slice 0 fixture should bind one
+  not-applicable constraint so the closure path is exercised, since slice 3's
+  test matrix currently only covers bind-one-vs-both.
+- **`{counterparts}` caveat.** It is computed only for `near-duplicate`
+  triggers, and `design` renders `askPlain` without counterparts, so §8.5's
+  "later improvement" note should also cover the `askPlain` path when it
+  lands.
+- **#205 coverage map.** The issue asks for eight areas and recommends the
+  profile mechanism this spec rejects. Add a short table mapping the eight
+  areas to covered-in-0.9 / deferred-with-a-home (authz, transport, topology,
+  deployment) / rejected-with-reason (orchestration-vs-choreography as
+  workflow completeness, Core exclusion). The reframe in §16 will land far
+  better with the issue author if the spec shows their list was processed
+  rather than replaced.
+
+---
+
+## Answers to §15
+
+**1. Policy kinds: optional profile (option A) or Core?** Profile, as
+proposed. Core kinds are lineage roots and every kind added to Core makes every
+workspace's `kind-untested` and future selectors heavier; conservative
+extension exists for exactly this shape; and §8.4 makes the questions skippable
+only if the kinds are *not* Core. The counter-case ("every workspace should see
+these questions") fails on the spec's own todo-app test. But option A is
+accepted **conditional on F5**: resolution mechanism, composition story, and
+the ADR reconciling with 0087. Without those, option A quietly becomes option
+B'-shaped advice ("copy this file into your workspace"), which is the
+brittleness option B was rejected for.
+
+**2. Authentication-only for first-wave trust?** Yes. A mega-trust question
+violates the distinct-closure thesis that justifies this whole design, and
+authz/mTLS/identity-propagation have a proven additive path (0.10 questions +
+policy 0.2 kinds, gracefully skipped by older workspaces per §8.4). Two
+conditions: name `authorizationConstraint` and `transportSecurityConstraint`
+as planned kinds in the profile ADR now, so 0.2 is anticipated rather than
+renegotiated; and make sure the authn question's materiality text does not
+imply it covers authorization, or the quiet interaction wave will be read as
+"security is done".
+
+**3. Constraint as the delivery/failure closer?** Yes, for 0.9. Requiring a
+failure behavior would smuggle workflow-completeness judgment into Core, which
+is an explicit exclusion, and H2's lesson is that the closer must be
+compiler-visible, which a bound constraint is. Keep the failure behavior as
+the *resolution hint's* stronger option, and let slice 5 tell us whether
+constraint-only closure produces briefs that change implementer edits. If it
+does not, that is evidence for the stronger closer in 0.10, measured rather
+than argued.
+
+**4. Skill-only stop vs `design --wave`?** Skill-only for 0.9, strengthened:
+the design step already carries `wave` (required in the step schema), so write
+the skill rule against that field, i.e. "stop when the served step's wave
+leaves `interaction` for the slice in focus". That is checkable in the slice 4
+skill tests and in dogfood transcripts, which converts the §14 risk ("agents
+will keep going") into something you can count before deciding whether
+`--wave` earns CLI surface. Note two existing tests assert unknown-option
+rejection, so `--wave` later is a deliberate, testable addition, not drift.
+
+**5. `hop-unrealised` on components or relationship subjects?** Components,
+for slice 1. Relationship-scope is the better noun and the worse first slice:
+it opens catalogue scope, selection, and identity questions (`selectSubjects`
+iterates concepts by construction) that F1 through F5 do not need. The
+component phrasing plus `openSubjects` batching covers the #205 estate. Ship
+it; revisit relationship-scope when the "Later: relationship-scope questions"
+issue has a concrete question that component phrasing cannot carry. It is not
+blocking.
+
+**6. Naming.** `yarramate/policy@0.1` is right, and the spec's own argument
+(webapps need `authenticationConstraint` too) is the correct defence against
+the "integration profile" drift named in §14; put that sentence in the
+profile's docs, not just this spec. Wave id `interaction` is acceptable;
+acknowledge the `applicationInteraction` kind collision (F6) in the doc.
+`deliveryConstraint` is the one id worth a second look: "delivery" reads
+postal/logistics in enterprise rooms; `reliabilityConstraint` or keeping
+delivery-retry-idempotency in the *name* of the created subjects may age
+better. Not a blocker.
+
+---
+
+## Slices and success criteria
+
+The slice cut is right, slice 0 especially: an oracle fixture before any
+engine work is what would have caught F2 mechanically. Adjustments:
+
+- **Slice 1** grows three items: the `no-subject-of-kind` lineage fix (F4),
+  the not-applicable report contract (F3), and `direction: either` on the new
+  conditions (F7). All are inside files slice 1 already touches.
+- **Slice 2** needs the shipped-profile resolution decision and ADR (F5)
+  *before* implementation; consider splitting "shipped-profile mechanism" out
+  as its own reviewable slice, since it outlives this design.
+- **Slice 3** redrafts §9.4 per F1/F2/F6 before authoring. Add two test rows
+  to the matrix: derived-kind closure (a subject of a kind *specializing*
+  `authenticationConstraint` closes the standard question, pinning F4) and
+  the not-applicable binding path.
+- **Slice 5** is correctly excluded from the merge gate. Keep it honest by
+  pre-registering the change-task rubric before slice 3 lands, so the
+  questions are not unconsciously authored to the measurement.
+- **Success criterion 6** should state the strict applicability definition
+  from F3.1, since it is the criterion that forces it.
+
+## Closing
+
+This is the strongest spec this repo has produced: it argues from evidence it
+did not cherry-pick (the not-worse and H2 negatives are load-bearing, not
+buried), it rejects the issue author's own preferred mechanism with reasons
+that survive scrutiny, and nearly every verifiable claim in it checked out
+against the code. The blocking findings are all of one family: the distance
+between a design table and an implementable catalogue under the engine's real
+semantics. Close that distance (F1 through F6), and slices 0 through 4 have my
+approval to proceed.

--- a/docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design.md
+++ b/docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design.md
@@ -1,0 +1,955 @@
+# Design: Interaction-first interrogation
+
+Status: **accepted for implementation** (review of 2026-08-20 adopted).
+
+Related:
+
+- Issue [#205](https://github.com/yarrasys/yarramate/issues/205) — integration
+  interrogation is dominated by generic model hygiene
+- Review:
+  `docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design-review.md`
+- PR [#204](https://github.com/yarrasys/yarramate/pull/204) — second
+  context-benchmark sweep, `yarramate@0.22.0`, 2026-08-19
+- Elicitation pilot:
+  `docs/research/context-benchmark/ELICITATION-PILOT-2026-07-31.md`
+- Spec-build family:
+  `docs/research/context-benchmark/spec-build/RESULTS-2026-07-31.md`
+- Catalogue contract: ADR 0053, 0058, 0063; `docs/INTERROGATION.md`;
+  `docs/AGENT-INTERFACE.md`
+- Capture: ADR 0004 (`flow.content`), 0015 (constraints), 0037
+  (descriptions are opaque), 0075 (`expects`), 0083 (serving does not pin
+  aspect)
+
+This document is the interrogation approach. A maintainer review accepted the
+direction and required table-to-engine distance closed before
+implementation. Those amendments are folded in; they do not change the
+thesis.
+
+---
+
+## Review amendments (2026-08-20)
+
+Locked decisions. Do not re-litigate in implementation PRs.
+
+1. **AND-only triggers.** A question `trigger` is `.every()` with no
+   combinator. Every question id has one conjunctive condition set. The
+   payload and mechanism rows that needed OR or a conditional closer are
+   split (F1).
+2. **Post-reification counterparts.** After `hop-unrealised` closes, the
+   hop’s serving/flow/triggering counterpart is a behavior or interface,
+   not a component. Trust, delivery, capacity, and mechanism use that
+   counterpart list (F2).
+3. **Applicability.** A question is applicable iff every concept or
+   relationship kind it names is contributed by a profile **selected by
+   at least one document** (`graph.profiles`), not merely loadable from
+   the manifest (F3.1). Inapplicable questions are **omitted** from the
+   `ask --open` report and from `summary.questions`. They are not
+   `open: false` (quiet-lie) and not `open: true` (forever-trap). No
+   `applicable: false` marker in the default report; diagnosis of “why
+   didn’t authn fire?” is that the question is absent, which means the
+   policy profile is not selected.
+4. **`no-subject-of-kind` lineage.** The evaluator must honour the
+   schema’s `kindMatching` default `descendants`. This is a trigger
+   loosening of four shipped workspace questions (`outcome-missing`,
+   `stakeholders-missing`, `constraints-missing`, `no-service-declared`)
+   and is changeloged as such (F4).
+5. **Shipped policy profile.** Built-in resolution of
+   `yarramate/policy@0.1` (catalogue-style), not a vendored copy. Adoption
+   is **multi-document, multi-profile**: policy subjects live in a
+   document that selects the policy profile; components may stay on an
+   existing org profile; hops bind with qualified `constraints[].ref`.
+   Re-basing an org profile onto policy is allowed and **not required**.
+   Multi-`extends` is out of scope. An ADR distinguishes this from ADR
+   0087 (notation is presentation; policy kinds are semantics) (F5,
+   composition pushback).
+6. **`applicationInteraction`** is a behavior kind on every behavior
+   list. `applicationCollaboration` is active-structure. Aggregating
+   components into a collaboration does **not** close `hop-unrealised`;
+   the selected component still needs assignment to a
+   behavior/interface. No aggregation walk (F6).
+7. **`has-linkage` / `exists-linkage` support `direction: either`.**
+   `missing-linkage` stays `outgoing|incoming` (F7).
+8. **Per-hop trust authority is `either`.** Workspace policy-standard
+   questions stay `human` (F8).
+9. **First-wave stop** is skill-only for 0.9, keyed off the design
+   step’s required `wave` field: when `design --json` serves a step
+   whose `wave` is not `interaction` for the slice in focus, stop and
+   render the brief. No `design --wave` in 0.9.
+10. **`reliability-constraint`**, not `delivery-constraint`. Planned 0.2
+    kinds `authorization-constraint` and `transport-security-constraint`
+    are named in the profile ADR now; they are not in 0.1. Profile local
+    ids are kebab-case (`schema/yarramate-profile.schema.json`); Core's
+    camelCase kinds are built-in code, not a YAML profile.
+11. **`askPlain`** on new questions is an authoring gate enforced by
+    slice 3 catalogue tests, not a schema `required` field.
+
+---
+
+## 1. Problem
+
+YarraMate already has a deterministic gap engine. `design` and `ask --open`
+evaluate `catalogues/core-enrichment.yaml` (0.8) against the compiled graph
+and report what nobody has decided yet. On an API-heavy integration model
+that already passes `check`, that engine does not behave like an integration
+architect. It behaves like an ontology linter.
+
+Issue #205 reproduced this on a valid 69-concept / 102-relationship estate
+(`yarramate@0.22.0`):
+
+```text
+yarramate ask .yarramate/workspace.yaml --open --json
+# 16 question types, 226 open subject-level instances
+```
+
+| Question | Wave | Instances |
+|---|---|---:|
+| `owner-missing` | business | 45 |
+| `kind-untested` | hygiene | 45 |
+| `component-unhosted` | technology | 35 |
+| `component-realizes-nothing` | application | 34 |
+| `planned-design-unattested` | application | 33 |
+| **Total** | | **192 / 226 (85%)** |
+
+The model already contained Experience → Process → System chains, proposed
+endpoint operations, and event subscriptions. The interview did not ask
+mechanism, trust, contract, failure, or capacity on those hops. An owner or
+attestation question cannot compensate for a hop whose protocol, trust
+boundary, delivery semantics, or failure behaviour is unknown.
+
+`design` serves `owner-missing` **once** with a 45-entry `openSubjects`
+roster (issue #116, PR #118), then continues wave order. The complaint is
+45 subjects on the agenda before any interaction question, not 45
+interviews.
+
+That is the product failure. The rest of this document is what to do about
+it without turning Core into an API specification language and without
+replacing the shipped interview with a domain wizard.
+
+---
+
+## 2. What this is not blaming
+
+The engine is doing what it was designed to do. The failure is a mismatch
+between **what the catalogue asks** and **where an integration model's
+load-bearing claims live**.
+
+Verified in this repo:
+
+- Catalogue scope is `subject` (concepts only) or `workspace`.
+  `selectSubjects` in `src/interrogate-command.ts` iterates compiled
+  concepts. Relationship subjects cannot be questioned.
+- Every current trigger is an *absence* (`missing-*`, `isolated`,
+  `no-subject-of-kind`, `unconstrained-kind`, …) except `near-duplicate`.
+  There is no `has-linkage`. The engine cannot say “this component
+  participates in a chain.”
+- `serving` does not pin aspect (ADR 0083). Only `assignment`, `access`,
+  `triggering`, and `influence` do. An Experience → Process → System estate
+  connected only by `serving` is, to `kind-untested`, a pile of untested
+  labels — even with 46 API-level relationships.
+- `owner-missing` lives in the **business** wave. `design` serves wave
+  order, then catalogue order (`src/design-command.ts`).
+- Relationships may carry `name`, `description`, `references`, `status`,
+  `presentIn`, `mode` (access), and `content` (flow). They may **not**
+  carry `owner`, `constraints`, or `attestations`
+  (`schema/yarramate-document.schema.json`). Identified `references` are
+  citations, not constraint bindings (ADR 0037).
+- Descriptions compile to claims and are opaque to Core. A catalogue
+  trigger cannot close on words in a description.
+- Core has one `constraint` kind and one `requirement` kind. The engine
+  cannot tell an authentication constraint from a rate-limit constraint
+  unless those answers are **different subjects** (or different kinds).
+
+So: the model *can* record integration decisions, if they are reified as
+subjects. The interview *does not ask* for those subjects, and cannot
+discriminate their closures today.
+
+---
+
+## 3. Evidence this proposal is required to honour
+
+### 3.1 Elicitation pilot (2026-07-31)
+
+Freehand agents asked load-bearing *how* questions (reminder channel, auth,
+timezone) and zero *why* questions. Tool-equipped agents, driven by the
+catalogue, all asked `outcome-missing` first, at every tier.
+
+The engine is structurally blind to decisions that live in requirement
+words rather than wiring. Combined-arm runs then ranked the agent’s channel
+question *above* `outcome-missing` at both Sonnet and Haiku. The recorded
+implication: **catalogue is the why-floor; agent judgment supplies how;
+neither arm is sufficient.** Composition, not replacement.
+
+The tool-arm models already showed capture vs interview:
+
+- Fable encoded Cloudflare as a `constraint` and the reminder as
+  `flow.content: reminder`.
+- Sonnet reified the reminder as `applicationEvent` → `applicationProcess`
+  → `flow` to the user — the only run that used `triggering`.
+- The catalogue treated Fable and Sonnet as equal (six open items, all
+  motivation/hygiene). Sonnet’s extra how-structure was invisible to
+  interrogation.
+
+### 3.2 Spec-build (2026-07-31)
+
+Designers interrogated until only unanswerable items remained. Three B
+models still had 47, 44, and 27 planned concepts for the same spec. A
+checked, catalogue-clean model did not beat a good design document on build
+convergence. What did show: **every extra truthful claim is a witness
+against a lie.** Correlated ownership, access, and description caught
+shifted edges. Lies with no redundant claim slipped through.
+
+`catalogue clean` is the wrong stop condition for design-readiness.
+Granularity is unconstrained. Enrichment pays off when it adds correlated
+structure, not labels.
+
+### 3.3 Second sweep (PR #204, 2026-08-19, `yarramate@0.22.0`)
+
+This is the current number, not the July 29 sweep.
+
+- Gallery models were **deliberately not enriched** for catalogue 0.8.
+  Open counts: httpie 43, fastify 55, uptime-kuma 40, miniflux 70, kafka 75,
+  keycloak 86. Hygiene dominates CLI-shaped models; kafka/keycloak open
+  more application/technology questions **because those subjects already
+  exist**. The catalogue asks about structure that is there. It does not
+  invent hops.
+- **H1:** pooled B−A still underpowered (+9.8 pts). The load-bearing split
+  is family: sonnet *change* B is 13/14 vs 8/14 in A. Sonnet
+  *comprehension* is flat at 28/32 with or without the model. The model
+  earns its keep on later **edits that consult it**, not on multi-hop
+  reading.
+- **H2:** flattening appears only on the deterministic loop (`check-pass`
+  24/24 both tiers; `no-contradicted` B 6/6 both). On change-B the Sonnet–
+  Haiku gap *widens* to 50 pts. How-questions without compiler-visible
+  homes will not flatten weaker generators.
+- **H3:** C ≥ A everywhere. Zero `staleInfluence`. Repair of injected
+  contradictions is rare and criterion-driven. Unused models do not
+  poison; they are also not consulted, and they are not repaired without
+  a gate.
+- Catalogue-not-worse (secondary gate, not comparable across sweeps
+  because of harness v3 delta 2): haiku 14/20, sonnet 13/20. Within this
+  run, when agents edit the model the interview often gets worse. Do not
+  quote this as a headline result.
+
+Implications this design takes as binding:
+
+1. Enrichment is for architecture-first design and later change work, not
+   for helping agents read kafka/keycloak source.
+2. Every accepted answer must be an `apply` that `check` can see.
+3. Do not score success as “fewer open questions on the gallery.”
+4. Do not grow the current hygiene catalogue against component inventories
+   and call that integration architecture.
+
+---
+
+## 4. Thesis
+
+Interrogation should **create interaction subjects that a later edit is
+forced to read**, then bind **named, distinct policy subjects** to those
+interactions.
+
+It should not:
+
+- rank the existing hygiene questions more cleverly
+- stamp protocol/auth/retry fields onto `serving` edges
+- offer an “integration architecture” vs “webapp” interrogation mode
+- close several NFRs because *some* constraint exists
+- treat `ask --open` going quiet as design-readiness
+
+The first wave after motivation asks for hops, mechanism, trust, failure,
+and capacity **as separate questions with separate closures**, and only
+where hop topology makes them load-bearing. Owner, hosting, attestation,
+and `kind-untested` remain in core-enrichment as later hardening.
+
+---
+
+## 5. Goals and non-goals
+
+### Goals
+
+1. On a model of components linked by `serving` / `flow` / `triggering`
+   with no assigned behavior, `design` asks for the interaction subject
+   **before** `owner-missing`.
+2. Security and rate limiting cannot close the same trigger. Each named
+   NFR has its own open condition and its own closing claim.
+3. Answers land as native subjects and relationships, in one `apply`
+   batch, and the next `design` run recomputes closure from the graph
+   (ADR 0053 / 0058).
+4. A brief of the affected slice names mechanism, payload, and the bound
+   policy subjects — so later change work has something to consult (H1).
+5. Core remains not-an-API-spec-language. Capture uses existing
+   relationship kinds plus constraint bindings on **behavior** subjects.
+6. Additive catalogue growth under ADR 0063 (new questions, loosened
+   triggers only). No silent change to what an existing “complete”
+   interview meant, except the honest reopen of *new* questions and the
+   F4 lineage loosening of `no-subject-of-kind`.
+
+### Non-goals (explicit rejections)
+
+- **No interrogation profile / named catalogue switch**
+  (`--profile integration-architecture`, `--catalogue` as the default
+  agent path, webapp-vs-integration wizard). Profiles in this repo are
+  vocabulary (`docs/PROFILES.md`). Catalogues are questions. The agent
+  contract says the catalogue is internal and harnesses never pass
+  catalogue files (`docs/AGENT-INTERFACE.md`). A domain mode-switch is
+  the wrong selector for mixed estates (an integration model has
+  Experience APIs; a webapp has system hops). Hop triggers in one
+  shipped catalogue are the selector.
+- **No materiality scoring** (fan-in, data sensitivity, SLA). Wave order
+  is the ranker we already have.
+- **No stakeholder question packs** as a product surface. `authority`,
+  `askPlain`, and `design --facilitate` already exist. `openSubjects`
+  already batches policy-once apply (issue #116, PR #118).
+- **No auto-detect “API-heavy” and silently change the interview.**
+  Completeness is not Core’s job. Opt-in is vocabulary presence and hop
+  topology, not a heuristic over names.
+- **No protocol/auth/retry fields on `serving`.** That is the API-spec
+  expansion #205 said it did not want.
+- **No relationship-scope, path walking, or synthetic flow subjects** in
+  the first slice. One-hop `has-linkage` is enough to start.
+- **No constraints-on-relationships** in the first slice. Useful later
+  as authoring convenience; not required if hops are reified as
+  behaviors that already accept `constraints`.
+- **No gallery hygiene enrichment** as part of this work. PR #204 left
+  those models unenriched on purpose.
+- **No “at least one constraint is bound” closer.** That is
+  `owner-missing` with different copy. Rate limiting must not silence
+  authentication.
+- **No `anyOf` trigger combinator.** Split questions instead.
+- **No multi-`extends`.** Composition is multi-document (see §6.5).
+
+---
+
+## 6. Capture: where answers live
+
+Native documents have no metadata bag. A fact is defined syntax that
+compiles to a claim, or it is a versioned profile kind.
+
+### 6.1 Structure (Core as it stands)
+
+| Decision | Honest home |
+|---|---|
+| Who participates | `applicationComponent` (already present in the #205 estate) |
+| What the hop *is* | `applicationProcess`, `applicationFunction`, `applicationInteraction`, `applicationEvent`, or `applicationInterface` — a **behavior or interface subject**, assigned from the component |
+| Sync request vs event vs content transfer | Relationship **kind** between behaviors: `serving`, `triggering`, `flow` |
+| What moves | `flow.content` (ADR 0004); `dataObject` / `contract`; `access` with `mode` |
+| Runtime | `node` / `systemSoftware` / `path` / `communicationNetwork` (already asked later as `component-unhosted`) |
+| Failure path | Additional behavior and `triggering` / `orJunction` as a *resolution hint*; 0.9 closer is a bound `reliability-constraint` |
+
+Invocation between two components is already documented as: name the
+behavior, assign the performers, relate behaviors (native authoring;
+YM404 if `triggering` is used between active-structure ends). This
+design uses that encoding as the interview’s first demand, not as a
+workaround.
+
+`applicationCollaboration` is active-structure, not a hop. Assigning a
+collaboration to an interaction does not close `hop-unrealised` on the
+member components. Those components still need their own assignment to
+a behavior or interface. No aggregation walk in 0.9.
+
+The wave id `interaction` sits next to the Core kind
+`applicationInteraction`. The wave is interview phase; the kind is a
+behavior. Both names stay.
+
+### 6.2 Policy (must be distinguishable)
+
+Core can *store* “OAuth client credentials” and “100 rps per client” as
+two `constraint` concepts. Core **cannot tell them apart for a trigger**
+while they share one kind.
+
+Distinct NFR questions therefore require distinct closing claims.
+Specialized constraint kinds in a conservative-extension profile
+(`yarramate/policy@0.1`):
+
+| Kind in 0.1 | Parent | Role |
+|---|---|---|
+| `authentication-constraint` | `constraint` | How the hop authenticates |
+| `rate-limit-constraint` | `constraint` | Capacity / none |
+| `reliability-constraint` | `constraint` | Retry, idempotency, dead-letter |
+| `mechanism-constraint` | `constraint` | Protocol on a `serving` hop where kind is not enough |
+
+Planned 0.2 (named now, not shipped): `authorization-constraint`,
+`transport-security-constraint`.
+
+Rejected alternatives: well-known binding ids, attestation-as-closer,
+description prose, Core fields on `serving`.
+
+This is a **vocabulary** profile, not an interrogation profile. Webapps
+that call a system API need `authentication-constraint` too. The kinds
+are policy topics, not estate types. Put that sentence in the profile’s
+docs.
+
+Conservative-extension rules apply (`docs/PROFILES.md`): a profile
+nobody **selects** changes nothing. These kinds only add descendants of
+`constraint`. They do not restate Core.
+
+Rigidity: omit. Annotating would be a fresh semantic claim.
+
+### 6.3 Binding
+
+Constraints bind to the **behavior** (or interface) subject, via the
+existing `constraints[].ref` list, compiling to
+`yarramate/constraint/requires` (ADR 0015). Core does not require the
+target to be a kind the *referring* document can declare, which is what
+makes multi-document adoption work.
+
+Workspace-scope interview turns create the *policy subjects*. Hop-scope
+turns bind them (this behavior requires that standard, or an explicit
+not-applicable subject).
+
+Not-applicable is a declared constraint of the same kind. Naming
+convention: local id `<policy>-not-applicable` (e.g.
+`ratelimit-not-applicable`). The description records **why**. Absence
+must not mean both “decided no” and “never asked.”
+
+Numeric or provider-backed values belong in `expects` on the **binding**
+(ADR 0075), e.g. `constraints: [{id: capacity, ref: …, expects:
+{provider: gateway, key: rps-per-client, value: "100"}}]`, not in prose
+on the constraint concept. A projection that is to brief those names
+must include the policy subjects; `relationships: connected` does not
+follow constraint refs.
+
+### 6.4 What we refuse to capture as a first-class closer
+
+Anything that only exists in `description`. Rationale may live there
+once the subject exists (MODEL-REVIEW.md). Closure never does.
+
+### 6.5 Adoption of `yarramate/policy@0.1`
+
+A document selects exactly one profile; a profile has exactly one
+`extends`. That is not a wall.
+
+A workspace already compiles several documents with several selected
+profiles. The adoption path:
+
+1. Policy subjects live in a document whose `profile:` is
+   `yarramate/policy@0.1`.
+2. Components and processes may stay on the estate’s existing extension
+   profile (this repository’s `engine.yaml` is one).
+3. Hops bind with a qualified `constraints[].ref` to the policy
+   document’s subjects.
+4. `missing-constraint` inspects the **target’s** kind.
+
+Re-basing an org profile onto policy is allowed if the estate wants
+those kinds in every document. It is not required, and it must not be
+the documented default: extending policy would make NFR questions
+applicable on every document that uses the org profile (§8.4), which is
+a coarser wizard than the domain interrogation profile this design
+rejects.
+
+Engine work (slice 2): resolve the identity `yarramate/policy@0.1`
+built-in, the way Core and the shipped catalogue resolve. Users do not
+copy a YAML file into `profiles/`. Loading the profile in the manifest
+without selecting it on a document still changes nothing.
+
+---
+
+## 7. How questions are selected (hop properties, not estate type)
+
+Reject workspace-global “this is an integration architecture.”
+
+The load-bearing unit is the **hop**.
+
+| Hop property | Questions it makes load-bearing |
+|---|---|
+| Component participates in `serving`/`flow`/`triggering` (either direction) and has no assigned behavior/interface | `hop-unrealised` |
+| Behavior is assigned from a component; the hop still needs a serving/triggering/flow | Folded into `hop-unrealised` resolution (a separate question fired on every assigned process with no outgoing hop, including internal ones) |
+| Behavior has `serving` and no `mechanism-constraint` | `interaction-protocol-unbound` (policy profile) |
+| Behavior has a `flow` with no `content` | `interaction-content-unknown` |
+| Behavior participates in a hop and has no access to `dataObject`/`contract` | `interaction-contract-unknown` |
+| Behavior participates in a hop and has no `authentication-constraint` | `interaction-trust-unbound` (policy profile) |
+| Behavior has `triggering` or `flow` and no `reliability-constraint` | `interaction-reliability-unbound` (policy profile) |
+| Behavior serves a `businessActor` and has no `rate-limit-constraint` | `interaction-capacity-unbound` (policy profile) |
+
+A greenfield todo app with one component and a user still gets
+motivation questions. It does not get federation, DLQ, or system-API
+mTLS questions. A mixed estate gets trust on the Salesforce hop and
+rate limit on the Experience hop without anyone classifying the
+workspace.
+
+Phase 1 does **not** compare owners or nodes. Trust fires on assigned
+behavior that participates in a hop (behavior/interface/component/actor
+counterparts). That is slightly broad. Counterpart owner/node
+discrimination is a follow-up.
+
+---
+
+## 8. Engine changes
+
+### 8.1 `has-linkage`
+
+Positive mirror of `missing-linkage`, with `direction: either` in
+addition to `outgoing` and `incoming`.
+
+```yaml
+- condition: has-linkage
+  kinds: [yarramate/core@0.1#serving, yarramate/core@0.1#flow, yarramate/core@0.1#triggering]
+  direction: either
+  counterpartKinds: [yarramate/core@0.1#applicationComponent]
+  kindMatching: descendants
+```
+
+Open when at least one relationship of those kinds, in that direction
+(`either` = incoming or outgoing), has a counterpart of those kinds.
+Lineage resolution identical to `missing-linkage`. Subject-scope (needs
+a subject id; workspace-scope use `exists-linkage`).
+
+Schema: copy `missing-linkage`, const `has-linkage`, direction enum
+includes `either`. Add `"default": "descendants"` on `kindMatching` for
+`has-linkage`, `exists-linkage`, `missing-linkage`, and
+`missing-constraint` while touching the schema (today the default lives
+only in code for `missing-linkage`).
+
+### 8.2 `missing-constraint`
+
+```yaml
+- condition: missing-constraint
+  kinds: [yarramate/policy@0.1#authentication-constraint]
+  kindMatching: descendants
+```
+
+Open when the subject has no `yarramate/constraint/requires` claim whose
+object’s concept kind matches. Default `kindMatching: descendants`.
+
+This is the discriminator that stops rate limiting from closing
+authentication.
+
+### 8.3 `exists-linkage` (workspace)
+
+Same shape as `has-linkage`, evaluated over every non-retired concept.
+Open when any concept would satisfy `has-linkage` with those parameters.
+Used so policy-subject questions fire once per workspace that has
+integration hops.
+
+### 8.4 `missing-flow-content`
+
+`flow.content` lives on the **relationship**, so `missing-claim` on the
+behavior cannot see it. Open when the subject is an endpoint of at least
+one `flow` relationship that has no `yarramate/flow/content` claim.
+Closes when every touching `flow` has `content`, or none exist.
+
+Required to implement `interaction-content-unknown` under AND-only
+triggers without selecting relationship subjects.
+
+### 8.5 Applicability (unknown-kind skip)
+
+A question is **not applicable** when any kind in its `subjects.kinds`,
+`trigger[].kinds`, or `trigger[].counterpartKinds` has a profile
+identity (the `id@version` before `#`) that is **not** in
+`graph.profiles` (selected lineage).
+
+Consequences:
+
+- Omitted from the report. Not `open: false` on a subject-scoped
+  unknown selector (today’s quiet-lie). Not `open: true` on a
+  workspace-scoped `no-subject-of-kind` with unknown kinds (today’s
+  forever-trap). Slice 1 tests pin **both** directions.
+- `summary.questions` counts applicable questions only.
+- Opt-in: select `yarramate/policy@0.1` on at least one document → NFR
+  questions become applicable. Do not select it → structure questions
+  (Core kinds) still apply; policy-kind questions vanish.
+- Conservative-extension: profile **loaded** in the manifest, selected
+  by no document → `graph.profiles` does not include it → skip still
+  skips → interrogation output byte-identical to core-only.
+
+### 8.6 `no-subject-of-kind` uses `kindMatches`
+
+Replace the exact-string `includes` with `kindMatches` and
+`kindMatching` default `descendants`, matching every other kind-aware
+condition. Test: a subject whose kind *specializes*
+`authentication-constraint` closes `authn-standard-missing` (and, on
+Core, a descendant of `goal` closes `outcome-missing`).
+
+This loosens four shipped questions. Changelog it. Existing core-only
+fixtures should not flip.
+
+### 8.7 Out of scope for slice 1
+
+Relationship-scope questions, path/chain scope, owner/node comparison,
+`{counterparts}` for `has-linkage` (today `near-duplicate` only; `design`
+`askPlain` also does not interpolate counterparts — when that lands,
+cover both paths), materiality scores, catalogue `extends`, `anyOf`.
+
+---
+
+## 9. Catalogue 0.9
+
+### 9.1 Versioning
+
+`core-enrichment` 0.8 → **0.9**. Minor, additive (ADR 0063): new wave,
+new questions, new optional conditions. Existing questions keep their
+ids, waves, and triggers. `since: "0.9"` on every new question.
+
+Do **not** move `owner-missing` out of business.
+
+### 9.2 Wave order
+
+```text
+motivation
+interaction     # NEW — interview phase; not the Core kind applicationInteraction
+business        # owner-missing still lives here
+application
+technology
+implementation
+hygiene         # kind-untested still lives here
+```
+
+Wave order is catalogue data. `design` walks `report.waves` in array
+order. No engine change.
+
+### 9.3 First-wave stop
+
+Skill / harness rule, not an engine gate:
+
+When `design --json` returns a step whose `wave` is not `interaction`
+for the slice in focus, stop and render the brief. `wave` is already
+required on `yarramate/design-step/v1`.
+
+`ask --open` still reports every applicable open question. `design`
+without `--subject` will offer `owner-missing` next; the skill must not
+drain it as part of hop design-readiness.
+
+No `design --wave` in 0.9. Existing tests reject unknown options; adding
+it later is a deliberate CLI-surface change.
+
+### 9.4 Question set
+
+Every row is one AND-only trigger. Policy-kind rows are omitted when
+the policy profile is not selected (§8.5).
+
+Behavior kinds (selectors and assignment counterparts):
+`applicationProcess`, `applicationFunction`, `applicationInteraction`,
+`applicationEvent`, `applicationInterface`.
+
+Hop counterparts after reification: those behavior kinds plus
+`applicationComponent`, `applicationInterface`, `businessActor`.
+
+#### Workspace — policy subjects
+
+| id | Intent | Trigger (AND) | Authority |
+|---|---|---|---|
+| `authn-standard-missing` | Default authentication for interactions | `exists-linkage` serving\|flow\|triggering, either, to component\|interface\|actor **and** `no-subject-of-kind` `authentication-constraint` | human |
+| `ratelimit-standard-missing` | Default capacity rule | `exists-linkage` serving, either, to `businessActor` **and** `no-subject-of-kind` `rate-limit-constraint` | human |
+| `reliability-standard-missing` | Default retry/idempotency/DLQ rule | `exists-linkage` flow\|triggering, either **and** `no-subject-of-kind` `reliability-constraint` | human |
+
+Closes when at least one subject of that policy kind exists (the
+standard, or a not-applicable subject). Materiality for authn must
+**not** imply it covers authorization.
+
+No workspace-level mechanism standard. Protocol is hop-local
+(`interaction-protocol-unbound`).
+
+#### Subject — reify the hop
+
+Selector: `applicationComponent`, statuses planned|current.
+
+| id | Intent | Trigger (AND) | Authority |
+|---|---|---|---|
+| `hop-unrealised` | Name the process, function, interaction, event, or interface this component is assigned to for the hop | `has-linkage` serving\|flow\|triggering, either, to component\|interface\|actor **and** `missing-linkage` assignment outgoing to the behavior/interface kinds | either |
+
+Resolution demands a new or existing behavior/interface subject, not
+“add realization or delete the component.” Overlap with
+`component-realizes-nothing` is acceptable (different wave). Do not
+delete the old question in 0.9.
+
+#### Subject — once a behavior exists
+
+Selector: behavior/interface kinds, statuses planned|current.
+
+| id | Intent | Trigger (AND) | Authority |
+|---|---|---|---|
+| `interaction-protocol-unbound` | Protocol on a serving hop | Policy applicable **and** `has-linkage` serving, either, to hop counterparts **and** `missing-constraint` `mechanism-constraint` | either |
+| `interaction-content-unknown` | `flow` with no `content` | `missing-flow-content` | either |
+| `interaction-contract-unknown` | Schema/contract access | `has-linkage` serving\|flow\|triggering, either, to hop counterparts **and** `missing-linkage` access to `dataObject`\|`contract` | either |
+| `interaction-trust-unbound` | Bind authentication | Policy applicable **and** `has-linkage` serving\|flow\|triggering, either, to hop counterparts **and** `missing-constraint` `authentication-constraint` | either |
+| `interaction-reliability-unbound` | Bind retry/idempotency/DLQ | Policy applicable **and** `has-linkage` triggering\|flow, either, to hop counterparts **and** `missing-constraint` `reliability-constraint` | either |
+| `interaction-capacity-unbound` | Bind rate limit or none | Policy applicable **and** `has-linkage` serving, either, to `businessActor` **and** `missing-constraint` `rate-limit-constraint` | either |
+
+`interaction-protocol-unbound` never matches event-driven hops (no
+serving). `interaction-capacity-unbound` includes an interface that
+serves an actor (Experience edge).
+
+0.9 reliability closer is the bound constraint. A failure behavior is
+the stronger *resolution hint*, measured in slice 5 before becoming a
+closer.
+
+### 9.5 Grouping
+
+Workspace-scope rows *are* the grouping. `openSubjects` batches
+subject-scoped leftovers. Do not build a new grouping engine.
+
+### 9.6 Phrasing bar
+
+Each question’s `materiality` names who acts differently if it stays
+open. “Security is critical” is not materiality. Authn materiality must
+not claim authorization is covered.
+
+Resolution hints name the apply shape. They do not say “write a
+paragraph.”
+
+`askPlain` is required on these questions as an **authoring gate**
+(slice 3 tests). The schema remains optional (ADR 0072).
+
+### 9.7 #205 coverage
+
+| #205 area | 0.9 | Later | Rejected |
+|---|---|---|---|
+| Interaction mechanism and protocol | `hop-unrealised` (relationship kind in the resolution), `interaction-protocol-unbound` | | |
+| Integration pattern / Exp-Prc-Sys | Partial: reified behaviors and serving chains | Layer labels stay names, not Core kinds | Orchestration vs choreography as workflow completeness (Core exclusion) |
+| Security and trust | Authentication (`authn-standard-missing`, `interaction-trust-unbound`) | Authz, transport, identity propagation (policy 0.2 + catalogue 0.10) | Mega-trust question |
+| Data and contract | `interaction-content-unknown`, `interaction-contract-unknown` | Versioning, classification, residency as further policy kinds | |
+| Failure and delivery | `reliability-standard-missing`, `interaction-reliability-unbound` | Failure behavior as closer if slice 5 says constraint-only briefs do not change edits | Workflow completeness inference |
+| Dependency topology | The serving/flow/triggering graph | Path/chain questions | |
+| Deployment and connectivity | Unchanged: `component-unhosted` (later wave) | | |
+| NFR / operational | Rate limit on Experience hops | Observability, RTO as further policy kinds | |
+
+---
+
+## 10. Loop, skill, and stop condition
+
+```text
+design → answer → apply (one batch) → check → design
+```
+
+Skill additions (canonical `skills/yarramate-architecture`):
+
+1. After motivation, work the `interaction` wave to quiet on the chain
+   in focus (`design --subject` when focusing).
+2. Land each answer as subjects and relationships, never as description
+   alone.
+3. Policy subjects in a policy-profile document; hops bind by qualified
+   ref. One apply batch may create and bind.
+4. When the served `design --json` step’s `wave` leaves `interaction`,
+   render the brief and **stop**. Do not drain `owner-missing`.
+5. Never pass a catalogue path.
+
+`--strict` remains evidence-gated and optional.
+
+---
+
+## 11. Why not the alternatives
+
+### 11.1 Domain interrogation profiles
+
+An `integration-architecture` vs `webapp` switch classifies the whole
+workspace. Wrong classification omits questions. Kafka and Keycloak in
+PR #204 are not one type. Specific questions need specific triggers and
+closures, not a wizard. A named catalogue also breaks “catalogue is
+internal.”
+
+### 11.2 “At least one constraint”
+
+Rejected. One constraint of any kind is hygiene. Rate limiting must not
+silence authentication.
+
+### 11.3 Putting protocol on `serving`
+
+Reify the hop as behavior; bind policy there; let relationship kind
+carry coarse mechanism.
+
+### 11.4 Retargeting `component-realizes-nothing` only
+
+That question is in the application wave. `owner-missing` is in
+business. Rephrasing does not change wave order.
+
+### 11.5 Growing Core with security kinds
+
+Conservative extension exists for this. Not every workspace should see
+NFR questions as applicable. §8.5 skip works only if the kinds are
+*not* Core.
+
+### 11.6 Quieter `ask --open` on the gallery
+
+PR #204 left those interviews open on purpose. Not this project.
+
+### 11.7 Re-base org profiles onto policy
+
+Couples interview opt-in to vocabulary parentage. Multi-document
+binding is the adoption path (§6.5).
+
+---
+
+## 12. Implementation slices
+
+Each slice independently reviewable. Do not bundle measurement into
+slice 1.
+
+### Slice 0 — Capture fixture (no new engine required for `check`)
+
+Regression fixture: Experience → Process → System document-transfer
+chain.
+
+- Architecture document, `profile: yarramate/core@0.1`: three API
+  components, assigned processes, `flow` with `content`, `contract` /
+  `dataObject` with `access`.
+- Policy document, selecting the policy profile (fixture-local
+  `example/policy@1.0` until slice 2 ships `yarramate/policy@0.1`):
+  `authentication-constraint`, `rate-limit-constraint` on the Experience
+  process; the same authn plus `ratelimit-not-applicable` on the System
+  process.
+- `check` passes.
+- A brief of the slice names mechanism (flow + content), payload, and
+  **both** policy subjects as distinct names. Binding only rate limit
+  must not make authn disappear from the brief. The focused projection
+  lists the policy subjects explicitly; connected expansion does not
+  follow `constraints[].ref`.
+
+This fixture is the oracle later catalogue tests close against. The
+not-applicable path is in the fixture so slice 3 does not only test
+bind-one-vs-both.
+
+Until slice 2, the fixture profile is `example/policy@1.0` extending
+Core with the same kind ids the shipped profile will use locally. Slice
+2 switches the policy document to `yarramate/policy@0.1` and deletes
+the stand-in if it is then redundant.
+
+### Slice 1 — Engine
+
+- `has-linkage`, `exists-linkage` (`direction: either`),
+  `missing-constraint`, `missing-flow-content`
+- `kindMatching` default `descendants` on those schema objects and on
+  `missing-linkage`
+- Applicability skip (§8.5), tests for both unknown-kind directions
+- `no-subject-of-kind` lineage (F4), with a derived-kind closure test
+- Conservative-extension: loaded-but-unselected profile ⇒
+  byte-identical interrogation
+- Changelog the `no-subject-of-kind` loosening
+
+No catalogue questions yet. Shipped interview output unchanged except
+the lineage loosening on the four workspace questions.
+
+### Slice 2 — Vocabulary profile `yarramate/policy@0.1`
+
+- ADR: semantics vs ADR 0087 notation; versioning additive in 0.x
+  mirroring ADR 0063; planned 0.2 kinds listed; naming
+  (`yarramate/policy`, webapps need authn too);
+  `reliability-constraint`; not-applicable convention; `expects` for
+  numeric values; multi-document adoption path
+- Built-in resolution of `yarramate/policy@0.1`
+- Switch the slice 0 policy document onto it
+
+Built-in resolution stays on this design’s critical path. Do not wait
+for a generic “shipped profile platform” if that would stall 0.9 NFR
+questions. Scope: resolve this identity the way Core resolves. No
+multi-`extends`.
+
+### Slice 3 — Catalogue 0.9
+
+Wave + questions in §9.4. `askPlain` present on every new question
+(test). Tests against the slice 0 fixture:
+
+- before reification: `hop-unrealised` open; `design` serves it before
+  `owner-missing`
+- after reification without policy profile: structure questions close;
+  policy questions omitted
+- after selecting policy profile without bindings: trust/capacity open
+- binding rate limit only: trust still open
+- binding both, plus not-applicable on the system hop: interaction wave
+  quiet on those subjects
+- derived-kind closure of `authn-standard-missing`
+
+Pre-register the slice 5 change-task rubric as a short paragraph before
+authoring question copy, so the questions are not fitted to the
+measurement.
+
+### Slice 4 — Skill
+
+Interaction wave, apply-as-subjects, stop when served `wave` leaves
+`interaction`, never pass catalogue paths. Tests can assert the skill
+text names the `wave` field.
+
+### Slice 5 — Measurement (not a merge gate)
+
+Change task on the fixture: unenriched component inventory vs
+interaction-wave-complete model. Sonnet change B−A from PR #204 is the
+defended comparison class. Pre-register the rubric in slice 3.
+
+Issue #205: this document is the parent; slices 0–4 are children;
+domain interrogation profiles stay closed unless 0.9 misfires.
+
+---
+
+## 13. Success criteria
+
+Slices 0–4 are done when:
+
+1. The document-transfer fixture’s brief names mechanism, payload, an
+   authentication rule, and a capacity rule as **distinct subjects**,
+   including one not-applicable binding.
+2. `design` on that workspace, policy profile selected, asks
+   `hop-unrealised` (or a workspace policy-subject question) **before**
+   `owner-missing`.
+3. Binding only a rate-limit constraint does **not** close
+   `interaction-trust-unbound`.
+4. Applying the answers uses existing Core relationship kinds plus
+   policy-profile constraint kinds. No new Core relationship fields.
+5. A core-only workspace (no policy profile selected) does not grow
+   open questions that mention policy kinds; those questions are
+   omitted, not closed.
+6. Conservative-extension: policy profile present in the workspace
+   manifest but **selected by no document** ⇒ interrogation output
+   byte-identical to core-only. Applicability uses `graph.profiles`.
+7. Catalogue bump is 0.8 → 0.9 with `since: "0.9"` on new questions
+   only.
+8. `no-subject-of-kind` descendant matching is tested on a derived
+   kind.
+
+Follow-up (slice 5), not a merge gate:
+
+9. A bounded implementer edit against the enriched slice outperforms
+   the unenriched inventory on the pre-registered rubric, at least at
+   Sonnet, in the change-family sense of PR #204.
+
+---
+
+## 14. Risks
+
+| Risk | Why it is real | Mitigation |
+|---|---|---|
+| `hop-unrealised` instance explosion | 27 APIs ⇒ 27 subjects | `openSubjects` + one apply batch; skill does not interview N times |
+| Overlap with `component-realizes-nothing` | Same subjects, later wave | Accept in 0.9 |
+| Policy profile described as “the integration profile” | Naming drift | `yarramate/policy`; docs; hop triggers remain the selector |
+| `exists-linkage` on trivial models | Two-component demo | Workspace NFR questions behind policy profile |
+| Collaboration models never close `hop-unrealised` | No aggregation walk | Documented modeling rule: assign the component |
+| First-wave stop ignored | Skill-only | Count `design --json` wave in dogfood before considering `--wave` |
+| Shipped-profile resolution stalls NFR questions | F5 surface area | Keep built-in resolution on this design’s critical path, scoped to one identity |
+| F4 flips existing interviews | Specialized motivation kinds | Changelog; core-only fixtures pinned |
+| Haiku will not reify hops | H2 | Verifier flattens validity; do not claim flattening of architect judgment |
+
+---
+
+## 15. Locked answers (reviewer questions)
+
+1. **Policy kinds: optional profile, not Core.** Conditional on slice 2
+   built-in resolution, multi-document adoption, and the ADR vs 0087.
+   Without those, option A becomes “copy this file,” which was rejected.
+2. **Authentication-only for first-wave trust.** Authz / transport in
+   0.10 + policy 0.2. Name those kinds in the profile ADR now. Authn
+   materiality must not imply authorization is done.
+3. **Constraint is the 0.9 reliability closer.** Failure behavior stays
+   a resolution hint. Slice 5 decides whether that is enough.
+4. **Skill-only stop**, keyed off `design-step.wave`. `--wave` later if
+   dogfood shows agents drain ownership anyway.
+5. **`hop-unrealised` selects components**, not relationship subjects.
+   Relationship-scope is a later issue when a concrete question cannot
+   be phrased on the component.
+6. **Naming:** `yarramate/policy@0.1`; wave id `interaction` with the
+   Core-kind collision acknowledged; `reliability-constraint` not
+   `delivery-constraint`.
+
+---
+
+## 16. Suggested issue split
+
+| Issue | Content |
+|---|---|
+| #205 (reframe) | Parent: diagnosis stands; this document is the direction; domain interrogation profiles are not the direction |
+| Child: capture fixture | Slice 0 |
+| Child: linkage/constraint conditions | Slice 1 |
+| Child: policy profile + built-in resolution + ADR | Slice 2 |
+| Child: core-enrichment 0.9 | Slice 3 |
+| Child: skill first-wave stop | Slice 4 |
+| Later: change-family measurement | Slice 5 |
+| Later: owner/node counterpart conditions | Trust-trigger tightening |
+| Later: relationship-scope questions | If hop-as-edge is needed |
+| Later: constraints on relationships | Authoring convenience |
+| Not unless 0.9 misfires | Named integration vs webapp catalogues |

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "assets/likec4",
     "schema",
     "catalogues",
+    "profiles",
     "skills/yarramate-architecture",
     "docs/CONSUMING-YARRAMATE.md"
   ],

--- a/profiles/yarramate-policy.yaml
+++ b/profiles/yarramate-policy.yaml
@@ -1,0 +1,18 @@
+format: yarramate/profile/v1
+id: yarramate/policy
+version: "0.1"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: authentication-constraint
+    name: Authentication constraint
+    parent: yarramate/core@0.1#constraint
+  - id: rate-limit-constraint
+    name: Rate-limit constraint
+    parent: yarramate/core@0.1#constraint
+  - id: reliability-constraint
+    name: Reliability constraint
+    parent: yarramate/core@0.1#constraint
+  - id: mechanism-constraint
+    name: Mechanism constraint
+    parent: yarramate/core@0.1#constraint
+relationshipKinds: []

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -290,7 +290,139 @@
               "enum": [
                 "exact",
                 "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
               ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "exists-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-constraint"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject is an endpoint of at least one flow relationship that has no yarramate/flow/content claim.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-flow-content"
             }
           }
         },

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -140,15 +140,24 @@ yarramate design .yarramate/workspace.yaml
    or read catalogue files. Answer one question at a time: questions the
    model or evidence can answer, answer from your authority; questions
    marked `human`, relay verbatim with their materiality. Land each answer
-   as one atomic batch (`yarramate apply <operations.yaml>
-   .yarramate/workspace.yaml`), then re-run `design` — the next question is
-   recomputed from the model, so the loop is resumable across sessions and
-   agents with no handover. Use `--subject <id>` to focus the interview on
-   one element. When a step reports many `openSubjects` sharing one
-   question (ownership is the classic case), do not interview N times:
-   collect the policy answer once — "who owns what, by area" — and land it
-   across every listed subject as one apply batch. The interview is
-   complete when `design` says so.
+   as subjects and relationships in one atomic batch (`yarramate apply
+   <operations.yaml> .yarramate/workspace.yaml`), never as description
+   alone. Then re-run `design` — the next question is recomputed from the
+   model, so the loop is resumable across sessions and agents with no
+   handover. Use `--subject <id>` to focus the interview on one element.
+   When a step reports many `openSubjects` sharing one question (ownership
+   is the classic case), do not interview N times: collect the policy
+   answer once — "who owns what, by area" — and land it across every listed
+   subject as one apply batch.
+
+   After motivation, work the `interaction` wave (hops, mechanism, payload,
+   trust, reliability, capacity) before ownership and hygiene. Policy
+   subjects (`authentication-constraint`, `rate-limit-constraint`, and
+   siblings) live in a document that selects `yarramate/policy@0.1`; hops
+   bind them with qualified `constraints[].ref`. One batch may create and
+   bind. When `design --json` returns a step whose `wave` is not
+   `interaction` for the slice in focus, stop, render the brief, and do not
+   drain `owner-missing`. The interview is complete when `design` says so.
 5. Create:
    - an alternatives projection for the decision;
    - a bounded target projection for implementation agents.

--- a/skills/yarramate-architecture/references/native-authoring.md
+++ b/skills/yarramate-architecture/references/native-authoring.md
@@ -200,6 +200,16 @@ rationale in the description and it becomes the non-goal record.
 Ownership is one accountable reference, not approval workflow. Constraints are
 identified references, not a policy engine or free-form metadata bag.
 
+Distinct NFR rules (authentication, rate limit, reliability, serving
+protocol) use `yarramate/policy@0.1` kinds, not Core `constraint` alone.
+Select that profile on the document that declares the policy subjects;
+other documents may keep their existing profile and bind with a
+qualified `constraints[].ref`. Do not copy a profile file into the
+workspace. A hop that must not have a rate limit binds a
+`ratelimit-not-applicable` subject of kind `rate-limit-constraint` with
+the reason in its description. Numeric caps go in `expects` on the
+binding.
+
 ## Attestations
 
 ```yaml

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -19,6 +19,10 @@ import profileSchema from '../schema/yarramate-profile.schema.json' with {
   type: 'json',
 }
 import { ATTESTATION_PREDICATE_PREFIX, attestationClaimValue } from './graph-claims.js'
+import {
+  shippedPolicyIdentity,
+  shippedPolicySource,
+} from './shipped-profile.js'
 
 const coreProfile = 'yarramate/core@0.1'
 // `ajv/dist/2020.js` is CJS. Its default-export shape is resolved
@@ -639,6 +643,49 @@ function compileWorkspaceResolved(
 
     const identity = `${value.id}@${value.version}`
     pendingProfiles.push({ input, value, identity, positionFor })
+  }
+
+  const alreadyDeclaresPolicy = pendingProfiles.some(
+    ({ identity }) => identity === shippedPolicyIdentity,
+  )
+  if (!alreadyDeclaresPolicy) {
+    const selected = documentInputs.some(({ entry }) => {
+      const value = entry.value as { readonly profile?: unknown }
+      return value.profile === shippedPolicyIdentity
+    })
+    const extended = pendingProfiles.some(
+      ({ value }) => value.extends === shippedPolicyIdentity,
+    )
+    if (selected || extended) {
+      const input = {
+        path: 'yarramate:profile:yarramate/policy@0.1',
+        source: shippedPolicySource,
+      }
+      const { entry, fresh } = parseWorkspaceSource(input)
+      const value = entry.value as NativeProfile
+      if (entry.schemaDiagnostics.length > 0) {
+        profileDiagnostics.push(...entry.schemaDiagnostics)
+      } else if (!validateProfile(value)) {
+        for (const error of validateProfile.errors ?? []) {
+          profileDiagnostics.push({
+            severity: 'error',
+            code: 'YM201',
+            message: `Profile schema violation: ${describeSchemaViolation(error)}`,
+            path: input.path,
+            pointer: error.instancePath || '/',
+            line: 1,
+            column: 1,
+          })
+        }
+      } else {
+        pendingProfiles.push({
+          input,
+          value,
+          identity: shippedPolicyIdentity,
+          positionFor: positionReader(input.source, entry.positions, fresh),
+        })
+      }
+    }
   }
 
   let unresolvedProfiles = pendingProfiles.sort((left, right) =>

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -39,6 +39,7 @@ type CatalogueCondition =
   | {
       readonly condition: 'no-subject-of-kind'
       readonly kinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
     }
   | { readonly condition: 'no-state-defined' }
   | {
@@ -48,6 +49,26 @@ type CatalogueCondition =
       readonly counterpartKinds: readonly string[]
       readonly kindMatching?: 'exact' | 'descendants'
     }
+  | {
+      readonly condition: 'has-linkage'
+      readonly kinds: readonly string[]
+      readonly direction: 'incoming' | 'outgoing' | 'either'
+      readonly counterpartKinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
+  | {
+      readonly condition: 'exists-linkage'
+      readonly kinds: readonly string[]
+      readonly direction: 'incoming' | 'outgoing' | 'either'
+      readonly counterpartKinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
+  | {
+      readonly condition: 'missing-constraint'
+      readonly kinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
+  | { readonly condition: 'missing-flow-content' }
   | {
       readonly condition: 'missing-reference'
       readonly predicate: string
@@ -315,6 +336,92 @@ const relationshipKindMatches = (
           ?.includes(selected) === true),
   )
 
+const profileIdentityOfKind = (qualifiedKind: string): string => {
+  const separator = qualifiedKind.indexOf('#')
+  return separator === -1 ? qualifiedKind : qualifiedKind.slice(0, separator)
+}
+
+const namedKinds = (question: CatalogueQuestion): readonly string[] => {
+  const kinds = [...(question.subjects?.kinds ?? [])]
+  for (const condition of question.trigger) {
+    switch (condition.condition) {
+      case 'missing-relationship':
+      case 'no-subject-of-kind':
+      case 'missing-constraint':
+        kinds.push(...condition.kinds)
+        break
+      case 'missing-linkage':
+      case 'has-linkage':
+      case 'exists-linkage':
+        kinds.push(...condition.kinds, ...condition.counterpartKinds)
+        break
+      default:
+        break
+    }
+  }
+  return kinds
+}
+
+const questionIsApplicable = (
+  question: CatalogueQuestion,
+  selectedProfiles: readonly string[],
+): boolean => {
+  const selected = new Set(selectedProfiles)
+  return namedKinds(question).every((kind) =>
+    selected.has(profileIdentityOfKind(kind)),
+  )
+}
+
+type LinkageShape = {
+  readonly kinds: readonly string[]
+  readonly direction: 'incoming' | 'outgoing' | 'either'
+  readonly counterpartKinds: readonly string[]
+  readonly kindMatching?: 'exact' | 'descendants'
+}
+
+const linkageHits = (
+  index: GraphIndex,
+  condition: LinkageShape,
+  subjectId: string,
+  profileContext: ResolvedProfileContext | undefined,
+): boolean => {
+  const matching = condition.kindMatching ?? 'descendants'
+  return index.relationshipClaims.some((claim) => {
+    if (!('ref' in claim.object)) return false
+    if (
+      !relationshipKindMatches(
+        claim.predicate,
+        condition.kinds,
+        matching,
+        profileContext,
+      )
+    ) {
+      return false
+    }
+    const counterparts: string[] = []
+    if (
+      (condition.direction === 'outgoing' || condition.direction === 'either') &&
+      claim.subject === subjectId
+    ) {
+      counterparts.push(claim.object.ref)
+    }
+    if (
+      (condition.direction === 'incoming' || condition.direction === 'either') &&
+      claim.object.ref === subjectId
+    ) {
+      counterparts.push(claim.subject)
+    }
+    return counterparts.some((counterpart) =>
+      kindMatches(
+        index.kindOf.get(counterpart),
+        condition.counterpartKinds,
+        matching,
+        profileContext,
+      ),
+    )
+  })
+}
+
 const conditionHolds = (
   index: GraphIndex,
   condition: CatalogueCondition,
@@ -360,46 +467,74 @@ const conditionHolds = (
           ({ object }) => 'ref' in object && object.ref === subjectId,
         )
       )
-    case 'no-subject-of-kind':
+    case 'no-subject-of-kind': {
+      const matching = condition.kindMatching ?? 'descendants'
       return ![...index.concepts].some((id) =>
-        condition.kinds.includes(index.kindOf.get(id) ?? ''),
+        kindMatches(
+          index.kindOf.get(id),
+          condition.kinds,
+          matching,
+          profileContext,
+        ),
       )
+    }
     case 'no-state-defined':
       return !index.hasStates
-    case 'missing-linkage': {
+    case 'missing-linkage':
       // The linkage-depth primitive: the subject lacks a relationship of
       // these kinds, in this direction, whose counterpart is of one of
       // these kinds. Both relationship and counterpart kinds resolve
       // through profile lineage by default, matching the selector rule.
+      return !linkageHits(
+        index,
+        condition,
+        subjectId!,
+        profileContext,
+      )
+    case 'has-linkage':
+      return (
+        subjectId !== undefined &&
+        linkageHits(index, condition, subjectId, profileContext)
+      )
+    case 'exists-linkage':
+      return [...index.concepts].some((id) =>
+        linkageHits(index, condition, id, profileContext),
+      )
+    case 'missing-constraint': {
       const matching = condition.kindMatching ?? 'descendants'
-      return !index.relationshipClaims.some((claim) => {
+      return !(index.claimsBySubject.get(subjectId!) ?? []).some(
+        (claim) =>
+          claim.predicate === 'yarramate/constraint/requires' &&
+          'ref' in claim.object &&
+          kindMatches(
+            index.kindOf.get(claim.object.ref),
+            condition.kinds,
+            matching,
+            profileContext,
+          ),
+      )
+    }
+    case 'missing-flow-content': {
+      if (subjectId === undefined) return false
+      const matching = 'descendants' as const
+      return index.relationshipClaims.some((claim) => {
         if (!('ref' in claim.object)) return false
         if (
           !relationshipKindMatches(
             claim.predicate,
-            condition.kinds,
+            ['yarramate/core@0.1#flow'],
             matching,
             profileContext,
           )
         ) {
           return false
         }
-        const counterpart =
-          condition.direction === 'outgoing'
-            ? claim.subject === subjectId
-              ? claim.object.ref
-              : undefined
-            : claim.object.ref === subjectId
-              ? claim.subject
-              : undefined
-        return (
-          counterpart !== undefined &&
-          kindMatches(
-            index.kindOf.get(counterpart),
-            condition.counterpartKinds,
-            matching,
-            profileContext,
-          )
+        if (claim.subject !== subjectId && claim.object.ref !== subjectId) {
+          return false
+        }
+        return !(index.claimsBySubject.get(claim.id) ?? []).some(
+          ({ predicate, object }) =>
+            predicate === 'yarramate/flow/content' && 'value' in object,
         )
       })
     }
@@ -497,10 +632,13 @@ export function evaluateCatalogue(
   const index = indexGraph(graph)
   let open = 0
   let openQuestions = 0
+  const applicableQuestions = catalogue.questions.filter((question) =>
+    questionIsApplicable(question, graph.profiles),
+  )
   const waves = catalogue.waves.map((wave) => ({
     id: wave.id,
     name: wave.name,
-    questions: catalogue.questions
+    questions: applicableQuestions
       .filter((question) => question.wave === wave.id)
       .map((question): ReportQuestion => {
         const base = {
@@ -559,7 +697,7 @@ export function evaluateCatalogue(
     format: 'yarramate/interrogation-report/v1',
     catalogue: `${catalogue.id}@${catalogue.version}`,
     summary: {
-      questions: catalogue.questions.length,
+      questions: applicableQuestions.length,
       openQuestions,
       open,
     },

--- a/src/shipped-profile.ts
+++ b/src/shipped-profile.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const shippedPolicyIdentity = 'yarramate/policy@0.1'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+export const shippedPolicySource = readFileSync(
+  join(here, '..', 'profiles', 'yarramate-policy.yaml'),
+  'utf8',
+)

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -1716,4 +1716,52 @@ relationships: []
       ],
     })
   })
+
+  it('resolves yarramate/policy@0.1 without a workspace profile file', () => {
+    const result = compileWorkspaceWithProfileContext([
+      {
+        path: 'policy.yaml',
+        source: `format: yarramate/v1
+id: policy
+profile: yarramate/policy@0.1
+concepts:
+  - id: oauth
+    kind: authentication-constraint
+    name: OAuth
+relationships: []
+`,
+      },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.graph.profiles).toEqual([
+      'yarramate/core@0.1',
+      'yarramate/policy@0.1',
+    ])
+    expect(
+      result.profileContext.conceptKindLineages.get(
+        'yarramate/policy@0.1#authentication-constraint',
+      ),
+    ).toEqual([
+      'yarramate/core@0.1#constraint',
+      'yarramate/policy@0.1#authentication-constraint',
+    ])
+  })
+
+  it('does not inject yarramate/policy@0.1 when no document selects it', () => {
+    const result = compileWorkspaceWithProfileContext([
+      {
+        path: 'minimal.yaml',
+        source: fixture('valid/minimal.yaml'),
+      },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.graph.profiles).toEqual(['yarramate/core@0.1'])
+    expect(
+      result.profileContext.conceptKindLineages.has(
+        'yarramate/policy@0.1#authentication-constraint',
+      ),
+    ).toBe(false)
+  })
 })

--- a/test/design-command.test.ts
+++ b/test/design-command.test.ts
@@ -108,6 +108,7 @@ describe('design command', () => {
     expect(payload.step?.wave).toBe('motivation')
     expect(payload.progress.waves.map(({ id }) => id)).toEqual([
       'motivation',
+      'interaction',
       'business',
       'application',
       'technology',

--- a/test/document-transfer-fixture.test.ts
+++ b/test/document-transfer-fixture.test.ts
@@ -14,7 +14,7 @@ const workspace =
 describe('document-transfer capture fixture', () => {
   it('checks and renders distinct authn and capacity subjects in the brief', () => {
     const checked = runCli(['check', workspace], repositoryRoot)
-    expect(checked.exitCode).toBe(0, checked.stderr)
+    expect(checked.exitCode).toBe(0)
 
     const asked = runCli(
       [
@@ -24,7 +24,7 @@ describe('document-transfer capture fixture', () => {
       ],
       repositoryRoot,
     )
-    expect(asked.exitCode).toBe(0, asked.stderr)
+    expect(asked.exitCode).toBe(0)
     expect(asked.stdout).toContain('OAuth client-credentials')
     expect(asked.stdout).toContain('100 requests per client per second')
     expect(asked.stdout).toContain('No caller-facing rate limit')

--- a/test/document-transfer-fixture.test.ts
+++ b/test/document-transfer-fixture.test.ts
@@ -1,0 +1,33 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const workspace =
+  'test/fixtures/valid/document-transfer.workspace.yaml'
+
+describe('document-transfer capture fixture', () => {
+  it('checks and renders distinct authn and capacity subjects in the brief', () => {
+    const checked = runCli(['check', workspace], repositoryRoot)
+    expect(checked.exitCode).toBe(0, checked.stderr)
+
+    const asked = runCli(
+      [
+        'ask',
+        workspace,
+        'test/fixtures/valid/document-transfer.projection.yaml',
+      ],
+      repositoryRoot,
+    )
+    expect(asked.exitCode).toBe(0, asked.stderr)
+    expect(asked.stdout).toContain('OAuth client-credentials')
+    expect(asked.stdout).toContain('100 requests per client per second')
+    expect(asked.stdout).toContain('No caller-facing rate limit')
+    expect(asked.stdout).toContain('Document payload')
+  })
+})

--- a/test/fixtures/valid/document-transfer.policy.yaml
+++ b/test/fixtures/valid/document-transfer.policy.yaml
@@ -1,0 +1,31 @@
+format: yarramate/v1
+id: document-transfer-policy
+profile: yarramate/policy@0.1
+concepts:
+  - id: oauth-m2m
+    kind: authentication-constraint
+    name: OAuth client-credentials
+    description: >-
+      Service identity uses OAuth 2.0 client credentials. User identity is
+      not propagated on this hop.
+  - id: experience-rate-limit
+    kind: rate-limit-constraint
+    name: 100 requests per client per second
+    description: Caller-facing Experience APIs are capacity-capped at the gateway.
+  - id: ratelimit-not-applicable
+    kind: rate-limit-constraint
+    name: No caller-facing rate limit
+    description: >-
+      System APIs are not caller-facing; capacity is owned by the Experience
+      hop. This records the decision not to apply a rate limit here.
+  - id: at-least-once
+    kind: reliability-constraint
+    name: At-least-once with idempotent store
+    description: >-
+      Document transfer retries on timeout; the eDRMS identifier is the
+      idempotency key.
+  - id: https-rest
+    kind: mechanism-constraint
+    name: HTTPS REST
+    description: Synchronous HTTP/JSON over TLS on Experience serving hops.
+relationships: []

--- a/test/fixtures/valid/document-transfer.profile.yaml
+++ b/test/fixtures/valid/document-transfer.profile.yaml
@@ -1,0 +1,18 @@
+format: yarramate/profile/v1
+id: example/policy
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: authentication-constraint
+    name: Authentication constraint
+    parent: yarramate/core@0.1#constraint
+  - id: rate-limit-constraint
+    name: Rate-limit constraint
+    parent: yarramate/core@0.1#constraint
+  - id: reliability-constraint
+    name: Reliability constraint
+    parent: yarramate/core@0.1#constraint
+  - id: mechanism-constraint
+    name: Mechanism constraint
+    parent: yarramate/core@0.1#constraint
+relationshipKinds: []

--- a/test/fixtures/valid/document-transfer.projection.yaml
+++ b/test/fixtures/valid/document-transfer.projection.yaml
@@ -1,0 +1,17 @@
+format: yarramate/projection/v1
+id: document-transfer-slice
+version: "1.0"
+query:
+  subjects:
+    - document-transfer#accept-document
+    - document-transfer#orchestrate-store
+    - document-transfer#persist-document
+    - document-transfer-policy#oauth-m2m
+    - document-transfer-policy#experience-rate-limit
+    - document-transfer-policy#ratelimit-not-applicable
+    - document-transfer-policy#at-least-once
+    - document-transfer-policy#https-rest
+  relationships: connected
+presentation:
+  title: Document transfer hop
+  description: Experience to process to eDRMS document store.

--- a/test/fixtures/valid/document-transfer.workspace.yaml
+++ b/test/fixtures/valid/document-transfer.workspace.yaml
@@ -1,0 +1,10 @@
+format: yarramate/workspace/v1
+id: document-transfer
+documents:
+  - document-transfer.yaml
+  - document-transfer.policy.yaml
+profiles: []
+projections:
+  - document-transfer.projection.yaml
+adapterMappings: []
+evidence: []

--- a/test/fixtures/valid/document-transfer.yaml
+++ b/test/fixtures/valid/document-transfer.yaml
@@ -1,0 +1,102 @@
+format: yarramate/v1
+id: document-transfer
+profile: yarramate/core@0.1
+concepts:
+  - id: claimant
+    kind: businessActor
+    name: Claimant
+  - id: document-exp-api
+    kind: applicationComponent
+    name: Document Experience API
+    status: planned
+  - id: document-prc-api
+    kind: applicationComponent
+    name: Document Process API
+    status: planned
+  - id: edrms-sys-api
+    kind: applicationComponent
+    name: eDRMS System API
+    status: planned
+  - id: accept-document
+    kind: applicationProcess
+    name: Accept document upload
+    status: planned
+    constraints:
+      - id: authn
+        ref: document-transfer-policy#oauth-m2m
+      - id: capacity
+        ref: document-transfer-policy#experience-rate-limit
+        expects:
+          provider: gateway
+          key: rps-per-client
+          value: "100"
+      - id: mechanism
+        ref: document-transfer-policy#https-rest
+      - id: reliability
+        ref: document-transfer-policy#at-least-once
+  - id: orchestrate-store
+    kind: applicationProcess
+    name: Orchestrate document store
+    status: planned
+    constraints:
+      - id: authn
+        ref: document-transfer-policy#oauth-m2m
+      - id: reliability
+        ref: document-transfer-policy#at-least-once
+  - id: persist-document
+    kind: applicationProcess
+    name: Persist document
+    status: planned
+    constraints:
+      - id: authn
+        ref: document-transfer-policy#oauth-m2m
+      - id: capacity
+        ref: document-transfer-policy#ratelimit-not-applicable
+      - id: reliability
+        ref: document-transfer-policy#at-least-once
+  - id: document-record
+    kind: contract
+    name: Document record
+    description: Authoritative document identifier and payload metadata.
+relationships:
+  - id: exp-assigned-accept
+    kind: assignment
+    from: document-exp-api
+    to: accept-document
+  - id: prc-assigned-orchestrate
+    kind: assignment
+    from: document-prc-api
+    to: orchestrate-store
+  - id: sys-assigned-persist
+    kind: assignment
+    from: edrms-sys-api
+    to: persist-document
+  - id: claimant-uses-accept
+    kind: serving
+    from: accept-document
+    to: claimant
+  - id: accept-flows-orchestrate
+    kind: flow
+    from: accept-document
+    to: orchestrate-store
+    content: Document payload
+  - id: orchestrate-flows-persist
+    kind: flow
+    from: orchestrate-store
+    to: persist-document
+    content: Document payload
+  - id: accept-writes-record
+    kind: access
+    from: accept-document
+    to: document-record
+    mode: write
+  - id: orchestrate-writes-record
+    kind: access
+    from: orchestrate-store
+    to: document-record
+    mode: read-write
+  - id: persist-writes-record
+    kind: access
+    from: persist-document
+    to: document-record
+    mode: write

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -1,0 +1,278 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const cataloguePath = join(repositoryRoot, 'catalogues/core-enrichment.yaml')
+
+const unenriched = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: exp
+    kind: applicationComponent
+    name: Experience API
+    status: planned
+  - id: sys
+    kind: applicationComponent
+    name: System API
+    status: planned
+relationships:
+  - id: exp-serves-sys
+    kind: serving
+    from: exp
+    to: sys
+`
+
+const unenrichedManifest = `format: yarramate/workspace/v1
+id: hop-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`
+
+describe('core-enrichment 0.9 interaction wave', () => {
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-interaction-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(join(workspace, 'architecture/main.yaml'), unenriched, 'utf8')
+    writeFileSync(join(workspace, 'workspace.yaml'), unenrichedManifest, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('authors askPlain on every 0.9 question', () => {
+    const catalogue = parseYaml(readFileSync(cataloguePath, 'utf8')) as {
+      version: string
+      questions: {
+        since?: string
+        askPlain?: string
+        id: string
+      }[]
+    }
+    expect(catalogue.version).toBe('0.9')
+    const added = catalogue.questions.filter((question) => question.since === '0.9')
+    expect(added.length).toBeGreaterThan(0)
+    for (const question of added) {
+      expect(question.askPlain?.trim().length, question.id).toBeGreaterThan(0)
+    }
+  })
+
+  it('serves hop-unrealised before owner-missing on a component hop', () => {
+    const result = runCli(
+      ['design', 'workspace.yaml', '--subject', 'main#exp', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0, result.stderr)
+    const payload = JSON.parse(result.stdout) as {
+      step: { questionId: string; wave: string }
+    }
+    expect(payload.step.wave).toBe('interaction')
+    expect(payload.step.questionId).toBe('hop-unrealised')
+  })
+
+  it('omits policy questions when yarramate/policy@0.1 is not selected', () => {
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0, result.stderr)
+    const ids = JSON.parse(result.stdout)
+      .report.waves.flatMap(
+        (wave: { questions: { id: string }[] }) => wave.questions,
+      )
+      .map((question: { id: string }) => question.id)
+    expect(ids).toContain('hop-unrealised')
+    expect(ids).not.toContain('authn-standard-missing')
+    expect(ids).not.toContain('interaction-trust-unbound')
+    expect(ids).not.toContain('interaction-protocol-unbound')
+  })
+
+  it('keeps trust open when only a rate-limit constraint is bound', () => {
+    writeFileSync(
+      join(workspace, 'architecture/policy.yaml'),
+      `format: yarramate/v1
+id: policy
+profile: yarramate/policy@0.1
+concepts:
+  - id: rps
+    kind: rate-limit-constraint
+    name: 100 rps
+relationships: []
+`,
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: accept
+    kind: applicationProcess
+    name: Accept
+    status: planned
+    constraints:
+      - id: capacity
+        ref: policy#rps
+  - id: user
+    kind: businessActor
+    name: User
+relationships:
+  - id: accept-serves-user
+    kind: serving
+    from: accept
+    to: user
+`,
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      `format: yarramate/workspace/v1
+id: hop-fixture
+documents:
+  - architecture/main.yaml
+  - architecture/policy.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`,
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0, result.stderr)
+    const ids = JSON.parse(result.stdout)
+      .report.waves.flatMap(
+        (wave: { questions: { id: string; open: boolean }[] }) =>
+          wave.questions,
+      )
+      .filter((question: { open: boolean }) => question.open)
+      .map((question: { id: string }) => question.id)
+    expect(ids).toContain('interaction-trust-unbound')
+    expect(ids).not.toContain('interaction-capacity-unbound')
+  })
+})
+
+describe('document-transfer against shipped catalogue 0.9', () => {
+  const workspace =
+    'test/fixtures/valid/document-transfer.workspace.yaml'
+
+  it('selects yarramate/policy@0.1 with no profile file in the workspace', () => {
+    const checked = runCli(['check', workspace, '--json'], repositoryRoot)
+    expect(checked.exitCode).toBe(0, checked.stderr)
+  })
+
+  it('has a quiet interaction wave on the reified hops', () => {
+    const result = runCli(
+      ['ask', workspace, '--open', '--json'],
+      repositoryRoot,
+    )
+    expect(result.exitCode).toBe(0, result.stderr)
+    const interaction = JSON.parse(result.stdout).report.waves.find(
+      (wave: { id: string }) => wave.id === 'interaction',
+    ) as { questions: { id: string; open: boolean }[] }
+    expect(interaction).toBeDefined()
+    const open = interaction.questions.filter((question) => question.open)
+    expect(open.map((question) => question.id)).toEqual([])
+  })
+
+  it('closes authn-standard-missing on a descendant of authentication-constraint', () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), 'yarramate-derived-authn-'))
+    try {
+      mkdirSync(join(workspaceDir, 'architecture'))
+      mkdirSync(join(workspaceDir, 'profiles'))
+      writeFileSync(
+        join(workspaceDir, 'profiles/org.yaml'),
+        `format: yarramate/profile/v1
+id: example/org
+version: "1.0"
+extends: yarramate/policy@0.1
+conceptKinds:
+  - id: oauth-constraint
+    name: OAuth constraint
+    parent: yarramate/policy@0.1#authentication-constraint
+relationshipKinds: []
+`,
+        'utf8',
+      )
+      writeFileSync(
+        join(workspaceDir, 'architecture/main.yaml'),
+        `format: yarramate/v1
+id: main
+profile: example/org@1.0
+concepts:
+  - id: oauth
+    kind: oauth-constraint
+    name: OAuth
+  - id: left
+    kind: applicationComponent
+    name: Left
+    status: planned
+  - id: right
+    kind: applicationComponent
+    name: Right
+    status: planned
+relationships:
+  - id: left-serves-right
+    kind: serving
+    from: left
+    to: right
+`,
+        'utf8',
+      )
+      writeFileSync(
+        join(workspaceDir, 'workspace.yaml'),
+        `format: yarramate/workspace/v1
+id: derived
+documents:
+  - architecture/main.yaml
+profiles:
+  - profiles/org.yaml
+projections: []
+adapterMappings: []
+evidence: []
+`,
+        'utf8',
+      )
+      const result = runCli(
+        ['ask', 'workspace.yaml', '--open', '--json'],
+        workspaceDir,
+      )
+      expect(result.exitCode).toBe(0, result.stderr)
+      const authn = JSON.parse(result.stdout)
+        .report.waves.flatMap(
+          (wave: { questions: { id: string; open: boolean }[] }) =>
+            wave.questions,
+        )
+        .find((question: { id: string }) => question.id === 'authn-standard-missing')
+      expect(authn?.open).toBe(false)
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -84,7 +84,7 @@ describe('core-enrichment 0.9 interaction wave', () => {
       ['design', 'workspace.yaml', '--subject', 'main#exp', '--json'],
       workspace,
     )
-    expect(result.exitCode).toBe(0, result.stderr)
+    expect(result.exitCode).toBe(0)
     const payload = JSON.parse(result.stdout) as {
       step: { questionId: string; wave: string }
     }
@@ -97,7 +97,7 @@ describe('core-enrichment 0.9 interaction wave', () => {
       ['ask', 'workspace.yaml', '--open', '--json'],
       workspace,
     )
-    expect(result.exitCode).toBe(0, result.stderr)
+    expect(result.exitCode).toBe(0)
     const ids = JSON.parse(result.stdout)
       .report.waves.flatMap(
         (wave: { questions: { id: string }[] }) => wave.questions,
@@ -165,7 +165,7 @@ evidence: []
       ['ask', 'workspace.yaml', '--open', '--json'],
       workspace,
     )
-    expect(result.exitCode).toBe(0, result.stderr)
+    expect(result.exitCode).toBe(0)
     const ids = JSON.parse(result.stdout)
       .report.waves.flatMap(
         (wave: { questions: { id: string; open: boolean }[] }) =>
@@ -184,7 +184,7 @@ describe('document-transfer against shipped catalogue 0.9', () => {
 
   it('selects yarramate/policy@0.1 with no profile file in the workspace', () => {
     const checked = runCli(['check', workspace, '--json'], repositoryRoot)
-    expect(checked.exitCode).toBe(0, checked.stderr)
+    expect(checked.exitCode).toBe(0)
   })
 
   it('has a quiet interaction wave on the reified hops', () => {
@@ -192,7 +192,7 @@ describe('document-transfer against shipped catalogue 0.9', () => {
       ['ask', workspace, '--open', '--json'],
       repositoryRoot,
     )
-    expect(result.exitCode).toBe(0, result.stderr)
+    expect(result.exitCode).toBe(0)
     const interaction = JSON.parse(result.stdout).report.waves.find(
       (wave: { id: string }) => wave.id === 'interaction',
     ) as { questions: { id: string; open: boolean }[] }
@@ -263,7 +263,7 @@ evidence: []
         ['ask', 'workspace.yaml', '--open', '--json'],
         workspaceDir,
       )
-      expect(result.exitCode).toBe(0, result.stderr)
+      expect(result.exitCode).toBe(0)
       const authn = JSON.parse(result.stdout)
         .report.waves.flatMap(
           (wave: { questions: { id: string; open: boolean }[] }) =>

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -558,6 +558,450 @@ describe('ask --open interrogation', () => {
     ).toEqual(['main#customer'])
   })
 
+  it('opens has-linkage including a flow sink via direction either', () => {
+    const linkageCatalogue =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: linkage-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: interaction\n' +
+      '    name: Interaction\n' +
+      'questions:\n' +
+      '  - id: hop-unrealised\n' +
+      '    wave: interaction\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+      '    trigger:\n' +
+      '      - condition: has-linkage\n' +
+      '        kinds: ["yarramate/core@0.1#flow"]\n' +
+      '        direction: either\n' +
+      '        counterpartKinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+      '      - condition: missing-linkage\n' +
+      '        kinds: ["yarramate/core@0.1#assignment"]\n' +
+      '        direction: outgoing\n' +
+      '        counterpartKinds: ["yarramate/core@0.1#applicationProcess"]\n' +
+      '    question: What process is {subject.name} assigned to for this hop?\n' +
+      '    materiality: A hop with no assigned behavior is inventory.\n' +
+      '    authority: either\n' +
+      '    resolution: Assign a process.\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), linkageCatalogue, 'utf8')
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: source\n' +
+        '    kind: applicationComponent\n' +
+        '    name: Source\n' +
+        '  - id: sink\n' +
+        '    kind: applicationComponent\n' +
+        '    name: Sink\n' +
+        'relationships:\n' +
+        '  - id: source-flows-sink\n' +
+        '    kind: flow\n' +
+        '    from: source\n' +
+        '    to: sink\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      'format: yarramate/workspace/v1\n' +
+        'id: interrogate-fixture\n' +
+        'documents:\n' +
+        '  - architecture/main.yaml\n' +
+        'profiles: []\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'evidence: []\n',
+      'utf8',
+    )
+    const before = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(before.exitCode).toBe(0)
+    const openIds = JSON.parse(before.stdout)
+      .report.waves[0].questions[0].subjects.map(
+        (subject: { readonly id: string }) => subject.id,
+      )
+      .sort()
+    expect(openIds).toEqual(['main#sink', 'main#source'])
+
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: source\n' +
+        '    kind: applicationComponent\n' +
+        '    name: Source\n' +
+        '  - id: sink\n' +
+        '    kind: applicationComponent\n' +
+        '    name: Sink\n' +
+        '  - id: ship\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Ship\n' +
+        'relationships:\n' +
+        '  - id: source-flows-sink\n' +
+        '    kind: flow\n' +
+        '    from: source\n' +
+        '    to: sink\n' +
+        '  - id: source-assigned\n' +
+        '    kind: assignment\n' +
+        '    from: source\n' +
+        '    to: ship\n' +
+        '  - id: sink-assigned\n' +
+        '    kind: assignment\n' +
+        '    from: sink\n' +
+        '    to: ship\n',
+      'utf8',
+    )
+    const after = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(after.exitCode).toBe(0)
+    expect(JSON.parse(after.stdout).report.summary.open).toBe(0)
+  })
+
+  it('omits questions that name unselected profile kinds rather than closing or sticking open', () => {
+    const policyCatalogue =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: policy-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: interaction\n' +
+      '    name: Interaction\n' +
+      'questions:\n' +
+      '  - id: authn-standard-missing\n' +
+      '    wave: interaction\n' +
+      '    scope: workspace\n' +
+      '    trigger:\n' +
+      '      - condition: no-subject-of-kind\n' +
+      '        kinds: ["example/policy@1.0#authentication-constraint"]\n' +
+      '    question: What is the default authentication mechanism?\n' +
+      '    materiality: Unbound hops pick a mechanism in code.\n' +
+      '    authority: human\n' +
+      '    resolution: Add an authentication-constraint.\n' +
+      '  - id: hop-trust\n' +
+      '    wave: interaction\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["example/policy@1.0#authentication-constraint"]\n' +
+      '    trigger:\n' +
+      '      - condition: isolated\n' +
+      '    question: Isolated policy subject {subject.name}?\n' +
+      '    materiality: Unused policy is noise.\n' +
+      '    authority: either\n' +
+      '    resolution: Bind it or remove it.\n' +
+      '  - id: outcome-missing\n' +
+      '    wave: interaction\n' +
+      '    scope: workspace\n' +
+      '    trigger:\n' +
+      '      - condition: no-subject-of-kind\n' +
+      '        kinds: ["yarramate/core@0.1#goal"]\n' +
+      '    question: What outcome justifies this system?\n' +
+      '    materiality: Without a goal every trade-off becomes taste.\n' +
+      '    authority: human\n' +
+      '    resolution: Add a goal.\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), policyCatalogue, 'utf8')
+    writeFileSync(
+      join(workspace, 'profiles/policy.yaml'),
+      readFileSync(
+        join(repositoryRoot, 'test/fixtures/valid/document-transfer.profile.yaml'),
+        'utf8',
+      ),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      'format: yarramate/workspace/v1\n' +
+        'id: interrogate-fixture\n' +
+        'documents:\n' +
+        '  - architecture/main.yaml\n' +
+        'profiles:\n' +
+        '  - profiles/platform.yaml\n' +
+        '  - profiles/policy.yaml\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'evidence: []\n',
+      'utf8',
+    )
+    const loadedUnselected = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(loadedUnselected.exitCode).toBe(0)
+    const loadedReport = JSON.parse(loadedUnselected.stdout).report
+    expect(loadedReport.summary.questions).toBe(1)
+    expect(loadedReport.waves[0].questions.map((q: { id: string }) => q.id)).toEqual(
+      ['outcome-missing'],
+    )
+
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      'format: yarramate/workspace/v1\n' +
+        'id: interrogate-fixture\n' +
+        'documents:\n' +
+        '  - architecture/main.yaml\n' +
+        'profiles:\n' +
+        '  - profiles/platform.yaml\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'evidence: []\n',
+      'utf8',
+    )
+    const coreOnly = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(coreOnly.exitCode).toBe(0)
+    expect(JSON.parse(coreOnly.stdout).report).toEqual(loadedReport)
+  })
+
+  it('closes no-subject-of-kind when the only match is a descendant kind', () => {
+    writeFileSync(
+      join(workspace, 'profiles/platform.yaml'),
+      'format: yarramate/profile/v1\n' +
+        'id: example/platform\n' +
+        'version: "1.0"\n' +
+        'extends: yarramate/core@0.1\n' +
+        'conceptKinds:\n' +
+        '  - id: platform-team\n' +
+        '    name: Platform team\n' +
+        '    parent: yarramate/core@0.1#businessActor\n' +
+        '  - id: specialized-goal\n' +
+        '    name: Specialized goal\n' +
+        '    parent: yarramate/core@0.1#goal\n' +
+        'relationshipKinds: []\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: example/platform@1.0\n' +
+        'concepts:\n' +
+        '  - id: north-star\n' +
+        '    kind: specialized-goal\n' +
+        '    name: North star\n' +
+        'relationships: []\n',
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const report = JSON.parse(result.stdout).report
+    const goalMissing = report.waves
+      .flatMap((wave: { questions: { id: string; open: boolean }[] }) =>
+        wave.questions,
+      )
+      .find((question: { id: string }) => question.id === 'goal-missing')
+    expect(goalMissing.open).toBe(false)
+  })
+
+  it('does not let a rate-limit constraint close a missing authentication constraint', () => {
+    writeFileSync(
+      join(workspace, 'profiles/policy.yaml'),
+      readFileSync(
+        join(repositoryRoot, 'test/fixtures/valid/document-transfer.profile.yaml'),
+        'utf8',
+      ),
+      'utf8',
+    )
+    const constraintCatalogue =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: constraint-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: interaction\n' +
+      '    name: Interaction\n' +
+      'questions:\n' +
+      '  - id: trust-unbound\n' +
+      '    wave: interaction\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#applicationProcess"]\n' +
+      '    trigger:\n' +
+      '      - condition: missing-constraint\n' +
+      '        kinds: ["example/policy@1.0#authentication-constraint"]\n' +
+      '    question: How is trust established for {subject.name}?\n' +
+      '    materiality: An unbound hop picks a mechanism in code.\n' +
+      '    authority: either\n' +
+      '    resolution: Bind an authentication-constraint.\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), constraintCatalogue, 'utf8')
+    writeFileSync(
+      join(workspace, 'architecture/policy.yaml'),
+      'format: yarramate/v1\n' +
+        'id: policy\n' +
+        'profile: example/policy@1.0\n' +
+        'concepts:\n' +
+        '  - id: oauth\n' +
+        '    kind: authentication-constraint\n' +
+        '    name: OAuth\n' +
+        '  - id: rps\n' +
+        '    kind: rate-limit-constraint\n' +
+        '    name: 100 rps\n' +
+        'relationships: []\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: accept\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Accept\n' +
+        '    constraints:\n' +
+        '      - id: capacity\n' +
+        '        ref: policy#rps\n' +
+        'relationships: []\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      'format: yarramate/workspace/v1\n' +
+        'id: interrogate-fixture\n' +
+        'documents:\n' +
+        '  - architecture/main.yaml\n' +
+        '  - architecture/policy.yaml\n' +
+        'profiles:\n' +
+        '  - profiles/policy.yaml\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'evidence: []\n',
+      'utf8',
+    )
+    const onlyRate = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(onlyRate.exitCode).toBe(0)
+    expect(JSON.parse(onlyRate.stdout).report.summary.open).toBe(1)
+
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: accept\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Accept\n' +
+        '    constraints:\n' +
+        '      - id: capacity\n' +
+        '        ref: policy#rps\n' +
+        '      - id: authn\n' +
+        '        ref: policy#oauth\n' +
+        'relationships: []\n',
+      'utf8',
+    )
+    const both = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(both.exitCode).toBe(0)
+    expect(JSON.parse(both.stdout).report.summary.open).toBe(0)
+  })
+
+  it('opens missing-flow-content until every touching flow has content', () => {
+    const flowCatalogue =
+      'format: yarramate/question-catalogue/v1\n' +
+      'id: flow-fixture\n' +
+      'version: "1.0"\n' +
+      'profile: yarramate/core@0.1\n' +
+      'waves:\n' +
+      '  - id: interaction\n' +
+      '    name: Interaction\n' +
+      'questions:\n' +
+      '  - id: content-unknown\n' +
+      '    wave: interaction\n' +
+      '    scope: subject\n' +
+      '    subjects:\n' +
+      '      kinds: ["yarramate/core@0.1#applicationProcess"]\n' +
+      '    trigger:\n' +
+      '      - condition: missing-flow-content\n' +
+      '    question: What does {subject.name} move?\n' +
+      '    materiality: A flow with no content is an unnamed payload.\n' +
+      '    authority: either\n' +
+      '    resolution: Set flow content.\n'
+    writeFileSync(join(workspace, 'catalogue.yaml'), flowCatalogue, 'utf8')
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: send\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Send\n' +
+        '  - id: receive\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Receive\n' +
+        'relationships:\n' +
+        '  - id: send-flows-receive\n' +
+        '    kind: flow\n' +
+        '    from: send\n' +
+        '    to: receive\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      'format: yarramate/workspace/v1\n' +
+        'id: interrogate-fixture\n' +
+        'documents:\n' +
+        '  - architecture/main.yaml\n' +
+        'profiles: []\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'evidence: []\n',
+      'utf8',
+    )
+    const before = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(before.exitCode).toBe(0)
+    expect(JSON.parse(before.stdout).report.summary.open).toBe(2)
+
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      'format: yarramate/v1\n' +
+        'id: main\n' +
+        'profile: yarramate/core@0.1\n' +
+        'concepts:\n' +
+        '  - id: send\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Send\n' +
+        '  - id: receive\n' +
+        '    kind: applicationProcess\n' +
+        '    name: Receive\n' +
+        'relationships:\n' +
+        '  - id: send-flows-receive\n' +
+        '    kind: flow\n' +
+        '    from: send\n' +
+        '    to: receive\n' +
+        '    content: Document payload\n',
+      'utf8',
+    )
+    const after = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml', '--json'],
+      workspace,
+    )
+    expect(after.exitCode).toBe(0)
+    expect(JSON.parse(after.stdout).report.summary.open).toBe(0)
+  })
+
   it('keeps the shipped catalogue fully closed on the repository self-model', () => {
     const result = runCli(
       ['ask', '.yarramate/workspace.yaml', '--open', '--json'],

--- a/test/journeys.test.ts
+++ b/test/journeys.test.ts
@@ -131,6 +131,10 @@ describe('agent journeys through the stable CLI', () => {
     expect(skill).toContain('yarramate ask')
     expect(skill).toContain('yarramate apply')
     expect(skill).toContain('yarramate design')
+    expect(skill).toContain('design --json')
+    expect(skill).toContain('wave')
+    expect(skill).toContain('yarramate/policy@0.1')
+    expect(skill).toContain('interaction')
     expect(skill.match(/yarramate export graph/g)).toHaveLength(2)
     for (const removed of [
       'yarramate status',

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -45,6 +45,7 @@ describe('consumer package contract', () => {
       'assets/likec4',
       'schema',
       'catalogues',
+      'profiles',
       'skills/yarramate-architecture',
       'docs/CONSUMING-YARRAMATE.md',
     ])
@@ -102,6 +103,8 @@ describe('consumer package contract', () => {
       expect(files).toContain('package/dist/cli.js')
       expect(files).toContain('package/assets/likec4/specification.likec4')
       expect(files).toContain('package/schema/yarramate-document.schema.json')
+      expect(files).toContain('package/profiles/yarramate-policy.yaml')
+      expect(files).toContain('package/catalogues/core-enrichment.yaml')
       expect(files).toContain(
         'package/schema/yarramate-reconciliation-report.schema.json',
       )


### PR DESCRIPTION
## Summary

API-heavy models that already pass `check` were interviewed as ontology inventories: `design` served `owner-missing` (and kind/hosting/attestation questions) before any hop-level decision. This change adds an `interaction` wave to `core-enrichment` 0.9 and a shipped optional profile `yarramate/policy@0.1` so authentication, rate limit, reliability, and serving protocol close independently.

The compiler injects the policy profile when a document selects `yarramate/policy@0.1` or another profile extends it; no workspace copy is required. Questions that name kinds from a profile no document has selected are omitted from `ask --open`, not reported closed. A rate-limit binding does not close an authentication question.

Adoption is multi-document: policy subjects live on a document that selects the policy profile; components may stay on an existing org profile and bind with qualified `constraints[].ref`.

Direction and the rejected alternatives (domain interrogation profiles, protocol fields on `serving`, “at least one constraint”) are in `docs/superpowers/specs/2026-08-20-interaction-first-interrogation-design.md`. ADR 0095 distinguishes this vocabulary from ADR 0087 (notation is presentation).

`interaction-mechanism-unknown` as first drafted opened on every assigned process with no outgoing hop, including this repository’s self-model. It is not in 0.9; choosing serving/triggering/flow is part of the `hop-unrealised` resolution.

## Validation

- `pnpm run verify` (typecheck, build, 1129 tests, self-check, LikeC4 validate)

## Related issue

#205

## Contract impact

- Catalogue `core-enrichment` 0.8 → 0.9 (additive: new wave and questions; `no-subject-of-kind` now honours descendant matching, a trigger loosening of four existing workspace questions).
- New interrogation conditions: `has-linkage`, `exists-linkage`, `missing-constraint`, `missing-flow-content`.
- New shipped profile identity `yarramate/policy@0.1` (ADR 0095).
- Inapplicable questions omitted from `yarramate/interrogation-report/v1` (`summary.questions` counts applicable questions only).
- No Core relationship fields; no CLI flag for catalogues as the default agent path.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.