### PR TITLE
chore: prepare 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.23.0
 
 - Interrogation: `has-linkage`, `exists-linkage` (`direction` includes
   `either`), `missing-constraint`, and `missing-flow-content` conditions.

--- a/assets/taglines.txt
+++ b/assets/taglines.txt
@@ -1,8 +1,9 @@
 # yarramate.dev rotating hero taglines.
 # Line 1 (first non-comment line) is the released version; every later
 # non-empty line is one tagline. Update with each release — docs/RELEASING.md.
-v0.22.0
+v0.23.0
 a design interview any agent can resume.
+the hop questions before the owner questions.
 the map your coding agents share.
 architecture your CI can check.
 a model that knows what's missing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Bump the package to 0.23.0 so consumers can pick up hop-first interrogation (`core-enrichment` 0.9) and the shipped optional profile `yarramate/policy@0.1` from npm. Folds the Unreleased changelog notes into 0.23.0 and sets the yarramate.dev tagline version to `v0.23.0`.

The product change landed in #206. This PR is the version, changelog, and tagline bump only.

## Validation

- `pnpm --version` is 11.7.0 (`packageManager`)
- `pnpm install --frozen-lockfile`
- `pnpm run verify` (typecheck, build, 1129 tests, self-check, LikeC4 validate)
- `npm pack --dry-run`: `yarramate@0.23.0`, 158 files, ~893 kB
  - includes runtime, schemas, `catalogues/core-enrichment.yaml`, `profiles/yarramate-policy.yaml`, skill, `docs/CONSUMING-YARRAMATE.md`, README, LICENSE
  - does not include `src/`, `test/`, `.yarramate/`, or research docs

## Related issue

Follows #206 / #205. No new issue.

## Contract impact

None. Version, changelog heading, and taglines only. Semantic changes already merged.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.