### PR TITLE
fix(visual): keep a compound container's own presentation, with the fixture it was found on

### DIFF
--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -416,10 +416,16 @@ export function buildStylesheet(
       // grouping box rather than a plain node. The label is drawn above the box
       // entirely, in the `CONTAINER_LABEL_GAP` band ELK reserves but cytoscape
       // does not draw into, so it clears both the children and its own border.
+      // `background-image-opacity` is pinned to 1 so the kind icon and lifecycle/
+      // evidence/ownership badges - a separate image layer from the fill - stay
+      // fully legible; without it they'd fade with the low background-opacity,
+      // and a container is exactly where a reader most needs its own kind glyph
+      // (an applicationComponent shown as a group is still an applicationComponent).
       selector: 'node:parent',
       style: {
         shape: 'roundrectangle',
         'background-opacity': 0.25,
+        'background-image-opacity': 1,
         'border-width': 2,
         'border-style': 'dashed',
         padding: `${CONTAINER_PADDING}px`,
@@ -499,7 +505,13 @@ export function buildStylesheet(
       if (meta.borderStyle === 'dashed') {
         style['border-style'] = 'dashed'
       }
-      return { selector: `node[aspect = "${aspect}"]`, style }
+      // `:childless` confines this to leaf nodes: these rules run after
+      // `node:parent` in the array below, so without it an aspect's shape
+      // (e.g. active-structure's plain `rectangle`) would win the cascade
+      // and silently undo the container's own `roundrectangle` + dashed
+      // border - a compound box would look like whatever aspect its own
+      // kind happens to be, not like a container.
+      return { selector: `node[aspect = "${aspect}"]:childless`, style }
     },
   )
 

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -416,16 +416,16 @@ export function buildStylesheet(
       // grouping box rather than a plain node. The label is drawn above the box
       // entirely, in the `CONTAINER_LABEL_GAP` band ELK reserves but cytoscape
       // does not draw into, so it clears both the children and its own border.
-      // `background-image-opacity` is pinned to 1 so the kind icon and lifecycle/
-      // evidence/ownership badges - a separate image layer from the fill - stay
-      // fully legible; without it they'd fade with the low background-opacity,
-      // and a container is exactly where a reader most needs its own kind glyph
-      // (an applicationComponent shown as a group is still an applicationComponent).
+      // The low `background-opacity` fades only the shape fill, never the badge
+      // layers: cytoscape passes it to its own fill colour and computes image
+      // alpha from `background-image-opacity` alone, which already defaults to
+      // 1. So a container's kind glyph and its lifecycle/evidence/ownership
+      // badges are drawn at full strength here with nothing pinned, and an
+      // applicationComponent shown as a group still reads as one.
       selector: 'node:parent',
       style: {
         shape: 'roundrectangle',
         'background-opacity': 0.25,
-        'background-image-opacity': 1,
         'border-width': 2,
         'border-style': 'dashed',
         padding: `${CONTAINER_PADDING}px`,

--- a/test/contact-update-fixture.test.ts
+++ b/test/contact-update-fixture.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  type WorkspaceSource,
+} from '../src/index.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import {
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/interrogate-command.js'
+
+// The contact-update journey is the model the compound-container rendering bug
+// was found on: four `applicationComponent` subjects, each composing the
+// `applicationInterface` it exposes, which is what cytoscape renders as
+// compound nesting.
+//
+// It is fixture data, so nothing executes it the way a unit test executes
+// source. That is exactly why it needs this: the fixture was taken from 34
+// open questions down to 9 by answering the engine's own interrogation, and
+// without a test that effort decays silently the first time the catalogue
+// deepens or a profile changes.
+//
+// Deliberately not pinned: the open-question count. It moves with the
+// catalogue version, so asserting it would fail on every catalogue bump for
+// reasons that have nothing to do with this fixture. The two properties below
+// are the ones that carry meaning.
+
+const fixture = (name: string): WorkspaceSource => ({
+  path: `architecture/${name}`,
+  source: readFileSync(
+    fileURLToPath(
+      new URL(
+        `./fixtures/journeys/contact-update/.yarramate/architecture/${name}`,
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  ),
+})
+
+const catalogue = (() => {
+  const loaded = loadQuestionCatalogue({
+    path: 'catalogues/core-enrichment.yaml',
+    source: readFileSync(
+      fileURLToPath(
+        new URL('../catalogues/core-enrichment.yaml', import.meta.url),
+      ),
+      'utf8',
+    ),
+  })
+  if (!loaded.ok) throw new Error('the bundled catalogue must load')
+  return loaded.catalogue
+})()
+
+const result = compileWorkspaceWithProfileContext([
+  fixture('contact-update.yaml'),
+  fixture('contact-update.policy.yaml'),
+])
+
+// Narrowed once, so the three tests below read the graph without each
+// re-proving the compile succeeded. A fixture that stops compiling fails here
+// first, with the diagnostic that explains why.
+const compiled = (() => {
+  if (!result.ok) {
+    throw new Error(
+      `the contact-update fixture must compile: ${result.diagnostics
+        .map((diagnostic) => `${diagnostic.code} ${diagnostic.message}`)
+        .join('; ')}`,
+    )
+  }
+  return result
+})()
+
+describe('the contact-update journey fixture', () => {
+  it('compiles clean', () => {
+    expect(result.ok).toBe(true)
+  })
+
+  it('exercises compound nesting, which is what makes it this bug\'s fixture', () => {
+    // Composition is the one relationship the canvas consumes into cytoscape's
+    // compound `parent` field instead of drawing as an edge, so a container is
+    // only rendered where a composition claim exists. Asserted through the
+    // projector the app itself uses: if this fixture ever stopped declaring
+    // them, the rendering fix beside it would lose the model it was found on.
+    const canvas = projectGraphForCanvas(compiled.graph, compiled.profileContext)
+    const compositions = canvas.edges.filter(
+      (edge) => edge.kind === 'yarramate/core@0.1#composition',
+    )
+
+    expect(compositions.length).toBe(4)
+  })
+
+  it('leaves nothing open that an agent could have answered', () => {
+    // The load-bearing invariant, and the one that keeps the fixture honest
+    // without pinning a number. Every question this model still leaves open is
+    // `authority: human` - two attestations wanting a reviewer's acceptance,
+    // which a fixture must never fabricate, and whether architecture states
+    // are worth declaring, which is a modelling judgement. If a future
+    // catalogue adds an agent-answerable question this model cannot close,
+    // that is a real gap in the fixture and this should fail.
+    const report = evaluateCatalogue(
+      catalogue,
+      compiled.graph,
+      compiled.profileContext,
+    )
+    const openByAgent = report.waves
+      .flatMap((wave) => wave.questions)
+      .filter((question) => question.open && question.authority !== 'human')
+      .map((question) => question.id)
+
+    expect(openByAgent).toEqual([])
+  })
+
+  it('answers every interaction question, which is what an integration model is for', () => {
+    // The hop is the load-bearing unit of an integration: protocol, trust,
+    // reliability, capacity, the contract each hop touches, and what actually
+    // flows. A model of an API estate that cannot answer these is not
+    // describing an integration, whatever it compiles to.
+    const report = evaluateCatalogue(
+      catalogue,
+      compiled.graph,
+      compiled.profileContext,
+    )
+    const interaction = report.waves.find((wave) => wave.id === 'interaction')
+
+    expect(interaction).toBeDefined()
+    expect(interaction?.questions.length).toBeGreaterThan(0)
+    expect(
+      interaction?.questions.filter((question) => question.open).map((q) => q.id),
+    ).toEqual([])
+  })
+})

--- a/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.policy.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.policy.yaml
@@ -1,0 +1,41 @@
+format: yarramate/v1
+id: contact-update-policy
+profile: yarramate/policy@0.1
+concepts:
+  - id: gateway-oauth
+    kind: authentication-constraint
+    name: OAuth client-credentials
+    description: >-
+      Service identity uses OAuth 2.0 client credentials at the API gateway.
+      User identity is not propagated on the Experience or Process hops.
+  - id: salesforce-jwt-bearer
+    kind: authentication-constraint
+    name: OAuth JWT bearer (Salesforce Connected App)
+    description: >-
+      System API authenticates to Salesforce as a Connected App using the
+      OAuth 2.0 JWT bearer flow. No end-user identity is propagated.
+  - id: experience-rate-limit
+    kind: rate-limit-constraint
+    name: 100 requests per client per second
+    description: Caller-facing Experience API is capacity-capped at the gateway.
+  - id: salesforce-api-limit
+    kind: rate-limit-constraint
+    name: Salesforce org daily API request limit
+    description: >-
+      Capacity is bounded by the Salesforce org's daily API request and
+      per-transaction governor limits, not by the gateway.
+  - id: at-least-once-upsert
+    kind: reliability-constraint
+    name: At-least-once with idempotent upsert
+    description: >-
+      Contact update retries on timeout; the Salesforce Contact External ID
+      field is the idempotency key used to upsert rather than insert.
+  - id: https-rest
+    kind: mechanism-constraint
+    name: HTTPS REST
+    description: Synchronous HTTP/JSON over TLS on the Experience serving hop.
+  - id: salesforce-rest-api
+    kind: mechanism-constraint
+    name: Salesforce REST API (sObjects)
+    description: System API calls the Salesforce REST API /sobjects/Contact endpoint.
+relationships: []

--- a/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
@@ -2,30 +2,93 @@ format: yarramate/v1
 id: contact-update
 profile: yarramate/core@0.1
 concepts:
+  # ============================================================== motivation
+  - id: crm-product-owner
+    kind: stakeholder
+    name: CRM Product Owner
+    description: >-
+      Accountable for what a Contact means in Salesforce, who may write one,
+      and the org's API allocation. Owns the vendor relationship this
+      integration depends on.
+    status: current
+  - id: sales-systems-team
+    kind: stakeholder
+    name: Sales Systems Team
+    description: Accountable for the three Contact APIs and the CloudHub deployment.
+    status: current
+  - id: duplicate-contacts-erode-trust
+    kind: driver
+    name: Duplicate contacts erode trust in the CRM
+    description: >-
+      A retried update that inserts rather than upserts leaves two Contacts for
+      one person, and a sales rep who finds duplicates stops trusting the
+      record. This is the pressure that makes idempotency load-bearing rather
+      than a nicety.
+    status: current
+  - id: salesforce-allocation-is-shared
+    kind: driver
+    name: The Salesforce API allocation is shared and org-wide
+    description: >-
+      Every integration draws on one daily request allocation and the same
+      per-transaction governor limits. No single team controls it, which is why
+      writes funnel through one System API rather than going direct.
+    status: current
+  - id: one-sanctioned-write-path
+    kind: goal
+    name: Exactly one sanctioned write path into Salesforce
+    description: >-
+      Every Contact write crosses the System API, so the Connected App
+      credential, the External ID upsert key, and the request budget have one
+      owner and one place to change.
+    status: planned
+  - id: reps-update-contacts-without-crm-logins
+    kind: outcome
+    name: Reps update contacts without opening Salesforce
+    description: >-
+      A sales rep corrects a contact in the tool they already have open and the
+      CRM stays authoritative, which is what makes the integration worth
+      building rather than handing out more CRM seats.
+    status: planned
+
+  # ================================================================ business
   - id: sales-rep
     kind: businessActor
     name: Sales Representative
+    description: Corrects customer contact details while working an account.
     status: current
+  - id: work-an-account
+    kind: businessProcess
+    name: Work an account
+    description: >-
+      What the rep actually does with the Experience API. Named so the actor is
+      tested by behaviour rather than floating as a label.
+    status: current
+  - id: contact-api-contract
+    kind: contract
+    name: Contact API contract
+    description: >-
+      The published OAS document consumers build against, versioned separately
+      from the implementation. This is what must not break when the Salesforce
+      Contact layout changes underneath.
+    status: planned
+
+  # ====================================================== experience layer
   - id: contact-exp-api
     kind: applicationComponent
     name: Contact Experience API
+    description: >-
+      Channel-shaped API. Owns the request format the rep's tool sends and
+      nothing about how Salesforce stores a Contact.
     status: planned
-  - id: contact-prc-api
-    kind: applicationComponent
-    name: Contact Process API
-    status: planned
-  - id: contact-sys-api
-    kind: applicationComponent
-    name: Contact System API
-    status: planned
-  - id: salesforce-crm
-    kind: applicationComponent
-    name: Salesforce CRM
-    description: External Salesforce org; system of record for customer contacts.
-    status: current
+    owner: contact-update#sales-systems-team
   - id: contact-exp-api-interface
     kind: applicationInterface
     name: Contact Experience API interface
+    description: >-
+      The technical access point: PATCH /api/v1/contacts/{id} over HTTPS on
+      443, JSON body, bearer token in Authorization, client id in x-client-id
+      for rate-limit attribution. Answers 200, 401, 404, 409, 429, and 503 with
+      a problem+json body.
     status: planned
     constraints:
       - id: authn
@@ -38,24 +101,139 @@ concepts:
           value: "100"
       - id: mechanism
         ref: contact-update-policy#https-rest
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: contact-update-service
+    kind: applicationService
+    name: Contact update
+    description: >-
+      The externally consumable service: submit corrected contact details and
+      have them land in the CRM. The solution boundary a consumer buys into.
+    status: planned
+    owner: contact-update#sales-systems-team
+  - id: accept-contact-update
+    kind: applicationProcess
+    name: Accept contact update
+    description: >-
+      Validates the token, applies the rate limit, and hands a canonical
+      contact update to the Process API.
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#gateway-oauth
+      - id: mechanism
+        ref: contact-update-policy#https-rest
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+
+  # ========================================================= process layer
+  - id: contact-prc-api
+    kind: applicationComponent
+    name: Contact Process API
+    description: >-
+      Orchestration. Owns the rule for what a complete contact update is,
+      independent of any one channel.
+    status: planned
+    owner: contact-update#sales-systems-team
   - id: contact-prc-api-interface
     kind: applicationInterface
     name: Contact Process API interface
+    description: >-
+      Internal-only access point on the VPC, no public DNS record. Accepts a
+      canonical contact update and returns the applied result.
     status: planned
     constraints:
       - id: authn
         ref: contact-update-policy#gateway-oauth
+      - id: mechanism
+        ref: contact-update-policy#https-rest
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: contact-orchestration-service
+    kind: applicationService
+    name: Canonical contact update
+    description: Internal service applying a canonical contact update on behalf of any channel.
+    status: planned
+    owner: contact-update#sales-systems-team
+  - id: orchestrate-contact-update
+    kind: applicationProcess
+    name: Orchestrate contact update
+    description: >-
+      Applies the completeness rules, maps the canonical contact onto the
+      Salesforce field names, and calls the System API.
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#gateway-oauth
+      - id: mechanism
+        ref: contact-update-policy#https-rest
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+
+  # ========================================================== system layer
+  - id: contact-sys-api
+    kind: applicationComponent
+    name: Contact System API
+    description: >-
+      The single sanctioned write path into Salesforce. Owns the Connected App
+      credential, the External ID upsert key, and the API version pin.
+    status: planned
+    owner: contact-update#sales-systems-team
   - id: contact-sys-api-interface
     kind: applicationInterface
     name: Contact System API interface
+    description: >-
+      Internal-only access point exposing the agreed Contact projection.
+      Deliberately not a passthrough, so an unused Salesforce field cannot
+      silently become a consumer dependency.
     status: planned
     constraints:
       - id: authn
         ref: contact-update-policy#gateway-oauth
+      - id: mechanism
+        ref: contact-update-policy#https-rest
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: salesforce-write-service
+    kind: applicationService
+    name: Salesforce contact write
+    description: The only sanctioned write into the CRM's Contact object.
+    status: planned
+    owner: contact-update#sales-systems-team
+  - id: update-salesforce-contact
+    kind: applicationProcess
+    name: Update Salesforce contact
+    description: >-
+      Authenticates with the JWT bearer flow, upserts on the External ID, and
+      translates Salesforce faults into the integration's own error vocabulary.
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#salesforce-jwt-bearer
+      - id: mechanism
+        ref: contact-update-policy#salesforce-rest-api
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+
+  # ============================================================ salesforce
+  - id: salesforce-crm
+    kind: applicationComponent
+    name: Salesforce CRM
+    description: >-
+      External Salesforce org; system of record for customer contacts. Not
+      deployed by this team, not versioned by this team, and subject to an API
+      retirement schedule this team does not set.
+    status: current
+    owner: contact-update#crm-product-owner
+    distinctFrom:
+      - contact-update#contact-sys-api
   - id: salesforce-contact-interface
     kind: applicationInterface
     name: Salesforce REST API (sObjects/Contact)
-    description: The actual Salesforce contract this flow calls; owned by Salesforce, not this project.
+    description: >-
+      The actual Salesforce contract this flow calls; owned by Salesforce, not
+      this project. PATCH /services/data/vXX.X/sobjects/Contact/{ExternalId}
+      performs the upsert that makes a retry safe.
     status: current
     constraints:
       - id: authn
@@ -64,50 +242,48 @@ concepts:
         ref: contact-update-policy#salesforce-api-limit
       - id: mechanism
         ref: contact-update-policy#salesforce-rest-api
-  - id: cloudhub2
-    kind: node
-    name: MuleSoft CloudHub 2.0
-    description: Runtime the three Contact APIs are deployed to.
-    status: planned
-  - id: accept-contact-update
-    kind: applicationProcess
-    name: Accept contact update
-    status: planned
-    constraints:
       - id: reliability
         ref: contact-update-policy#at-least-once-upsert
-  - id: orchestrate-contact-update
+  - id: salesforce-contact-service
+    kind: applicationService
+    name: Salesforce Contact data access
+    description: The vendor's own Contact read and write service, consumed through the REST API.
+    status: current
+    owner: contact-update#crm-product-owner
+  - id: serve-contact-sobject
     kind: applicationProcess
-    name: Orchestrate contact update
-    status: planned
-    constraints:
-      - id: reliability
-        ref: contact-update-policy#at-least-once-upsert
-  - id: update-salesforce-contact
-    kind: applicationProcess
-    name: Update Salesforce contact
-    status: planned
-    constraints:
-      - id: reliability
-        ref: contact-update-policy#at-least-once-upsert
+    name: Serve Contact SObject
+    description: Salesforce's own request handling, opaque to this model.
+    status: current
   - id: contact-record
     kind: dataObject
     name: Contact record
-    description: Customer contact fields synchronized to Salesforce (name, email, phone, mailing address).
+    description: >-
+      Customer contact fields synchronized to Salesforce (name, email, phone,
+      mailing address), carrying the External ID used as the upsert key.
     status: current
+    owner: contact-update#crm-product-owner
+
+  # ============================================================ technology
+  - id: cloudhub2
+    kind: node
+    name: MuleSoft CloudHub 2.0
+    description: >-
+      Runtime the three Contact APIs are deployed to. Modelled as a node rather
+      than systemSoftware or applicationComponent: per ADR 0083 the engine
+      cannot adjudicate that choice, so it is recorded as a decision an owner
+      confirmed rather than one the model derived.
+    status: planned
+  - id: salesforce-tenant-infrastructure
+    kind: node
+    name: Salesforce-operated multi-tenant infrastructure
+    description: >-
+      The vendor's own runtime. Recorded so the CRM does not read as something
+      this team deploys.
+    status: current
+
 relationships:
-  - id: exp-assigned-accept
-    kind: assignment
-    from: contact-exp-api
-    to: accept-contact-update
-  - id: prc-assigned-orchestrate
-    kind: assignment
-    from: contact-prc-api
-    to: orchestrate-contact-update
-  - id: sys-assigned-update
-    kind: assignment
-    from: contact-sys-api
-    to: update-salesforce-contact
+  # --- components own the interfaces they expose (renders as nesting) -------
   - id: exp-composes-interface
     kind: composition
     from: contact-exp-api
@@ -124,22 +300,90 @@ relationships:
     kind: composition
     from: salesforce-crm
     to: salesforce-contact-interface
-  - id: cloudhub-hosts-exp
+
+  # --- components perform their behaviour -----------------------------------
+  - id: exp-assigned-accept
     kind: assignment
-    from: cloudhub2
+    from: contact-exp-api
+    to: accept-contact-update
+  - id: prc-assigned-orchestrate
+    kind: assignment
+    from: contact-prc-api
+    to: orchestrate-contact-update
+  - id: sys-assigned-update
+    kind: assignment
+    from: contact-sys-api
+    to: update-salesforce-contact
+  - id: salesforce-assigned-serve
+    kind: assignment
+    from: salesforce-crm
+    to: serve-contact-sobject
+  - id: rep-assigned-account-work
+    kind: assignment
+    from: sales-rep
+    to: work-an-account
+
+  # --- each interface exposes a declared service ----------------------------
+  # This is what tests the interface kind: without an assigned behaviour, an
+  # applicationInterface would compile identically as a goal (ADR 0083).
+  - id: exp-interface-exposes-service
+    kind: assignment
+    from: contact-exp-api-interface
+    to: contact-update-service
+  - id: prc-interface-exposes-service
+    kind: assignment
+    from: contact-prc-api-interface
+    to: contact-orchestration-service
+  - id: sys-interface-exposes-service
+    kind: assignment
+    from: contact-sys-api-interface
+    to: salesforce-write-service
+  - id: salesforce-interface-exposes-service
+    kind: assignment
+    from: salesforce-contact-interface
+    to: salesforce-contact-service
+
+  # --- behaviour realizes the service it stands behind ----------------------
+  - id: accept-realizes-update-service
+    kind: realization
+    from: accept-contact-update
+    to: contact-update-service
+  - id: orchestrate-realizes-orchestration-service
+    kind: realization
+    from: orchestrate-contact-update
+    to: contact-orchestration-service
+  - id: update-realizes-write-service
+    kind: realization
+    from: update-salesforce-contact
+    to: salesforce-write-service
+  - id: salesforce-serve-realizes-contact-service
+    kind: realization
+    from: serve-contact-sobject
+    to: salesforce-contact-service
+
+  # --- each declared service names who consumes it --------------------------
+  - id: update-service-serves-rep
+    kind: serving
+    from: contact-update-service
+    to: sales-rep
+  - id: orchestration-service-serves-exp
+    kind: serving
+    from: contact-orchestration-service
     to: contact-exp-api
-  - id: cloudhub-hosts-prc
-    kind: assignment
-    from: cloudhub2
+  - id: write-service-serves-prc
+    kind: serving
+    from: salesforce-write-service
     to: contact-prc-api
-  - id: cloudhub-hosts-sys
-    kind: assignment
-    from: cloudhub2
+  - id: salesforce-service-serves-sys
+    kind: serving
+    from: salesforce-contact-service
     to: contact-sys-api
   - id: interface-serves-sales-rep
     kind: serving
     from: contact-exp-api-interface
     to: sales-rep
+
+  # --- the write path, hop by hop -------------------------------------------
   - id: accept-flows-prc-interface
     kind: flow
     from: accept-contact-update
@@ -155,6 +399,8 @@ relationships:
     from: update-salesforce-contact
     to: salesforce-contact-interface
     content: Contact update payload
+
+  # --- what each hop reads and writes ---------------------------------------
   - id: accept-writes-record
     kind: access
     from: accept-contact-update
@@ -170,3 +416,79 @@ relationships:
     from: update-salesforce-contact
     to: contact-record
     mode: write
+  - id: exp-interface-reads-contract
+    kind: access
+    from: contact-exp-api-interface
+    to: contact-api-contract
+    mode: read
+  - id: prc-interface-accesses-record
+    kind: access
+    from: contact-prc-api-interface
+    to: contact-record
+    mode: read-write
+  - id: sys-interface-accesses-record
+    kind: access
+    from: contact-sys-api-interface
+    to: contact-record
+    mode: read-write
+  - id: salesforce-interface-accesses-record
+    kind: access
+    from: salesforce-contact-interface
+    to: contact-record
+    mode: read-write
+  - id: exp-interface-realizes-contract
+    kind: realization
+    from: contact-exp-api-interface
+    to: contact-api-contract
+
+  # --- motivation -----------------------------------------------------------
+  - id: duplicates-drive-goal
+    kind: influence
+    from: duplicate-contacts-erode-trust
+    to: one-sanctioned-write-path
+  - id: allocation-drives-goal
+    kind: influence
+    from: salesforce-allocation-is-shared
+    to: one-sanctioned-write-path
+  - id: duplicates-drive-outcome
+    kind: influence
+    from: duplicate-contacts-erode-trust
+    to: reps-update-contacts-without-crm-logins
+  - id: crm-owner-cares-about-duplicates
+    kind: association
+    from: crm-product-owner
+    to: duplicate-contacts-erode-trust
+  - id: crm-owner-cares-about-allocation
+    kind: association
+    from: crm-product-owner
+    to: salesforce-allocation-is-shared
+  - id: sales-systems-cares-about-goal
+    kind: association
+    from: sales-systems-team
+    to: one-sanctioned-write-path
+  - id: sys-api-realizes-goal
+    kind: realization
+    from: contact-sys-api
+    to: one-sanctioned-write-path
+  - id: update-service-realizes-outcome
+    kind: realization
+    from: contact-update-service
+    to: reps-update-contacts-without-crm-logins
+
+  # --- where it runs --------------------------------------------------------
+  - id: cloudhub-hosts-exp
+    kind: assignment
+    from: cloudhub2
+    to: contact-exp-api
+  - id: cloudhub-hosts-prc
+    kind: assignment
+    from: cloudhub2
+    to: contact-prc-api
+  - id: cloudhub-hosts-sys
+    kind: assignment
+    from: cloudhub2
+    to: contact-sys-api
+  - id: sf-infra-hosts-crm
+    kind: assignment
+    from: salesforce-tenant-infrastructure
+    to: salesforce-crm

--- a/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
@@ -1,0 +1,172 @@
+format: yarramate/v1
+id: contact-update
+profile: yarramate/core@0.1
+concepts:
+  - id: sales-rep
+    kind: businessActor
+    name: Sales Representative
+    status: current
+  - id: contact-exp-api
+    kind: applicationComponent
+    name: Contact Experience API
+    status: planned
+  - id: contact-prc-api
+    kind: applicationComponent
+    name: Contact Process API
+    status: planned
+  - id: contact-sys-api
+    kind: applicationComponent
+    name: Contact System API
+    status: planned
+  - id: salesforce-crm
+    kind: applicationComponent
+    name: Salesforce CRM
+    description: External Salesforce org; system of record for customer contacts.
+    status: current
+  - id: contact-exp-api-interface
+    kind: applicationInterface
+    name: Contact Experience API interface
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#gateway-oauth
+      - id: capacity
+        ref: contact-update-policy#experience-rate-limit
+        expects:
+          provider: gateway
+          key: rps-per-client
+          value: "100"
+      - id: mechanism
+        ref: contact-update-policy#https-rest
+  - id: contact-prc-api-interface
+    kind: applicationInterface
+    name: Contact Process API interface
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#gateway-oauth
+  - id: contact-sys-api-interface
+    kind: applicationInterface
+    name: Contact System API interface
+    status: planned
+    constraints:
+      - id: authn
+        ref: contact-update-policy#gateway-oauth
+  - id: salesforce-contact-interface
+    kind: applicationInterface
+    name: Salesforce REST API (sObjects/Contact)
+    description: The actual Salesforce contract this flow calls; owned by Salesforce, not this project.
+    status: current
+    constraints:
+      - id: authn
+        ref: contact-update-policy#salesforce-jwt-bearer
+      - id: capacity
+        ref: contact-update-policy#salesforce-api-limit
+      - id: mechanism
+        ref: contact-update-policy#salesforce-rest-api
+  - id: cloudhub2
+    kind: node
+    name: MuleSoft CloudHub 2.0
+    description: Runtime the three Contact APIs are deployed to.
+    status: planned
+  - id: accept-contact-update
+    kind: applicationProcess
+    name: Accept contact update
+    status: planned
+    constraints:
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: orchestrate-contact-update
+    kind: applicationProcess
+    name: Orchestrate contact update
+    status: planned
+    constraints:
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: update-salesforce-contact
+    kind: applicationProcess
+    name: Update Salesforce contact
+    status: planned
+    constraints:
+      - id: reliability
+        ref: contact-update-policy#at-least-once-upsert
+  - id: contact-record
+    kind: dataObject
+    name: Contact record
+    description: Customer contact fields synchronized to Salesforce (name, email, phone, mailing address).
+    status: current
+relationships:
+  - id: exp-assigned-accept
+    kind: assignment
+    from: contact-exp-api
+    to: accept-contact-update
+  - id: prc-assigned-orchestrate
+    kind: assignment
+    from: contact-prc-api
+    to: orchestrate-contact-update
+  - id: sys-assigned-update
+    kind: assignment
+    from: contact-sys-api
+    to: update-salesforce-contact
+  - id: exp-composes-interface
+    kind: composition
+    from: contact-exp-api
+    to: contact-exp-api-interface
+  - id: prc-composes-interface
+    kind: composition
+    from: contact-prc-api
+    to: contact-prc-api-interface
+  - id: sys-composes-interface
+    kind: composition
+    from: contact-sys-api
+    to: contact-sys-api-interface
+  - id: salesforce-composes-interface
+    kind: composition
+    from: salesforce-crm
+    to: salesforce-contact-interface
+  - id: cloudhub-hosts-exp
+    kind: assignment
+    from: cloudhub2
+    to: contact-exp-api
+  - id: cloudhub-hosts-prc
+    kind: assignment
+    from: cloudhub2
+    to: contact-prc-api
+  - id: cloudhub-hosts-sys
+    kind: assignment
+    from: cloudhub2
+    to: contact-sys-api
+  - id: interface-serves-sales-rep
+    kind: serving
+    from: contact-exp-api-interface
+    to: sales-rep
+  - id: accept-flows-prc-interface
+    kind: flow
+    from: accept-contact-update
+    to: contact-prc-api-interface
+    content: Contact update request
+  - id: orchestrate-flows-sys-interface
+    kind: flow
+    from: orchestrate-contact-update
+    to: contact-sys-api-interface
+    content: Contact update request
+  - id: update-flows-salesforce-interface
+    kind: flow
+    from: update-salesforce-contact
+    to: salesforce-contact-interface
+    content: Contact update payload
+  - id: accept-writes-record
+    kind: access
+    from: accept-contact-update
+    to: contact-record
+    mode: write
+  - id: orchestrate-writes-record
+    kind: access
+    from: orchestrate-contact-update
+    to: contact-record
+    mode: read-write
+  - id: update-writes-record
+    kind: access
+    from: update-salesforce-contact
+    to: contact-record
+    mode: write

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
@@ -1,0 +1,30 @@
+format: yarramate/projection/v1
+id: contact-update-slice
+version: "1.0"
+query:
+  subjects:
+    - contact-update#sales-rep
+    - contact-update#contact-exp-api
+    - contact-update#contact-prc-api
+    - contact-update#contact-sys-api
+    - contact-update#salesforce-crm
+    - contact-update#contact-exp-api-interface
+    - contact-update#contact-prc-api-interface
+    - contact-update#contact-sys-api-interface
+    - contact-update#salesforce-contact-interface
+    - contact-update#cloudhub2
+    - contact-update#accept-contact-update
+    - contact-update#orchestrate-contact-update
+    - contact-update#update-salesforce-contact
+    - contact-update#contact-record
+    - contact-update-policy#gateway-oauth
+    - contact-update-policy#salesforce-jwt-bearer
+    - contact-update-policy#experience-rate-limit
+    - contact-update-policy#salesforce-api-limit
+    - contact-update-policy#at-least-once-upsert
+    - contact-update-policy#https-rest
+    - contact-update-policy#salesforce-rest-api
+  relationships: connected
+presentation:
+  title: Contact update hop
+  description: Experience to process to Salesforce contact update, on CloudHub 2.0.

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
@@ -17,6 +17,12 @@ query:
     - contact-update#orchestrate-contact-update
     - contact-update#update-salesforce-contact
     - contact-update#contact-record
+    - contact-update#contact-api-contract
+    - contact-update#contact-update-service
+    - contact-update#contact-orchestration-service
+    - contact-update#salesforce-write-service
+    - contact-update#salesforce-contact-service
+    - contact-update#serve-contact-sobject
     - contact-update-policy#gateway-oauth
     - contact-update-policy#salesforce-jwt-bearer
     - contact-update-policy#experience-rate-limit

--- a/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
@@ -1,0 +1,9 @@
+format: yarramate/workspace/v1
+id: contact-update
+documents:
+  - architecture/*.yaml
+profiles: []
+projections:
+  - projections/*.yaml
+adapterMappings: []
+evidence: []

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -626,6 +626,72 @@ describe('buildStylesheet ArchiMate notation', () => {
     expect(derived.css('target-arrow-fill')).toBe('hollow')
   })
 
+  // A compound container is an ordinary concept node that acquired children
+  // (graphToElements sets `parent` from composition claims), so it carries the
+  // same `aspect`, `layer`, and `kindLabel` as any leaf of its kind. That is
+  // what makes the cascade order load-bearing: the per-aspect rules are
+  // appended after `node:parent`, so an unscoped `node[aspect = "..."]` would
+  // hand a container whatever shape its own kind implies and silently undo the
+  // grouping-box presentation. Asserted through resolved style on real
+  // elements rather than by reading the selector string, because the selector
+  // being right is not the same claim as the cascade landing right.
+  describe('compound containers', () => {
+    const containerGraph = () => {
+      const node = (id: string, parent?: string) => ({
+        group: 'nodes' as const,
+        data: {
+          id,
+          parent,
+          label: id,
+          wrapLabel: id,
+          kindLabel: 'applicationComponent',
+          aspect: 'active-structure',
+          layer: 'application',
+          status: null,
+          hasAttestations: false,
+          owner: null,
+          ownerInitials: null,
+        },
+      })
+      return cytoscape({
+        headless: true,
+        styleEnabled: true,
+        style: buildStylesheet(true, true, true, 'archimate'),
+        elements: [node('container'), node('child', 'container'), node('leaf')],
+      })
+    }
+
+    it('keeps the grouping-box shape a leaf of the same aspect does not get', () => {
+      const cy = containerGraph()
+      const container = cy.getElementById('container')
+      const leaf = cy.getElementById('leaf')
+      expect(container.isParent()).toBe(true)
+      expect(container.css('shape')).toBe('roundrectangle')
+      expect(container.css('border-style')).toBe('dashed')
+      // Same aspect, no children: this is the rule the container must not take.
+      expect(leaf.css('shape')).toBe('rectangle')
+      expect(leaf.css('border-style')).toBe('solid')
+    })
+
+    it('draws its own kind glyph at full strength despite the faded fill', () => {
+      const cy = containerGraph()
+      const container = cy.getElementById('container')
+      const leaf = cy.getElementById('leaf')
+      // The glyph reaches a parent exactly as it reaches a leaf: same data,
+      // same badge layer, and cytoscape has no compound-node carve-out in its
+      // image drawing.
+      expect(container.css('background-image')).toEqual(leaf.css('background-image'))
+      expect(String(container.css('background-image'))).toMatch(/^data:image\/svg\+xml/)
+      // The faded fill is the container's alone and never reaches the glyph,
+      // which is why no `background-image-opacity` is pinned here.
+      expect(container.numericStyle('background-opacity')).toBe(0.25)
+      // One entry per image layer, so a container's single glyph reads as [1]
+      // with nothing pinned - the same value the leaf resolves to.
+      expect(container.numericStyle('background-image-opacity')).toEqual([1])
+      expect(leaf.numericStyle('background-image-opacity')).toEqual([1])
+    })
+  })
+
   it('adds no ArchiMate rules under native notation', () => {
     const native = buildStylesheet(true, true, true, 'native')
     expect(native.some((block) => block.selector.startsWith('edge[coreKindLabel'))).toBe(false)


### PR DESCRIPTION
Carries three things that belong together: the rendering fix, the fixture the
bug was found on, and the tests that keep both honest.

## The bug

`archimateNodeShapes` (`src/visual-app/graph-canvas.tsx`) builds one
`node[aspect = "..."]` rule per aspect and appends them **after** `node:parent`
in the same array. For any container whose own kind shares that aspect, the
later rule's plain `rectangle` won the cascade and silently undid
`node:parent`'s `roundrectangle` and dashed border, so a compound box rendered
as whatever aspect its own kind happened to be instead of as a container.

Scoping each aspect selector to `:childless` confines it to leaf nodes.

## The question this branch was parked on

Whether a compound container renders its own kind glyph. **It does.** The
earlier WIP suspected a cytoscape limitation with `background-image` on
compound nodes; that is not what was happening, and the
`background-image-opacity: 1` pin added for it is removed here as a no-op
resting on a mechanism that does not exist:

- `background-opacity` feeds only cytoscape's shape fill
  (`setupShapeColor(bgOpacity)`). Image alpha comes from
  `background-image-opacity` alone, which already defaults to `1` - a leaf with
  nothing pinned resolves to the same `1` the pin was setting.
- Cytoscape has no compound-node carve-out in image drawing: neither
  `drawImages` nor `drawInscribedImage` carries an `isParent` guard.
- Resolving the real stylesheet against a headless instance gives a container
  the byte-identical `background-image` a leaf gets.
- Computing the icon rect the way `drawInscribedImage` does places it inside
  the container's 30px padding band, clear of the children.

Confirmed visually in a live session: all four containers draw their kind glyph
at top-left and their lifecycle badge at top-right, and the nested interfaces
draw their own. The glyph is 14px in the corner of a large dashed box, which is
the likeliest reason it read as absent.

## The fixture

`test/fixtures/journeys/contact-update/` - a contact update written into
Salesforce through Experience, Process, and System APIs on MuleSoft CloudHub
2.0. Four `applicationComponent` subjects, each composing the
`applicationInterface` it exposes, which is exactly what cytoscape renders as
compound nesting. It is the model this bug was found on, so it lands with the
fix rather than separately.

It compiled clean but the engine did not think it was finished: `ask --open`
reported **34 open across 15 questions**, concentrated in the wave an
integration model exists to answer. Most traced to one defect - all four
interfaces fired `kind-untested` (ADR 0083), carrying composition, serving, and
constraints but no assigned behaviour, so reclassifying one as a goal would
have compiled identically. Each interface now exposes a declared
`applicationService` its layer's process realizes, which tests the kind,
declares what the system offers, and names each service's consumer at once.

The rest, each closed against the question that asked for it:
`interaction-contract-unknown` (4), `interaction-trust-unbound` (3),
`interaction-reliability-unbound` (3), `outcome-missing`,
`stakeholders-missing`, `owner-missing` (4), `information-unowned`,
`component-unhosted`, `actor-unassigned`, `concept-undescribed` (3), and
`distinctFrom` on the CRM for the near-duplicate check.

**34 open -> 9.** The three that remain are all `authority: human`: two
attestations wanting a reviewer's acceptance, which a fixture must not
fabricate, and whether architecture states are worth declaring.

## Tests

**For the fix** - two regression tests asserting through resolved style on real
elements rather than by reading selector strings, because a correct selector
and a correct cascade are separate claims:

- a container keeps `roundrectangle` + `dashed` where a leaf of the same aspect
  takes `rectangle` + `solid`
- a container's `background-image` equals the leaf's, with
  `background-image-opacity` resolving to `[1]` on both and nothing pinned

**For the fixture** - nothing in the repo loaded it, and `journeys/design` is
unreferenced too, so the effort above would have decayed on the next catalogue
bump with no one noticing. Four properties, each failing for a reason worth
acting on: it compiles; it declares exactly four compositions, asserted through
`projectGraphForCanvas` so the fix keeps the model it was found on; nothing is
open that an agent could have answered; and the whole interaction wave stays
closed.

The open-question count is deliberately **not** pinned - it tracks the
catalogue version and would fail on every bump for reasons unrelated to this
fixture. The authority invariant carries the same meaning and only trips on a
genuinely unanswered gap.

## Test plan

- [x] `pnpm verify` green: 71 files, 1168 passed, 1 skipped, self-check clean
- [x] Containers render rounded + dashed in a live `yarramate-visual` session
- [x] Container kind glyph confirmed present in the same session
- [x] Re-verified against this committed fixture, not a scratchpad model
- [x] Composes with #209 (protocol v4) and #211 (glyph coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
