### PR TITLE
feat(visual)!: publish session paths as canonical file URIs (protocol v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- **Breaking.** Visual session paths are published as canonical local `file:`
+  URIs rather than bare path strings (ADR 0096). `sessionRoot`,
+  `descriptorPath`, `journalPath`, and `transcriptPath` are encoded with
+  `pathToFileURL` and decoded with `fileURLToPath`, refusing anything
+  malformed, nonlocal, or noncanonical as `YMVS414` before a descriptor's
+  bearer capabilities are read. This closes two defects the old
+  backslash-to-slash transform could not: two distinct native paths could
+  produce one indistinguishable wire string, and a UNC path passed as an
+  ordinary local one. `yarramate/visual-protocol/v3` becomes `v4`;
+  `visual-session-started`, `visual-session-descriptor`, and `visual-handoff`
+  become `v2`; the eight documents that carry no path stay at `v1`. A v3
+  document is refused, never translated. `yarramate-visual
+  wait|respond|status|recover|stop` now take the exact `descriptorPath` URI
+  `start` published, copied back verbatim: a native path is refused, and the
+  argument is no longer resolved against the working directory (#208).
+
 ## 0.23.0
 
 - Interrogation: `has-linkage`, `exists-linkage` (`direction` includes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,8 +150,8 @@ notation.
   `.yarramate/visual-layout` sidecars. Dropdown-constrained field edits
   accumulate in a changeset that commits through `yarramate/operations/v1` and
   `yarramate apply`, so the browser holds no private write path. The wire is
-  the published `yarramate/visual-protocol/v3` contract; see
-  `docs/VISUAL-ADAPTER.md` and ADRs 0081 and 0084 to 0088. Ordered in-app
+  the published `yarramate/visual-protocol/v4` contract; see
+  `docs/VISUAL-ADAPTER.md` and ADRs 0081, 0084 to 0088, and 0096. Ordered in-app
   undo and redo over the staged changeset walks an ordered history of whole
   staged-operation snapshots, covering staging, one discarded row, and a
   discard-all alike, and stops at the commit: what has landed is reverted with

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -140,11 +140,11 @@ than leaving a stale named view selected.
 yarramate-visual request [--view <id>] [--title <text>]
                          [--description <text>] [--chat]
 yarramate-visual start <request.json>
-yarramate-visual wait <descriptor.json> [--after <sequence>]
-yarramate-visual respond <descriptor.json> <response.json>
-yarramate-visual status <descriptor.json>
-yarramate-visual recover <descriptor.json> [--transcript]
-yarramate-visual stop <descriptor.json> [--transcript]
+yarramate-visual wait <descriptor-uri> [--after <sequence>]
+yarramate-visual respond <descriptor-uri> <response.json>
+yarramate-visual status <descriptor-uri>
+yarramate-visual recover <descriptor-uri> [--transcript]
+yarramate-visual stop <descriptor-uri> [--transcript]
 ```
 
 `request` is the only verb that reads the repository instead of a session: it
@@ -157,10 +157,12 @@ hand-authors one. A workspace that cannot be read or cannot compile refuses
 here, before any session exists, with the compiler's own diagnostics.
 
 `start` is a managed foreground process, not a one-shot call: it publishes one
-`yarramate/visual-session-started/v1` line on stdout carrying `browserUrl` and
+`yarramate/visual-session-started/v2` line on stdout carrying `browserUrl` and
 `descriptorPath`, then blocks, serving the session until `stop` ends it. Every
 other command is an ordinary one-shot call against the printed
-`descriptorPath`. A harness with no facility for hosting a foreground process
+`descriptorPath`, which is a canonical local `file:` URI and is passed back
+verbatim: it is never hand-typed as a native path and never resolved against
+the working directory (ADR 0096). A harness with no facility for hosting a foreground process
 across tool calls cannot run this journey; fall back to `yarramate ask`,
 `export markdown`, or `yarramate-likec4 export-project`.
 
@@ -170,8 +172,12 @@ Eleven closed `yarramate/visual-*/v1` JSON documents, each with
 `additionalProperties: false`, published from `./schema`:
 session request, session started, session descriptor, event, response,
 status, handoff, model, graph, layout, and diagnostic result.
-`yarramate/visual-protocol/v3` is the version the started result, the
-descriptor, and status agree on. The wire is a published contract, not a
+`yarramate/visual-protocol/v4` is the version the started result, the
+descriptor, and status agree on. Every filesystem path any of these documents
+carries - `sessionRoot`, `descriptorPath`, `journalPath`, `transcriptPath` - is
+a canonical local `file:` URI rather than a bare path string, which is why the
+three documents that carry one are at `v2` while the eight that do not stay at
+`v1` (ADR 0096). The wire is a published contract, not a
 process-local convention, because the journal that recovers a crashed session
 has to be readable by a process that did not write it — see
 [ADR 0081](adr/0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md).

--- a/docs/adr/0096-visual-session-paths-are-published-as-canonical-file-uris.md
+++ b/docs/adr/0096-visual-session-paths-are-published-as-canonical-file-uris.md
@@ -1,0 +1,141 @@
+# Visual session paths are published as canonical file URIs
+
+Status: accepted
+
+`VisualSessionDescriptor`, `VisualSessionStarted`, and `VisualHandoff` carry
+absolute filesystem paths — `sessionRoot`, `descriptorPath`, `journalPath`,
+`transcriptPath`. Until now those were bare strings, minted by a single string
+transform in `src/adapters/visual/protocol.ts` that replaced every backslash
+with a forward slash. This ADR records replacing that representation with
+canonical local `file:` URIs, encoded and decoded through Node's own
+`pathToFileURL`/`fileURLToPath`, and the version bumps that follow.
+
+## Why a lossy transform was not enough
+
+The transform stood in for a path encoding without being one. It fails in both
+directions.
+
+**It aliases.** A POSIX directory whose own name contains a literal backslash
+and a Windows path joined with native separators collapse to indistinguishable
+forward-slash text. That is not theoretical: it is the defect that opened this
+work. Before the fix on this branch, `visualSessionPaths` returned the mangled
+form, so `fs` calls against the marker, the journal, and the root missed the
+directory `createVisualSession` had just made. Moving the mangling to the
+serialization sites stopped the ENOENT without restoring an invertible mapping:
+two distinct native paths could still produce one wire string, and nothing
+detected it.
+
+**It has no concept of a host.** A UNC path became a double-slash-rooted
+string, which satisfied the schema's POSIX-rooted pattern as an ordinary local
+path. [ADR 0081](0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md)
+fixes the runtime's authorization model on a server that is loopback and
+ephemeral, with nothing shareable, resumable, or reachable from another
+machine. A session document that can silently name a network share breaks that
+invariant at the one layer a consuming harness cannot independently re-check.
+
+**It cannot back a proof of identity.** `readVisualSessionDescriptor` treats an
+on-disk descriptor as hostile until its `sessionRoot`/`journalPath` are shown
+to name the same file the CLI was told to open (`YMVS403`). That check was a
+byte compare of two transform outputs. A transform with no defined canonical
+form and no inverse cannot prove two paths are the same file; it can only fail
+to disprove it, which is a materially weaker guarantee for the check that gates
+whether the descriptor's bearer capabilities are spent at all.
+
+## Decided
+
+Every path field on the wire is a canonical local `file:` URI.
+
+- **Encode** is `pathToFileURL(native).href`, at the sites that previously
+  called the string transform and nowhere else. `VisualSessionPaths` stays
+  native throughout: it is consumed as a filesystem path far more often than it
+  is serialized, so encoding belongs at the boundary rather than at its source.
+- **Decode** is `fileURLToPath`, wrapped so every failure Node itself raises is
+  a refusal rather than an exception, and gated on two further checks: the
+  URL's host must be empty, and re-encoding the decoded path must reproduce the
+  input byte for byte. A URI that decodes but does not re-encode to itself is
+  refused as noncanonical, never repaired.
+- The old `toWireAbsolutePath` is deleted rather than deprecated.
+
+`file:` URIs win over a stricter regex because a pattern can describe what a
+string looks like but not which native path it denotes, and aliasing is exactly
+two inputs sharing one appearance. They win over a custom tagged format
+(a platform tag beside a path) because `pathToFileURL`/`fileURLToPath` are the
+runtime's existing, dependency-free, already-vetted answer to this problem, and
+a custom format would still need its own round-trip check to earn the same
+guarantee. The host check falls out of the same primitive: `pathToFileURL`
+leaves the host empty for every local path, so "nonlocal" is an empty-hostname
+test rather than a rule to invent.
+
+Refusals are reported as **`YMVS414`**, one code with three message shapes
+(malformed, nonlocal, noncanonical), following the convention `YMVS401` already
+sets by covering two distinct underlying causes. `YMVS401`, `YMVS402`, and
+`YMVS403` keep their meanings and now run after a successful decode, on a path
+already proven canonical.
+
+Per ADR 0081's own "what the schemas alone do not say" precedent, JSON Schema
+cannot express "is a canonical local file URI". The `sessionFileUri` definition
+keeps a coarse structural gate, requiring the three-slash local form that a
+UNC-derived URI fails outright; the real enforcement lives in `protocol.ts`
+beside the Ajv validators, where the byte-length and path-confinement checks
+already live.
+
+## Why this bumps the wire, and what it does not bump
+
+[ADR 0088](0088-removing-the-agents-mutation-path-bumps-the-wire.md) drew the
+line between a document that grew a member and a member whose contract changed.
+A field that was a bare path and is now a URI is the second kind: the name is
+identical, so nothing about the shape of the document warns a v3 consumer, and
+every such field it reads decodes to something it will use as a filesystem
+path. That is precisely the detectable incompatibility the version exists to
+turn into a refusal.
+
+- `VISUAL_PROTOCOL_VERSION` becomes `yarramate/visual-protocol/v4`, pinned as a
+  `const` in the three documents that agree on it (started, descriptor, and
+  status), so a v3 consumer meets the mismatch in whichever it reads first.
+- The three documents that carry a path move to `v2`:
+  `visual-session-started`, `visual-session-descriptor`, `visual-handoff`.
+- The eight that carry no path stay at `v1`. `visual-status` keeps
+  `yarramate/visual-status/v1` and moves only its `protocolVersion` const,
+  exactly the detection-only case ADR 0088 recorded for itself.
+
+## Not a compatibility shim
+
+A v3 document is refused by `const` mismatch through the existing parse codes,
+with a diagnostic pointing at `/format` or `/protocolVersion`. There is no
+dual-read path, no translation, and no bespoke "v3 detected" code, matching
+ADR 0088's own choice not to special-case the shape it removed. A v3 runtime
+and a v4 CLI refuse each other at the first document exchanged.
+
+The CLI argument breaks with it. `wait`, `respond`, `status`, `recover`, and
+`stop` took a native path resolved against `cwd`; they now take the exact
+`descriptorPath` URI `start` published, copied back verbatim by the calling
+skill or harness. Working-directory resolution is removed from that argument
+rather than kept alongside: a `file:` URI is inherently absolute, so the class
+of ambiguity this change closes cannot re-enter through the one string an
+operator still passes by hand. A native path is refused with `YMVS414`, which
+is the intended behavior and is asserted as such.
+
+## Consequences
+
+- Two distinct native paths can no longer produce one accepted wire string, and
+  one native path has exactly one accepted spelling.
+- A nonlocal path can never appear as a valid `sessionRoot`, `descriptorPath`,
+  `journalPath`, or `transcriptPath`.
+- The `YMVS403` ownership check strengthens rather than merely moving: both
+  sides of the compare are independently round-trip-verified first, so a match
+  proves the descriptor names the file that was opened.
+- A `localhost` file host is refused as noncanonical rather than nonlocal.
+  WHATWG `URL` normalizes that host away before the host check sees it, leaving
+  a URI that is simply not the spelling this codec mints. It is refused either
+  way; only the reported reason differs.
+- The length bound on a path field doubles to 8192, sized for a path whose
+  every byte needs three characters of percent-encoding. This widens the wire
+  envelope, not the 4096-byte native path bound, which is unchanged.
+- Case-insensitive-filesystem aliasing is untouched. `pathToFileURL` and
+  `fileURLToPath` are pure string functions with no filesystem access, so they
+  cannot resolve case folding, and nothing else in this codebase does either.
+  That is a pre-existing platform property of every path this runtime already
+  handles, not something this change introduces.
+
+The design this ADR was written against is
+`docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md`.

--- a/docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md
+++ b/docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md
@@ -1,8 +1,14 @@
 # Visual wire paths as canonical `file:` URIs (protocol v4)
 
 **Date:** 2026-08-21
-**Status:** Approved design — not yet implemented. This document specifies
-the change; no source, schema, or test file is touched by it.
+**Status:** Implemented. This document specified the change; it is recorded as
+[ADR 0096](../../adr/0096-visual-session-paths-are-published-as-canonical-file-uris.md)
+and landed on this branch. Two details resolved differently in implementation
+and are noted where they occur: a `localhost` file host lands in the
+`noncanonical` refusal rather than `nonlocal` (WHATWG `URL` normalizes that
+host away before the host check can see it), and an over-encoded path
+separator lands in `malformed` because `fileURLToPath` refuses it itself. Both
+are still refused; only the reported reason differs from the sketch below.
 
 Supersedes the intent of commit `7663f0a` ("keep VisualSessionPaths native,
 wire-normalize only at the boundary") on this branch. That commit is a

--- a/docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md
+++ b/docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md
@@ -1,0 +1,403 @@
+# Visual wire paths as canonical `file:` URIs (protocol v4)
+
+**Date:** 2026-08-21
+**Status:** Approved design — not yet implemented. This document specifies
+the change; no source, schema, or test file is touched by it.
+
+Supersedes the intent of commit `7663f0a` ("keep VisualSessionPaths native,
+wire-normalize only at the boundary") on this branch. That commit is a
+correctness patch for `toWireAbsolutePath`'s worst symptom and is **not**
+merge-ready: it leaves the representation this design replaces in place. Its
+regression test (a POSIX directory name containing a literal backslash) is
+valuable evidence and is kept in the verification matrix below, but the fix
+it accompanies does not ship as-is.
+
+## Problem and the security invariant at stake
+
+`VisualSessionDescriptor`, `VisualSessionStarted`, and `VisualHandoff` carry
+absolute filesystem paths — `sessionRoot`, `descriptorPath`, `journalPath`,
+`transcriptPath` — as bare strings validated by `$defs.absolutePath`
+(`schema/yarramate-visual-session-started.schema.json`, pattern
+`^(?:/|[A-Za-z]:/)[^\u0000\\]*$`) and produced by
+`toWireAbsolutePath` (`src/adapters/visual/protocol.ts`):
+
+```ts
+export const toWireAbsolutePath = (native: string): string =>
+  native.replace(/\\/g, '/')
+```
+
+This is a lossy, non-invertible string transform standing in for a real
+filesystem-path encoding, and it fails in both directions:
+
+- **Aliasing.** A POSIX path whose own name contains a literal backslash
+  (`/tmp/yarramate-visual-\store-abc/…`) and a Windows path joined with
+  native separators both collapse to indistinguishable forward-slash text.
+  Commit `7663f0a`'s regression test proves this concretely: before that
+  fix, `visualSessionPaths` returned the mangled form, so `fs` calls against
+  `paths.marker`/`paths.journal`/`paths.root` missed the directory
+  `createVisualSession` actually created. `7663f0a` moved the mangling to
+  the three serialization sites, which stops the ENOENT but does not
+  restore an invertible mapping: two distinct native paths can still
+  produce the same wire string, and nothing detects it.
+- **Nonlocal paths pass as local.** `toWireAbsolutePath` has no concept of a
+  host. A UNC path such as `\\server\share\x` becomes `//server/share/x`,
+  which satisfies the current `^/[^\u0000]*$`-descended pattern as an
+  ordinary POSIX-rooted path. ADR 0081 fixes the runtime's authorization
+  model on the server being "loopback and ephemeral... nothing shareable,
+  resumable, or reachable from another machine" — a session document that
+  can silently name a network share violates that invariant at the one
+  layer (the wire) that a consuming harness has no independent way to
+  re-check.
+- **No round-trip guarantee on untrusted input.** `readVisualSessionDescriptor`
+  (`src/adapters/visual/client.ts`) treats an on-disk descriptor as
+  untrusted until its `sessionRoot`/`journalPath` are proven to name the
+  same file the CLI was told to open (`YMVS403`). That check is currently a
+  byte-string compare of two `toWireAbsolutePath` outputs. A transform with
+  no defined canonical form and no reversal function cannot back a proof
+  of identity; it can only fail to *disprove* one, which is a materially
+  weaker guarantee for a check that gates whether the descriptor's bearer
+  capabilities (`browserUrl`'s bootstrap key, `webSocketUrl`) get used at
+  all.
+
+**The invariant this design restores:** every filesystem path a visual
+protocol document carries is a canonical `file:` URI with a defined,
+lossless native-path encoding and a decode path that refuses anything that
+is not unambiguously one specific local file. "Descriptor authority" — the
+embedded bearer capabilities — is never exercised on a document whose path
+fields have not first passed that decode.
+
+## Non-goals
+
+- Changing how `sessionId`, `browserUrl`, `webSocketUrl`, or any bearer
+  capability is minted, transported, or authenticated. The URI change is
+  about path fields only; capability handling is untouched.
+- Fixing case-insensitive-filesystem aliasing (e.g. `/Users/Foo` vs.
+  `/users/foo` on default APFS or NTFS). `pathToFileURL`/`fileURLToPath`
+  are pure string functions with no filesystem access; they cannot and do
+  not resolve case-folding, and neither does anything else in this
+  codebase today (`resolve()` doesn't either). This is a pre-existing
+  platform property of every path this runtime already handles, not
+  something introduced by or fixable through the wire representation.
+- Preserving support for a hand-typed native or `cwd`-relative path as the
+  operator-facing CLI argument to `wait`/`respond`/`status`/`recover`/
+  `stop`. §CLI cutover below makes that argument the published URI, full
+  stop; this is a deliberate compatibility break, not an oversight.
+- Model-source relative-path confinement (`isConfinedRelativePath`,
+  `.yarramate/…` document paths). That check already lives in a disjoint
+  code path with its own already-correct POSIX-only rule and is unaffected.
+- Writing the ADR, schema, parser, CLI, fixtures, or tests. This document
+  is the specification those land against.
+
+## Chosen representation: canonical local `file:` URIs
+
+Every absolute path field on the wire (`sessionRoot`, `descriptorPath`,
+`journalPath`, `transcriptPath`) becomes a `file:` URI string, encoded and
+decoded exclusively through Node's own URL primitives:
+
+- **Encode** (native → wire): `pathToFileURL(nativePath).href`, at the
+  handful of sites that currently call `toWireAbsolutePath` — nowhere else.
+  `VisualSessionPaths` (`src/adapters/visual/session-store.ts`) stays
+  native, exactly as `7663f0a` left it; `visualSessionPaths(root)` is
+  unconditionally native `resolve`/`join` output and is never serialized
+  directly. This half of `7663f0a`'s change is correct and is kept.
+- **Decode** (wire → native, untrusted input): `fileURLToPath(uri)`,
+  wrapped so every failure mode Node itself raises
+  (`ERR_INVALID_URL`, `ERR_INVALID_URL_SCHEME`, `ERR_INVALID_FILE_URL_HOST`,
+  `ERR_INVALID_FILE_URL_PATH`) is caught and reported as a refusal rather
+  than an uncaught exception.
+- **Canonical round-trip identity is mandatory for every URI that did not
+  originate in this process.** After decode, re-encode
+  (`pathToFileURL(fileURLToPath(uri)).href`) and require byte-for-byte
+  equality with the input string before the decoded native path is used
+  for anything — including before the descriptor's own bearer capabilities
+  are read. A URI that decodes but does not re-encode to itself is refused
+  as noncanonical, never "fixed up" or silently accepted.
+
+Why this over the alternatives considered:
+
+- **Percent-encoding wins over stricter regex tightening** (e.g. banning
+  literal backslashes outright) because a regex can describe what a string
+  looks like but not what native path it denotes; the aliasing bug is
+  exactly two different native inputs producing one indistinguishable wire
+  string, which only an invertible encoding closes.
+- **`file:` URI wins over a custom tagged format** (e.g. `{ platform:
+  'win32' | 'posix', path: string }`) because `pathToFileURL`/
+  `fileURLToPath` are the runtime's existing, already-vetted, dependency-
+  free implementation of exactly this problem, used the same way
+  elsewhere in the Node ecosystem (`import.meta.url`, ESM loaders). A
+  custom format would have to reinvent percent-encoding and host handling
+  and would still need its own decode-side round-trip check to get the
+  same guarantee.
+- **The host check falls out of the same primitive.** `pathToFileURL` on a
+  UNC path (`\\server\share\x`) produces a URI with a non-empty
+  `hostname` (`file://server/share/x`); on any local absolute path,
+  `hostname` is always empty. "Nonlocal" is therefore not a new pattern to
+  invent — it is `new URL(uri).hostname !== ''`, checked as part of decode,
+  before the round trip.
+
+Per ADR 0081's own precedent ("What the schemas alone do not say" —
+byte-length and cross-field ownership are enforced in `protocol.ts` beside
+the Ajv validators, not expressed as schema keywords), JSON Schema cannot
+express "is a canonical local file URI." The schema keeps a coarse
+structural gate; the decode-and-round-trip check is the real enforcement,
+living in code beside the validators exactly where `isConfinedRelativePath`
+and the byte-length checks already live.
+
+## v4 versioning and schema implications
+
+Following ADR 0088's rule directly: a field whose value shape changes
+under a stable `$id` — bare-path string becoming a URI string — is not an
+additive change, even though every field keeps its name. It mints new
+document versions and bumps the protocol version that names the wire, the
+same way ADR 0088 bumped `v1` → `v2` for a response-document member change.
+
+- **`VISUAL_PROTOCOL_VERSION`** (`src/adapters/visual/protocol-contract.ts:21`)
+  becomes `yarramate/visual-protocol/v4`. It is pinned as a `const` in the
+  three documents that already agree on it —
+  `visual-session-descriptor`, `visual-session-started`, `visual-status` —
+  so a v3 consumer sees the mismatch in any of the three before it acts on
+  one, unchanged from the ADR 0081/0088 mechanism.
+- **Path-carrying documents get new `format`/`$id` versions**, because
+  their field *shapes* changed (bare string → URI string), which is the
+  ADR 0088 line between "grew a member" and "a member's contract changed":
+  - `yarramate/visual-session-started/v1` → `v2`
+    (`schema/yarramate-visual-session-started.schema.json` →
+    `$id: https://yarramate.org/schema/visual-session-started/v2`)
+  - `yarramate/visual-session-descriptor/v1` → `v2`
+  - `yarramate/visual-handoff/v1` → `v2`
+- **Documents that do not carry a path field are untouched**: `format`
+  stays `v1` for `visual-session-request`, `visual-event`,
+  `visual-response`, `visual-model`, `visual-diagnostic-result`,
+  `visual-graph`, `visual-layout`. `visual-status` keeps `format:
+  yarramate/visual-status/v1` — it has no path field — and only its
+  `protocolVersion` const moves, exactly as ADR 0088 records for the
+  detection-only case.
+- **The shared `$defs` path definition** moves from `absolutePath`
+  (pattern `^(?:/|[A-Za-z]:/)[^\u0000\\]*$`, `maxLength: 4096`, native
+  form) to a new `sessionFileUri` definition on the v2 `visual-session-started`
+  schema, referenced by the v2 descriptor and v2 handoff schemas the same
+  way the three already cross-reference each other today:
+  - `pattern: "^file:///[^\\u0000]*$"` — the coarse structural gate. Every
+    URI `pathToFileURL` produces for a local path starts `file:///`
+    (POSIX: empty host + `/`-rooted path; Windows: empty host + `/C:/…`),
+    and a UNC-derived URI (`file://server/…`, two slashes before the host)
+    fails this pattern outright, so the nonlocal case is caught
+    structurally as well as in code.
+  - `maxLength: 8192` — doubled from the native bound, sized for the
+    worst case where every byte of a 4096-byte native path requires
+    3-character percent-encoding; this widens the wire envelope to hold a
+    legally encoded path, not the underlying path-length invariant, which
+    is unchanged.
+  - The real check — decode succeeds, host is empty, round-trip is
+    byte-identical — is enforced in `protocol.ts`, per the "what the
+    schemas alone do not say" precedent above, and reported through the
+    document's existing parse code (`YMVS102`/`YMVS103`/`YMVS107`) when it
+    runs as part of schema-adjacent semantics, or through a new client
+    code (below) when it runs against a bare CLI argument before any
+    document has been parsed yet.
+- **`toWireAbsolutePath` is deleted**, not deprecated. Its three call
+  sites (`session-server.ts:2219-2233`, `session-store.ts:517-518,
+  recoverVisualSession`'s `transcriptPath`) call the new encode helper
+  instead; the two comparison call sites (`session-store.ts`'s
+  `writeVisualSessionDescriptor`, `client.ts`'s `readVisualSessionDescriptor`)
+  compare canonical URI strings produced by the same encode helper against
+  the URI fields already carried on the parsed document, which is a
+  strictly stronger check than today's wire-string compare because both
+  sides are now provably canonical.
+
+## Producer/consumer flow and where authority is gated
+
+```mermaid
+sequenceDiagram
+    participant Store as session-store.ts<br/>(native VisualSessionPaths)
+    participant Server as session-server.ts<br/>(encode: pathToFileURL)
+    participant Disk as descriptor.json / journal.jsonl
+    participant CLI as visual-cli.ts / client.ts<br/>(decode: fileURLToPath)
+    participant Skill as calling skill / harness
+
+    Store->>Server: native sessionRoot, journalPath
+    Server->>Disk: write VisualSessionStarted / VisualSessionDescriptor<br/>(URI fields, round-trip-clean by construction)
+    Server-->>Skill: VisualSessionStarted.descriptorPath (URI, stdout)
+    Skill->>CLI: yarramate-visual wait <descriptorPath URI>
+    CLI->>CLI: decode URI -> native path (refuse: malformed / nonlocal / noncanonical)
+    CLI->>Disk: open native path, O_NOFOLLOW/O_NONBLOCK (unchanged, YMVS401)
+    Disk-->>CLI: VisualSessionDescriptor (URI fields)
+    CLI->>CLI: re-encode own resolved path, own journal path;<br/>compare against descriptor's URI fields (ownership, YMVS403)
+    CLI->>CLI: only past this point: use browserUrl / webSocketUrl (descriptor authority)
+```
+
+- **Producers** are `session-server.ts` (`VisualSessionStarted`,
+  `VisualSessionDescriptor`) and `session-store.ts`'s `recoverVisualSession`
+  (`VisualHandoff.transcriptPath`). All three call the encode helper on a
+  native `VisualSessionPaths` field they already hold; encoding a path this
+  process just resolved cannot fail (`pathToFileURL` has no error path for
+  an already-absolute native string), so there is no producer-side refusal
+  code — only an assertion that the input was absolute, which is a
+  programming error, not a protocol fault, if it trips.
+- **Consumers** are `client.ts`'s `readVisualSessionDescriptor` (decodes
+  the CLI's positional argument and the descriptor's own `sessionRoot`/
+  `journalPath`) and `visualSessionAlreadyStopped` (decodes the same
+  argument on the already-stopped path). Both are untrusted-input
+  boundaries and both must run decode-refuse-round-trip **before** the
+  descriptor's bearer capabilities are read — `agentRequest`,
+  `waitForVisualEvent`, `sendVisualResponse`, `fetchVisualStatus`, and
+  `stopVisualSessionClient` all take an already-parsed, already-verified
+  `VisualSessionDescriptor` as their argument, so gating happens once, at
+  the top of `readVisualSessionDescriptor`, and nothing downstream can
+  reach an ungated document.
+- **The ownership check strengthens, not just relocates.** Today
+  `paths.descriptor !== target` compares two `toWireAbsolutePath` outputs
+  that may both be wrong the same way (aliasing is symmetric). Under this
+  design both sides are independently round-trip-verified before the
+  compare, so the check proves the descriptor names the exact file that
+  was opened, not merely that their mangled forms happened to match.
+
+## Error handling
+
+New refusals are minted following the existing per-band, per-category
+convention (`docs/superpowers/plans/2026-08-15-visual-editing-and-commit.md`:
+"take the next contiguous code rather than backfilling a gap"; verified via
+`grep -rEoh "YMVS[0-9]{3}" src/adapters/visual/*.ts | sort -u`, highest
+1xx code in use is `YMVS132`, highest 4xx code in use is `YMVS413`):
+
+- **`YMVS414`** — new client-side code (band 4xx: `client.ts` boundary
+  refusals, alongside `YMVS401` unreadable/non-regular,
+  `YMVS402` not JSON, `YMVS403` names artefacts outside its own directory).
+  One code, three message shapes, matching the existing convention of one
+  code covering a semantic category (`YMVS401` already covers two distinct
+  underlying causes):
+  - *Malformed*: the argument or a document's path field is not a
+    parseable `file:` URI, or `fileURLToPath` rejects it
+    (`ERR_INVALID_URL_SCHEME`, `ERR_INVALID_FILE_URL_PATH`, etc.) — `Session
+    descriptor path "…" is not a canonical file: URI`.
+  - *Nonlocal*: decode succeeds but `new URL(uri).hostname !== ''` — `Session
+    descriptor path "…" names a nonlocal location`.
+  - *Noncanonical / aliasing*: decode succeeds, host is empty, but
+    re-encoding the decoded native path does not reproduce the input
+    string byte-for-byte — `Session descriptor path "…" is not the
+    canonical encoding of its own target`.
+- **Existing codes are reused, not replaced, once decode has succeeded**:
+  `YMVS401`/`YMVS402` (open/parse failures) and `YMVS403` (ownership
+  mismatch) keep their current meaning and trigger after a successful
+  `YMVS414` gate, on the now-canonical native path.
+- **A v3 descriptor is refused generically, not specially.** A v3 document
+  fails the v4 schema's `protocolVersion`/`format` `const` checks like any
+  other schema violation, surfaced through the document's existing parse
+  code (`YMVS102`/`YMVS103`) with a diagnostic pointing at
+  `/protocolVersion` or `/format`. No bespoke "v3 detected" code or
+  message is introduced — this is deliberate, matching ADR 0088's own
+  choice not to special-case the old shape.
+- **No server-side refusal code is needed for encoding**: as noted above,
+  encoding a native path this process already resolved has no failure
+  mode; a non-absolute input reaching the encode helper is a programming
+  error and throws, uncaught, the same way an internal invariant violation
+  elsewhere in this codebase does.
+
+## v3 cutover policy
+
+This is a v4-only change with no compatibility shim, matching ADR 0088's
+"Not a compatibility shim" precedent:
+
+- A v3 session descriptor, started result, or status document is refused
+  by schema `const` mismatch (above), never parsed leniently, never
+  translated to v4 shape. There is no dual-read path and none is added.
+- A running v3 runtime and a v4 CLI (or the reverse) simply refuse each
+  other at the first document exchanged — the same detectable-incompatibility
+  property ADR 0088 established is preserved, not weakened, by adding a
+  second breaking field-shape change on top of the removal ADR 0088 already
+  recorded.
+- **CLI argument cutover.** `yarramate-visual wait|respond|status|recover|stop`
+  currently take a native (`cwd`-relative-or-absolute) path
+  (`src/adapters/visual-cli.ts`, `descriptorPath: string`,
+  `readVisualSessionDescriptor(descriptorPath, cwd)`). Under v4 the
+  argument is the `file:` URI `yarramate-visual start` published as
+  `VisualSessionStarted.descriptorPath` — copied back verbatim by the
+  calling skill/harness, never hand-typed as a native path. `cwd`-relative
+  resolution is removed from this argument entirely: a `file:` URI is
+  inherently absolute, so the class of bug this whole design closes (an
+  ambiguous, platform-dependent path string) cannot re-enter through the
+  one remaining untrusted string input. The usage banner
+  (`visualUsage` in `visual-cli.ts`) is updated to read `<descriptor-uri>`
+  in place of `<descriptor.json>` at each of the five call sites.
+- **`7663f0a` is superseded, not built on.** Its native-`VisualSessionPaths`
+  half (keeping `visualSessionPaths` unconditionally native) is correct
+  and is retained as-is. Its wire-normalization half
+  (`toWireAbsolutePath` at three serialization sites, wire-form comparison
+  at two consumption sites) is replaced wholesale by the encode/decode
+  helpers above; none of `toWireAbsolutePath`'s call sites survive
+  unchanged. `b501f1e`'s schema pattern widening
+  (`^(?:/|[A-Za-z]:/)[^\u0000\\]*$`) is likewise replaced by the
+  `sessionFileUri` `$def`. Neither commit is reverted — both are superseded
+  by new commits built on this design, so the branch history keeps the
+  record of the symptom that motivated the fix.
+
+## Test and verification matrix
+
+| Area | Case | Expected |
+|---|---|---|
+| Encode | POSIX absolute path, ASCII | `pathToFileURL` → `file:///a/b/c`; round-trips |
+| Encode | POSIX path with space, `#`, `?`, non-ASCII byte | percent-encoded; round-trips |
+| Encode | Windows drive-root path (native separators) | `file:///C:/Users/x`; round-trips |
+| Encode | POSIX directory name containing a literal backslash | percent-encoded as `%5C`, distinguishable from a path separator (regression carried over from `7663f0a`, re-targeted at the new encoder) |
+| Decode | Well-formed local `file:///…` URI | decodes to native path; matches what encode produced |
+| Decode | Non-`file:` scheme (`http://`, `data:`) | refused `YMVS414`, malformed |
+| Decode | Syntactically invalid URI (unbalanced `%`, control chars) | refused `YMVS414`, malformed |
+| Decode | UNC-derived URI (`file://server/share/x`) | refused `YMVS414`, nonlocal |
+| Decode | Same native target, two different percent-encodings of one byte | refused `YMVS414`, noncanonical (round-trip mismatch) |
+| Decode | URI with a trailing-slash or `.`/`..` variance vs. the canonical form | refused `YMVS414`, noncanonical |
+| Ownership | Descriptor's `sessionRoot`/`journalPath` URIs match the session that was opened | accepted, unchanged `YMVS403`-guarded path |
+| Ownership | Descriptor copied beside a different session directory | refused `YMVS403`, now comparing two independently round-trip-verified URIs |
+| Protocol | v3 `VisualSessionDescriptor`/`Started`/`Status` fed to the v4 parser | refused by `const` mismatch, existing parse code, no new code |
+| Protocol | v4 documents round-trip through the full `start`→`wait`→`respond`→`recover`→`stop` CLI sequence against a real filesystem session | unchanged observable behavior other than URI-shaped path fields |
+| CLI | `wait`/`respond`/`status`/`recover`/`stop` invoked with the exact `descriptorPath` URI `start` printed | succeeds |
+| CLI | Same commands invoked with a native path (old-style argument) | refused `YMVS414`, malformed — this is the intended breaking behavior, asserted explicitly |
+| Regression | `7663f0a`'s backslash-directory-name subprocess/unit test | re-target at `visualSessionPaths` (native, unchanged) and at the new encoder (wire-safe), both passing |
+| Cross-platform | Windows-only assertions currently skipped on POSIX (`it.skipIf(!posixOnly)` and its Windows-side counterparts) | both platform branches exercised in CI, matching existing `test/visual-cli.test.ts`/`visual-session-store.test.ts` conventions |
+
+## Planned ADR and issue requirements
+
+Implementation is out of scope for this document and is tracked
+separately:
+
+1. **New ADR**, next available slot after `0095`
+   (`docs/adr/0096-…` at the time of writing — confirm the actual next
+   number when the ADR lands, since sibling work may claim `0096` first),
+   titled to name the decision directly, e.g. "Visual session paths are
+   published as canonical file URIs." It records, in ADR 0081/0088's own
+   voice: the aliasing/nonlocal defects this design fixes, the choice of
+   `pathToFileURL`/`fileURLToPath` over a custom encoding, the v3→v4
+   protocol bump and the `v1`→`v2` bump on the three path-carrying
+   documents, and the "not a compatibility shim" cutover decision — the
+   same four elements ADR 0088 covered for its own removal.
+2. **A tracked issue** for the implementation work itself, scoped to:
+   schema edits (`yarramate-visual-session-started`,
+   `-session-descriptor`, `-handoff` → `v2`; new `sessionFileUri` `$def`),
+   `protocol.ts`/`protocol-contract.ts` (delete `toWireAbsolutePath`, add
+   encode/decode helpers, bump `VISUAL_PROTOCOL_VERSION`), `session-server.ts`
+   and `session-store.ts` (swap call sites), `client.ts` and
+   `visual-cli.ts` (URI-only CLI argument, `YMVS414`), fixtures under
+   `test/` for every row of the matrix above, and the ADR from item 1. The
+   issue should link this design document and record that it supersedes
+   the intent of `7663f0a` on `fix/visual-adapter-windows-absolute-paths`.
+3. Both the ADR and the issue are written and filed as part of that later
+   implementation work, not as part of this specification.
+
+## Acceptance criteria
+
+1. No protocol document accepts a bare native-path string in a field
+   previously typed `$defs.absolutePath`; every such field is a `file:`
+   URI validated by decode-refuse-round-trip, not by pattern alone.
+2. A UNC or otherwise nonlocal path can never appear as a valid
+   `sessionRoot`, `descriptorPath`, `journalPath`, or `transcriptPath` —
+   provable by the "nonlocal" row of the verification matrix.
+3. Two distinct native paths never produce the same accepted wire string,
+   and one native path has exactly one accepted wire string — provable by
+   the aliasing and noncanonical rows.
+4. A v3 `VisualSessionStarted`, `VisualSessionDescriptor`, or `VisualStatus`
+   document is refused by the v4 parser with no translation path, and the
+   refusal is visible before any descriptor bearer capability is read.
+5. `yarramate-visual wait|respond|status|recover|stop` accept exactly the
+   URI `start` published and refuse a native-path argument.
+6. `7663f0a` and `b501f1e` remain in branch history, superseded by new
+   commits implementing this design; neither is treated as merge-ready on
+   its own, and neither is reverted.

--- a/schema/yarramate-visual-handoff.schema.json
+++ b/schema/yarramate-visual-handoff.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://yarramate.org/schema/visual-handoff/v1",
+  "$id": "https://yarramate.org/schema/visual-handoff/v2",
   "title": "YarraMate visual conversation handoff",
   "description": "Recoverable summary returned to the main agent. The raw transcript appears only when it was explicitly requested.",
   "type": "object",
@@ -22,7 +22,7 @@
   ],
   "properties": {
     "format": {
-      "const": "yarramate/visual-handoff/v1"
+      "const": "yarramate/visual-handoff/v2"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
@@ -56,7 +56,7 @@
       "$ref": "https://yarramate.org/schema/visual-response/v1#/$defs/viewList"
     },
     "transcriptPath": {
-      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+      "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/sessionFileUri"
     },
     "transcript": {
       "type": "array",

--- a/schema/yarramate-visual-session-descriptor.schema.json
+++ b/schema/yarramate-visual-session-descriptor.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://yarramate.org/schema/visual-session-descriptor/v1",
+  "$id": "https://yarramate.org/schema/visual-session-descriptor/v2",
   "title": "YarraMate visual session descriptor",
   "description": "Private mode 0600 file that carries the local agent credential used by the one-shot `yarramate-visual` commands.",
   "type": "object",
@@ -17,26 +17,26 @@
   ],
   "properties": {
     "format": {
-      "const": "yarramate/visual-session-descriptor/v1"
+      "const": "yarramate/visual-session-descriptor/v2"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v3"
+      "const": "yarramate/visual-protocol/v4"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
     },
     "origin": {
-      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/localOrigin"
+      "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/localOrigin"
     },
     "agentCapability": {
       "type": "string",
       "pattern": "^[0-9a-f]{64}$"
     },
     "sessionRoot": {
-      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+      "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/sessionFileUri"
     },
     "journalPath": {
-      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/absolutePath"
+      "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/sessionFileUri"
     },
     "createdAt": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/timestamp"

--- a/schema/yarramate-visual-session-started.schema.json
+++ b/schema/yarramate-visual-session-started.schema.json
@@ -93,10 +93,11 @@
       "pattern": "^http://127\\.0\\.0\\.1:[0-9]{1,5}$"
     },
     "absolutePath": {
+      "description": "Forward-slash absolute path, on every platform: either POSIX-rooted (leading /) or a normalized Windows drive root (e.g. C:/Users/...). Never a literal backslash, so a descriptor is byte-identical regardless of which platform's `yarramate-visual` wrote it.",
       "type": "string",
       "minLength": 1,
       "maxLength": 4096,
-      "pattern": "^/[^\\u0000]*$"
+      "pattern": "^(?:/|[A-Za-z]:/)[^\\u0000\\\\]*$"
     },
     "capabilities": {
       "description": "Features the browser session may use. Diagram-only mode disables chat.",

--- a/schema/yarramate-visual-session-started.schema.json
+++ b/schema/yarramate-visual-session-started.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://yarramate.org/schema/visual-session-started/v1",
+  "$id": "https://yarramate.org/schema/visual-session-started/v2",
   "title": "YarraMate visual session started",
   "description": "Public first line printed by `yarramate-visual start`. It never carries the private agent capability.",
   "type": "object",
@@ -22,10 +22,10 @@
   ],
   "properties": {
     "format": {
-      "const": "yarramate/visual-session-started/v1"
+      "const": "yarramate/visual-session-started/v2"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v3"
+      "const": "yarramate/visual-protocol/v4"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
@@ -53,10 +53,10 @@
       "$ref": "#/$defs/localOrigin"
     },
     "descriptorPath": {
-      "$ref": "#/$defs/absolutePath"
+      "$ref": "#/$defs/sessionFileUri"
     },
     "sessionRoot": {
-      "$ref": "#/$defs/absolutePath"
+      "$ref": "#/$defs/sessionFileUri"
     },
     "capabilities": {
       "$ref": "#/$defs/capabilities"
@@ -92,12 +92,12 @@
       "type": "string",
       "pattern": "^http://127\\.0\\.0\\.1:[0-9]{1,5}$"
     },
-    "absolutePath": {
-      "description": "Forward-slash absolute path, on every platform: either POSIX-rooted (leading /) or a normalized Windows drive root (e.g. C:/Users/...). Never a literal backslash, so a descriptor is byte-identical regardless of which platform's `yarramate-visual` wrote it.",
+    "sessionFileUri": {
+      "description": "Canonical local `file:` URI naming one filesystem path, as minted by Node's `pathToFileURL`. This pattern is a coarse structural gate only: every URI a local path encodes to begins `file:///` (empty host, then a POSIX `/` root or a Windows `/C:/` drive root), so a UNC-derived `file://server/share/x` fails it outright. The real check cannot be written as a schema keyword and lives beside these validators in `protocol.ts`: decode with `fileURLToPath`, refuse a non-empty host, and require that re-encoding the decoded path reproduces this string byte-for-byte. `maxLength` is double the 4096-byte native path bound because a fully percent-encoded path costs three characters per byte; it widens the wire envelope, not the path-length invariant.",
       "type": "string",
-      "minLength": 1,
-      "maxLength": 4096,
-      "pattern": "^(?:/|[A-Za-z]:/)[^\\u0000\\\\]*$"
+      "minLength": 8,
+      "maxLength": 8192,
+      "pattern": "^file:///[^\\u0000]*$"
     },
     "capabilities": {
       "description": "Features the browser session may use. Diagram-only mode disables chat.",

--- a/schema/yarramate-visual-status.schema.json
+++ b/schema/yarramate-visual-status.schema.json
@@ -24,7 +24,7 @@
       "const": "yarramate/visual-status/v1"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v3"
+      "const": "yarramate/visual-protocol/v4"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"
@@ -42,7 +42,7 @@
       "properties": {
         "listening": { "type": "boolean" },
         "origin": {
-          "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/localOrigin"
+          "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/localOrigin"
         }
       }
     },
@@ -110,7 +110,7 @@
       }
     },
     "capabilities": {
-      "$ref": "https://yarramate.org/schema/visual-session-started/v1#/$defs/capabilities"
+      "$ref": "https://yarramate.org/schema/visual-session-started/v2#/$defs/capabilities"
     },
     "transcriptBytes": {
       "type": "integer",

--- a/skills/yarramate-architecture/references/visual-conversations.md
+++ b/skills/yarramate-architecture/references/visual-conversations.md
@@ -75,16 +75,19 @@ session offers: `chat`, `choices`, `navigation`, `transcript`.
 
 ```sh
 yarramate-visual start <request.json>
-yarramate-visual wait <descriptor.json> [--after <sequence>]
-yarramate-visual respond <descriptor.json> <response.json>
-yarramate-visual status <descriptor.json>
-yarramate-visual recover <descriptor.json> [--transcript]
-yarramate-visual stop <descriptor.json> [--transcript]
+yarramate-visual wait <descriptor-uri> [--after <sequence>]
+yarramate-visual respond <descriptor-uri> <response.json>
+yarramate-visual status <descriptor-uri>
+yarramate-visual recover <descriptor-uri> [--transcript]
+yarramate-visual stop <descriptor-uri> [--transcript]
 ```
 
-`start` publishes one `yarramate/visual-session-started/v1` line on stdout
+`start` publishes one `yarramate/visual-session-started/v2` line on stdout
 carrying `browserUrl`, `descriptorPath`, `sessionRoot`, and `capabilities`,
-then blocks, serving the session until it is stopped.
+then blocks, serving the session until it is stopped. `descriptorPath` is a
+canonical local `file:` URI (`file:///...`): copy it back verbatim as the
+argument to every other command. A native path is refused with `YMVS414`, and
+nothing is resolved against the working directory.
 
 It is a managed foreground process, not a shell job and not a daemon. Launch it
 through the harness's long-running-process facility: register it under a stable
@@ -224,9 +227,9 @@ all take one path. You are the parent and the source of authority; the child is
 disposable.
 
 ```sh
-yarramate-visual recover <descriptor.json>              # structured handoff
-yarramate-visual recover <descriptor.json> --transcript # only if the summary is not enough
-yarramate-visual stop <descriptor.json>                 # shuts down, prints the handoff, then deletes
+yarramate-visual recover <descriptor-uri>              # structured handoff
+yarramate-visual recover <descriptor-uri> --transcript # only if the summary is not enough
+yarramate-visual stop <descriptor-uri>                 # shuts down, prints the handoff, then deletes
 ```
 
 1. `recover` first, always, before anything is torn down. It returns

--- a/src/adapters/visual-cli.ts
+++ b/src/adapters/visual-cli.ts
@@ -29,11 +29,14 @@ export const visualUsage =
   '  yarramate-visual request [--view <id>] [--title <text>]\n' +
   '                           [--description <text>] [--chat]\n' +
   '  yarramate-visual start <request.json>\n' +
-  '  yarramate-visual wait <descriptor.json> [--after <sequence>]\n' +
-  '  yarramate-visual respond <descriptor.json> <response.json>\n' +
-  '  yarramate-visual status <descriptor.json>\n' +
-  '  yarramate-visual recover <descriptor.json> [--transcript]\n' +
-  '  yarramate-visual stop <descriptor.json> [--transcript]\n' +
+  '  yarramate-visual wait <descriptor-uri> [--after <sequence>]\n' +
+  '  yarramate-visual respond <descriptor-uri> <response.json>\n' +
+  '  yarramate-visual status <descriptor-uri>\n' +
+  '  yarramate-visual recover <descriptor-uri> [--transcript]\n' +
+  '  yarramate-visual stop <descriptor-uri> [--transcript]\n' +
+  '\n' +
+  '<descriptor-uri> is the `descriptorPath` file: URI `start` published,\n' +
+  'copied back verbatim. It is never resolved against the working directory.\n' +
   '  yarramate-visual --version\n'
 
 /**
@@ -161,13 +164,12 @@ const requestCliCommand = (
 }
 
 const waitCliCommand = async (
-  descriptorPath: string,
+  descriptorUri: string,
   rest: readonly string[],
-  cwd: string,
 ): Promise<CliResult> => {
   const after = sequenceFlag(rest)
   if (after === undefined) return usageResult
-  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  const descriptor = await readVisualSessionDescriptor(descriptorUri)
   if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
   const delivery = await waitForVisualEvent(descriptor.value, after)
   if (!delivery.ok) return refusalResult(delivery.diagnostics)
@@ -181,14 +183,17 @@ const waitCliCommand = async (
 }
 
 const respondCliCommand = async (
-  descriptorPath: string,
+  descriptorUri: string,
   rest: readonly string[],
   cwd: string,
 ): Promise<CliResult> => {
   const [responsePath, ...trailing] = rest
   if (responsePath === undefined || trailing.length > 0) return usageResult
-  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  const descriptor = await readVisualSessionDescriptor(descriptorUri)
   if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
+  // The response document is the agent's own file, named however the agent
+  // likes: it is not a protocol path field, so it stays a native path
+  // resolved against `cwd`.
   const document = await readVisualJsonDocument(responsePath, cwd)
   if (!document.ok) return refusalResult(document.diagnostics)
   // Validated here as well as by the runtime, so an invalid response never
@@ -201,12 +206,11 @@ const respondCliCommand = async (
 }
 
 const statusCliCommand = async (
-  descriptorPath: string,
+  descriptorUri: string,
   rest: readonly string[],
-  cwd: string,
 ): Promise<CliResult> => {
   if (rest.length > 0) return usageResult
-  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  const descriptor = await readVisualSessionDescriptor(descriptorUri)
   if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
   const status = await fetchVisualStatus(descriptor.value)
   if (!status.ok) return refusalResult(status.diagnostics)
@@ -214,13 +218,12 @@ const statusCliCommand = async (
 }
 
 const recoverCliCommand = async (
-  descriptorPath: string,
+  descriptorUri: string,
   rest: readonly string[],
-  cwd: string,
 ): Promise<CliResult> => {
   const includeTranscript = transcriptFlag(rest)
   if (includeTranscript === undefined) return usageResult
-  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  const descriptor = await readVisualSessionDescriptor(descriptorUri)
   if (!descriptor.ok) return refusalResult(descriptor.diagnostics)
   const handoff = await recoverVisualSessionClient(
     descriptor.value,
@@ -245,15 +248,14 @@ const recoverCliCommand = async (
  * descriptor fails exactly as before.
  */
 const stopCliCommand = async (
-  descriptorPath: string,
+  descriptorUri: string,
   rest: readonly string[],
-  cwd: string,
 ): Promise<CliResult> => {
   const includeTranscript = transcriptFlag(rest)
   if (includeTranscript === undefined) return usageResult
-  const descriptor = await readVisualSessionDescriptor(descriptorPath, cwd)
+  const descriptor = await readVisualSessionDescriptor(descriptorUri)
   if (!descriptor.ok) {
-    return (await visualSessionAlreadyStopped(descriptorPath, cwd))
+    return (await visualSessionAlreadyStopped(descriptorUri))
       ? { exitCode: 0, stdout: '', stderr: '' }
       : refusalResult(descriptor.diagnostics)
   }
@@ -285,17 +287,20 @@ export async function runVisualClientCli(
   if (command === '--version') return versionResult('yarramate-visual')
   if (command === 'request') return requestCliCommand(args.slice(1), cwd)
   if (descriptor === undefined) return usageResult
+  // `cwd` reaches only the commands that still read a native path of their
+  // own. The descriptor argument is a `file:` URI and is never resolved
+  // against anything.
   switch (command) {
     case 'wait':
-      return waitCliCommand(descriptor, rest, cwd)
+      return waitCliCommand(descriptor, rest)
     case 'respond':
       return respondCliCommand(descriptor, rest, cwd)
     case 'status':
-      return statusCliCommand(descriptor, rest, cwd)
+      return statusCliCommand(descriptor, rest)
     case 'recover':
-      return recoverCliCommand(descriptor, rest, cwd)
+      return recoverCliCommand(descriptor, rest)
     case 'stop':
-      return stopCliCommand(descriptor, rest, cwd)
+      return stopCliCommand(descriptor, rest)
     default:
       return usageResult
   }
@@ -323,7 +328,7 @@ const processIo: VisualStartIo = {
  * Serves one visual session in the foreground.
  *
  * The request is validated before any filesystem or network effect, so a bad
- * document costs nothing. Exactly one public `visual-session-started/v1` line is
+ * document costs nothing. Exactly one public `visual-session-started/v2` line is
  * published before the command blocks — it names the private descriptor but
  * never carries the agent capability, which lives only in that mode 0600 file.
  * The command then holds the session open until the runtime closes it, whether

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -8,6 +8,7 @@ import {
   parseVisualHandoff,
   parseVisualSessionDescriptor,
   parseVisualStatus,
+  toWireAbsolutePath,
   type ParseResult,
   type VisualDiagnostic,
   type VisualHandoff,
@@ -199,7 +200,9 @@ export const readVisualSessionDescriptor = async (
   path: string,
   cwd: string = process.cwd(),
 ): Promise<ParseResult<VisualSessionDescriptor>> => {
-  const target = resolve(cwd, path)
+  // Normalized to match `paths.descriptor` below: both name the same file,
+  // and the ownership check just past the read is a literal string compare.
+  const target = toWireAbsolutePath(resolve(cwd, path))
   let raw: string
   // One handle, opened once: the descriptor is the only file carrying the agent
   // capability, so the thing that is checked has to be the thing that is read.

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -3,18 +3,20 @@ import { lstat, open, readFile, stat } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import {
   VISUAL_PROTOCOL_VERSION,
+  fromWireFileUri,
   parseVisualDiagnosticResult,
   parseVisualEvent,
   parseVisualHandoff,
   parseVisualSessionDescriptor,
   parseVisualStatus,
-  toWireAbsolutePath,
+  toWireFileUri,
   type ParseResult,
   type VisualDiagnostic,
   type VisualHandoff,
   type VisualResponse,
   type VisualSessionDescriptor,
   type VisualStatus,
+  type WireFileUriRefusal,
 } from './protocol.js'
 import {
   VISUAL_SERVER_LIMITS,
@@ -80,6 +82,38 @@ export const visualClientDiagnostic = (
 const refused = <T>(
   diagnostics: readonly VisualDiagnostic[],
 ): ParseResult<T> => ({ ok: false, diagnostics })
+
+/**
+ * How each way a wire path can be refused reads. One code carries all three,
+ * the way `YMVS401` already covers two distinct underlying causes.
+ */
+const WIRE_URI_REFUSAL: Readonly<Record<WireFileUriRefusal, string>> = {
+  malformed: 'is not a canonical file: URI',
+  nonlocal: 'names a nonlocal location',
+  noncanonical: 'is not the canonical encoding of its own target',
+}
+
+/**
+ * Decode one untrusted wire path to native, or refuse it.
+ *
+ * Nothing is resolved against `cwd`. A `file:` URI is inherently absolute, so
+ * the ambiguous, platform-dependent path string this representation retires
+ * cannot re-enter through the one argument an operator still passes by hand:
+ * `wait`/`respond`/`status`/`recover`/`stop` take the exact `descriptorPath`
+ * URI `start` published, copied back verbatim. A native path is refused here
+ * visibly rather than half-working.
+ */
+const decodeWireUri = (label: string, uri: string): ParseResult<string> => {
+  const decoded = fromWireFileUri(uri)
+  return decoded.ok
+    ? { ok: true, value: decoded.value }
+    : refused([
+        visualClientDiagnostic(
+          'YMVS414',
+          `${label} "${uri}" ${WIRE_URI_REFUSAL[decoded.reason]}`,
+        ),
+      ])
+}
 
 export const visualFailureDiagnostics = (
   cause: unknown,
@@ -177,10 +211,13 @@ const readsStoppedMarker = async (
  * teardown and names the vanished session directory.
  */
 export const visualSessionAlreadyStopped = async (
-  path: string,
-  cwd: string = process.cwd(),
+  uri: string,
 ): Promise<boolean> => {
-  const target = resolve(cwd, path)
+  // A descriptor URI that will not decode names no session at all, so it is
+  // not evidence that one was stopped; the caller's own refusal stands.
+  const decoded = fromWireFileUri(uri)
+  if (!decoded.ok) return false
+  const target = decoded.value
   const sessionRoot = dirname(target)
   const sessionId = basename(sessionRoot)
   return (
@@ -197,14 +234,15 @@ export const visualSessionAlreadyStopped = async (
  * capability, so a redirected or planted one must never be spent.
  */
 export const readVisualSessionDescriptor = async (
-  path: string,
-  cwd: string = process.cwd(),
+  uri: string,
 ): Promise<ParseResult<VisualSessionDescriptor>> => {
-  // `target` is native, for `open()`; `targetWire` is the wire form the
-  // ownership check below compares byte-for-byte against the normalized
-  // `descriptorPath`/`journalPath` a descriptor names.
-  const target = resolve(cwd, path)
-  const targetWire = toWireAbsolutePath(target)
+  // The URI is proven to be one specific local file before that file is
+  // opened, and long before the capability inside it is spent. `target` is the
+  // native path `open()` needs; `uri` itself is already canonical past this
+  // point, so the ownership check below compares it directly.
+  const decoded = decodeWireUri('Session descriptor path', uri)
+  if (!decoded.ok) return decoded
+  const target = decoded.value
   let raw: string
   // One handle, opened once: the descriptor is the only file carrying the agent
   // capability, so the thing that is checked has to be the thing that is read.
@@ -260,13 +298,27 @@ export const readVisualSessionDescriptor = async (
   }
   const parsed = parseVisualSessionDescriptor(document)
   if (!parsed.ok) return parsed
-  const paths = visualSessionPaths(parsed.value.sessionRoot)
+  // The document's own path fields are untrusted too, and are decoded on the
+  // same terms as the argument: `sessionRoot` because it is about to be used
+  // as a filesystem path, `journalPath` so a refusal names the field that was
+  // malformed rather than reporting it as a vaguer ownership mismatch.
+  const root = decodeWireUri('Session root', parsed.value.sessionRoot)
+  if (!root.ok) return root
+  const journal = decodeWireUri(
+    'Session journal path',
+    parsed.value.journalPath,
+  )
+  if (!journal.ok) return journal
+  const paths = visualSessionPaths(root.value)
   // A descriptor authorises work on the session it lives in and no other: this
   // is the same invariant the runtime enforced when it published the file, so a
   // copied or planted descriptor cannot direct a stop at another directory.
+  // Both sides of each compare are now canonical by construction, so a match
+  // proves the descriptor names the exact file that was opened rather than
+  // merely failing to disprove it.
   if (
-    toWireAbsolutePath(paths.descriptor) !== targetWire ||
-    toWireAbsolutePath(paths.journal) !== parsed.value.journalPath
+    toWireFileUri(paths.descriptor) !== uri ||
+    toWireFileUri(paths.journal) !== parsed.value.journalPath
   ) {
     return refused([
       visualClientDiagnostic(
@@ -276,6 +328,25 @@ export const readVisualSessionDescriptor = async (
     ])
   }
   return parsed
+}
+
+/**
+ * The session directory a verified descriptor names.
+ *
+ * Every descriptor that reaches the commands below came through
+ * `readVisualSessionDescriptor`, which already proved `sessionRoot` decodes to
+ * one canonical local path. The only way this can fail is a caller that
+ * skipped that gate, which is a programming error rather than a protocol
+ * fault, so it throws where the surrounding refusals return.
+ */
+const sessionPathsOf = (descriptor: VisualSessionDescriptor) => {
+  const decoded = fromWireFileUri(descriptor.sessionRoot)
+  if (!decoded.ok) {
+    throw new Error(
+      `Session root "${descriptor.sessionRoot}" was never decoded: ${decoded.reason}`,
+    )
+  }
+  return visualSessionPaths(decoded.value)
 }
 
 /** One JSON document the agent hands to a command, read from the filesystem. */
@@ -481,7 +552,7 @@ export const sendVisualResponse = async (
 const localVisualStatus = async (
   descriptor: VisualSessionDescriptor,
 ): Promise<ParseResult<VisualStatus>> => {
-  const paths = visualSessionPaths(descriptor.sessionRoot)
+  const paths = sessionPathsOf(descriptor)
   let lastSequence = 0
   let transcriptBytes = 0
   try {
@@ -545,7 +616,7 @@ export const recoverVisualSessionClient = async (
     return {
       ok: true,
       value: await recoverVisualSession(
-        visualSessionPaths(descriptor.sessionRoot),
+        sessionPathsOf(descriptor),
         includeTranscript,
       ),
     }
@@ -585,7 +656,7 @@ export const stopVisualSessionClient = async (
   descriptor: VisualSessionDescriptor,
   includeTranscript = false,
 ): Promise<ParseResult<VisualHandoff | undefined>> => {
-  const paths = visualSessionPaths(descriptor.sessionRoot)
+  const paths = sessionPathsOf(descriptor)
   if (!(await exists(paths.root))) return { ok: true, value: undefined }
   const recovered = await recoverVisualSessionClient(
     descriptor,

--- a/src/adapters/visual/client.ts
+++ b/src/adapters/visual/client.ts
@@ -200,9 +200,11 @@ export const readVisualSessionDescriptor = async (
   path: string,
   cwd: string = process.cwd(),
 ): Promise<ParseResult<VisualSessionDescriptor>> => {
-  // Normalized to match `paths.descriptor` below: both name the same file,
-  // and the ownership check just past the read is a literal string compare.
-  const target = toWireAbsolutePath(resolve(cwd, path))
+  // `target` is native, for `open()`; `targetWire` is the wire form the
+  // ownership check below compares byte-for-byte against the normalized
+  // `descriptorPath`/`journalPath` a descriptor names.
+  const target = resolve(cwd, path)
+  const targetWire = toWireAbsolutePath(target)
   let raw: string
   // One handle, opened once: the descriptor is the only file carrying the agent
   // capability, so the thing that is checked has to be the thing that is read.
@@ -262,7 +264,10 @@ export const readVisualSessionDescriptor = async (
   // A descriptor authorises work on the session it lives in and no other: this
   // is the same invariant the runtime enforced when it published the file, so a
   // copied or planted descriptor cannot direct a stop at another directory.
-  if (paths.descriptor !== target || paths.journal !== parsed.value.journalPath) {
+  if (
+    toWireAbsolutePath(paths.descriptor) !== targetWire ||
+    toWireAbsolutePath(paths.journal) !== parsed.value.journalPath
+  ) {
     return refused([
       visualClientDiagnostic(
         'YMVS403',

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -18,7 +18,14 @@ import type {
   ProjectionQuery,
 } from "../../projection.js";
 
-export const VISUAL_PROTOCOL_VERSION = "yarramate/visual-protocol/v3" as const;
+/**
+ * The wire this adapter speaks. v4 retypes every path-carrying field from a
+ * bare native string to a canonical local `file:` URI (ADR 0096), which is a
+ * field-shape change rather than an additive one, so it mints a new protocol
+ * version and new `format` versions on the three documents that carry a path.
+ * A v3 peer and a v4 peer refuse each other at the first document exchanged.
+ */
+export const VISUAL_PROTOCOL_VERSION = "yarramate/visual-protocol/v4" as const;
 
 export const VISUAL_LIMITS = {
   messageBytes: 64 * 1024,
@@ -71,7 +78,7 @@ export interface VisualSessionRequest {
 }
 
 export interface VisualSessionStarted {
-  readonly format: "yarramate/visual-session-started/v1";
+  readonly format: "yarramate/visual-session-started/v2";
   readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION;
   readonly sessionId: string;
   readonly authority: VisualAuthority;
@@ -80,19 +87,26 @@ export interface VisualSessionStarted {
   readonly browserUrl: string;
   readonly webSocketUrl: string;
   readonly origin: string;
+  /** Canonical local `file:` URI. Copy it back verbatim as the argument to
+   * `wait`/`respond`/`status`/`recover`/`stop`; it is never hand-typed as a
+   * native path. Minted by `toWireFileUri`, read by `fromWireFileUri`. */
   readonly descriptorPath: string;
+  /** Canonical local `file:` URI, as `descriptorPath`. */
   readonly sessionRoot: string;
   readonly capabilities: VisualCapabilities;
   readonly startedAt: string;
 }
 
 export interface VisualSessionDescriptor {
-  readonly format: "yarramate/visual-session-descriptor/v1";
+  readonly format: "yarramate/visual-session-descriptor/v2";
   readonly protocolVersion: typeof VISUAL_PROTOCOL_VERSION;
   readonly sessionId: string;
   readonly origin: string;
   readonly agentCapability: string;
+  /** Canonical local `file:` URI. Proven against the session actually opened
+   * before `agentCapability` is ever spent. */
   readonly sessionRoot: string;
+  /** Canonical local `file:` URI, as `sessionRoot`. */
   readonly journalPath: string;
   readonly createdAt: string;
 }
@@ -354,12 +368,13 @@ export type VisualTerminationReason =
   | "compiler-failed";
 
 export interface VisualHandoff extends VisualHandoffSummary {
-  readonly format: "yarramate/visual-handoff/v1";
+  readonly format: "yarramate/visual-handoff/v2";
   readonly sessionId: string;
   readonly authority: VisualAuthority;
   readonly decision: VisualHandoffDecision;
   readonly terminationReason: VisualTerminationReason;
   readonly lastSequence: number;
+  /** Canonical local `file:` URI. */
   readonly transcriptPath: string;
   readonly transcript?: readonly (VisualEvent | VisualResponse)[];
   readonly completedAt: string;

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -226,6 +226,22 @@ const isConfinedRelativePath = (candidate: string): boolean => {
     )
 }
 
+/**
+ * Every absolute path on the wire is forward-slash, on every platform,
+ * matching the rule `isConfinedRelativePath` already holds relative paths
+ * to: a backslash is never a wire separator, POSIX host or not. `join`/
+ * `resolve` answer in the platform's own separator, so a Windows caller
+ * building `sessionRoot`, `descriptorPath`, `journalPath`, or
+ * `transcriptPath` produces a native path that must be converted before it
+ * is placed in a schema-checked document. The conversion is unconditional
+ * rather than gated on the running platform's `path.sep`, so it behaves
+ * identically under test on any host. Node's own `fs`/`path` APIs accept
+ * forward slashes back on Windows, so the conversion loses nothing a later
+ * read needs.
+ */
+export const toWireAbsolutePath = (native: string): string =>
+  native.replace(/\\/g, '/')
+
 const modelSemantics = (
   input: unknown,
   path: string,

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
-import { posix } from 'node:path'
+import { isAbsolute, posix } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import type { ErrorObject, ValidateFunction } from 'ajv'
 import Ajv2020Module from 'ajv/dist/2020.js'
 import {
@@ -125,10 +126,10 @@ const validateVisualSessionRequest = visualValidator(
   'visual-session-request/v1',
 )
 const validateVisualSessionStarted = visualValidator(
-  'visual-session-started/v1',
+  'visual-session-started/v2',
 )
 const validateVisualSessionDescriptor = visualValidator(
-  'visual-session-descriptor/v1',
+  'visual-session-descriptor/v2',
 )
 const BROWSER_INPUT_REFERENCE =
   'https://yarramate.org/schema/visual-event/v1#/$defs/browserInput'
@@ -158,7 +159,7 @@ const browserInputBranches = new Map<string, ValidateFunction>(
 )
 const validateVisualEvent = visualValidator('visual-event/v1')
 const validateVisualResponse = visualValidator('visual-response/v1')
-const validateVisualHandoff = visualValidator('visual-handoff/v1')
+const validateVisualHandoff = visualValidator('visual-handoff/v2')
 const validateVisualStatus = visualValidator('visual-status/v1')
 const validateVisualDiagnosticResult = visualValidator(
   'visual-diagnostic-result/v1',
@@ -227,20 +228,86 @@ const isConfinedRelativePath = (candidate: string): boolean => {
 }
 
 /**
- * Every absolute path on the wire is forward-slash, on every platform,
- * matching the rule `isConfinedRelativePath` already holds relative paths
- * to: a backslash is never a wire separator, POSIX host or not. `join`/
- * `resolve` answer in the platform's own separator, so a Windows caller
- * building `sessionRoot`, `descriptorPath`, `journalPath`, or
- * `transcriptPath` produces a native path that must be converted before it
- * is placed in a schema-checked document. The conversion is unconditional
- * rather than gated on the running platform's `path.sep`, so it behaves
- * identically under test on any host. Node's own `fs`/`path` APIs accept
- * forward slashes back on Windows, so the conversion loses nothing a later
- * read needs.
+ * Encode a native absolute path for the wire.
+ *
+ * Every filesystem path a protocol document carries is a canonical local
+ * `file:` URI, minted by Node's own `pathToFileURL`. A URI is invertible
+ * where the forward-slash string transform it replaces was not: a POSIX
+ * directory whose own name contains a literal backslash percent-encodes to
+ * `%5C` and stays distinguishable from a Windows separator, and a UNC path
+ * grows a non-empty host rather than passing as an ordinary POSIX-rooted
+ * path.
+ *
+ * Encoding cannot fail. `pathToFileURL` has no error path for an
+ * already-absolute native string, and every caller holds a `resolve`/`join`
+ * result it produced itself. A relative path reaching here is a programming
+ * error rather than a protocol fault, and throws as one.
  */
-export const toWireAbsolutePath = (native: string): string =>
-  native.replace(/\\/g, '/')
+export const toWireFileUri = (native: string): string => {
+  if (!isAbsolute(native)) {
+    throw new Error(`A visual wire path must be absolute, not "${native}"`)
+  }
+  return pathToFileURL(native).href
+}
+
+/** Why one wire path was refused. Each shape is reported as `YMVS414`. */
+export type WireFileUriRefusal = 'malformed' | 'nonlocal' | 'noncanonical'
+
+export type WireFileUriResult =
+  | { readonly ok: true; readonly value: string }
+  | { readonly ok: false; readonly reason: WireFileUriRefusal }
+
+/**
+ * Decode a wire path back to native, the way untrusted input has to be read.
+ *
+ * A descriptor's bearer capabilities are never spent on a document whose path
+ * fields have not passed this first, so the three refusals are checked in a
+ * fixed order and none of them is ever quietly repaired:
+ *
+ * - `malformed` — not a parseable `file:` URI, or one `fileURLToPath` itself
+ *   rejects (`ERR_INVALID_URL`, `ERR_INVALID_URL_SCHEME`,
+ *   `ERR_INVALID_FILE_URL_PATH`). A bare native path lands here too: it has
+ *   no scheme, or, for a Windows drive root, one that is not `file:`.
+ * - `nonlocal` — a non-empty host, which `pathToFileURL` never produces for a
+ *   local path: `file://server/share/x` names a network share. The host is
+ *   read off the parsed URL rather than inferred from a `fileURLToPath`
+ *   failure, because that call refuses a foreign host on POSIX but resolves
+ *   one to a UNC path on Windows, and reading it directly is the only way one
+ *   URI earns the same refusal on both.
+ * - `noncanonical` — decodes, host is empty, but re-encoding the decoded path
+ *   does not reproduce the input byte-for-byte. Two spellings of one target is
+ *   the aliasing this representation exists to close, so the other spelling is
+ *   refused rather than normalized into the canonical one. `file://localhost/x`
+ *   lands here rather than in `nonlocal`: WHATWG `URL` normalizes a
+ *   `localhost` file host away, leaving a URI that is simply not the spelling
+ *   this codec mints for `/x`.
+ */
+export const fromWireFileUri = (uri: string): WireFileUriResult => {
+  let parsed: URL
+  try {
+    parsed = new URL(uri)
+  } catch {
+    return { ok: false, reason: 'malformed' }
+  }
+  if (parsed.protocol !== 'file:') return { ok: false, reason: 'malformed' }
+  if (parsed.hostname !== '') return { ok: false, reason: 'nonlocal' }
+  let native: string
+  try {
+    native = fileURLToPath(parsed)
+  } catch {
+    return { ok: false, reason: 'malformed' }
+  }
+  let canonical: string
+  try {
+    canonical = toWireFileUri(native)
+  } catch {
+    // `fileURLToPath` answering with something this platform does not call
+    // absolute is not a path this runtime can act on, whatever the URI meant.
+    return { ok: false, reason: 'malformed' }
+  }
+  if (canonical !== uri) return { ok: false, reason: 'noncanonical' }
+  return { ok: true, value: native }
+}
 
 const modelSemantics = (
   input: unknown,
@@ -409,7 +476,7 @@ const semanticsByDocument: Readonly<Record<string, DocumentSemantics>> = {
   'visual-browser-input/v1': chatCarryingSemantics,
   'visual-event/v1': chatCarryingSemantics,
   'visual-response/v1': responseSemantics,
-  'visual-handoff/v1': handoffSemantics,
+  'visual-handoff/v2': handoffSemantics,
 }
 
 const schemaDiagnostics = (

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -26,7 +26,7 @@ import {
   parseVisualResponse,
   parseVisualSessionStarted,
   parseVisualStatus,
-  toWireAbsolutePath,
+  toWireFileUri,
   visualBrowserInputType,
   type VisualAuthority,
   type VisualBrowserInput,
@@ -2211,17 +2211,17 @@ export const startVisualServer = async (
   let started: VisualSessionStarted;
   try {
     await writeVisualSessionDescriptor(paths, {
-      format: "yarramate/visual-session-descriptor/v1",
+      format: "yarramate/visual-session-descriptor/v2",
       protocolVersion: VISUAL_PROTOCOL_VERSION,
       sessionId,
       origin,
       agentCapability: session.agentToken,
-      sessionRoot: toWireAbsolutePath(paths.root),
-      journalPath: toWireAbsolutePath(paths.journal),
+      sessionRoot: toWireFileUri(paths.root),
+      journalPath: toWireFileUri(paths.journal),
       createdAt: stamp(),
     });
     started = {
-      format: "yarramate/visual-session-started/v1",
+      format: "yarramate/visual-session-started/v2",
       protocolVersion: VISUAL_PROTOCOL_VERSION,
       sessionId,
       authority: request.authority,
@@ -2230,8 +2230,8 @@ export const startVisualServer = async (
       browserUrl: `${origin}/bootstrap?key=${session.browserToken}`,
       webSocketUrl,
       origin,
-      descriptorPath: toWireAbsolutePath(paths.descriptor),
-      sessionRoot: toWireAbsolutePath(paths.root),
+      descriptorPath: toWireFileUri(paths.descriptor),
+      sessionRoot: toWireFileUri(paths.root),
       capabilities,
       startedAt: stamp(),
     };

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -26,6 +26,7 @@ import {
   parseVisualResponse,
   parseVisualSessionStarted,
   parseVisualStatus,
+  toWireAbsolutePath,
   visualBrowserInputType,
   type VisualAuthority,
   type VisualBrowserInput,
@@ -2215,8 +2216,8 @@ export const startVisualServer = async (
       sessionId,
       origin,
       agentCapability: session.agentToken,
-      sessionRoot: paths.root,
-      journalPath: paths.journal,
+      sessionRoot: toWireAbsolutePath(paths.root),
+      journalPath: toWireAbsolutePath(paths.journal),
       createdAt: stamp(),
     });
     started = {
@@ -2229,8 +2230,8 @@ export const startVisualServer = async (
       browserUrl: `${origin}/bootstrap?key=${session.browserToken}`,
       webSocketUrl,
       origin,
-      descriptorPath: paths.descriptor,
-      sessionRoot: paths.root,
+      descriptorPath: toWireAbsolutePath(paths.descriptor),
+      sessionRoot: toWireAbsolutePath(paths.root),
       capabilities,
       startedAt: stamp(),
     };

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -251,19 +251,21 @@ const writePrivateJson = async (path: string, value: unknown) => {
 }
 
 /**
- * The one place `VisualSessionPaths` is constructed, so it is the one place
- * that has to know a platform's own `join`/`resolve` can answer in its
- * native separator: every field is normalized to the wire's forward-slash
- * form here, once, rather than at each of the several sites that later
- * serialize one of these paths into a schema-checked document.
+ * The one place `VisualSessionPaths` is constructed. Every field stays a
+ * native filesystem path — the form `fs`/`path` APIs, the in-process state
+ * maps keyed by `paths.journal`, and directory cleanup all need — because
+ * this is consumed as a filesystem path far more often than it is ever
+ * serialized. The few sites that write one of these fields into a
+ * schema-checked wire document normalize it there, with `toWireAbsolutePath`,
+ * rather than here.
  */
 export const visualSessionPaths = (root: string): VisualSessionPaths => {
   const base = resolve(root)
   return {
-    root: toWireAbsolutePath(base),
-    marker: toWireAbsolutePath(join(base, 'session.json')),
-    descriptor: toWireAbsolutePath(join(base, 'descriptor.json')),
-    journal: toWireAbsolutePath(join(base, 'journal.jsonl')),
+    root: base,
+    marker: join(base, 'session.json'),
+    descriptor: join(base, 'descriptor.json'),
+    journal: join(base, 'journal.jsonl'),
   }
 }
 
@@ -512,8 +514,8 @@ export const writeVisualSessionDescriptor = async (
     )
   }
   if (
-    validated.value.sessionRoot !== paths.root ||
-    validated.value.journalPath !== paths.journal
+    validated.value.sessionRoot !== toWireAbsolutePath(paths.root) ||
+    validated.value.journalPath !== toWireAbsolutePath(paths.journal)
   ) {
     throw storeError(
       'YMVS125',
@@ -819,7 +821,7 @@ export const recoverVisualSession = async (
     requestedChanges: summary?.requestedChanges ?? [],
     unresolvedQuestions: summary?.unresolvedQuestions ?? [],
     finalViews: summary?.finalViews ?? visited.slice(-256),
-    transcriptPath: paths.journal,
+    transcriptPath: toWireAbsolutePath(paths.journal),
     completedAt: last?.timestamp ?? marker.createdAt,
     // Present and undefined rather than absent, so a caller cannot mistake the
     // summary-only handoff for one whose transcript it forgot to read.

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -19,7 +19,7 @@ import {
   parseVisualResponse,
   parseVisualSessionDescriptor,
   parseVisualSessionRequest,
-  toWireAbsolutePath,
+  toWireFileUri,
   type VisualAuthority,
   type VisualDiagnostic,
   type VisualEvent,
@@ -256,8 +256,8 @@ const writePrivateJson = async (path: string, value: unknown) => {
  * maps keyed by `paths.journal`, and directory cleanup all need — because
  * this is consumed as a filesystem path far more often than it is ever
  * serialized. The few sites that write one of these fields into a
- * schema-checked wire document normalize it there, with `toWireAbsolutePath`,
- * rather than here.
+ * schema-checked wire document encode it there, with `toWireFileUri`, rather
+ * than here.
  */
 export const visualSessionPaths = (root: string): VisualSessionPaths => {
   const base = resolve(root)
@@ -514,8 +514,8 @@ export const writeVisualSessionDescriptor = async (
     )
   }
   if (
-    validated.value.sessionRoot !== toWireAbsolutePath(paths.root) ||
-    validated.value.journalPath !== toWireAbsolutePath(paths.journal)
+    validated.value.sessionRoot !== toWireFileUri(paths.root) ||
+    validated.value.journalPath !== toWireFileUri(paths.journal)
   ) {
     throw storeError(
       'YMVS125',
@@ -808,7 +808,7 @@ export const recoverVisualSession = async (
 
   const last = journal.records.at(-1)
   const handoff: VisualHandoff = {
-    format: 'yarramate/visual-handoff/v1',
+    format: 'yarramate/visual-handoff/v2',
     sessionId: marker.id,
     authority: marker.authority,
     decision,
@@ -821,7 +821,7 @@ export const recoverVisualSession = async (
     requestedChanges: summary?.requestedChanges ?? [],
     unresolvedQuestions: summary?.unresolvedQuestions ?? [],
     finalViews: summary?.finalViews ?? visited.slice(-256),
-    transcriptPath: toWireAbsolutePath(paths.journal),
+    transcriptPath: toWireFileUri(paths.journal),
     completedAt: last?.timestamp ?? marker.createdAt,
     // Present and undefined rather than absent, so a caller cannot mistake the
     // summary-only handoff for one whose transcript it forgot to read.

--- a/src/adapters/visual/session-store.ts
+++ b/src/adapters/visual/session-store.ts
@@ -19,6 +19,7 @@ import {
   parseVisualResponse,
   parseVisualSessionDescriptor,
   parseVisualSessionRequest,
+  toWireAbsolutePath,
   type VisualAuthority,
   type VisualDiagnostic,
   type VisualEvent,
@@ -249,13 +250,20 @@ const writePrivateJson = async (path: string, value: unknown) => {
   await syncDirectory(dirname(path))
 }
 
+/**
+ * The one place `VisualSessionPaths` is constructed, so it is the one place
+ * that has to know a platform's own `join`/`resolve` can answer in its
+ * native separator: every field is normalized to the wire's forward-slash
+ * form here, once, rather than at each of the several sites that later
+ * serialize one of these paths into a schema-checked document.
+ */
 export const visualSessionPaths = (root: string): VisualSessionPaths => {
   const base = resolve(root)
   return {
-    root: base,
-    marker: join(base, 'session.json'),
-    descriptor: join(base, 'descriptor.json'),
-    journal: join(base, 'journal.jsonl'),
+    root: toWireAbsolutePath(base),
+    marker: toWireAbsolutePath(join(base, 'session.json')),
+    descriptor: toWireAbsolutePath(join(base, 'descriptor.json')),
+    journal: toWireAbsolutePath(join(base, 'journal.jsonl')),
   }
 }
 

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -43,7 +43,7 @@ const model = (
 const digest = (seed: string): string => seed.repeat(64).slice(0, 64);
 
 const serverSnapshot: VisualSessionSnapshot = {
-  protocolVersion: "yarramate/visual-protocol/v3",
+  protocolVersion: "yarramate/visual-protocol/v4",
   sessionId: "0".repeat(32),
   authority: "canonical",
   title: "Choose a delivery design",

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -28,7 +28,8 @@ import {
   parseVisualHandoff,
   parseVisualSessionStarted,
   parseVisualStatus,
-  toWireAbsolutePath,
+  fromWireFileUri,
+  toWireFileUri,
   type VisualBrowserInput,
   type VisualEvent,
   type VisualHandoff,
@@ -152,8 +153,22 @@ const refusalCodes = (result: CliResult): readonly string[] => {
   return parsed.value.diagnostics.map((diagnostic) => diagnostic.code)
 }
 
-const readDescriptorFile = async (path: string) =>
-  JSON.parse(await readFile(path, 'utf8')) as VisualSessionDescriptor
+/**
+ * The wire publishes `file:` URIs, so a test that goes on to touch the
+ * filesystem decodes one the way a client does.
+ */
+const nativePath = (uri: string): string => {
+  const decoded = fromWireFileUri(uri)
+  if (!decoded.ok) {
+    throw new Error(`"${uri}" is not a canonical wire path: ${decoded.reason}`)
+  }
+  return decoded.value
+}
+
+const readDescriptorFile = async (uri: string) =>
+  JSON.parse(
+    await readFile(nativePath(uri), 'utf8'),
+  ) as VisualSessionDescriptor
 
 // ------------------------------------------------------- live browser traffic
 
@@ -299,18 +314,27 @@ const plantSession = async (
     { mode: 0o600 },
   )
   const descriptor: VisualSessionDescriptor = {
-    format: 'yarramate/visual-session-descriptor/v1',
+    format: 'yarramate/visual-session-descriptor/v2',
     protocolVersion: VISUAL_PROTOCOL_VERSION,
     sessionId: id,
     origin: `http://127.0.0.1:${options.port ?? CLOSED_PORT}`,
     agentCapability: 'a'.repeat(64),
-    sessionRoot: toWireAbsolutePath(root),
-    journalPath: toWireAbsolutePath(join(root, 'journal.jsonl')),
+    sessionRoot: toWireFileUri(root),
+    journalPath: toWireFileUri(join(root, 'journal.jsonl')),
     createdAt,
   }
   const descriptorPath = join(root, 'descriptor.json')
   await writeJson(descriptorPath, descriptor)
-  return { id, root, descriptor, descriptorPath, records }
+  return {
+    id,
+    root,
+    descriptor,
+    // Native, for the tests that plant, break, or remove the file itself.
+    descriptorPath,
+    // What `start` would have published, and what every command now takes.
+    descriptorUri: toWireFileUri(descriptorPath),
+    records,
+  }
 }
 
 // --------------------------------------------------------- foreground `start`
@@ -426,41 +450,41 @@ describe('runVisualClientCli usage', () => {
   })
 
   it('prints usage for an unknown flag', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     for (const rest of [['--since', '1'], ['--transcript']]) {
       await expect(
-        runVisualClientCli(['wait', descriptorPath, ...rest], workDir),
+        runVisualClientCli(['wait', descriptorUri, ...rest], workDir),
       ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
     }
   })
 
   it('prints usage for an --after that is not a sequence', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     for (const value of ['-1', 'first', '1.5', '', '0x2', ' 1']) {
       await expect(
-        runVisualClientCli(['wait', descriptorPath, '--after', value], workDir),
+        runVisualClientCli(['wait', descriptorUri, '--after', value], workDir),
       ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
     }
     await expect(
-      runVisualClientCli(['wait', descriptorPath, '--after'], workDir),
+      runVisualClientCli(['wait', descriptorUri, '--after'], workDir),
     ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
   })
 
   it('prints usage when respond has no response document', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     await expect(
-      runVisualClientCli(['respond', descriptorPath], workDir),
+      runVisualClientCli(['respond', descriptorUri], workDir),
     ).resolves.toMatchObject({ exitCode: 2, stderr: visualUsage })
   })
 
   it('prints usage for a trailing argument', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     const rejected: readonly (readonly string[])[] = [
-      ['status', descriptorPath, '--transcript'],
-      ['recover', descriptorPath, '--transcript', '--transcript'],
-      ['stop', descriptorPath, 'now'],
-      ['respond', descriptorPath, 'response.json', 'extra.json'],
-      ['wait', descriptorPath, '--after', '1', '--transcript'],
+      ['status', descriptorUri, '--transcript'],
+      ['recover', descriptorUri, '--transcript', '--transcript'],
+      ['stop', descriptorUri, 'now'],
+      ['respond', descriptorUri, 'response.json', 'extra.json'],
+      ['wait', descriptorUri, '--after', '1', '--transcript'],
     ]
     for (const args of rejected) {
       await expect(runVisualClientCli(args, workDir)).resolves.toMatchObject({
@@ -482,7 +506,7 @@ describe('runVisualClientCli usage', () => {
 describe('descriptor confinement', () => {
   it('refuses a descriptor that is not there', async () => {
     const result = await runVisualClientCli(
-      ['status', join(workDir, 'missing.json')],
+      ['status', toWireFileUri(join(workDir, 'missing.json'))],
       workDir,
     )
     expect(result).toMatchObject({ exitCode: 1, stdout: '' })
@@ -490,10 +514,13 @@ describe('descriptor confinement', () => {
   })
 
   it('refuses a descriptor that is a symlink', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorPath, descriptorUri } = await plantSession()
     const link = join(workDir, 'linked.json')
     await symlink(descriptorPath, link)
-    const result = await runVisualClientCli(['status', link], workDir)
+    const result = await runVisualClientCli(
+      ['status', toWireFileUri(link)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS401'])
   })
@@ -511,7 +538,7 @@ describe('descriptor confinement', () => {
 
       const result = spawnSync(
         process.execPath,
-        ['dist/adapters/visual-cli.js', 'status', fifo],
+        ['dist/adapters/visual-cli.js', 'status', toWireFileUri(fifo)],
         {
           cwd: repositoryRoot,
           encoding: 'utf8',
@@ -534,7 +561,10 @@ describe('descriptor confinement', () => {
   it('refuses a descriptor that is not JSON', async () => {
     const path = join(workDir, 'descriptor.json')
     await writeFile(path, '{"format":')
-    const result = await runVisualClientCli(['status', path], workDir)
+    const result = await runVisualClientCli(
+      ['status', toWireFileUri(path)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS402'])
   })
@@ -542,7 +572,10 @@ describe('descriptor confinement', () => {
   it('refuses a document that is not a session descriptor', async () => {
     const path = join(workDir, 'descriptor.json')
     await writeJson(path, { format: 'yarramate/visual-status/v1' })
-    const result = await runVisualClientCli(['status', path], workDir)
+    const result = await runVisualClientCli(
+      ['status', toWireFileUri(path)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toContain('YMVS103')
   })
@@ -551,7 +584,10 @@ describe('descriptor confinement', () => {
     const { descriptor, root } = await plantSession()
     const path = join(root, 'descriptor.json')
     await writeJson(path, { ...descriptor, origin: 'http://model.example.com' })
-    const result = await runVisualClientCli(['status', path], workDir)
+    const result = await runVisualClientCli(
+      ['status', toWireFileUri(path)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toContain('YMVS103')
   })
@@ -560,11 +596,14 @@ describe('descriptor confinement', () => {
     const { descriptor } = await plantSession()
     const copied = join(workDir, 'descriptor.json')
     await writeJson(copied, descriptor)
-    const result = await runVisualClientCli(['stop', copied], workDir)
+    const result = await runVisualClientCli(
+      ['stop', toWireFileUri(copied)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS403'])
     // The session a redirected descriptor would have deleted is still there.
-    expect(existsSync(descriptor.sessionRoot)).toBe(true)
+    expect(existsSync(nativePath(descriptor.sessionRoot))).toBe(true)
   })
 
   it('refuses a descriptor whose journal is not the session journal', async () => {
@@ -572,20 +611,41 @@ describe('descriptor confinement', () => {
     const path = join(root, 'descriptor.json')
     await writeJson(path, {
       ...descriptor,
-      journalPath: toWireAbsolutePath(join(root, 'candidates', 'journal.jsonl')),
+      journalPath: toWireFileUri(join(root, 'candidates', 'journal.jsonl')),
     })
-    const result = await runVisualClientCli(['recover', path], workDir)
+    const result = await runVisualClientCli(
+      ['recover', toWireFileUri(path)],
+      workDir,
+    )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS403'])
   })
 
-  it('resolves a descriptor path against the working directory', async () => {
-    const { descriptor, root } = await plantSession()
-    const result = await runVisualClientCli(['recover', 'descriptor.json'], root)
-    expect(result.exitCode).toBe(0)
-    expect(JSON.parse(result.stdout)).toMatchObject({
-      sessionId: descriptor.sessionId,
-    })
+  it.each([
+    ['a working-directory-relative path', 'descriptor.json'],
+    ['an absolute native path', null],
+  ])('refuses %s as a descriptor argument', async (_label, relative) => {
+    // The v4 argument is the URI `start` published, copied back verbatim.
+    // Nothing is resolved against `cwd`, so the ambiguous path string this
+    // representation retires cannot re-enter through the one remaining
+    // hand-passed argument. This is the intended breaking change.
+    const { descriptorPath, root } = await plantSession()
+    const result = await runVisualClientCli(
+      ['recover', relative ?? descriptorPath],
+      root,
+    )
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS414'])
+  })
+
+  it.each([
+    ['a nonlocal location', 'file://server/share/descriptor.json'],
+    ['a noncanonical encoding', 'file:///tmp/yarra%2Dmate/descriptor.json'],
+    ['a non-file scheme', 'http://127.0.0.1:51234/descriptor.json'],
+  ])('refuses %s before it opens anything', async (_label, argument) => {
+    const result = await runVisualClientCli(['status', argument], workDir)
+    expect(result.exitCode).toBe(1)
+    expect(refusalCodes(result)).toEqual(['YMVS414'])
   })
 })
 
@@ -654,7 +714,7 @@ describe('wait', () => {
   it('reports a server that refuses the descriptor capability', async () => {
     const handle = await startServer()
     const descriptor = await readDescriptorFile(handle.started.descriptorPath)
-    await writeJson(handle.started.descriptorPath, {
+    await writeJson(nativePath(handle.started.descriptorPath), {
       ...descriptor,
       agentCapability: 'b'.repeat(64),
     })
@@ -667,8 +727,8 @@ describe('wait', () => {
   })
 
   it('reports a session server that is not listening', async () => {
-    const { descriptorPath } = await plantSession()
-    const result = await runVisualClientCli(['wait', descriptorPath], workDir)
+    const { descriptorUri } = await plantSession()
+    const result = await runVisualClientCli(['wait', descriptorUri], workDir)
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS404'])
   })
@@ -705,7 +765,7 @@ describe('respond', () => {
       lastSequence: 2,
     })
     expect(
-      await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'),
+      await readFile(join(nativePath(handle.started.sessionRoot), 'journal.jsonl'), 'utf8'),
     ).toContain('"type":"chat.response"')
   })
 
@@ -764,7 +824,7 @@ describe('respond', () => {
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toContain('YMVS105')
     expect(
-      await readFile(join(handle.started.sessionRoot, 'journal.jsonl'), 'utf8'),
+      await readFile(join(nativePath(handle.started.sessionRoot), 'journal.jsonl'), 'utf8'),
     ).not.toContain('"type":"chat.response"')
   })
 
@@ -804,14 +864,14 @@ describe('respond', () => {
   })
 
   it('reports a session server that is not listening', async () => {
-    const { descriptor, descriptorPath } = await plantSession()
+    const { descriptor, descriptorUri } = await plantSession()
     const responsePath = join(workDir, 'response.json')
     await writeJson(
       responsePath,
       responseFor(descriptor.sessionId, identifier(1)),
     )
     const result = await runVisualClientCli(
-      ['respond', descriptorPath, responsePath],
+      ['respond', descriptorUri, responsePath],
       workDir,
     )
     expect(result.exitCode).toBe(1)
@@ -841,8 +901,8 @@ describe('status', () => {
   })
 
   it('falls back to a stopped status when the server is gone', async () => {
-    const { descriptorPath, id } = await plantSession()
-    const result = await runVisualClientCli(['status', descriptorPath], workDir)
+    const { descriptorUri, id } = await plantSession()
+    const result = await runVisualClientCli(['status', descriptorUri], workDir)
     expect(result).toMatchObject({ exitCode: 0, stderr: '' })
     const status: unknown = JSON.parse(result.stdout)
     expect(parseVisualStatus(status).ok).toBe(true)
@@ -860,13 +920,14 @@ describe('status', () => {
   })
 
   it('reports a stopped status for a session that is already gone', async () => {
-    const { descriptor, descriptorPath, root } = await plantSession()
+    const { descriptor, descriptorPath, descriptorUri, root } =
+      await plantSession()
     await rm(root, { recursive: true, force: true })
     // Only the descriptor is restored, so confinement still holds while every
     // other session document has gone with the runtime that owned it.
     await mkdir(root, { recursive: true, mode: 0o700 })
     await writeJson(descriptorPath, descriptor)
-    const result = await runVisualClientCli(['status', descriptorPath], workDir)
+    const result = await runVisualClientCli(['status', descriptorUri], workDir)
     expect(result.exitCode).toBe(0)
     expect(JSON.parse(result.stdout)).toMatchObject({
       lifecycle: 'stopped',
@@ -878,13 +939,13 @@ describe('status', () => {
 
 describe('recover', () => {
   it('recovers the journaled handoff while the server is gone', async () => {
-    const { descriptorPath, id, root } = await plantSession()
-    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    const { descriptorUri, id, root } = await plantSession()
+    const result = await runVisualClientCli(['recover', descriptorUri], workDir)
     expect(result).toMatchObject({ exitCode: 0, stderr: '' })
     const handoff = JSON.parse(result.stdout) as VisualHandoff
     expect(parseVisualHandoff(handoff).ok).toBe(true)
     expect(handoff).toMatchObject({
-      format: 'yarramate/visual-handoff/v1',
+      format: 'yarramate/visual-handoff/v2',
       sessionId: id,
       authority: 'canonical',
       decision: 'completed',
@@ -893,7 +954,7 @@ describe('recover', () => {
       summary: 'Design A isolates delivery.',
       confirmedDecisions: ['Isolate delivery'],
       finalViews: ['choices'],
-      transcriptPath: toWireAbsolutePath(join(root, 'journal.jsonl')),
+      transcriptPath: toWireFileUri(join(root, 'journal.jsonl')),
     })
     expect('transcript' in handoff).toBe(false)
     // Recovery is a read: the session survives it.
@@ -901,9 +962,9 @@ describe('recover', () => {
   })
 
   it('includes the raw transcript when asked', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     const result = await runVisualClientCli(
-      ['recover', descriptorPath, '--transcript'],
+      ['recover', descriptorUri, '--transcript'],
       workDir,
     )
     expect(result.exitCode).toBe(0)
@@ -916,15 +977,15 @@ describe('recover', () => {
   })
 
   it('refuses a journal that is not a valid transcript', async () => {
-    const { descriptorPath, root } = await plantSession()
+    const { descriptorUri, root } = await plantSession()
     await writeFile(join(root, 'journal.jsonl'), '{"format":"nonsense"}\n')
-    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    const result = await runVisualClientCli(['recover', descriptorUri], workDir)
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS123'])
   })
 
   it('refuses a directory whose marker names another session', async () => {
-    const { descriptorPath, root } = await plantSession({
+    const { descriptorUri, root } = await plantSession({
       marker: {
         format: 'yarramate/visual-session-marker/v1',
         id: identifier(0xfeed),
@@ -932,7 +993,7 @@ describe('recover', () => {
         authority: 'canonical',
       },
     })
-    const result = await runVisualClientCli(['recover', descriptorPath], workDir)
+    const result = await runVisualClientCli(['recover', descriptorUri], workDir)
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS125'])
     expect(existsSync(root)).toBe(true)
@@ -949,7 +1010,7 @@ describe('stop', () => {
     )
     expect(result).toMatchObject({ exitCode: 0, stderr: '' })
     expect(JSON.parse(result.stdout)).toMatchObject({
-      format: 'yarramate/visual-handoff/v1',
+      format: 'yarramate/visual-handoff/v2',
       sessionId: handle.started.sessionId,
       // The runtime's own terminal event, past the arrival and the chat
       // message, and the cause this stop closed the session under.
@@ -958,7 +1019,7 @@ describe('stop', () => {
     })
     // Recovered before cleanup: the summary above came out of a journal the
     // same command then deleted.
-    expect(existsSync(handle.started.sessionRoot)).toBe(false)
+    expect(existsSync(nativePath(handle.started.sessionRoot))).toBe(false)
     await expect(handle.closed).resolves.toMatchObject({
       reason: 'main-cancelled',
       alreadyStopped: false,
@@ -970,8 +1031,8 @@ describe('stop', () => {
   })
 
   it('converges when the server is already absent', async () => {
-    const { descriptorPath, root, id } = await plantSession()
-    const result = await runVisualClientCli(['stop', descriptorPath], workDir)
+    const { descriptorUri, root, id } = await plantSession()
+    const result = await runVisualClientCli(['stop', descriptorUri], workDir)
     expect(result).toMatchObject({ exitCode: 0, stderr: '' })
     expect(JSON.parse(result.stdout)).toMatchObject({
       sessionId: id,
@@ -982,9 +1043,9 @@ describe('stop', () => {
   })
 
   it('includes the raw transcript when asked', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorUri } = await plantSession()
     const result = await runVisualClientCli(
-      ['stop', descriptorPath, '--transcript'],
+      ['stop', descriptorUri, '--transcript'],
       workDir,
     )
     expect(result.exitCode).toBe(0)
@@ -1007,27 +1068,27 @@ describe('stop', () => {
   })
 
   it('reports the already-stopped state when the stop is repeated', async () => {
-    const { descriptorPath, root } = await plantSession()
+    const { descriptorUri, root } = await plantSession()
     expect(
-      (await runVisualClientCli(['stop', descriptorPath], workDir)).exitCode,
+      (await runVisualClientCli(['stop', descriptorUri], workDir)).exitCode,
     ).toBe(0)
     expect(existsSync(root)).toBe(false)
 
     // The first stop took the descriptor and the session root together, which
     // is the one shape of unreadable descriptor that means "already stopped".
     await expect(
-      runVisualClientCli(['stop', descriptorPath], workDir),
+      runVisualClientCli(['stop', descriptorUri], workDir),
     ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
     await expect(
-      runVisualClientCli(['stop', descriptorPath, '--transcript'], workDir),
+      runVisualClientCli(['stop', descriptorUri, '--transcript'], workDir),
     ).resolves.toEqual({ exitCode: 0, stdout: '', stderr: '' })
   })
 
   it('keeps a descriptor missing from a live session root fail-closed', async () => {
-    const { descriptorPath, root } = await plantSession()
+    const { descriptorPath, descriptorUri, root } = await plantSession()
     await rm(descriptorPath)
 
-    const orphaned = await runVisualClientCli(['stop', descriptorPath], workDir)
+    const orphaned = await runVisualClientCli(['stop', descriptorUri], workDir)
 
     expect(orphaned.exitCode).toBe(1)
     expect(refusalCodes(orphaned)).toEqual(['YMVS401'])
@@ -1036,10 +1097,10 @@ describe('stop', () => {
   })
 
   it('refuses an unreadable descriptor rather than calling it stopped', async () => {
-    const { descriptorPath } = await plantSession()
+    const { descriptorPath, descriptorUri } = await plantSession()
     await writeFile(descriptorPath, '{"format":')
 
-    const corrupt = await runVisualClientCli(['stop', descriptorPath], workDir)
+    const corrupt = await runVisualClientCli(['stop', descriptorUri], workDir)
 
     expect(corrupt.exitCode).toBe(1)
     expect(refusalCodes(corrupt)).toEqual(['YMVS402'])
@@ -1047,7 +1108,7 @@ describe('stop', () => {
     // A path that never was a session directory is not a stop either: only
     // commands aimed at a vanished session root report the benign state.
     const stray = await runVisualClientCli(
-      ['stop', join(workDir, 'stray.json')],
+      ['stop', toWireFileUri(join(workDir, 'stray.json'))],
       workDir,
     )
     expect(stray.exitCode).toBe(1)
@@ -1056,14 +1117,17 @@ describe('stop', () => {
 
   it('does not call an arbitrary missing parent an already-stopped session', async () => {
     const missing = join(workDir, 'missing', 'parent', 'descriptor.json')
-    const result = await runVisualClientCli(['stop', missing], workDir)
+    const result = await runVisualClientCli(
+      ['stop', toWireFileUri(missing)],
+      workDir,
+    )
 
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS401'])
   })
 
   it('never deletes a directory whose marker names another session', async () => {
-    const { descriptorPath, root } = await plantSession({
+    const { descriptorUri, root } = await plantSession({
       marker: {
         format: 'yarramate/visual-session-marker/v1',
         id: identifier(0xfeed),
@@ -1071,7 +1135,7 @@ describe('stop', () => {
         authority: 'canonical',
       },
     })
-    const result = await runVisualClientCli(['stop', descriptorPath], workDir)
+    const result = await runVisualClientCli(['stop', descriptorUri], workDir)
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS125'])
     expect(existsSync(root)).toBe(true)
@@ -1080,7 +1144,7 @@ describe('stop', () => {
   it('never deletes a session the server refused to hand over', async () => {
     const handle = await startServer()
     const descriptor = await readDescriptorFile(handle.started.descriptorPath)
-    await writeJson(handle.started.descriptorPath, {
+    await writeJson(nativePath(handle.started.descriptorPath), {
       ...descriptor,
       agentCapability: 'b'.repeat(64),
     })
@@ -1090,7 +1154,7 @@ describe('stop', () => {
     )
     expect(result.exitCode).toBe(1)
     expect(refusalCodes(result)).toEqual(['YMVS405'])
-    expect(existsSync(handle.started.sessionRoot)).toBe(true)
+    expect(existsSync(nativePath(handle.started.sessionRoot))).toBe(true)
     expect(handle.status().lifecycle).toBe('running')
   })
 })
@@ -1109,7 +1173,7 @@ describe('runVisualStart', () => {
     expect(foreground.stdout).toEqual([line(started)])
     expect(foreground.stderr).toEqual([])
     expect(started).toMatchObject({
-      format: 'yarramate/visual-session-started/v1',
+      format: 'yarramate/visual-session-started/v2',
       protocolVersion: VISUAL_PROTOCOL_VERSION,
       authority: 'canonical',
       title: 'Choose a delivery design',
@@ -1117,7 +1181,7 @@ describe('runVisualStart', () => {
       capabilities: { chat: true, transcript: true },
     })
     expect(started.sessionRoot).toBe(
-      toWireAbsolutePath(join(workDir, VISUAL_SESSION_DIRECTORY, started.sessionId)),
+      toWireFileUri(join(workDir, VISUAL_SESSION_DIRECTORY, started.sessionId)),
     )
 
     foreground.signals.emit('SIGTERM')
@@ -1148,7 +1212,7 @@ describe('runVisualStart', () => {
 
     foreground.signals.emit('SIGTERM')
     await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
-    expect(existsSync(started.sessionRoot)).toBe(false)
+    expect(existsSync(nativePath(started.sessionRoot))).toBe(false)
     await expect(fetch(`${started.origin}/api/session`)).rejects.toThrow()
   })
 
@@ -1158,7 +1222,7 @@ describe('runVisualStart', () => {
 
     foreground.signals.emit('SIGINT')
     await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
-    expect(existsSync(started.sessionRoot)).toBe(false)
+    expect(existsSync(nativePath(started.sessionRoot))).toBe(false)
   })
 
   it('removes its signal handlers once it returns', async () => {
@@ -1185,7 +1249,7 @@ describe('runVisualStart', () => {
       stdout: '',
       stderr: '',
     })
-    expect(existsSync(started.sessionRoot)).toBe(false)
+    expect(existsSync(nativePath(started.sessionRoot))).toBe(false)
   })
 
   /**
@@ -1210,7 +1274,7 @@ describe('runVisualStart', () => {
     async () => {
       const foreground = startForeground(await writeRequest(), workDir)
       const started = await foreground.started
-      const journal = join(started.sessionRoot, 'journal.jsonl')
+      const journal = join(nativePath(started.sessionRoot), 'journal.jsonl')
       const rejections: unknown[] = []
       const observe = (reason: unknown) => rejections.push(reason)
       // One turn of the loop, which is also one turn of the teardown's own
@@ -1225,7 +1289,7 @@ describe('runVisualStart', () => {
       try {
         // Readable and traversable, so the recovery a stop reads still
         // succeeds; not writable, so the removal that follows it cannot.
-        await chmod(started.sessionRoot, 0o500)
+        await chmod(nativePath(started.sessionRoot), 0o500)
         foreground.signals.emit('SIGTERM')
 
         // The terminal event is the last thing journaled before the removal
@@ -1251,13 +1315,13 @@ describe('runVisualStart', () => {
         // The teardown failed: the command is still blocked, its session is
         // still on disk, and the runtime was told about none of it.
         expect(blocked).toBeUndefined()
-        expect(existsSync(started.sessionRoot)).toBe(true)
+        expect(existsSync(nativePath(started.sessionRoot))).toBe(true)
         expect(rejections).toEqual([])
 
         // A stop that failed stopped nothing: a later signal runs the teardown
         // again. One that lands on an attempt still in flight is absorbed by
         // it, so the command is signalled every turn until it returns.
-        await chmod(started.sessionRoot, 0o700)
+        await chmod(nativePath(started.sessionRoot), 0o700)
         let closed = await turn()
         for (
           let spin = 0;
@@ -1269,14 +1333,14 @@ describe('runVisualStart', () => {
         }
 
         expect(closed).toMatchObject({ exitCode: 0 })
-        expect(existsSync(started.sessionRoot)).toBe(false)
+        expect(existsSync(nativePath(started.sessionRoot))).toBe(false)
         expect(rejections).toEqual([])
       } finally {
         process.off('unhandledRejection', observe)
         // Whatever failed, the temporary directory cannot be collected while
         // one of its sessions refuses to be unlinked from.
-        if (existsSync(started.sessionRoot)) {
-          await chmod(started.sessionRoot, 0o700)
+        if (existsSync(nativePath(started.sessionRoot))) {
+          await chmod(nativePath(started.sessionRoot), 0o700)
         }
       }
     },
@@ -1336,13 +1400,13 @@ describe('runVisualStart', () => {
       // The runtime recovered the handoff before it deleted the session.
       expect(await stopped.json()).toMatchObject({
         reason,
-        handoff: { format: 'yarramate/visual-handoff/v1' },
+        handoff: { format: 'yarramate/visual-handoff/v2' },
       })
 
       const result = await foreground.result
       expect(result).toMatchObject({ exitCode: 1, stdout: '' })
       expect(refusalCodes(result)).toEqual(['YMVS409'])
-      expect(existsSync(started.sessionRoot)).toBe(false)
+      expect(existsSync(nativePath(started.sessionRoot))).toBe(false)
       expect(foreground.signals.listenerCount('SIGTERM')).toBe(0)
     },
   )
@@ -1421,7 +1485,7 @@ describe('runVisualStart', () => {
     const foreground = startForeground(await writeRequest(), workDir)
     const started = await foreground.started
     expect(existsSync(root)).toBe(false)
-    expect(existsSync(started.sessionRoot)).toBe(true)
+    expect(existsSync(nativePath(started.sessionRoot))).toBe(true)
 
     foreground.signals.emit('SIGTERM')
     await expect(foreground.result).resolves.toMatchObject({ exitCode: 0 })
@@ -1433,8 +1497,8 @@ describe('runVisualStart', () => {
       stdout: `yarramate-visual ${packageVersion}\n`,
       stderr: '',
     })
-    const { descriptorPath, id } = await plantSession()
-    const dispatched = await runVisualCli(['recover', descriptorPath], workDir)
+    const { descriptorUri, id } = await plantSession()
+    const dispatched = await runVisualCli(['recover', descriptorUri], workDir)
     expect(dispatched).toMatchObject({ exitCode: 0, stderr: '' })
     expect(JSON.parse(dispatched.stdout)).toMatchObject({ sessionId: id })
   })

--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -28,6 +28,7 @@ import {
   parseVisualHandoff,
   parseVisualSessionStarted,
   parseVisualStatus,
+  toWireAbsolutePath,
   type VisualBrowserInput,
   type VisualEvent,
   type VisualHandoff,
@@ -303,8 +304,8 @@ const plantSession = async (
     sessionId: id,
     origin: `http://127.0.0.1:${options.port ?? CLOSED_PORT}`,
     agentCapability: 'a'.repeat(64),
-    sessionRoot: root,
-    journalPath: join(root, 'journal.jsonl'),
+    sessionRoot: toWireAbsolutePath(root),
+    journalPath: toWireAbsolutePath(join(root, 'journal.jsonl')),
     createdAt,
   }
   const descriptorPath = join(root, 'descriptor.json')
@@ -571,7 +572,7 @@ describe('descriptor confinement', () => {
     const path = join(root, 'descriptor.json')
     await writeJson(path, {
       ...descriptor,
-      journalPath: join(root, 'candidates', 'journal.jsonl'),
+      journalPath: toWireAbsolutePath(join(root, 'candidates', 'journal.jsonl')),
     })
     const result = await runVisualClientCli(['recover', path], workDir)
     expect(result.exitCode).toBe(1)
@@ -892,7 +893,7 @@ describe('recover', () => {
       summary: 'Design A isolates delivery.',
       confirmedDecisions: ['Isolate delivery'],
       finalViews: ['choices'],
-      transcriptPath: join(root, 'journal.jsonl'),
+      transcriptPath: toWireAbsolutePath(join(root, 'journal.jsonl')),
     })
     expect('transcript' in handoff).toBe(false)
     // Recovery is a read: the session survives it.
@@ -1116,7 +1117,7 @@ describe('runVisualStart', () => {
       capabilities: { chat: true, transcript: true },
     })
     expect(started.sessionRoot).toBe(
-      join(workDir, VISUAL_SESSION_DIRECTORY, started.sessionId),
+      toWireAbsolutePath(join(workDir, VISUAL_SESSION_DIRECTORY, started.sessionId)),
     )
 
     foreground.signals.emit('SIGTERM')

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   VISUAL_LIMITS,
   digestOf,
+  fromWireFileUri,
   type VisualBrowserInput,
   type VisualEvent,
   type VisualHandoff,
@@ -159,9 +160,23 @@ const completeHandoff = (event: VisualEvent, summary: VisualHandoffSummary) =>
 
 // -------------------------------------------------------------------- harness
 
+/**
+ * The wire publishes `file:` URIs, so a test that goes on to touch the
+ * filesystem decodes one the way a client does.
+ */
+const nativePath = (uri: string): string => {
+  const decoded = fromWireFileUri(uri)
+  if (!decoded.ok) {
+    throw new Error(`"${uri}" is not a canonical wire path: ${decoded.reason}`)
+  }
+  return decoded.value
+}
+
 interface VisualFixture {
   readonly handle: VisualServerHandle
+  /** The URI every client command takes, exactly as `start` published it. */
   readonly descriptorPath: string
+  /** Decoded, because the assertions here reach for the directory itself. */
   readonly sessionRoot: string
   readonly sessionId: string
   readonly origin: string
@@ -208,7 +223,7 @@ const startVisualFixture = async (
   return {
     handle,
     descriptorPath: handle.started.descriptorPath,
-    sessionRoot: handle.started.sessionRoot,
+    sessionRoot: nativePath(handle.started.sessionRoot),
     sessionId: handle.started.sessionId,
     origin: handle.started.origin,
     graceScheduled: armed.promise,
@@ -388,7 +403,9 @@ const waitForVisualEvent = async <Type extends VisualEvent['type']>(
   after: number,
   type: Type,
 ): Promise<Extract<VisualEvent, { readonly type: Type }>> => {
-  const { journalPath } = await descriptorAt(descriptorPath)
+  const journalPath = nativePath(
+    (await descriptorAt(descriptorPath)).journalPath,
+  )
   // The callback watcher, not `fs/promises.watch`: the promise form is an async
   // generator that registers nothing until its first iteration, so it cannot be
   // armed ahead of the read. This one is watching from the moment it is

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -10,7 +10,8 @@ import {
   parseVisualSessionRequest,
   parseVisualSessionStarted,
   parseVisualStatus,
-  toWireAbsolutePath,
+  fromWireFileUri,
+  toWireFileUri,
   VISUAL_LIMITS,
   VISUAL_PROTOCOL_VERSION,
 } from '../src/adapters/visual/protocol.js'
@@ -58,6 +59,8 @@ const sessionRequest = {
   initialModel: model,
 } as const
 
+const posixOnly = process.platform !== 'win32'
+
 const capabilities = {
   chat: true,
   choices: true,
@@ -66,7 +69,7 @@ const capabilities = {
 } as const
 
 const sessionStarted = {
-  format: 'yarramate/visual-session-started/v1',
+  format: 'yarramate/visual-session-started/v2',
   protocolVersion: VISUAL_PROTOCOL_VERSION,
   sessionId,
   authority: 'canonical',
@@ -75,21 +78,21 @@ const sessionStarted = {
   browserUrl: 'http://127.0.0.1:51234/bootstrap?key=0123456789abcdef',
   webSocketUrl: 'ws://127.0.0.1:51234/socket',
   origin: 'http://127.0.0.1:51234',
-  descriptorPath: '/tmp/yarramate-visual/session/descriptor.json',
-  sessionRoot: '/tmp/yarramate-visual/session',
+  descriptorPath: 'file:///tmp/yarramate-visual/session/descriptor.json',
+  sessionRoot: 'file:///tmp/yarramate-visual/session',
   capabilities,
   startedAt: timestamp,
 } as const
 
 const sessionDescriptor = {
-  format: 'yarramate/visual-session-descriptor/v1',
+  format: 'yarramate/visual-session-descriptor/v2',
   protocolVersion: VISUAL_PROTOCOL_VERSION,
   sessionId,
   origin: 'http://127.0.0.1:51234',
   agentCapability:
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-  sessionRoot: '/tmp/yarramate-visual/session',
-  journalPath: '/tmp/yarramate-visual/session/journal.jsonl',
+  sessionRoot: 'file:///tmp/yarramate-visual/session',
+  journalPath: 'file:///tmp/yarramate-visual/session/journal.jsonl',
   createdAt: timestamp,
 } as const
 
@@ -163,13 +166,13 @@ const responsePayloads: Readonly<Record<string, unknown>> = {
 }
 
 const handoff = {
-  format: 'yarramate/visual-handoff/v1',
+  format: 'yarramate/visual-handoff/v2',
   sessionId,
   authority: 'canonical',
   decision: 'completed',
   terminationReason: 'user-ended',
   lastSequence: 3,
-  transcriptPath: '/tmp/yarramate-visual/session/journal.jsonl',
+  transcriptPath: 'file:///tmp/yarramate-visual/session/journal.jsonl',
   completedAt: timestamp,
   ...handoffSummary,
 } as const
@@ -256,32 +259,64 @@ describe('visual protocol', () => {
     })
   })
 
-  it('accepts a normalized Windows drive root as an absolute path', () => {
+  it('accepts a Windows drive-root file URI', () => {
     expect(
       parseVisualSessionStarted({
         ...sessionStarted,
-        descriptorPath: 'C:/Users/nabsha/.yarramate-visual/abc123/descriptor.json',
-        sessionRoot: 'C:/Users/nabsha/.yarramate-visual/abc123',
+        descriptorPath:
+          'file:///C:/Users/nabsha/.yarramate-visual/abc123/descriptor.json',
+        sessionRoot: 'file:///C:/Users/nabsha/.yarramate-visual/abc123',
       }),
     ).toMatchObject({ ok: true })
     expect(
       parseVisualSessionDescriptor({
         ...sessionDescriptor,
-        sessionRoot: 'C:/Users/nabsha/.yarramate-visual/abc123',
-        journalPath: 'C:/Users/nabsha/.yarramate-visual/abc123/journal.jsonl',
+        sessionRoot: 'file:///C:/Users/nabsha/.yarramate-visual/abc123',
+        journalPath:
+          'file:///C:/Users/nabsha/.yarramate-visual/abc123/journal.jsonl',
       }),
     ).toMatchObject({ ok: true })
   })
 
-  it('rejects a raw Windows path: a backslash is never a wire separator', () => {
+  it.each([
+    ['a raw POSIX path', '/tmp/yarramate-visual/abc123/descriptor.json'],
+    [
+      'a raw Windows path',
+      'C:\\Users\\nabsha\\.yarramate-visual\\abc123\\descriptor.json',
+    ],
+    [
+      'a forward-slash Windows path, the v3 wire form',
+      'C:/Users/nabsha/.yarramate-visual/abc123/descriptor.json',
+    ],
+    ['a UNC-derived URI', 'file://server/share/abc123/descriptor.json'],
+    ['a non-file scheme', 'http://127.0.0.1:51234/descriptor.json'],
+  ])('rejects %s as a wire path', (_label, descriptorPath) => {
     expect(
-      parseVisualSessionStarted({
-        ...sessionStarted,
-        descriptorPath:
-          'C:\\Users\\nabsha\\.yarramate-visual\\abc123\\descriptor.json',
-        sessionRoot: 'C:\\Users\\nabsha\\.yarramate-visual\\abc123',
-      }),
+      parseVisualSessionStarted({ ...sessionStarted, descriptorPath }),
     ).toMatchObject({ ok: false })
+  })
+
+  it('refuses a v3 document rather than translating it', () => {
+    // No bespoke "v3 detected" code: the version consts fail like any other
+    // schema violation, which is what makes the incompatibility detectable.
+    expect(
+      parseVisualSessionDescriptor({
+        ...sessionDescriptor,
+        format: 'yarramate/visual-session-descriptor/v1',
+        protocolVersion: 'yarramate/visual-protocol/v3',
+        sessionRoot: '/tmp/yarramate-visual/session',
+        journalPath: '/tmp/yarramate-visual/session/journal.jsonl',
+      }),
+    ).toMatchObject({
+      ok: false,
+      diagnostics: expect.arrayContaining([
+        expect.objectContaining({ code: 'YMVS103', pointer: '/format' }),
+        expect.objectContaining({
+          code: 'YMVS103',
+          pointer: '/protocolVersion',
+        }),
+      ]),
+    })
   })
 
   it.each(Object.keys(eventPayloads))('accepts the %s event', (type) => {
@@ -820,24 +855,97 @@ describe('visual protocol', () => {
   })
 })
 
-describe('toWireAbsolutePath', () => {
-  it('converts a Windows drive path to forward slashes', () => {
-    expect(toWireAbsolutePath('C:\\Users\\nabsha\\.yarramate-visual\\abc123')).toBe(
-      'C:/Users/nabsha/.yarramate-visual/abc123',
+describe('toWireFileUri', () => {
+  it('encodes a POSIX path as a local file URI that round-trips', () => {
+    expect(toWireFileUri('/tmp/yarramate-visual/abc123')).toBe(
+      'file:///tmp/yarramate-visual/abc123',
     )
+    expect(
+      fromWireFileUri('file:///tmp/yarramate-visual/abc123'),
+    ).toMatchObject({ ok: true, value: '/tmp/yarramate-visual/abc123' })
   })
 
-  it('leaves a POSIX path unchanged', () => {
-    expect(toWireAbsolutePath('/tmp/yarramate-visual/abc123')).toBe(
-      '/tmp/yarramate-visual/abc123',
-    )
+  it.each([
+    ['a space', '/tmp/yarra mate/abc123'],
+    ['a hash', '/tmp/yarramate#1/abc123'],
+    ['a question mark', '/tmp/yarramate?1/abc123'],
+    ['a non-ASCII byte', '/tmp/yarramaté/abc123'],
+  ])('percent-encodes %s and round-trips it', (_label, native) => {
+    const uri = toWireFileUri(native)
+    expect(uri.startsWith('file:///')).toBe(true)
+    expect(fromWireFileUri(uri)).toMatchObject({ ok: true, value: native })
   })
 
-  it('is unconditional: it does not depend on the running platform', () => {
-    // A backslash is never a wire separator (matching isConfinedRelativePath's
-    // rule for relative paths), so the conversion always runs rather than
-    // being gated on this process's own path.sep — otherwise the Windows
-    // branch would be untestable on a POSIX CI runner.
-    expect(toWireAbsolutePath('relative\\segment')).toBe('relative/segment')
+  // The defect that motivated the change: under the forward-slash transform
+  // this directory and a Windows path joined with native separators
+  // collapsed to the same wire string, and `fs` calls then missed the
+  // directory the session actually created.
+  it.skipIf(!posixOnly)(
+    'keeps a directory name containing a backslash distinct from a separator',
+    () => {
+      const native = '/tmp/yarramate-visual-\\store-abc/journal.jsonl'
+      const uri = toWireFileUri(native)
+      expect(uri).toBe('file:///tmp/yarramate-visual-%5Cstore-abc/journal.jsonl')
+      expect(uri).not.toBe(toWireFileUri('/tmp/yarramate-visual-/store-abc/journal.jsonl'))
+      expect(fromWireFileUri(uri)).toMatchObject({ ok: true, value: native })
+    },
+  )
+
+  it.skipIf(posixOnly)('encodes a Windows drive-root path', () => {
+    const uri = toWireFileUri('C:\\Users\\nabsha\\.yarramate-visual\\abc123')
+    expect(uri).toBe('file:///C:/Users/nabsha/.yarramate-visual/abc123')
+    expect(fromWireFileUri(uri)).toMatchObject({
+      ok: true,
+      value: 'C:\\Users\\nabsha\\.yarramate-visual\\abc123',
+    })
+  })
+
+  it('refuses to encode a relative path: that is a programming error', () => {
+    expect(() => toWireFileUri('relative/segment')).toThrow(
+      /must be absolute/,
+    )
+  })
+})
+
+describe('fromWireFileUri', () => {
+  it.each([
+    ['a non-file scheme', 'http://127.0.0.1/tmp/abc123'],
+    ['a data URI', 'data:text/plain,abc123'],
+    ['a bare POSIX path', '/tmp/yarramate-visual/abc123'],
+    ['a bare Windows path', 'C:\\Users\\nabsha\\abc123'],
+    ['a forward-slash Windows path', 'C:/Users/nabsha/abc123'],
+    ['an unbalanced percent escape', 'file:///tmp/abc%2'],
+    // `fileURLToPath` refuses an encoded separator itself: a path segment
+    // that decodes to one containing `/` is not a path this runtime can open.
+    ['an over-encoded separator', 'file:///tmp%2Fyarramate-visual/abc123'],
+  ])('refuses %s as malformed', (_label, uri) => {
+    expect(fromWireFileUri(uri)).toEqual({ ok: false, reason: 'malformed' })
+  })
+
+  it('refuses a UNC-derived URI as nonlocal', () => {
+    // Read off the parsed URL, not inferred from a `fileURLToPath` failure,
+    // so the same URI earns the same refusal on POSIX and on Windows.
+    expect(fromWireFileUri('file://server/share/abc123')).toEqual({
+      ok: false,
+      reason: 'nonlocal',
+    })
+  })
+
+  it.each([
+    [
+      'an explicit localhost host',
+      'file://localhost/tmp/abc123',
+      // WHATWG `URL` normalizes a `localhost` file host away, so this never
+      // reaches the host check: it is caught one step later, as the second
+      // spelling of a target whose canonical form is `file:///tmp/abc123`.
+    ],
+    ['an unnecessary escape', 'file:///tmp/yarramate%2Dvisual/abc123'],
+    ['a dot segment', 'file:///tmp/yarramate-visual/./abc123'],
+    ['a parent segment', 'file:///tmp/yarramate-visual/x/../abc123'],
+  ])('refuses %s as noncanonical', (_label, uri) => {
+    // One native target has exactly one accepted spelling. A second spelling
+    // is refused rather than normalized: normalizing is what made two
+    // distinct paths indistinguishable in the first place.
+    expect(fromWireFileUri(uri)).toEqual({ ok: false, reason: 'noncanonical' })
   })
 })

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -10,6 +10,7 @@ import {
   parseVisualSessionRequest,
   parseVisualSessionStarted,
   parseVisualStatus,
+  toWireAbsolutePath,
   VISUAL_LIMITS,
   VISUAL_PROTOCOL_VERSION,
 } from '../src/adapters/visual/protocol.js'
@@ -253,6 +254,34 @@ describe('visual protocol', () => {
     expect(parseVisualDiagnosticResult(diagnosticResult)).toMatchObject({
       ok: true,
     })
+  })
+
+  it('accepts a normalized Windows drive root as an absolute path', () => {
+    expect(
+      parseVisualSessionStarted({
+        ...sessionStarted,
+        descriptorPath: 'C:/Users/nabsha/.yarramate-visual/abc123/descriptor.json',
+        sessionRoot: 'C:/Users/nabsha/.yarramate-visual/abc123',
+      }),
+    ).toMatchObject({ ok: true })
+    expect(
+      parseVisualSessionDescriptor({
+        ...sessionDescriptor,
+        sessionRoot: 'C:/Users/nabsha/.yarramate-visual/abc123',
+        journalPath: 'C:/Users/nabsha/.yarramate-visual/abc123/journal.jsonl',
+      }),
+    ).toMatchObject({ ok: true })
+  })
+
+  it('rejects a raw Windows path: a backslash is never a wire separator', () => {
+    expect(
+      parseVisualSessionStarted({
+        ...sessionStarted,
+        descriptorPath:
+          'C:\\Users\\nabsha\\.yarramate-visual\\abc123\\descriptor.json',
+        sessionRoot: 'C:\\Users\\nabsha\\.yarramate-visual\\abc123',
+      }),
+    ).toMatchObject({ ok: false })
   })
 
   it.each(Object.keys(eventPayloads))('accepts the %s event', (type) => {
@@ -788,5 +817,27 @@ describe('visual protocol', () => {
         },
       }),
     ).toMatchObject({ ok: true })
+  })
+})
+
+describe('toWireAbsolutePath', () => {
+  it('converts a Windows drive path to forward slashes', () => {
+    expect(toWireAbsolutePath('C:\\Users\\nabsha\\.yarramate-visual\\abc123')).toBe(
+      'C:/Users/nabsha/.yarramate-visual/abc123',
+    )
+  })
+
+  it('leaves a POSIX path unchanged', () => {
+    expect(toWireAbsolutePath('/tmp/yarramate-visual/abc123')).toBe(
+      '/tmp/yarramate-visual/abc123',
+    )
+  })
+
+  it('is unconditional: it does not depend on the running platform', () => {
+    // A backslash is never a wire separator (matching isConfinedRelativePath's
+    // rule for relative paths), so the conversion always runs rather than
+    // being gated on this process's own path.sep — otherwise the Windows
+    // branch would be untestable on a POSIX CI runner.
+    expect(toWireAbsolutePath('relative\\segment')).toBe('relative/segment')
   })
 })

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -20,6 +20,7 @@ import { WebSocket } from "ws";
 import { parse } from "yaml";
 import {
   VISUAL_LIMITS,
+  fromWireFileUri,
   parseVisualDiagnosticResult,
   parseVisualSessionDescriptor,
   type VisualDiagnostic,
@@ -112,16 +113,29 @@ const start = async (overrides: Partial<VisualServerOptions> = {}) => {
 };
 
 /**
+ * The wire publishes `file:` URIs, so a test that goes on to touch the
+ * filesystem decodes one exactly the way a client does — which also asserts
+ * that what the runtime published is decodable at all.
+ */
+const nativePath = (uri: string): string => {
+  const decoded = fromWireFileUri(uri);
+  if (!decoded.ok) {
+    throw new Error(`"${uri}" is not a canonical wire path: ${decoded.reason}`);
+  }
+  return decoded.value;
+};
+
+/**
  * Reads the private descriptor through the protocol parser, so a test that
  * depends on one of its fields also asserts the document is valid.
  */
-const readDescriptor = async (descriptorPath: string) => {
+const readDescriptor = async (descriptorUri: string) => {
   const parsed = parseVisualSessionDescriptor(
-    JSON.parse(await readFile(descriptorPath, "utf8")),
+    JSON.parse(await readFile(nativePath(descriptorUri), "utf8")),
   );
   if (!parsed.ok) {
     throw new Error(
-      `descriptor "${descriptorPath}" is invalid: ${parsed.diagnostics[0]?.message}`,
+      `descriptor "${descriptorUri}" is invalid: ${parsed.diagnostics[0]?.message}`,
     );
   }
   return parsed.value;
@@ -304,11 +318,13 @@ const chatResponse = (
  * next would hand one of those back as the event under test.
  */
 const waitForVisualEvent = async <Type extends VisualEvent["type"]>(
-  descriptorPath: string,
+  descriptorUri: string,
   after: number,
   type: Type,
 ): Promise<Extract<VisualEvent, { readonly type: Type }>> => {
-  const { journalPath } = await readDescriptor(descriptorPath);
+  const journalPath = nativePath(
+    (await readDescriptor(descriptorUri)).journalPath,
+  );
   // The callback watcher, not `fs/promises.watch`: the promise form is an async
   // generator that registers nothing until its first iteration, so it cannot be
   // armed ahead of the read the way this window needs. This one is watching
@@ -347,7 +363,7 @@ const waitForVisualEvent = async <Type extends VisualEvent["type"]>(
 };
 
 const journalOf = async (handle: VisualServerHandle) =>
-  (await readFile(join(handle.started.sessionRoot, "journal.jsonl"), "utf8"))
+  (await readFile(join(nativePath(handle.started.sessionRoot), "journal.jsonl"), "utf8"))
     .split("\n")
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as VisualEvent | VisualResponse);
@@ -1716,11 +1732,11 @@ describe("startVisualServer lifecycle", () => {
   it("writes a private descriptor carrying only the agent capability", async () => {
     const server = await start();
     const descriptor: unknown = JSON.parse(
-      await readFile(server.started.descriptorPath, "utf8"),
+      await readFile(nativePath(server.started.descriptorPath), "utf8"),
     );
     expect(descriptor).toMatchObject({
-      format: "yarramate/visual-session-descriptor/v1",
-      protocolVersion: "yarramate/visual-protocol/v3",
+      format: "yarramate/visual-session-descriptor/v2",
+      protocolVersion: "yarramate/visual-protocol/v4",
       sessionId: server.started.sessionId,
       origin: server.started.origin,
       sessionRoot: server.started.sessionRoot,
@@ -1730,7 +1746,9 @@ describe("startVisualServer lifecycle", () => {
     ) as string;
     expect(JSON.stringify(descriptor)).not.toContain(token);
     if (process.platform !== "win32") {
-      expect((await stat(server.started.descriptorPath)).mode & 0o777).toBe(
+      expect(
+        (await stat(nativePath(server.started.descriptorPath))).mode & 0o777,
+      ).toBe(
         0o600,
       );
     }
@@ -1756,7 +1774,7 @@ describe("startVisualServer lifecycle", () => {
       capability,
       chatResponse(server, accepted.eventId, 1),
     );
-    const root = server.started.sessionRoot;
+    const root = nativePath(server.started.sessionRoot);
 
     const closed = await server.stop("user-ended");
     expect(closed).toMatchObject({
@@ -1764,7 +1782,7 @@ describe("startVisualServer lifecycle", () => {
       alreadyStopped: false,
     });
     expect(closed.handoff).toMatchObject({
-      format: "yarramate/visual-handoff/v1",
+      format: "yarramate/visual-handoff/v2",
       sessionId: server.started.sessionId,
       // The reviewer's own End was never journaled here, so the shutdown's
       // terminal event is the record past the chat it recovered.
@@ -1802,7 +1820,7 @@ describe("startVisualServer lifecycle", () => {
     await expect(response.json()).resolves.toMatchObject({
       reason: "user-ended",
       alreadyStopped: false,
-      handoff: { format: "yarramate/visual-handoff/v1" },
+      handoff: { format: "yarramate/visual-handoff/v2" },
     });
     await server.closed;
     await expect(
@@ -1940,7 +1958,10 @@ describe("startVisualServer lifecycle", () => {
   it("does not admit a browser whose connected event cannot be journaled", async () => {
     const server = await start();
     const { cookie } = await bootstrap(server);
-    await chmod(join(server.started.sessionRoot, "journal.jsonl"), 0o400);
+    await chmod(
+      join(nativePath(server.started.sessionRoot), "journal.jsonl"),
+      0o400,
+    );
 
     const socket = await openBrowserSocket(server, cookie);
     await once(socket, "close");
@@ -2034,7 +2055,9 @@ describe("startVisualServer shutdown and admission races", () => {
       alreadyStopped: true,
     });
     // Nothing may recreate the session directory after recovery deleted it.
-    await expect(stat(server.started.sessionRoot)).rejects.toThrow();
+    await expect(
+      stat(nativePath(server.started.sessionRoot)),
+    ).rejects.toThrow();
     expect(await rejections.settled()).toEqual([]);
   });
 
@@ -2099,7 +2122,9 @@ describe("startVisualServer shutdown and admission races", () => {
       .filter((record) => record.type === "chat.message")
       .map((record) => JSON.stringify(record.payload));
     expect(texts).toEqual([JSON.stringify({ text: "in time" })]);
-    await expect(stat(server.started.sessionRoot)).rejects.toThrow();
+    await expect(
+      stat(nativePath(server.started.sessionRoot)),
+    ).rejects.toThrow();
     expect(await rejections.settled()).toEqual([]);
   });
 });
@@ -2226,7 +2251,7 @@ describe("startVisualServer teardown retries", () => {
     "retries a teardown the first stop failed to finish",
     async () => {
       const server = await start();
-      const root = server.started.sessionRoot;
+      const root = nativePath(server.started.sessionRoot);
       // Readable and traversable, so the recovery the stop reads still
       // succeeds; not writable, so the removal that follows it cannot.
       await chmod(root, 0o500);
@@ -2244,7 +2269,7 @@ describe("startVisualServer teardown retries", () => {
         alreadyStopped: false,
       });
       expect(closed.handoff).toMatchObject({
-        format: "yarramate/visual-handoff/v1",
+        format: "yarramate/visual-handoff/v2",
         sessionId: server.started.sessionId,
       });
       await expect(stat(root)).rejects.toThrow();

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -17,7 +17,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   VISUAL_LIMITS,
   parseVisualDiagnosticResult,
-  toWireAbsolutePath,
+  toWireFileUri,
   type VisualDiagnostic,
   type VisualEvent,
   type VisualModel,
@@ -283,13 +283,13 @@ describe("visual session store", () => {
       paths: VisualSessionPaths,
       overrides: Partial<VisualSessionDescriptor> = {},
     ): VisualSessionDescriptor => ({
-      format: "yarramate/visual-session-descriptor/v1",
-      protocolVersion: "yarramate/visual-protocol/v3",
+      format: "yarramate/visual-session-descriptor/v2",
+      protocolVersion: "yarramate/visual-protocol/v4",
       sessionId,
       origin: "http://127.0.0.1:49152",
       agentCapability: "5c".repeat(32),
-      sessionRoot: paths.root,
-      journalPath: paths.journal,
+      sessionRoot: toWireFileUri(paths.root),
+      journalPath: toWireFileUri(paths.journal),
       createdAt: "2026-08-08T00:00:00.000Z",
       ...overrides,
     });
@@ -338,7 +338,7 @@ describe("visual session store", () => {
         writeVisualSessionDescriptor(
           session.paths,
           descriptorFor(session.paths, {
-            journalPath: toWireAbsolutePath(join(parent, "x.jsonl")),
+            journalPath: toWireFileUri(join(parent, "x.jsonl")),
           }),
         ),
       ).rejects.toThrow(/YMVS125/);
@@ -683,7 +683,7 @@ describe("visual session store", () => {
       await appendVisualResponse(session.paths, handoffResponse);
 
       expect(await recoverVisualSession(session.paths, false)).toMatchObject({
-        format: "yarramate/visual-handoff/v1",
+        format: "yarramate/visual-handoff/v2",
         summary: handoffResponse.payload.summary,
         transcript: undefined,
         lastSequence: 1,
@@ -705,7 +705,7 @@ describe("visual session store", () => {
         decision: "completed",
         terminationReason: "user-ended",
         lastSequence: 2,
-        transcriptPath: session.paths.journal,
+        transcriptPath: toWireFileUri(session.paths.journal),
         completedAt: "2026-08-08T00:01:00.000Z",
         confirmedDecisions: handoffResponse.payload.confirmedDecisions,
         unresolvedQuestions: handoffResponse.payload.unresolvedQuestions,

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   VISUAL_LIMITS,
   parseVisualDiagnosticResult,
+  toWireAbsolutePath,
   type VisualDiagnostic,
   type VisualEvent,
   type VisualModel,
@@ -160,16 +161,11 @@ describe("visual session store", () => {
     it("places every session artefact inside one private directory", async () => {
       const session = await startSession();
 
-      expect(session.paths).toEqual(
-        visualSessionPaths(join(parent, sessionId)),
-      );
-      expect(session.paths.root).toBe(join(parent, sessionId));
-      expect(session.paths.marker).toBe(
-        join(parent, sessionId, "session.json"),
-      );
-      expect(session.paths.journal).toBe(
-        join(parent, sessionId, "journal.jsonl"),
-      );
+      const expected = visualSessionPaths(join(parent, sessionId));
+      expect(session.paths).toEqual(expected);
+      expect(session.paths.root).toBe(expected.root);
+      expect(session.paths.marker).toBe(expected.marker);
+      expect(session.paths.journal).toBe(expected.journal);
       expect(await readFile(session.paths.journal, "utf8")).toBe("");
     });
 
@@ -230,7 +226,9 @@ describe("visual session store", () => {
       expect(session.browserToken).toHaveLength(64);
       expect(session.agentToken).toHaveLength(64);
       expect(session.browserToken).not.toBe(session.agentToken);
-      expect(session.paths.root).toBe(join(parent, "01".repeat(16)));
+      expect(session.paths.root).toBe(
+        visualSessionPaths(join(parent, "01".repeat(16))).root,
+      );
     });
 
     it("never reuses an existing session directory", async () => {
@@ -311,7 +309,7 @@ describe("visual session store", () => {
         writeVisualSessionDescriptor(
           session.paths,
           descriptorFor(session.paths, {
-            journalPath: join(parent, "x.jsonl"),
+            journalPath: toWireAbsolutePath(join(parent, "x.jsonl")),
           }),
         ),
       ).rejects.toThrow(/YMVS125/);

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -247,6 +247,35 @@ describe("visual session store", () => {
         expect(await modeOf(session.paths.journal)).toBe(0o600);
       },
     );
+
+    it.skipIf(!posixOnly)(
+      "keeps a base directory name containing a literal backslash on its own native directory",
+      async () => {
+        const weird = await mkdtemp(
+          join(tmpdir(), "yarramate-visual-\\store-"),
+        );
+        try {
+          const session = await createVisualSession(
+            request,
+            sessionDeps(weird),
+          );
+
+          expect(session.paths.root).toBe(join(weird, sessionId));
+          expect(session.paths.marker).toBe(
+            join(weird, sessionId, "session.json"),
+          );
+          expect(session.paths.journal).toBe(
+            join(weird, sessionId, "journal.jsonl"),
+          );
+          expect(JSON.parse(await readFile(session.paths.marker, "utf8"))).toMatchObject(
+            { id: sessionId },
+          );
+          expect(await readFile(session.paths.journal, "utf8")).toBe("");
+        } finally {
+          await rm(weird, { recursive: true, force: true });
+        }
+      },
+    );
   });
 
   describe("agent descriptor", () => {


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-21-visual-wire-path-v4-design.md`
and records the decision as ADR 0096.

**Breaking**, in two ways: the wire moves to `yarramate/visual-protocol/v4`
with no compatibility shim, and `yarramate-visual wait|respond|status|recover|stop`
now take a `file:` URI instead of a native path.

## What was wrong

Every absolute path a visual protocol document carried (`sessionRoot`,
`descriptorPath`, `journalPath`, `transcriptPath`) was a bare string produced
by one transform, `toWireAbsolutePath`, that replaced backslashes with forward
slashes. That stood in for a path encoding without being one:

- **It aliased.** A POSIX directory whose own name contains a backslash and a
  Windows path joined with native separators collapsed to indistinguishable
  wire text. This is the defect that opened the branch: `fs` calls missed the
  directory `createVisualSession` had just made.
- **It had no concept of a host.** A UNC path became `//server/share/x`, which
  satisfied the schema as an ordinary POSIX-rooted local path. ADR 0081 fixes
  the runtime's authorization model on a loopback, ephemeral server with
  nothing reachable from another machine; a session document that can name a
  network share breaks that at the one layer a consuming harness cannot
  re-check for itself.
- **It could not prove identity.** `YMVS403` gates whether a descriptor's
  bearer capabilities are spent, and it compared two transform outputs. A
  transform with no canonical form and no inverse can fail to disprove that
  two paths are one file, but it cannot prove it.

## What this does

Every path field on the wire is a canonical local `file:` URI.

- **Encode** `pathToFileURL(native).href`, only at the boundary.
  `VisualSessionPaths` stays native throughout.
- **Decode** `fileURLToPath`, gated on an empty host and on re-encoding
  reproducing the input byte for byte. Refusals are `YMVS414` with three
  message shapes (malformed, nonlocal, noncanonical), following the
  convention `YMVS401` already sets by covering two causes under one code.
  Nothing is ever repaired.
- Decode runs **before the file is opened** and long before the capability
  inside it is read. The descriptor's own `sessionRoot` and `journalPath` are
  decoded on the same terms, so `YMVS403` now compares two independently
  round-trip-verified URIs: a match proves the descriptor names the file that
  was opened.
- `toWireAbsolutePath` is deleted, not deprecated.

`file:` URIs over a stricter regex, because a pattern describes what a string
looks like, not which native path it denotes, and the bug is two inputs
sharing one appearance. Over a custom tagged format, because
`pathToFileURL`/`fileURLToPath` are the runtime's existing, dependency-free
answer, and a custom format would still need its own round-trip check to earn
the same guarantee. The host check falls out of the same primitive.

## Versioning

Per ADR 0088: a member whose contract changed is not an additive change.

| | |
|---|---|
| `yarramate/visual-protocol` | `v3` → `v4` |
| `visual-session-started`, `-descriptor`, `-handoff` | `v1` → `v2` |
| the eight documents carrying no path | stay `v1` |
| `visual-status` | `format` stays `v1`, only `protocolVersion` moves |

A v3 document is refused by `const` mismatch through the existing parse codes,
pointing at `/format` or `/protocolVersion`. No dual-read path, no
translation, no bespoke "v3 detected" code, matching ADR 0088's own choice.

The new `sessionFileUri` `$def` is a coarse structural gate only. Per
ADR 0081's "what the schemas alone do not say", the real check lives in
`protocol.ts` beside the Ajv validators, where the byte-length and
path-confinement checks already are.

## Breaking for callers

`wait`, `respond`, `status`, `recover`, and `stop` take the exact
`descriptorPath` URI `start` published, copied back verbatim. Working-directory
resolution is removed from that argument rather than kept alongside: a `file:`
URI is inherently absolute, so the ambiguity this change closes cannot
re-enter through the one string still passed by hand. A native path is
refused with `YMVS414`, and that is asserted explicitly. `respond` still
resolves its own `response.json` against `cwd`, because that is the agent's
file, not a protocol path field.

## Two details that resolved differently from the design

Both still refused; only the reported reason differs, and both are recorded
in the ADR and in the spec's status line:

- A `localhost` file host lands in `noncanonical`, not `nonlocal`. WHATWG
  `URL` normalizes that host away before the host check can see it.
- An over-encoded separator lands in `malformed`, because `fileURLToPath`
  refuses it itself.

## On this branch

`b501f1e` (schema pattern widening) and `7663f0a` (native `VisualSessionPaths`,
wire-normalize at the boundary) are **superseded, not reverted**. `7663f0a`'s
native-paths half is kept as correct; its wire-normalization half is replaced
wholesale. Both stay in history because they record the symptom that motivated
the fix, and `7663f0a`'s backslash-directory regression is carried forward,
re-targeted at the new encoder.

## Test plan

- [x] `pnpm verify` green: 1160 passed, 1 skipped, self-check clean at 260
      concepts / 359 relationships
- [x] Encode: POSIX ASCII, space / `#` / `?` / non-ASCII percent-encoding,
      Windows drive root, POSIX directory name containing a backslash, and a
      relative path refused as a programming error
- [x] Decode: non-`file:` scheme, invalid URI, UNC-derived URI, bare native
      paths (POSIX, Windows, and the v3 forward-slash form), dot and parent
      segments, redundant escapes
- [x] Ownership: matching descriptor accepted, descriptor copied beside
      another session refused `YMVS403`
- [x] Protocol: a v3 descriptor refused with diagnostics at `/format` and
      `/protocolVersion`
- [x] CLI: the published URI accepted; a native path and a `cwd`-relative
      path both refused `YMVS414`
- [x] Full `start` → `wait` → `respond` → `recover` → `stop` journey against a
      real filesystem session, unchanged but for URI-shaped path fields
- [ ] The one skipped test is the Windows-side encode assertion, which needs a
      Windows runner

Refs #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
