### PR TITLE
fix: keep shipped policy compiler entrypoint Worker-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {

--- a/src/shipped-profile.ts
+++ b/src/shipped-profile.ts
@@ -1,12 +1,21 @@
-import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
 export const shippedPolicyIdentity = 'yarramate/policy@0.1'
 
-const here = dirname(fileURLToPath(import.meta.url))
-
-export const shippedPolicySource = readFileSync(
-  join(here, '..', 'profiles', 'yarramate-policy.yaml'),
-  'utf8',
-)
+export const shippedPolicySource = `format: yarramate/profile/v1
+id: yarramate/policy
+version: "0.1"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: authentication-constraint
+    name: Authentication constraint
+    parent: yarramate/core@0.1#constraint
+  - id: rate-limit-constraint
+    name: Rate-limit constraint
+    parent: yarramate/core@0.1#constraint
+  - id: reliability-constraint
+    name: Reliability constraint
+    parent: yarramate/core@0.1#constraint
+  - id: mechanism-constraint
+    name: Mechanism constraint
+    parent: yarramate/core@0.1#constraint
+relationshipKinds: []
+`

--- a/test/shipped-profile-worker-safe.test.ts
+++ b/test/shipped-profile-worker-safe.test.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+
+const forbiddenBuiltin = (module: string) => () => {
+  throw new Error(`forbidden Node builtin: ${module}`)
+}
+
+describe('shipped policy compiler entrypoint', () => {
+  it('loads and resolves the shipped policy without filesystem, path, or URL modules', async () => {
+    vi.resetModules()
+    vi.doMock('node:fs', forbiddenBuiltin('node:fs'))
+    vi.doMock('node:path', forbiddenBuiltin('node:path'))
+    vi.doMock('node:url', forbiddenBuiltin('node:url'))
+
+    try {
+      // The compiler must be imported after its forbidden builtins are mocked.
+      const { compileWorkspaceWithProfileContext } = await import('../src/compiler.js')
+      const result = compileWorkspaceWithProfileContext([
+        {
+          path: 'policy.yaml',
+          source: `format: yarramate/v1
+id: policy
+profile: yarramate/policy@0.1
+concepts:
+  - id: oauth
+    kind: authentication-constraint
+    name: OAuth
+relationships: []
+`,
+        },
+      ])
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.graph.profiles).toEqual([
+        'yarramate/core@0.1',
+        'yarramate/policy@0.1',
+      ])
+    } finally {
+      vi.doUnmock('node:fs')
+      vi.doUnmock('node:path')
+      vi.doUnmock('node:url')
+      vi.resetModules()
+    }
+  })
+
+  it('keeps the static shipped policy byte-for-byte equal to its canonical YAML', async () => {
+    const canonical = await readFile(
+      new URL('../profiles/yarramate-policy.yaml', import.meta.url),
+      'utf8',
+    )
+    // This import follows the mock-resetting test so it can read the real export.
+    const { shippedPolicyIdentity, shippedPolicySource } = await import('../src/shipped-profile.js')
+
+    expect(shippedPolicyIdentity).toBe('yarramate/policy@0.1')
+    expect(shippedPolicySource).toBe(canonical)
+  })
+})


### PR DESCRIPTION
## Summary

Replace the shipped-policy filesystem loader with a static YAML export so the compiler entrypoint can load in a Worker bundle. Add a test that blocks `node:fs`, `node:path`, and `node:url` before dynamically importing and exercising policy compilation; it also guards byte-for-byte equality with the canonical published YAML.

## Validation

- `pnpm typecheck && pnpm build && pnpm test` — 70 files, 1,131 tests passed.
- Confirmed built `dist/shipped-profile.js` contains no `node:fs`, `node:path`, or `node:url` import.

## Related issue

None.

## Contract impact

None. Compiler profile semantics and published policy YAML remain unchanged; this removes only filesystem/path/URL imports from the compiler-reachable module graph.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.