### PR TITLE
fix: accept an operation's document as the manifest names it

### DIFF
--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import {
   isMap,
   isScalar,
@@ -578,20 +578,43 @@ export const applyOperations = (
       `/operations/${index}/document`,
     ),
   })
+  // An operation names its document either the way the manifest names it
+  // (relative to the manifest directory) or the way diagnostics print it
+  // (relative to the working directory). Resolving only against `cwd` refused
+  // the manifest-relative form outright whenever the manifest did not sit in
+  // the working directory - the standard `.yarramate/` layout - and made the
+  // same operations document apply from one directory and fail from another
+  // (#216). Both readings are tried, and only a path that actually names a
+  // document of this workspace is accepted, so admitting the second form
+  // cannot make an address ambiguous.
+  const manifestDirectory = dirname(resolve(cwd, workspace.path))
   for (const [index, operation] of operationList.entries()) {
-    const absolute = resolve(cwd, operation.document)
     const overlay = operation.op.endsWith('-observation')
-    const manifestPath = overlay
-      ? workspaceEvidence.get(absolute)
-      : workspaceDocuments.get(absolute)
+    const known = overlay ? workspaceEvidence : workspaceDocuments
+    const readings = [
+      resolve(manifestDirectory, operation.document),
+      resolve(cwd, operation.document),
+    ]
+    const absolute = readings.find((reading) => known.has(reading)) ?? readings[1]!
+    const manifestPath = known.get(absolute)
     const locate = (message: string): Diagnostic =>
       locateOperation(index, message)
     if (manifestPath === undefined) {
+      const accepted = [...known.values()].sort()
+      const shown = accepted.slice(0, 5)
+      const remainder =
+        accepted.length > shown.length
+          ? ` and ${accepted.length - shown.length} more`
+          : ''
       return failed([
         locate(
           `Operation ${index} targets "${operation.document}", which is not ${
             overlay ? 'an evidence document' : 'a document'
-          } of workspace "${resolvedWorkspace.id}"`,
+          } of workspace "${resolvedWorkspace.id}". This workspace declares ${
+            accepted.length === 0
+              ? 'none'
+              : `${shown.map((path) => `"${path}"`).join(', ')}${remainder}`
+          }`,
         ),
       ])
     }

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -1224,3 +1224,85 @@ operations:
     expect(now).toContain('    content: >-\n      Flow content that is itself a folded\n')
   })
 })
+
+// #216: an operation's `document:` was resolved only against the working
+// directory, so the manifest-relative form every author writes was refused
+// whenever the manifest did not sit in the working directory - which is the
+// standard `.yarramate/` layout - and the same operations document applied
+// from one directory and failed from another.
+describe('apply document addressing (#216)', () => {
+  let root: string
+
+  const nested = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+relationships: []
+`
+
+  const nestedManifest = `format: yarramate/workspace/v1
+id: nested-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence: []
+`
+
+  const operationsNaming = (path: string): string =>
+    `format: yarramate/operations/v1
+operations:
+  - op: update-concept
+    document: ${path}
+    concept:
+      id: user
+      description: Addressed from the repository root.
+`
+
+  beforeEach(() => {
+    // The manifest lives under `.yarramate/`, as `init` produces and every
+    // showcase uses, and commands run from the repository root above it.
+    root = mkdtempSync(join(tmpdir(), 'yarramate-nested-'))
+    mkdirSync(join(root, '.yarramate/architecture'), { recursive: true })
+    writeFileSync(join(root, '.yarramate/architecture/main.yaml'), nested, 'utf8')
+    writeFileSync(join(root, '.yarramate/workspace.yaml'), nestedManifest, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  const applyNaming = (path: string) => {
+    writeFileSync(join(root, 'operations.yaml'), operationsNaming(path), 'utf8')
+    return runCli(
+      ['apply', 'operations.yaml', '.yarramate/workspace.yaml'],
+      root,
+    )
+  }
+
+  const documentNow = (): string =>
+    readFileSync(join(root, '.yarramate/architecture/main.yaml'), 'utf8')
+
+  it('accepts the manifest-relative form from the repository root', () => {
+    const result = applyNaming('architecture/main.yaml')
+    expect(result.exitCode).toBe(0)
+    expect(documentNow()).toContain('Addressed from the repository root.')
+  })
+
+  it('still accepts the working-directory-relative form', () => {
+    const result = applyNaming('.yarramate/architecture/main.yaml')
+    expect(result.exitCode).toBe(0)
+    expect(documentNow()).toContain('Addressed from the repository root.')
+  })
+
+  it('names the documents it does accept when the address matches none', () => {
+    const result = applyNaming('architecture/nowhere.yaml')
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('is not a document of workspace')
+    expect(result.stdout).toContain('.yarramate/architecture/main.yaml')
+  })
+})


### PR DESCRIPTION
Closes #216. **Stacked on #217** (`fix/apply-folded-scalar`), which should merge
first; this branch contains that commit too.

`apply` resolved an operation's `document:` only against the working directory,
so the manifest-relative form an author naturally writes was refused whenever
the manifest did not sit in the working directory. That is the standard
`.yarramate/` layout, which `init` produces and every gallery showcase uses. It
also made an operations document non-portable: the same file applied from one
directory and failed from another.

## Fix

Both readings are tried, manifest-relative first, and **only a path that
actually names a document of this workspace is accepted**, so admitting the
second form cannot make an address ambiguous.

The working-directory form keeps working deliberately: the visual session
server addresses documents that way today (it runs with the workspace root as
cwd while the manifest is at `.yarramate/workspace.yaml`), so switching purely
to manifest-relative would have broken the browser commit path.

The refusal now also names the documents the workspace declares, up to five,
instead of only saying the address was wrong. An author or a UI handed the
diagnostic can see what it should have said.

## Tests

Three new tests over a `.yarramate/`-layout fixture driven from the repository
root: the manifest-relative form applies, the working-directory form still
applies, and a bogus address names the accepted documents. The first fails
without the change.

End to end on the `contact-update` journey fixture, manifest-relative
addressing with a folded description, exercising this and #215 in one
operation: applies cleanly, workspace still checks at 37 concepts and 54
relationships.

`pnpm test` 72 files, 1226 passed, 1 skipped. `pnpm self:check` clean at 267
concepts and 375 relationships.

## Note for the coming refactor

This is the pragmatic fix. The stated rule in `docs/PRODUCT-CONTRACT.md` is
that paths resolve relative to the manifest, and the reason both readings exist
at all is that `ResolvedWorkspace.documents` re-expresses manifest-relative
globs as working-directory-relative strings (`src/workspace.ts`). The planned
source-store seam is the right place to collapse that to one representation.
