### PR TITLE
fix: keep the line break behind a block scalar when apply replaces it

### DIFF
--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -128,6 +128,24 @@ const splice = (
   text: string,
 ): string => source.slice(0, start) + text + source.slice(end)
 
+// Replaces a *value* range, keeping whatever line break the original occupied.
+//
+// A block scalar's range ends after its terminating newline; a plain scalar's
+// ends at its last character. Splicing the range wholesale therefore swallows
+// the line break behind every `>-` and `|-` value and glues the following
+// field onto its line, producing `description: new    status: current`, which
+// then fails to reparse as YM101 "Nested mappings are not allowed in compact
+// mappings" - a document `check` accepts that `apply` refuses (#215). Putting
+// the original trailing newlines back makes the two scalar styles behave
+// identically.
+const spliceValue = (
+  source: string,
+  start: number,
+  end: number,
+  text: string,
+): string =>
+  splice(source, start, end, text + (/\n*$/.exec(source.slice(start, end))?.[0] ?? ''))
+
 // Insert a newline-terminated block at a line boundary, tolerating a
 // source that does not end in a newline.
 const insertBlock = (
@@ -316,7 +334,7 @@ const setScalarField = (
     )
   }
   const [start, valueEnd] = nodeRange(pair.value)
-  return splice(source, start, valueEnd, rendered)
+  return spliceValue(source, start, valueEnd, rendered)
 }
 
 const appendListField = (
@@ -369,7 +387,7 @@ const appendListField = (
     }).trimEnd()
     return splice(source, start, valueEnd, flow)
   }
-  return splice(
+  return spliceValue(
     source,
     start,
     valueEnd,

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -1080,3 +1080,147 @@ operations:
     })
   })
 })
+
+// #215: a block scalar's YAML range ends *after* its terminating newline,
+// unlike a plain scalar's. `apply` spliced that range wholesale, swallowing
+// the line break and gluing the next field onto the value's line, so every
+// `>-` and `|-` field refused with YM101 on a document `check` accepts.
+describe('apply over block scalars (#215)', () => {
+  let workspace: string
+
+  const blockDocument = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  # This comment must survive a programmatic write.
+  - id: folded
+    kind: applicationComponent
+    name: Folded
+    description: >-
+      A folded block scalar that wraps onto
+      a second line.
+    status: current
+  - id: literal
+    kind: applicationComponent
+    name: Literal
+    description: |-
+      A literal block scalar.
+      Its second line.
+    status: current
+relationships:
+  - id: folded-flows
+    kind: flow
+    from: folded
+    to: literal
+    content: >-
+      Flow content that is itself a folded
+      block scalar.
+`
+
+  const blockManifest = `format: yarramate/workspace/v1
+id: block-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`
+
+  const write = (name: string, body: string): void =>
+    writeFileSync(join(workspace, name), body, 'utf8')
+
+  const documentNow = (): string =>
+    readFileSync(join(workspace, 'architecture/main.yaml'), 'utf8')
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-block-'))
+    mkdirSync(join(workspace, 'architecture'))
+    write('architecture/main.yaml', blockDocument)
+    write('workspace.yaml', blockManifest)
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('replaces a folded description without swallowing the next field', () => {
+    write(
+      'operations.yaml',
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: folded
+      description: Replaced.
+`,
+    )
+    const result = runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(0)
+
+    const now = documentNow()
+    expect(now).toContain('    description: Replaced.\n    status: current\n')
+    expect(runCli(['check', 'workspace.yaml'], workspace).exitCode).toBe(0)
+  })
+
+  it('replaces a literal description without swallowing the next field', () => {
+    write(
+      'operations.yaml',
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: literal
+      description: Replaced too.
+`,
+    )
+    const result = runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(0)
+    expect(documentNow()).toContain(
+      '    description: Replaced too.\n    status: current\n',
+    )
+    expect(runCli(['check', 'workspace.yaml'], workspace).exitCode).toBe(0)
+  })
+
+  it("replaces a relationship's block-scalar content", () => {
+    write(
+      'operations.yaml',
+      `format: yarramate/operations/v1
+operations:
+  - op: update-relationship
+    document: architecture/main.yaml
+    relationship:
+      id: folded-flows
+      content: A single line now.
+`,
+    )
+    const result = runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(0)
+    expect(documentNow()).toContain('    content: A single line now.\n')
+    expect(runCli(['check', 'workspace.yaml'], workspace).exitCode).toBe(0)
+  })
+
+  it('leaves untouched block scalars and comments exactly as authored', () => {
+    write(
+      'operations.yaml',
+      `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: architecture/main.yaml
+    concept:
+      id: folded
+      description: Only this one changes.
+`,
+    )
+    expect(
+      runCli(['apply', 'operations.yaml', 'workspace.yaml'], workspace).exitCode,
+    ).toBe(0)
+
+    const now = documentNow()
+    expect(now).toContain('  # This comment must survive a programmatic write.')
+    expect(now).toContain('    description: |-\n      A literal block scalar.\n')
+    expect(now).toContain('    content: >-\n      Flow content that is itself a folded\n')
+  })
+})


### PR DESCRIPTION
Closes #215.

`apply` refused every document whose target field was authored as a `>-` or
`|-` block scalar, failing with `YM101 Nested mappings are not allowed in
compact mappings` and writing nothing, on documents `check` accepts. That style
is the idiomatic one in every shipped model, so in practice `apply` could not
update the description of most real subjects.

## Root cause

A block scalar's YAML range ends *after* its terminating newline; a plain
scalar's ends at its last character. `setScalarField` spliced that range
wholesale, so the replacement swallowed the line break and glued the following
field onto the value's line:

```
description: Replaced.    status: current
```

which then fails to reparse, surfacing as YM101 pointed at the `description:`
line.

## Fix

`spliceValue` puts back whatever trailing newlines the replaced range occupied,
so both scalar styles behave identically. `appendListField`'s value-replacing
splice uses it too, so the same class of bug cannot recur there.

## Tests

Four new tests: a folded description, a literal description, a relationship's
block-scalar `content`, and that untouched block scalars plus surrounding
comments survive a write. All four fail without the fix and pass with it
(verified by reverting the one-line change).

Also confirmed end to end against the `contact-update` journey fixture: the
update now applies, the workspace still checks clean at 37 concepts and 54
relationships, and all 26 YAML comments survive.

`pnpm verify` green: 72 files, 1223 passed, 1 skipped, LikeC4 validate clean.

## Notes

Pre-existing, not a regression from #214. #216 (operations resolving
`document:` against CWD rather than the manifest) is a separate bug found in
the same investigation and is not addressed here.
