### PR TITLE
feat!: one layout backend, and a first paint that matches the settled layout

### DIFF
--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -73,19 +73,34 @@ reviewable input rather than a reproducible artifact
 An unreadable or invalid sidecar is skipped: presentation must never fail a
 session.
 
-### Layout backends
+### Layout
 
-Three layout algorithms render the canvas automatically, selected via `presentation.layout`:
+One backend: **`layered`** (`elk layered`), selected by `presentation.layout`,
+which now admits only that value. It honours `presentation.direction`
+(`top-down` → `elk.direction: DOWN`, `left-right` → `RIGHT`) and measured
+112 ms on this repository's 258-node graph.
 
-- **`layered`** (`elk layered`) — honours `presentation.direction` (`top-down` → `elk.direction: DOWN`, `left-right` → `RIGHT`). Measured 112 ms on this repository's 258-node graph. Deterministic; seed (`presentation.seed`) is ignored.
-- **`radial`** (cytoscape `concentric`) — degree-ranked rings, hubs in the centre. Ignores `direction` and `seed`. Measured 4 ms with zero node overlaps. Not elk-based; compound parents wrap children instead of being positioned concentrically themselves.
-- **`force`** (elk `stress` + `sporeOverlap`) — a two-pass layout: elk `stress` (`desiredEdgeLength: 320`) first, then (once that settles) `sporeOverlap` to remove overlaps. Takes 5.4 s on the full graph but reaches zero overlapping pairs. Seed deterministically shifts initial random placement — the only backend where seed visibly alters final positions. Shows a `"Laying out..."` busy notice during the run and supersedes a request while another is in flight rather than stacking a second pass.
+`radial` (cytoscape `concentric`) and `force` (elk `stress` then
+`sporeOverlap`) were removed in 1.0. Measured against `layered` on every view
+of the contact-update journey, both lost on all three counts that decide
+whether a diagram can be read: edge crossings, total edge length, and how
+large the graph draws once fitted to the canvas. On the solution view, for
+instance, `layered` produced 79 crossings and 16,349px of edge at a fit zoom of
+0.94, against `radial`'s 86 / 18,634 / 0.75 and `force`'s 73 / 25,783 / 0.71.
+`force` also cost seconds of blocked main thread and the whole apparatus that
+went with it: a busy notice, a two-pass chain, and an in-flight guard so a
+newer request could supersede a running one. None of that has anything left to
+guard now.
 
-The three measurements above are from this repository's own graph (258 concepts, 352 relationships, 220×64 px nodes), not a synthetic fixture. **`radial` is not elk `radial`** — ELK's radial is a tree algorithm that produced 17,578 overlapping pairs on this graph and did not terminate when overlap removal was attempted afterward. `radial` maps instead to cytoscape's built-in `concentric`, and `force` takes no new dependency beyond the already-installed `cytoscape-elk`, avoiding `cytoscape-cola` and `cytoscape-fcose` which either stalled, produced degenerate output, or left too many overlaps to be useful. See [ADR 0086](adr/0086-radial-is-concentric-and-force-is-stress-then-spore.md) for the full measurement table and rejected alternatives.
+`presentation.seed` went with them. Only `force` ever read it, yet the
+projection schema had required a seed of every view that declared a layout at
+all. Removing it also removes that conditional, so declaring a layout no longer
+obliges a view to invent a seed it has no use for.
 
-Seed is a string on the wire and is FNV-1a-hashed to a signed int32 before being handed to `elk.randomSeed` (the browser hashes it with `Math.imul`). It is saved for every view but only reproduces a `force` layout; `layered` is deterministic and ignores it, and `concentric` is deterministic by construction.
-
-`elk.direction` is only honoured by `layered`; the other two backends ignore it entirely.
+[ADR 0086](adr/0086-radial-is-concentric-and-force-is-stress-then-spore.md)
+recorded what those two backends mapped onto and why the obvious ELK choices
+were rejected; it is superseded here. A future layout mechanism is expected,
+and `presentation.layout` stays an enum so it has somewhere to land.
 
 ### Presentation toggles
 

--- a/docs/adr/0086-radial-is-concentric-and-force-is-stress-then-spore.md
+++ b/docs/adr/0086-radial-is-concentric-and-force-is-stress-then-spore.md
@@ -2,6 +2,15 @@
 
 Status: accepted
 
+> Superseded in 1.0: `radial` and `force` are removed, leaving `layered` as
+> the only backend, and `presentation.seed` is removed with them because only
+> `force` read it. Measured on every view of the contact-update journey,
+> both lost to `layered` on edge crossings, total edge length, and how large
+> the graph draws once fitted to the canvas. What this ADR decided remains
+> true of the code it described: `radial` was cytoscape `concentric`, not ELK
+> radial, and `force` was `stress` followed by `sporeOverlap`. A future layout
+> mechanism will be recorded in its own ADR.
+
 [ADR 0085](0085-a-dragged-position-is-presentation-the-repository-keeps.md)
 settled where a layout's *output* lives once a reviewer touches it by hand.
 This ADR settles what an *automatic* layout actually runs, because the

--- a/schema/yarramate-projection-result.schema.json
+++ b/schema/yarramate-projection-result.schema.json
@@ -26,14 +26,10 @@
           "minLength": 1
         },
         "layout": {
-          "enum": ["layered", "radial", "force"]
+          "enum": ["layered"]
         },
         "direction": {
           "enum": ["top-down", "left-right"]
-        },
-        "seed": {
-          "type": "string",
-          "minLength": 1
         },
         "showLifecycle": {
           "type": "boolean"

--- a/schema/yarramate-projection.schema.json
+++ b/schema/yarramate-projection.schema.json
@@ -127,13 +127,10 @@
           "$ref": "#/$defs/nonEmptyText"
         },
         "layout": {
-          "enum": ["layered", "radial", "force"]
+          "enum": ["layered"]
         },
         "direction": {
           "enum": ["top-down", "left-right"]
-        },
-        "seed": {
-          "$ref": "#/$defs/nonEmptyText"
         },
         "showLifecycle": {
           "type": "boolean"
@@ -147,17 +144,7 @@
         "notation": {
           "enum": ["native", "archimate"]
         }
-      },
-      "allOf": [
-        {
-          "if": {
-            "required": ["layout"]
-          },
-          "then": {
-            "required": ["seed"]
-          }
-        }
-      ]
+      }
     },
     "id": {
       "type": "string",

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -50,9 +50,8 @@ export interface ProjectionDefinition {
   readonly presentation?: {
     readonly title?: string
     readonly description?: string
-    readonly layout?: 'layered' | 'radial' | 'force'
+    readonly layout?: 'layered'
     readonly direction?: 'top-down' | 'left-right'
-    readonly seed?: string
     readonly showLifecycle?: boolean
     readonly showEvidence?: boolean
     readonly showOwnership?: boolean
@@ -118,7 +117,6 @@ export function canonicalProjection(
             ...(presentation.description === undefined ? {} : { description: presentation.description }),
             ...(presentation.layout === undefined ? {} : { layout: presentation.layout }),
             ...(presentation.direction === undefined ? {} : { direction: presentation.direction }),
-            ...(presentation.seed === undefined ? {} : { seed: presentation.seed }),
             ...(presentation.showLifecycle === undefined ? {} : { showLifecycle: presentation.showLifecycle }),
             ...(presentation.showEvidence === undefined ? {} : { showEvidence: presentation.showEvidence }),
             ...(presentation.showOwnership === undefined ? {} : { showOwnership: presentation.showOwnership }),
@@ -395,9 +393,6 @@ export function evaluateProjection(
             ...(projection.presentation.direction === undefined
               ? {}
               : { direction: projection.presentation.direction }),
-            ...(projection.presentation.seed === undefined
-              ? {}
-              : { seed: projection.presentation.seed }),
             ...(projection.presentation.showLifecycle === undefined
               ? {}
               : { showLifecycle: projection.presentation.showLifecycle }),

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -95,7 +95,7 @@ const endTransitionStatus = (state: VisualAppState): string => {
 // combination whatever is stored, and leaves every other one alone. Radial and
 // force never read a direction at all, so ArchiMate pins nothing there.
 const directionPinned = (
-  layout: "layered" | "radial" | "force",
+  layout: "layered",
   notation: "native" | "archimate",
 ): boolean => layout === "layered" && notation === "archimate";
 
@@ -113,7 +113,6 @@ const CommandStrip = ({
   onToggleDirection,
   onSelectLayout,
   notation,
-  seed,
   onSelectNotation,
   showLifecycle,
   showEvidence,
@@ -133,14 +132,13 @@ const CommandStrip = ({
   readonly detailsOpen: boolean;
   readonly conversationOpen: boolean;
   readonly unread: number;
-  readonly layout: "layered" | "radial" | "force";
+  readonly layout: "layered";
   readonly direction: "top-down" | "left-right";
   readonly views: readonly VisualViewSummary[];
   readonly onToggleDetails: () => void;
   readonly onToggleConversation: () => void;
-  readonly onSelectLayout: (layout: "layered" | "radial" | "force") => void;
+  readonly onSelectLayout: (layout: "layered") => void;
   readonly notation: "native" | "archimate";
-  readonly seed: string;
   readonly onSelectNotation: (notation: "native" | "archimate") => void;
   readonly onToggleDirection: () => void;
   readonly showLifecycle: boolean;
@@ -199,7 +197,6 @@ const CommandStrip = ({
         layout={layout}
         direction={direction}
         notation={notation}
-        seed={seed}
         showLifecycle={showLifecycle}
         showEvidence={showEvidence}
         showOwnership={showOwnership}
@@ -208,19 +205,6 @@ const CommandStrip = ({
         onSave={onSaveView}
         onDismissNotice={onDismissSavedNotice}
       />
-      <select
-        aria-label="Layout"
-        value={layout}
-        onChange={(e) =>
-          onSelectLayout(
-            e.currentTarget.value as "layered" | "radial" | "force",
-          )
-        }
-      >
-        <option value="layered">Layered</option>
-        <option value="radial">Radial</option>
-        <option value="force">Force</option>
-      </select>
       <select
         aria-label="Notation"
         value={notation}
@@ -347,29 +331,25 @@ const DiagramWorkspace = ({
   layout,
   direction,
   notation,
-  seed,
   showLifecycle,
   showEvidence,
   showOwnership,
   onSelect,
   onClearFilter,
   onSaveLayout,
-  onWaitingChange,
 }: {
   readonly state: VisualAppState;
   readonly selectedId: string | null;
   readonly waiting: string | null;
-  readonly layout: "layered" | "radial" | "force";
+  readonly layout: "layered";
   readonly direction: "top-down" | "left-right";
   readonly notation: "native" | "archimate";
-  readonly seed: string;
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
   readonly onSelect: (subject: SelectedDiagramSubject) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
-  readonly onWaitingChange: (waiting: string | null) => void;
 }) => {
   // An edge names its endpoints by node id; the reviewer reads titles. The
   // rendering model the renderer itself draws answers that, so nothing here
@@ -422,17 +402,14 @@ const DiagramWorkspace = ({
             }}
             matchedIds={state.activeFilter?.matchedIds ?? null}
             quickFilterText={state.quickFilterText}
-            layout={layout}
             direction={direction}
             notation={notation}
-            seed={seed}
             showLifecycle={showLifecycle}
             showEvidence={showEvidence}
             showOwnership={showOwnership}
             activeViewId={state.activeView}
             savedPositions={state.model.layouts[state.activeView]}
             onSaveLayout={onSaveLayout}
-            onWaitingChange={onWaitingChange}
           />
         )}
         {state.layoutNotice === null ? null : (
@@ -945,7 +922,6 @@ export const App = () => {
         layout={workspace.layout}
         direction={workspace.direction}
         notation={workspace.notation}
-        seed={workspace.seed}
         showLifecycle={workspace.showLifecycle}
         showEvidence={workspace.showEvidence}
         showOwnership={workspace.showOwnership}
@@ -991,7 +967,6 @@ export const App = () => {
           layout={workspace.layout}
           direction={workspace.direction}
           notation={workspace.notation}
-          seed={workspace.seed}
           showLifecycle={workspace.showLifecycle}
           showEvidence={workspace.showEvidence}
           showOwnership={workspace.showOwnership}
@@ -1000,7 +975,6 @@ export const App = () => {
           }
           onClearFilter={clearFilter}
           onSaveLayout={saveLayout}
-          onWaitingChange={setLayoutWaiting}
         />
         {conversationOpen ? (
           <ConversationSeparator

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -863,6 +863,7 @@ export function GraphCanvas({
   const directionRef = useRef(direction)
   const notationRef = useRef(notation)
   const pendingViewFitRef = useRef(false)
+  const matchedIdsRef = useRef(matchedIds)
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
   const onSaveLayoutRef = useRef(onSaveLayout)
   const savedPositionsRef = useRef(savedPositions)
@@ -1073,7 +1074,25 @@ export function GraphCanvas({
   useEffect(() => {
     if (!cyRef.current) return
     applyFilter(cyRef.current, matchedIds, quickFilterText)
-    if (pendingViewFitRef.current) {
+    // A structural filter result lands in a later commit than the view id that
+    // asked for it. The arming effect above fires only on a view / direction /
+    // notation change, so on a session's first paint the one layout that runs
+    // is computed over every element - including the ones the filter is about
+    // to hide - and the survivors are left spread across a layout built for a
+    // graph that is no longer on screen, so it sprawls. Measured on the
+    // contact-update solution view, which draws 20 of the workspace's 37
+    // elements: first paint spanned 1910x2958 with 25,235px of edge at a fit
+    // zoom of 0.34, against 922x2584 and 21,335px at 0.39 once any control was
+    // touched - more than twice as wide for the same twenty nodes, purely
+    // because touching a control re-ran the layout over the visible set.
+    // (Crossings go the other way, 31 against 37: a sprawled layout crosses
+    // less precisely because it is not compact.) Relaying out
+    // whenever the matched set itself changes closes that gap, and `matchedIds`
+    // is compared by reference because the server hands back a fresh array per
+    // `filter-result` frame.
+    const matchedChanged = matchedIds !== matchedIdsRef.current
+    matchedIdsRef.current = matchedIds
+    if (pendingViewFitRef.current || matchedChanged) {
       pendingViewFitRef.current = false
       relayoutVisible(cyRef.current, direction, notation)
     }

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useEffect, useRef } from 'react'
 import cytoscape from 'cytoscape'
-import type { Core, CollectionReturnValue, ElementDefinition, Layouts, NodeCollection, NodeSingular } from 'cytoscape'
+import type { Core, CollectionReturnValue, ElementDefinition, NodeCollection, NodeSingular } from 'cytoscape'
 import elk from 'cytoscape-elk'
 import type {
   CanvasGraph,
@@ -142,85 +142,27 @@ const ELK_SPACING: Record<string, unknown> = {
   'elk.padding': `[top=${CONTAINER_PADDING + CONTAINER_LABEL_GAP},left=${CONTAINER_PADDING},bottom=${CONTAINER_PADDING},right=${CONTAINER_PADDING}]`,
 }
 
-// FNV-1a hash: deterministically convert a seed string to a signed int32.
-// ELK's `org.eclipse.elk.randomSeed` is INT-typed; handed a non-numeric string
-// (like the `'default'` a view that declares no seed of its own lays out under)
-// it silently ignores the option, so the wire-format string seed has to become
-// an integer before it reaches elk.
-//
-// `Math.imul` is the exact int32 multiply - a plain `hash * 16777619` overflows
-// the 53-bit mantissa once `hash` passes 2^29 and starts rounding, which is
-// still deterministic but is no longer FNV-1a. Same string always hashes to the
-// same int32, across reloads and machines.
-function seedToInt32(seed: string): number {
-  let hash = 2166136261 // FNV offset basis
-  for (let i = 0; i < seed.length; i++) {
-    hash = Math.imul(hash ^ seed.charCodeAt(i), 16777619)
-  }
-  return hash | 0
-}
-
 // Shared by the full-graph layout effect and the visible-subgraph relayout
-// that runs on view switch, so both always agree on algorithm/direction.
+// that runs on view switch, so both always agree on algorithm and direction.
 //
-// Three backends, chosen by headless measurement on this repo's own 258-node
-// graph:
-// - `layered` - elk's `layered` algorithm, today's default directional
-//   (org-chart style) layout. Seed has no measurable effect on crossing
-//   minimization on this repo's graph and is silently ignored.
-// - `radial` - cytoscape's own built-in `concentric`, not elk's `radial`
-//   algorithm (measured unusable on this graph: a tree algorithm, 17.5k
-//   overlapping node pairs). Concentric filters compound parents itself
-//   (`eles.nodes().not(':parent')`), so parents wrap their children instead
-//   of being concentric-positioned themselves - measured 0 parent overlaps.
-//   Not elk-based, so no seed support.
-// - `force` - elk's `stress` algorithm, first pass only. Seed deterministically
-//   changes the initial random placement; measured to be the only backend where
-//   randomSeed visibly alters final positions. The `sporeOverlap` overlap-removal
-//   second pass is Task 3's business: it needs this first pass to have finished
-//   before it can run.
+// One backend. `radial` (cytoscape `concentric`) and `force` (elk `stress`
+// then `sporeOverlap`) were measured against `layered` on every view of the
+// contact-update journey and lost on all three counts that matter: edge
+// crossings, total edge length, and how large the graph draws once fitted to
+// the canvas. They are removed rather than deprecated, and the `seed` only
+// `force` ever read went with them - the projection schema had required a
+// seed of every view that declared a layout at all, for one backend's benefit.
 //
-// `elk.direction` is ignored by every elk algorithm except `layered`
-// (verified: identical container boxes for DOWN and RIGHT on `stress`), so
-// only `layered` reads `direction`. Under ArchiMate notation, `layered`
-// pins `elk.direction: 'DOWN'` regardless of `direction` - ArchiMate's
-// layer bands (motivation/strategy/business/application/technology) only
-// read top-down, so a left-right layered run under ArchiMate would draw
-// bands that don't correspond to anything. The pin is applied here, at
-// config-build time, and nowhere else: stored `direction` in workspace
-// state is never overwritten, so switching back to native notation
-// restores whatever direction the reviewer had declared.
+// `elk.direction` is read only by `layered`. Under ArchiMate notation it is
+// pinned to `DOWN` regardless of `direction`: ArchiMate's layer bands only
+// read top-down, so a left-right run would draw bands corresponding to
+// nothing. The pin is applied here, at config-build time, and nowhere else -
+// stored `direction` is never overwritten, so returning to native notation
+// restores whatever direction the reviewer declared.
 export function buildLayoutConfig(
-  layout: 'layered' | 'radial' | 'force',
   direction: 'top-down' | 'left-right',
-  seed?: string,
   notation: 'native' | 'archimate' = 'native',
 ): cytoscape.LayoutOptions {
-  if (layout === 'radial') {
-    return {
-      name: 'concentric',
-      avoidOverlap: true,
-      spacingFactor: 1.4,
-      animate: false,
-      nodeDimensionsIncludeLabels: false,
-    }
-  }
-  if (layout === 'force') {
-    const config: ElkLayoutOptions = {
-      name: 'elk',
-      elk: {
-        algorithm: 'stress',
-        'org.eclipse.elk.stress.desiredEdgeLength': 320,
-      },
-    }
-    if (seed !== undefined) {
-      config.elk['elk.randomSeed'] = seedToInt32(seed)
-    }
-    return config as unknown as cytoscape.LayoutOptions
-  }
-  // layered: no seed wiring (seed has no measurable effect on crossing
-  // minimization in this repo's graph; measured via headless elk on a
-  // 10-node asymmetric crossing-prone fixture)
   const elk: ElkLayoutOptions['elk'] = {
     algorithm: 'layered',
     'elk.direction':
@@ -760,114 +702,21 @@ export function applyFilter(
     .style('display', 'element')
 }
 
-// Shown while a `force` run is in flight. Measured at 5.4 s on this repo's
-// 258-node graph, so the canvas must say something rather than sit frozen.
-const LAYOUT_BUSY_NOTICE = 'Laying out...'
-
-// elk's overlap-removal algorithm, run as `force`'s second pass over the same
-// collection the first pass just placed. It reads the positions already on the
-// nodes, so it carries no configuration of its own.
-const SPORE_OVERLAP_CONFIG: ElkLayoutOptions = {
-  name: 'elk',
-  elk: { algorithm: 'sporeOverlap' },
-}
-
-// Runs `work` only once the browser has had its chance to paint the notice the
-// caller just announced. Two hops are needed, and neither one covers the other:
-//
-//   1. React does not commit a `setState` made from inside an effect during
-//      that effect - it schedules the re-render as a task. So the notice is
-//      still absent from the DOM when this function is called, and a frame
-//      taken right now would paint the canvas exactly as it already was. The
-//      timer yields to that already-queued render task first.
-//   2. A `requestAnimationFrame` callback runs *before* its own frame renders,
-//      so one frame is not enough either: the second frame's callback is the
-//      first point at which the previous frame - now carrying the committed
-//      notice - is on screen.
-//
-// Without rAF (the headless tests) or with the tab hidden, where rAF never
-// fires at all and there is nothing to paint anyway, the work runs straight
-// away rather than never.
-function paintFirst(work: () => void): void {
-  const hidden = typeof document !== 'undefined' && document.hidden
-  if (typeof requestAnimationFrame !== 'function' || hidden) {
-    work()
-    return
-  }
-  setTimeout(() => {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => work())
-    })
-  }, 0)
-}
-
-// The `force` backend's first pass (elk `stress`) still leaves nodes
-// overlapping; `sporeOverlap` is a second elk pass that spreads them apart
-// once the first has settled, so it can only start after the first pass's
-// own `layoutstop` fires. Every other backend stays the single synchronous
-// pass it always was - built once by `buildLayoutConfig` and run.
-//
-// `inFlightRef` is shared by every caller (the graph-change effect and
-// `relayoutVisible`) so a newer request - of either kind - supersedes a
-// force chain still running: it becomes the new `inFlightRef.current`, and
-// each layoutstop handler below compares itself against `inFlightRef.current`
-// before acting, so a superseded run can neither start its second pass over
-// a collection a newer request has already moved past nor flip `waiting`
-// back to idle after that newer request claimed it. `.stop()` is still
-// called on the way out for any future backend whose `stop()` really does
-// cancel a running layout.
+// One synchronous pass, built by `buildLayoutConfig` and run. The busy notice,
+// the two-pass chain and the in-flight guard that used to live here existed
+// only for the `force` backend, whose elk `stress` pass blocked the main
+// thread for seconds and then needed a second `sporeOverlap` pass to separate
+// the nodes it left overlapping. With `layered` the only backend a layout run
+// cannot still be in flight when the next one is requested, so none of that
+// apparatus has anything left to guard.
 function runLayout(
   eles: Core | CollectionReturnValue,
-  layout: 'layered' | 'radial' | 'force',
   direction: 'top-down' | 'left-right',
-  inFlightRef: { current: Layouts | null },
-  onWaitingChange: (waiting: string | null) => void,
   notation: 'native' | 'archimate' = 'native',
-  seed?: string,
 ): void {
-  // Clear the ref *before* stopping: `stop()` can emit `layoutstop`
-  // synchronously, and the superseded run's handler must already see itself
-  // disowned when it does.
-  const superseded = inFlightRef.current
-  inFlightRef.current = null
-  superseded?.stop()
-
-  const first = eles.layout(buildLayoutConfig(layout, direction, seed, notation))
-  if (layout !== 'force') {
-    // A superseded force chain's handlers all bail on the guards below, so
-    // nobody else will retire its busy notice. This run owns the canvas now,
-    // and it is the single synchronous pass it always was - nothing to wait
-    // for, so switching backends mid-force clears "Laying out..." here.
-    onWaitingChange(null)
-    first.run()
-    return
-  }
-
-  inFlightRef.current = first
-  onWaitingChange(LAYOUT_BUSY_NOTICE)
-  first.one('layoutstop', () => {
-    if (inFlightRef.current !== first) return
-    const second = eles.layout(SPORE_OVERLAP_CONFIG as unknown as cytoscape.LayoutOptions)
-    inFlightRef.current = second
-    second.one('layoutstop', () => {
-      if (inFlightRef.current !== second) return
-      inFlightRef.current = null
-      onWaitingChange(null)
-    })
-    second.run()
-  })
-  // elk's `stress` pass blocks the main thread outright - measured 6.1 s on this
-  // repo's 258-node graph - so React cannot commit the notice above until the
-  // pass is already over: it would only ever paint *after* the freeze it exists
-  // to explain. Yielding until the notice has actually painted (see
-  // `paintFirst`) puts it on screen first, then the pass runs. A newer request
-  // can claim `inFlightRef` while this one waits for its frames, so it
-  // re-checks that it still owns the canvas before handing elk the thread.
-  paintFirst(() => {
-    if (inFlightRef.current !== first) return
-    first.run()
-  })
+  eles.layout(buildLayoutConfig(direction, notation)).run()
 }
+
 
 // Positions come from the last full-graph layout, which packs every node
 // (including ones a view hides) into one shared coordinate space. Reusing
@@ -876,32 +725,15 @@ function runLayout(
 // each view a fresh, compact layout instead. cytoscape-elk's own `fit: true`
 // default re-frames the viewport to the result, so no separate fit call is
 // needed; `layout()` is a no-op on an empty visible collection, so callers
-// never need to guard against "the new view matched nothing". `inFlightRef`
-// and `onWaitingChange` default to a fresh, unshared guard and a no-op
-// callback so every existing caller that only cares about layered/radial's
-// synchronous behaviour keeps working unchanged. `notation` likewise
+// never need to guard against "the new view matched nothing". `notation`
 // defaults to `'native'` so a caller that has never heard of ArchiMate
-// notation gets the direction mapping it always did. `seed` is the active
-// view's `presentation.seed`; only the `force` backend reads it (see
-// `buildLayoutConfig`), and omitting it leaves elk on its own default.
+// notation gets the direction mapping it always did.
 export function relayoutVisible(
   cy: Core,
-  layout: 'layered' | 'radial' | 'force',
   direction: 'top-down' | 'left-right',
-  inFlightRef: { current: Layouts | null } = { current: null },
-  onWaitingChange: (waiting: string | null) => void = () => {},
   notation: 'native' | 'archimate' = 'native',
-  seed?: string,
 ): void {
-  runLayout(
-    cy.elements(':visible'),
-    layout,
-    direction,
-    inFlightRef,
-    onWaitingChange,
-    notation,
-    seed,
-  )
+  runLayout(cy.elements(':visible'), direction, notation)
 }
 
 // `dragfree` fires once per drag (unlike `position`, which fires on every
@@ -987,23 +819,15 @@ interface GraphCanvasProps {
   readonly onSelect: (id: string, type: 'node' | 'edge') => void
   readonly matchedIds: readonly string[] | null
   readonly quickFilterText: string
-  readonly layout: 'layered' | 'radial' | 'force'
   readonly direction: 'top-down' | 'left-right'
   readonly showLifecycle: boolean
   readonly showEvidence: boolean
   readonly showOwnership: boolean
   readonly notation: 'native' | 'archimate'
-  /**
-   * The active view's `presentation.seed`. Only the `force` backend reads it
-   * (elk `stress`'s initial random placement); the other two are deterministic
-   * by construction and ignore it.
-   */
-  readonly seed: string
   readonly activeViewId: string
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
-  readonly onWaitingChange: (waiting: string | null) => void
 }
 
 /**
@@ -1021,17 +845,14 @@ export function GraphCanvas({
   onSelect,
   matchedIds,
   quickFilterText,
-  layout,
   direction,
   activeViewId,
   savedPositions,
   onSaveLayout,
-  onWaitingChange,
   showLifecycle,
   showEvidence,
   showOwnership,
   notation,
-  seed,
 }: GraphCanvasProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<Core | null>(null)
@@ -1040,9 +861,7 @@ export function GraphCanvas({
   const isInitialPresentationSyncRef = useRef(true)
   const activeViewIdRef = useRef(activeViewId)
   const directionRef = useRef(direction)
-  const layoutRef = useRef(layout)
   const notationRef = useRef(notation)
-  const seedRef = useRef(seed)
   const pendingViewFitRef = useRef(false)
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
   const onSaveLayoutRef = useRef(onSaveLayout)
@@ -1051,10 +870,6 @@ export function GraphCanvas({
   // The force backend's in-flight layout (see `runLayout`), shared by the
   // graph-change effect and the view-switch relayout so either can supersede
   // the other instead of stacking a second stress+sporeOverlap chain on top.
-  const forceLayoutRef = useRef<Layouts | null>(null)
-  // Keep latest onWaitingChange for effects and the layoutstop handlers
-  // `runLayout` sets up, which must always report through the current prop.
-  const onWaitingChangeRef = useRef(onWaitingChange)
   // The viewport a layout (or a resize refit) last left behind. Anything else
   // on screen is the reviewer's own pan/zoom, which a resize must not discard.
   const autoViewportRef = useRef<{
@@ -1076,12 +891,6 @@ export function GraphCanvas({
   useEffect(() => {
     savedPositionsRef.current = savedPositions
   }, [savedPositions])
-
-  // Keep onWaitingChangeRef up-to-date so runLayout's layoutstop handlers
-  // always report busy state through the latest prop
-  useEffect(() => {
-    onWaitingChangeRef.current = onWaitingChange
-  }, [onWaitingChange])
 
   // Cancel pending drag-save when the active view changes, so a queued save
   // never lands against a different view's sidecar. Also cleared on unmount.
@@ -1173,9 +982,6 @@ export function GraphCanvas({
       cancelAnimationFrame(pendingFrame)
       observer.disconnect()
       dragSaveHandleRef.current?.dispose()
-      forceLayoutRef.current?.stop()
-      forceLayoutRef.current = null
-      onWaitingChangeRef.current(null)
       cy.destroy()
       cyRef.current = null
     }
@@ -1214,18 +1020,7 @@ export function GraphCanvas({
       cyRef.current.add(elements)
     }
 
-    // Read through the ref inside the wrapper, not once at the call site:
-    // an async force chain keeps calling this long after the effect ran, and
-    // it must always reach the current prop (same reason as `registerDragSave`).
-    runLayout(
-      cyRef.current,
-      layout,
-      direction,
-      forceLayoutRef,
-      (waiting) => onWaitingChangeRef.current(waiting),
-      notation,
-      seed,
-    )
+    runLayout(cyRef.current, direction, notation)
   }, [graph])
 
   // Update selection highlight when selectedId or graph changes
@@ -1256,25 +1051,19 @@ export function GraphCanvas({
   // commit.
   useEffect(() => {
     const viewChanged = activeViewId !== activeViewIdRef.current
-    const layoutChanged = layout !== layoutRef.current
     const directionChanged = direction !== directionRef.current
     const notationChanged = notation !== notationRef.current
-    const seedChanged = seed !== seedRef.current
     if (
       !viewChanged &&
-      !layoutChanged &&
       !directionChanged &&
-      !notationChanged &&
-      !seedChanged
+      !notationChanged
     )
       return
     activeViewIdRef.current = activeViewId
-    layoutRef.current = layout
     directionRef.current = direction
     notationRef.current = notation
-    seedRef.current = seed
     pendingViewFitRef.current = true
-  }, [activeViewId, layout, direction, notation, seed])
+  }, [activeViewId, direction, notation])
 
   // Apply structural filter (matchedIds) and quick-filter narrowing, then,
   // only once a pending view-switch relayout is armed and its filter result
@@ -1286,17 +1075,9 @@ export function GraphCanvas({
     applyFilter(cyRef.current, matchedIds, quickFilterText)
     if (pendingViewFitRef.current) {
       pendingViewFitRef.current = false
-      relayoutVisible(
-        cyRef.current,
-        layout,
-        direction,
-        forceLayoutRef,
-        (waiting) => onWaitingChangeRef.current(waiting),
-        notation,
-        seed,
-      )
+      relayoutVisible(cyRef.current, direction, notation)
     }
-  }, [matchedIds, quickFilterText, graph, layout, direction, notation, seed])
+  }, [matchedIds, quickFilterText, graph, direction, notation])
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
 }

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -10,13 +10,12 @@ export interface SaveViewControlProps {
   readonly views: readonly VisualViewSummary[];
   readonly activeViewId: string;
   readonly query: ProjectionQuery | null;
-  readonly layout: "layered" | "radial" | "force";
+  readonly layout: "layered";
   readonly direction: "top-down" | "left-right";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
   readonly notation: "native" | "archimate";
-  readonly seed: string;
   readonly pendingSave: boolean;
   readonly notice: boolean;
   readonly onSave: (payload: VisualViewSavePayload) => void;
@@ -31,13 +30,12 @@ export interface BuildPayloadParams {
   readonly title: string;
   readonly description: string;
   readonly query: ProjectionQuery | null;
-  readonly layout: "layered" | "radial" | "force";
+  readonly layout: "layered";
   readonly direction: "top-down" | "left-right";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
   readonly notation: "native" | "archimate";
-  readonly seed: string;
 }
 
 /** Pure translation from the form's local state to the wire payload — no
@@ -55,7 +53,6 @@ export const buildPayload = ({
   showEvidence,
   showOwnership,
   notation,
-  seed,
 }: BuildPayloadParams): VisualViewSavePayload => ({
   ...(id === undefined ? {} : { id }),
   title,
@@ -64,7 +61,6 @@ export const buildPayload = ({
   presentation: {
     layout,
     direction,
-    seed,
     showLifecycle,
     showEvidence,
     showOwnership,
@@ -89,7 +85,6 @@ export function SaveViewControl({
   showEvidence,
   showOwnership,
   notation,
-  seed,
   pendingSave,
   notice,
   onSave,
@@ -131,7 +126,6 @@ export function SaveViewControl({
       showEvidence,
       showOwnership,
       notation,
-      seed,
     });
 
   const submit = (id: string | undefined) => {

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -104,7 +104,7 @@ export interface VisualWorkspaceState {
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   readonly direction: "top-down" | "left-right";
-  readonly layout: "layered" | "radial" | "force";
+  readonly layout: "layered";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
@@ -115,7 +115,6 @@ export interface VisualWorkspaceState {
    * and elk ignores the seed outright, `radial` is not elk-based at all (see
    * `docs/VISUAL-ADAPTER.md`).
    */
-  readonly seed: string;
 }
 
 export type VisualWorkspaceAction =
@@ -136,10 +135,9 @@ export type VisualWorkspaceAction =
     }
   | {
       readonly type: "layout.set";
-      readonly layout: "layered" | "radial" | "force";
+      readonly layout: "layered";
     }
   | { readonly type: "notation.set"; readonly notation: "native" | "archimate" }
-  | { readonly type: "seed.set"; readonly seed: string }
   | {
       readonly type: "presentation.toggled";
       readonly flag: "showLifecycle" | "showEvidence" | "showOwnership";
@@ -161,7 +159,7 @@ export type VisualWorkspaceAction =
 export const presentationActionsFor = (
   presentation:
     | {
-        readonly layout?: "layered" | "radial" | "force";
+        readonly layout?: "layered";
         readonly direction?: "top-down" | "left-right";
         readonly notation?: "native" | "archimate";
         readonly showLifecycle?: boolean;
@@ -174,9 +172,6 @@ export const presentationActionsFor = (
   const actions: VisualWorkspaceAction[] = [];
   if (presentation?.layout !== undefined) {
     actions.push({ type: "layout.set", layout: presentation.layout });
-  }
-  if (presentation?.seed !== undefined) {
-    actions.push({ type: "seed.set", seed: presentation.seed });
   }
   if (presentation?.direction !== undefined) {
     actions.push({ type: "direction.set", direction: presentation.direction });
@@ -289,7 +284,6 @@ export const createVisualWorkspaceState = (
   // save of such a view writes it back - `presentation.seed` is required
   // wherever `presentation.layout` is (`schema/yarramate-projection.schema.json`),
   // so there is no "unset" to round-trip.
-  seed: "default",
 });
 
 export const visualWorkspaceReducer = (
@@ -366,10 +360,6 @@ export const visualWorkspaceReducer = (
       return { ...state, layout: action.layout };
     case "notation.set":
       return { ...state, notation: action.notation };
-    case "seed.set":
-      return state.seed === action.seed
-        ? state
-        : { ...state, seed: action.seed };
     case "presentation.toggled":
       return { ...state, [action.flag]: action.value };
     case "model.replaced": {

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -222,355 +222,42 @@ const countOverlappingPairs = (cy: cytoscape.Core): number => {
 }
 
 describe('buildLayoutConfig', () => {
-  it.each(['layered', 'radial', 'force'] as const)(
-    'lays out the %s backend with zero overlapping node bounding boxes',
-    async (layout) => {
-      const cy = buildLayoutFixture()
-      await runLayout(cy, buildLayoutConfig(layout, 'top-down'))
-      expect(countOverlappingPairs(cy)).toBe(0)
-    }
-  )
-
-  it('radial and force configs carry no elk.direction', () => {
-    const radial = buildLayoutConfig('radial', 'top-down') as unknown as Record<string, unknown>
-    expect(radial).not.toHaveProperty('elk')
-
-    const force = buildLayoutConfig('force', 'top-down') as unknown as {
-      elk: Record<string, unknown>
-    }
-    expect(Object.keys(force.elk)).not.toContain('elk.direction')
+  it('lays out with zero overlapping node bounding boxes', async () => {
+    const cy = buildLayoutFixture()
+    await runLayout(cy, buildLayoutConfig('top-down'))
+    expect(countOverlappingPairs(cy)).toBe(0)
   })
 
-  it('archimate notation pins layered direction to DOWN regardless of the stored direction', () => {
-    const archimate = buildLayoutConfig('layered', 'left-right', undefined, 'archimate') as unknown as {
+  it('archimate notation pins direction to DOWN regardless of the stored direction', () => {
+    const archimate = buildLayoutConfig('left-right', 'archimate') as unknown as {
       elk: Record<string, unknown>
     }
     expect(archimate.elk['elk.direction']).toBe('DOWN')
 
-    const native = buildLayoutConfig('layered', 'left-right', undefined, 'native') as unknown as {
+    const native = buildLayoutConfig('left-right', 'native') as unknown as {
       elk: Record<string, unknown>
     }
     expect(native.elk['elk.direction']).toBe('RIGHT')
 
-    const nativeTopDown = buildLayoutConfig('layered', 'top-down', undefined, 'native') as unknown as {
+    const nativeTopDown = buildLayoutConfig('top-down', 'native') as unknown as {
       elk: Record<string, unknown>
     }
     expect(nativeTopDown.elk['elk.direction']).toBe('DOWN')
   })
 
-  it('archimate notation does not add elk.direction to radial or force', () => {
-    const radial = buildLayoutConfig('radial', 'left-right', undefined, 'archimate') as unknown as Record<
-      string,
-      unknown
-    >
-    expect(radial).not.toHaveProperty('elk')
-
-    const force = buildLayoutConfig('force', 'left-right', undefined, 'archimate') as unknown as {
-      elk: Record<string, unknown>
-    }
-    expect(Object.keys(force.elk)).not.toContain('elk.direction')
-  })
-
-  it('force backend with the same seed produces identical positions across two runs', async () => {
-    const cyA = buildLayoutFixture()
-    const cyB = buildLayoutFixture()
-    await runLayout(cyA, buildLayoutConfig('force', 'top-down', 'seed-alpha'))
-    await runLayout(cyB, buildLayoutConfig('force', 'top-down', 'seed-alpha'))
-
-    expect(buildPositionMap(cyA.nodes())).toEqual(buildPositionMap(cyB.nodes()))
-  })
-
-  it('force backend with different seeds produces different positions', async () => {
-    const cyA = buildLayoutFixture()
-    const cyB = buildLayoutFixture()
-    await runLayout(cyA, buildLayoutConfig('force', 'top-down', 'seed-alpha'))
-    await runLayout(cyB, buildLayoutConfig('force', 'top-down', 'seed-beta'))
-
-    expect(buildPositionMap(cyA.nodes())).not.toEqual(buildPositionMap(cyB.nodes()))
+  // `layered` is the only backend, so a layout run is one synchronous elk
+  // pass. Nothing can still be in flight when the next request arrives, which
+  // is what retired the busy notice, the two-pass chain and the in-flight
+  // guard that `force` needed.
+  it('relayouts the visible subgraph in one synchronous pass', () => {
+    const cy = buildHubFixture()
+    relayoutVisible(cy, 'top-down')
+    expect(buildPositionMap(cy.nodes()).size ?? Object.keys(buildPositionMap(cy.nodes())).length)
+      .toBeGreaterThan(0)
   })
 })
 
-// `requestAnimationFrame` does not exist in this environment, so
-// `relayoutVisible`'s paint-first yield runs its work straight away and every
-// test above sees the single synchronous chain it always did. Installing a
-// queue-backed rAF holds a `force` request where the browser holds it: after
-// the busy notice is announced, before elk takes the main thread.
-const withFrameQueue = (
-  body: (frames: {
-    readonly step: () => void
-    readonly drain: () => void
-    readonly pending: () => number
-  }) => Promise<void>
-): Promise<void> => {
-  const frames: FrameRequestCallback[] = []
-  const host = globalThis as {
-    requestAnimationFrame?: (callback: FrameRequestCallback) => number
-  }
-  let frame = 0
-  host.requestAnimationFrame = (callback) => frames.push(callback)
-  // One `step` is one frame: it runs the callbacks registered for it, and any
-  // callback they register lands in the next frame rather than this one - which
-  // is what lets a test see a yield that spans two frames as two steps.
-  const step = () => {
-    frames.splice(0, frames.length).forEach((callback) => callback(frame++))
-  }
-  const drain = () => {
-    for (let guard = 0; guard < 8 && frames.length > 0; guard++) step()
-  }
-  return body({ step, drain, pending: () => frames.length }).finally(() => {
-    delete host.requestAnimationFrame
-  })
-}
 
-// The render task React would use to commit the notice: `relayoutVisible`
-// yields to it before it starts counting frames, so a test that never lets a
-// task run never sees a frame armed at all.
-const nextTask = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
-
-describe('relayoutVisible force second pass', () => {
-  it('resolves overlaps a single stress pass leaves, and signals busy state through onWaitingChange', async () => {
-    const baseline = buildHubFixture()
-    await runLayout(baseline, buildLayoutConfig('force', 'top-down'))
-    expect(countOverlappingPairs(baseline)).toBeGreaterThan(0)
-
-    const cy = buildHubFixture()
-    const waitingCalls: (string | null)[] = []
-    const idle = Promise.withResolvers<void>()
-    relayoutVisible(cy, 'force', 'top-down', { current: null }, (waiting) => {
-      waitingCalls.push(waiting)
-      if (waiting === null) idle.resolve()
-    })
-    await idle.promise
-
-    expect(waitingCalls[0]).toBe('Laying out...')
-    expect(waitingCalls.at(-1)).toBeNull()
-    expect(countOverlappingPairs(cy)).toBe(0)
-  })
-
-  // The canvas never calls `buildLayoutConfig` itself, so a view's declared
-  // seed reaches elk only if `relayoutVisible` forwards it down.
-  it('threads the seed through to the force backend', async () => {
-    const runSeeded = async (seed: string) => {
-      const cy = buildHubFixture()
-      const idle = Promise.withResolvers<void>()
-      relayoutVisible(
-        cy,
-        'force',
-        'top-down',
-        { current: null },
-        (waiting) => {
-          if (waiting === null) idle.resolve()
-        },
-        'native',
-        seed,
-      )
-      await idle.promise
-      return buildPositionMap(cy.nodes())
-    }
-
-    expect(await runSeeded('seed-alpha')).toEqual(await runSeeded('seed-alpha'))
-    expect(await runSeeded('seed-alpha')).not.toEqual(await runSeeded('seed-beta'))
-  })
-
-  it('supersedes an in-flight force run instead of stacking a second pass on top', async () => {
-    const cy = buildHubFixture()
-    const inFlightRef: { current: cytoscape.Layouts | null } = { current: null }
-    const waitingCalls: (string | null)[] = []
-    // Every `.run()` emits exactly one `layoutstart`, a stopped run included,
-    // so this counts layout passes actually started. The superseded run's own
-    // `layoutstop` necessarily precedes the winner's (it started first over
-    // the same collection), so by the time busy goes idle a stray fourth pass
-    // would already have been started and counted - no settling wait needed.
-    let started = 0
-    cy.on('layoutstart', () => {
-      started++
-    })
-
-    const idle = Promise.withResolvers<void>()
-    const onWaitingChange = (waiting: string | null) => {
-      waitingCalls.push(waiting)
-      if (waiting === null) idle.resolve()
-    }
-    relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    // Supersede before the first request's own layoutstop can fire.
-    relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    await idle.promise
-
-    // Three passes, and only three: the superseded stress run, the winning
-    // stress run, and the winner's single `sporeOverlap` pass. A fourth means
-    // the superseded run's `layoutstop` started an overlap pass of its own
-    // over a collection the newer request had already claimed.
-    expect(started).toBe(3)
-    // Nor may that superseded chain flip busy back to idle a second time:
-    // exactly one idle transition, however many busy announcements preceded it.
-    expect(waitingCalls.filter((w) => w === null)).toHaveLength(1)
-    expect(countOverlappingPairs(cy)).toBe(0)
-  })
-
-  it('keeps a run superseded during its second pass from reporting idle', async () => {
-    const cy = buildHubFixture()
-    const inFlightRef: { current: cytoscape.Layouts | null } = { current: null }
-    const waitingCalls: (string | null)[] = []
-
-    // Five passes in total, all sequenced by layout events rather than
-    // wall-clock waits: request A's stress run, request B's stress run and
-    // its `sporeOverlap` pass, then request C's two. C is issued as B's
-    // overlap pass starts, so it lands while that pass is in flight - the
-    // only way to reach the second pass's own supersede guard. On the real
-    // 258-node graph that window is seconds wide and the event loop stays
-    // free throughout, so a reviewer's click lands here routinely; on this
-    // fixture the pass settles within its own task, so the request has to be
-    // issued from `layoutstart` to fall inside it at all.
-    const settled = Promise.withResolvers<void>()
-    const onWaitingChange = (waiting: string | null) => {
-      waitingCalls.push(waiting)
-    }
-    let started = 0
-    cy.on('layoutstart', () => {
-      started++
-      if (started === 3) relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    })
-    let stopped = 0
-    cy.on('layoutstop', () => {
-      stopped++
-      if (stopped === 5) settled.resolve()
-    })
-
-    relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    await settled.promise
-
-    expect(started).toBe(5)
-    // Only the last request may report idle. An overlap pass whose collection
-    // a newer request already claimed must stay silent, or the canvas drops
-    // its "Laying out..." notice while a layout is still moving nodes.
-    expect(waitingCalls.filter((w) => w === null)).toHaveLength(1)
-    expect(waitingCalls.at(-1)).toBeNull()
-    expect(countOverlappingPairs(cy)).toBe(0)
-  })
-
-  it('retires the busy notice when a layered request supersedes an in-flight force run', async () => {
-    const cy = buildHubFixture()
-    const inFlightRef: { current: cytoscape.Layouts | null } = { current: null }
-    const waitingCalls: (string | null)[] = []
-    const onWaitingChange = (waiting: string | null) => {
-      waitingCalls.push(waiting)
-    }
-
-    // Two passes: the force stress run, stopped where it stands, and the
-    // layered run that took the canvas off it. The superseded chain's own
-    // handlers are guarded into silence, so if the layered branch does not
-    // retire the notice itself nothing ever will and "Laying out..." sticks
-    // for the rest of the session.
-    const settled = Promise.withResolvers<void>()
-    let started = 0
-    cy.on('layoutstart', () => {
-      started++
-    })
-    let stopped = 0
-    cy.on('layoutstop', () => {
-      stopped++
-      if (stopped === 2) settled.resolve()
-    })
-
-    relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-    expect(waitingCalls).toEqual(['Laying out...'])
-    relayoutVisible(cy, 'layered', 'top-down', inFlightRef, onWaitingChange)
-    await settled.promise
-
-    expect(started).toBe(2)
-    expect(waitingCalls.at(-1)).toBeNull()
-    expect(waitingCalls.filter((w) => w === null)).toHaveLength(1)
-    expect(inFlightRef.current).toBeNull()
-  })
-
-  it('arms the blocking pass on a painted frame rather than the task that announces it', async () => {
-    await withFrameQueue(async (frames) => {
-      const cy = buildHubFixture()
-      const inFlightRef: { current: cytoscape.Layouts | null } = { current: null }
-      const waitingCalls: (string | null)[] = []
-      let started = 0
-      cy.on('layoutstart', () => {
-        started++
-      })
-      const idle = Promise.withResolvers<void>()
-
-      relayoutVisible(cy, 'force', 'top-down', inFlightRef, (waiting) => {
-        waitingCalls.push(waiting)
-        if (waiting === null) idle.resolve()
-      })
-
-      // The notice is announced and nothing is armed yet: React commits a
-      // `setState` made from inside an effect as a task, so a frame taken in
-      // this task would paint the canvas exactly as it already was.
-      expect(waitingCalls).toEqual(['Laying out...'])
-      expect(frames.pending()).toBe(0)
-      expect(started).toBe(0)
-
-      // Once that render task has had its turn, the pass that blocks the main
-      // thread for seconds is waiting on a frame rather than running here.
-      await nextTask()
-      expect(frames.pending()).toBe(1)
-      expect(started).toBe(0)
-
-      // A callback runs *before* its own frame renders, so the first frame is
-      // only the one that carries the notice: elk must still be waiting after
-      // it, for the frame after the notice has actually gone to the screen.
-      frames.step()
-      expect(started).toBe(0)
-      expect(frames.pending()).toBe(1)
-
-      frames.drain()
-      await idle.promise
-
-      expect(started).toBe(2)
-      expect(waitingCalls.at(-1)).toBeNull()
-      expect(countOverlappingPairs(cy)).toBe(0)
-    })
-  })
-
-  it('drops a force request superseded before its frames arrive without ever reaching elk', async () => {
-    await withFrameQueue(async (frames) => {
-      const cy = buildHubFixture()
-      const inFlightRef: { current: cytoscape.Layouts | null } = { current: null }
-      const waitingCalls: (string | null)[] = []
-      let started = 0
-      cy.on('layoutstart', () => {
-        started++
-      })
-      const idle = Promise.withResolvers<void>()
-      const onWaitingChange = (waiting: string | null) => {
-        waitingCalls.push(waiting)
-        if (waiting === null) idle.resolve()
-      }
-
-      // A reviewer switching direction while the first request is still waiting
-      // for its frames. The first request has nothing running to `stop()`, so
-      // only its own guard can keep its multi-second pass off the main thread.
-      relayoutVisible(cy, 'force', 'top-down', inFlightRef, onWaitingChange)
-      relayoutVisible(cy, 'force', 'left-right', inFlightRef, onWaitingChange)
-      expect(started).toBe(0)
-
-      await nextTask()
-      expect(frames.pending()).toBe(2)
-      frames.drain()
-      await idle.promise
-
-      // The winner's stress and sporeOverlap passes, and no third pass from the
-      // request that lost the canvas before it started.
-      expect(started).toBe(2)
-      expect(inFlightRef.current).toBeNull()
-      expect(countOverlappingPairs(cy)).toBe(0)
-    })
-  })
-})
-
-// Task 11: ArchiMate notation mode. `buildStylesheet`'s edge rules key off
-// `coreKindLabel` (the edge's resolved core-vocabulary kind, projected in
-// graph-projection.ts) rather than `kindLabel`, so a derived development
-// kind like `yarramate/development@1.0#implements` - which projects with
-// kindLabel "implements" but coreKindLabel "realization" - renders through
-// the exact same rule as a directly-declared core "realization" edge.
 describe('buildStylesheet ArchiMate notation', () => {
   const edgeRule = (
     sheet: cytoscape.StylesheetJsonBlock[],

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -170,7 +170,7 @@ describe('relayoutVisible', () => {
     const visibleBefore = { ...cy.getElementById('node1').position() }
     const settled = new Promise<void>((resolve) => cy.one('layoutstop', () => resolve()))
 
-    relayoutVisible(cy, 'layered', 'top-down')
+    relayoutVisible(cy, 'top-down')
     await settled
 
     expect(cy.getElementById('node3').position()).toEqual(hiddenBefore)
@@ -180,6 +180,6 @@ describe('relayoutVisible', () => {
   it('is a safe no-op when nothing is visible', () => {
     const cy = buildPositionedCy()
     applyFilter(cy, [], '')
-    expect(() => relayoutVisible(cy, 'layered', 'top-down')).not.toThrow()
+    expect(() => relayoutVisible(cy, 'top-down')).not.toThrow()
   })
 })

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -669,7 +669,6 @@ query:
         '  description: Stable output\n' +
         '  layout: layered\n' +
         '  direction: top-down\n' +
-        '  seed: stable-layout\n' +
         '  showLifecycle: true\n' +
         '  showEvidence: false\n' +
         '  showOwnership: true\n',
@@ -679,7 +678,6 @@ query:
       source:
         'presentation:\n' +
         '  showOwnership: true\n' +
-        '  seed: stable-layout\n' +
         '  description: Stable output\n' +
         '  showEvidence: false\n' +
         '  direction: top-down\n' +
@@ -772,9 +770,8 @@ presentation:
       presentation: {
         title: 'Capabilities',
         description: 'Current capability context',
-        layout: 'radial',
+        layout: 'layered',
         direction: 'top-down',
-        seed: 'capabilities',
         showLifecycle: true,
         showEvidence: true,
         showOwnership: true,

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -17,7 +17,6 @@ describe('buildPayload', () => {
       showEvidence: true,
       showOwnership: false,
       notation: 'native',
-      seed: 'default',
     })
 
     expect(payload).toEqual({
@@ -28,7 +27,6 @@ describe('buildPayload', () => {
       presentation: {
         layout: 'layered',
         direction: 'top-down',
-        seed: 'default',
         showLifecycle: true,
         showEvidence: true,
         showOwnership: false,
@@ -49,7 +47,6 @@ describe('buildPayload', () => {
       showEvidence: true,
       showOwnership: true,
       notation: 'native',
-      seed: 'default',
     })
 
     expect(payload.presentation?.showLifecycle).toBe(false)
@@ -69,7 +66,6 @@ describe('buildPayload', () => {
       showEvidence: true,
       showOwnership: false,
       notation: 'native',
-      seed: 'default',
     })
 
     expect(payload).not.toHaveProperty('id')
@@ -80,7 +76,6 @@ describe('buildPayload', () => {
       presentation: {
         layout: 'layered',
         direction: 'left-right',
-        seed: 'default',
         showLifecycle: true,
         showEvidence: true,
         showOwnership: false,
@@ -101,7 +96,6 @@ describe('buildPayload', () => {
       showEvidence: true,
       showOwnership: false,
       notation: 'native',
-      seed: 'default',
     })
 
     expect(payload.title).toBe('Exact Title')
@@ -122,34 +116,31 @@ describe('buildPayload', () => {
       showEvidence: false,
       showOwnership: false,
       notation: 'native',
-      seed: 'default',
     })
 
     expect(payload.query).toEqual({})
   })
 
-  it('carries layout through to presentation when radial is selected', () => {
+  it('carries the layout through to presentation', () => {
     const payload = buildPayload({
       id: 'view-id',
-      title: 'Radial View',
-      description: 'A radial layout test',
+      title: 'Layered View',
+      description: 'A layout round-trip test',
       query,
-      layout: 'radial',
+      layout: 'layered',
       direction: 'top-down',
       showLifecycle: true,
       showEvidence: false,
       showOwnership: false,
       notation: 'native',
-      seed: 'default',
     })
 
-    expect(payload.presentation?.layout).toBe('radial')
+    expect(payload.presentation?.layout).toBe('layered')
     expect(payload.id).toBe('view-id')
-    expect(payload.title).toBe('Radial View')
-    expect(payload.description).toBe('A radial layout test')
+    expect(payload.title).toBe('Layered View')
+    expect(payload.description).toBe('A layout round-trip test')
     expect(payload.query).toEqual(query)
     expect(payload.presentation?.direction).toBe('top-down')
-    expect(payload.presentation?.seed).toBe('default')
   })
 
   it('carries notation through to presentation', () => {
@@ -164,7 +155,6 @@ describe('buildPayload', () => {
       showEvidence: true,
       showOwnership: false,
       notation: 'archimate',
-      seed: 'default',
     })
 
     expect(payload.presentation?.notation).toBe('archimate')
@@ -178,15 +168,13 @@ describe('buildPayload', () => {
       title: 'Seeded View',
       description: 'A reviewer-chosen seed',
       query,
-      layout: 'force',
+      layout: 'layered',
       direction: 'top-down',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
       notation: 'native',
-      seed: 'reviewer-seed-7',
     })
 
-    expect(payload.presentation?.seed).toBe('reviewer-seed-7')
   })
 })

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -1049,7 +1049,6 @@ describe("visualAppReducer acknowledgement and refusal", () => {
         presentation: {
           layout: "layered",
           direction: "top-down",
-          seed: "default",
         },
       },
     });
@@ -1098,7 +1097,6 @@ describe("visualAppReducer acknowledgement and refusal", () => {
         presentation: {
           layout: "layered",
           direction: "top-down",
-          seed: "default",
         },
       },
     });
@@ -1467,7 +1465,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "top-down",
-        seed: "test",
       } as const,
     };
     const sent = visualAppReducer(initialVisualAppState, {
@@ -1486,7 +1483,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "top-down",
-        seed: "test",
       } as const,
     };
     const sent = visualAppReducer(initialVisualAppState, {
@@ -1503,7 +1499,7 @@ describe("visualAppReducer view save", () => {
       title: "My view",
       description: "A test view",
       query: { subjects: ["Q1"] },
-      presentation: { layout: "layered", direction: "top-down", seed: "test" },
+      presentation: { layout: "layered", direction: "top-down" },
     });
     expect(saved.viewSaveNotice).toBe(true);
     expect(saved.pendingViewSave).toBe(null);
@@ -1518,7 +1514,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "top-down",
-        seed: "test",
       } as const,
     };
     const state = { ...initialVisualAppState, views: [view1] };
@@ -1530,7 +1525,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "left-right",
-        seed: "test",
       } as const,
     };
     const sent = visualAppReducer(state, {
@@ -1553,7 +1547,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "top-down",
-        seed: "test",
       } as const,
     };
     const sent = visualAppReducer(initialVisualAppState, {
@@ -1593,7 +1586,6 @@ describe("visualAppReducer view save", () => {
       presentation: {
         layout: "layered",
         direction: "top-down",
-        seed: "test",
       } as const,
     };
     const state = {

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -125,7 +125,7 @@ const eventPayloads: Readonly<Record<string, unknown>> = {
     title: 'My View',
     description: 'desc',
     query: { kinds: ['yarramate/core@0.1#applicationComponent'] },
-    presentation: { layout: 'layered', seed: 'seed-1' },
+    presentation: { layout: 'layered' },
   },
   'session.end': { reason: 'user-ended' },
   'browser.connected': { connectionId: 'c1' },

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -2707,7 +2707,7 @@ evidence: []
       title: "My View",
       description: "desc",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered", seed: "seed-1" },
+      presentation: { layout: "layered" },
     });
 
     expect(frame.result).toEqual({
@@ -2729,7 +2729,6 @@ evidence: []
         title: "My View",
         description: "desc",
         layout: "layered",
-        seed: "seed-1",
       },
     });
     socket.close();
@@ -2755,7 +2754,7 @@ evidence: []
       title: "Reload View",
       description: "first",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "force", seed: "seed-1" },
+      presentation: { layout: "layered" },
     });
 
     expect(await reloadedViews()).toEqual([
@@ -2765,8 +2764,7 @@ evidence: []
         description: "first",
         query: { kinds: ["yarramate/core@0.1#businessActor"] },
         presentation: {
-          layout: "force",
-          seed: "seed-1",
+          layout: "layered",
           title: "Reload View",
           description: "first",
         },
@@ -2780,7 +2778,7 @@ evidence: []
       title: "Reload View",
       description: "second",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "radial", seed: "seed-2" },
+      presentation: { layout: "layered" },
     });
 
     const after = await reloadedViews();
@@ -2788,7 +2786,7 @@ evidence: []
     expect(after[0]).toMatchObject({
       id: "reload-view",
       description: "second",
-      presentation: { layout: "radial" },
+      presentation: { layout: "layered" },
     });
     socket.close();
   });
@@ -2803,7 +2801,7 @@ evidence: []
       title: "Original Title",
       description: "original desc",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered", seed: "seed-1" },
+      presentation: { layout: "layered" },
     });
     expect(created.result).toEqual({
       ok: true,
@@ -2816,7 +2814,7 @@ evidence: []
       title: "Updated Title",
       description: "updated desc",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "radial", seed: "seed-2" },
+      presentation: { layout: "layered" },
     });
     expect(overwritten.result).toEqual({
       ok: true,
@@ -2833,8 +2831,7 @@ evidence: []
       presentation: {
         title: "Updated Title",
         description: "updated desc",
-        layout: "radial",
-        seed: "seed-2",
+        layout: "layered",
       },
     });
     socket.close();
@@ -2882,7 +2879,7 @@ evidence: []
       title: "Audit Test",
       description: "test",
       query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered", seed: "seed-1" },
+      presentation: { layout: "layered" },
     });
 
     const journal = await journalOf(server);

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -296,22 +296,22 @@ describe("visualWorkspaceReducer layout", () => {
     expect(workspaceState.layout).toBe("layered");
   });
 
-  it("sets the layout backend on layout.set", () => {
+  it("carries the layout through layout.set without touching direction", () => {
     const next = visualWorkspaceReducer(workspaceState, {
       type: "layout.set",
-      layout: "force",
+      layout: "layered",
     });
-    expect(next.layout).toBe("force");
+    expect(next.layout).toBe("layered");
     expect(next.direction).toBe(workspaceState.direction);
   });
 
   it("adopts a selected view declared layout and direction", () => {
     const actions = presentationActionsFor({
-      layout: "radial",
+      layout: "layered",
       direction: "left-right",
     });
     const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next.layout).toBe("radial");
+    expect(next.layout).toBe("layered");
     expect(next.direction).toBe("left-right");
   });
 
@@ -322,8 +322,8 @@ describe("visualWorkspaceReducer layout", () => {
   });
 
   it("adopts only the field a view actually declares", () => {
-    const actions = presentationActionsFor({ layout: "force" });
-    expect(actions).toEqual([{ type: "layout.set", layout: "force" }]);
+    const actions = presentationActionsFor({ layout: "layered" });
+    expect(actions).toEqual([{ type: "layout.set", layout: "layered" }]);
   });
 });
 
@@ -415,54 +415,6 @@ describe("visualWorkspaceReducer notation", () => {
   it("adopts only the notation field a view actually declares", () => {
     const actions = presentationActionsFor({ notation: "archimate" });
     expect(actions).toEqual([{ type: "notation.set", notation: "archimate" }]);
-  });
-});
-
-describe("visualWorkspaceReducer seed", () => {
-  const workspaceState = createVisualWorkspaceState(1280);
-
-  // `presentation.seed` is required wherever `presentation.layout` is, so a
-  // view always names the seed it lays out under; this is the value a view
-  // that never declared one of its own falls back to.
-  it("starts with the default seed", () => {
-    expect(workspaceState.seed).toBe("default");
-  });
-
-  it("sets the seed on seed.set", () => {
-    const next = visualWorkspaceReducer(workspaceState, {
-      type: "seed.set",
-      seed: "reviewer-seed-7",
-    });
-    expect(next.seed).toBe("reviewer-seed-7");
-  });
-
-  it("adopts a selected view declared seed", () => {
-    const actions = presentationActionsFor({
-      layout: "force",
-      seed: "reviewer-seed-7",
-    });
-    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next.seed).toBe("reviewer-seed-7");
-    expect(next.layout).toBe("force");
-  });
-
-  it("leaves the seed untouched when a view declares none", () => {
-    const actions = presentationActionsFor({});
-    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next).toBe(workspaceState);
-  });
-
-  it("adopts only the seed field a view actually declares", () => {
-    const actions = presentationActionsFor({ seed: "reviewer-seed-7" });
-    expect(actions).toEqual([{ type: "seed.set", seed: "reviewer-seed-7" }]);
-  });
-
-  it("returns the same state when the declared seed is already current", () => {
-    const next = visualWorkspaceReducer(workspaceState, {
-      type: "seed.set",
-      seed: "default",
-    });
-    expect(next).toBe(workspaceState);
   });
 });
 


### PR DESCRIPTION
Two layout changes, both measured in a real browser rather than reasoned about.
Branched from main, independent of #217 and #218.

## 1. One layout backend (BREAKING)

`presentation.layout` admits only `layered`, and `presentation.seed` is gone.

`radial` (cytoscape `concentric`) and `force` (elk `stress` then
`sporeOverlap`) were measured against `layered` on every view of the
contact-update journey and lost on all three counts that decide whether a
diagram can be read: edge crossings, total edge length, and how large the graph
draws once fitted to the canvas.

| view | layered | radial | force |
|---|---|---|---|
| solution | **79 cross, 16.3k, fit 0.94** | 86, 18.6k, 0.75 | 73, 25.8k, 0.71 |
| deployment | **0, 2.3k, 1.87** | 0, 3.0k, 0.90 | — |
| context | **0, 1.4k, 1.20** | 0, 3.6k, 0.44 | — |
| hop slice | **122, 25.8k, 0.70** | 140, 27.0k, 0.57 | — |

`seed` goes because only `force` ever read it, yet the projection schema
*required* a seed of every view declaring a layout at all. That conditional
leaves with it, so declaring a layout no longer obliges a view to invent a
value it has no use for.

`force` was the only asynchronous backend, so its whole apparatus retires with
it: the "Laying out..." busy notice, the two-pass chain, the paint-first frame
yield, and the in-flight guard letting a newer request supersede a running one.
With one synchronous pass nothing can still be running when the next request
arrives. The Layout picker goes too, having nothing left to pick.

`presentation.layout` stays an enum so the replacement mechanism has somewhere
to land. ADR 0086 carries a supersession note.

## 2. First paint uses the layout the view settles into

Independent bug found while measuring the above. Mount starts cytoscape with
`layout: { name: 'null' }`, and the arming effect fires only on a *change* -
its refs are seeded with the initial values, so nothing changes on mount. The
one layout that runs therefore happens before the structural filter result
lands, laying out all 37 elements and then hiding 17, leaving the survivors
spread across a layout built for a graph no longer on screen.

Measured on the solution view: first paint spanned **1910x2958 with 25,235px of
edge at fit zoom 0.34**, against **922x2584 and 21,335px at 0.39** once any
control was touched. More than twice as wide for the same twenty nodes.
Crossings run the other way (31 vs 37) because a sprawled layout crosses less
precisely by being less compact, which is exactly why the reviewer sees a worse
diagram rather than a better one.

Relaying out when the matched set changes closes it. Verified in a browser:
first paint now reports the same geometry, edge length and fit zoom as the
settled layout, with no control touched.

## Verification

`pnpm verify` green: 72 files, 1201 passed, 1 skipped, self-check clean at 267
concepts / 375 relationships, LikeC4 validate clean.

Driven in Chrome on the contact-update solution view: four compound containers
render under ArchiMate notation, every visible node positioned, no Layout
control in the toolbar, no new console errors.

Net −646 lines.
