### PR TITLE
feat: a published diagnostic names the subject it is about

### DIFF
--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -360,6 +360,23 @@ compiled result (ADR 0091).
 Diagnostics have stable codes, severity, message, source path, YAML pointer,
 and one-based line and column.
 
+A published result also names the **subjects** a diagnostic is about, most
+relevant first, wherever its pointer identifies one. A consumer that draws the
+model needs the subject rather than the byte offset, and the rules already knew
+it: YM404 interpolates both endpoint ids into its own message. The list is
+derived once from the pointer, at the boundary that publishes the result, so
+the compiler's own diagnostics stay a pure function of the model and no rule
+has to remember to name what it refused.
+
+Absence is meaningful, and is not the same as "not populated". Every diagnostic
+pointing into `/concepts/<n>` or `/relationships/<n>` carries its subject, so
+the ones that carry none are exactly the ones that belong to no subject: a YAML
+parse failure, a whole-document schema violation, a projection's own
+definition, a workspace manifest. A consumer may treat an empty list as "this
+belongs somewhere other than the canvas" rather than as missing data, and
+should surface those somewhere, or a reviewer sees a refusal with nothing
+marked anywhere.
+
 | Range | Category | Initial codes |
 | --- | --- | --- |
 | `YM1xx` | YAML parsing | `YM101` malformed YAML |

--- a/schema/yarramate-check-result.schema.json
+++ b/schema/yarramate-check-result.schema.json
@@ -112,6 +112,15 @@
         "column": {
           "type": "integer",
           "minimum": 1
+        },
+        "subjects": {
+          "description": "Subjects this diagnostic is about, most relevant first, when its pointer names one. Absent when the diagnostic belongs to no subject: a parse failure, a whole-document schema violation, a manifest, or a projection's own definition.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     }

--- a/schema/yarramate-diagnostic-result.schema.json
+++ b/schema/yarramate-diagnostic-result.schema.json
@@ -57,6 +57,15 @@
         "column": {
           "type": "integer",
           "minimum": 1
+        },
+        "subjects": {
+          "description": "Subjects this diagnostic is about, most relevant first, when its pointer names one. Absent when the diagnostic belongs to no subject: a parse failure, a whole-document schema violation, a manifest, or a projection's own definition.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     }

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -14,7 +14,7 @@ import {
   usage,
   type CliResult,
 } from './cli-support.js'
-import { compileWorkspace } from './compiler.js'
+import { compileWorkspace, withDiagnosticSubjects } from './compiler.js'
 import {
   checkCoreContract,
   loadCoreContract,
@@ -280,9 +280,15 @@ export function runCheckCommand(
       ...evidenceDiagnostics,
     ])
     const ok = result.ok && optionalDiagnostics.length === 0
-    const diagnostics = result.ok
-      ? optionalDiagnostics
-      : result.diagnostics
+    // Published results name the subject a diagnostic is about wherever its
+    // pointer identifies one, so a consumer that draws the model can put the
+    // refusal on the element rather than on a byte offset. Derived here, at
+    // the boundary that publishes the document, so the compiler's own
+    // diagnostics stay a pure function of the model.
+    const diagnostics = withDiagnosticSubjects(
+      result.ok ? optionalDiagnostics : result.diagnostics,
+      sources,
+    )
 
     // Strict only tightens a passing check: base diagnostics already fail
     // the gate, so contradictions are folded in only once everything else

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import type Ajv2020Type from 'ajv/dist/2020.js'
-import { LineCounter, parseDocument } from 'yaml'
+import { LineCounter, parse, parseDocument } from 'yaml'
 import {
   conceptKinds,
   relationshipPolicies,
@@ -57,6 +57,22 @@ export interface Diagnostic {
   readonly pointer: string
   readonly line: number
   readonly column: number
+  /**
+   * The subjects this diagnostic is about, most relevant first, when its
+   * pointer names one. A consumer that draws the model - a canvas badging the
+   * element a rule refused - needs the subject, not the byte offset, and the
+   * rules already knew it: YM404 interpolates both endpoint ids into its own
+   * message.
+   *
+   * Absence is meaningful and is not the same as "not yet populated". These
+   * are derived in one place from the pointer, so every diagnostic that names
+   * a concept or a relationship carries them, and the ones that stay empty are
+   * exactly the ones that belong to no subject: a YAML parse failure, a
+   * whole-document schema violation, a projection's own definition, a
+   * manifest. A consumer can therefore treat an empty list as "this belongs
+   * somewhere other than the canvas" rather than as missing data.
+   */
+  readonly subjects?: readonly string[]
 }
 
 interface NativeConcept {
@@ -569,6 +585,66 @@ const parseSources = (
     return { input, entry, fresh }
   })
   return { parsed, cache: { sources: entries }, reused }
+}
+
+// Resolves each diagnostic's subject from the pointer it already carries, so
+// the rules themselves stay unchanged and no construction site has to remember
+// to name what it refused.
+//
+// A pointer into a document reads `/concepts/<n>/...` or
+// `/relationships/<n>/...`, and `<n>` indexes the authored array, so the id is
+// one lookup away in the same parsed value the diagnostic was located against.
+// Pointers are positional - inserting a concept shifts every index below it -
+// which is exactly why this is done here, against the parse that produced the
+// diagnostic, rather than by a consumer against whatever it holds later.
+//
+// Anything else keeps no subjects: a parse failure, a whole-document schema
+// violation, a manifest, a projection's own definition. That absence is the
+// signal a consumer needs, so it is left empty rather than guessed at.
+const subjectsForPointer = (
+  pointer: string,
+  documentValue: unknown,
+): readonly string[] => {
+  const match = /^\/(concepts|relationships)\/(\d+)(?:\/|$)/.exec(pointer)
+  if (match === null) return []
+  const value = documentValue as
+    | { readonly id?: unknown; readonly [key: string]: unknown }
+    | undefined
+  const documentId = typeof value?.id === 'string' ? value.id : undefined
+  if (documentId === undefined) return []
+  const items = value?.[match[1]!]
+  if (!Array.isArray(items)) return []
+  const item = items[Number(match[2])] as { readonly id?: unknown } | undefined
+  return typeof item?.id === 'string' ? [`${documentId}#${item.id}`] : []
+}
+
+export const withDiagnosticSubjects = (
+  diagnostics: readonly Diagnostic[],
+  sources: readonly WorkspaceSource[],
+): readonly Diagnostic[] => {
+  if (diagnostics.length === 0) return diagnostics
+  // Only the documents something was actually said about are parsed, and each
+  // at most once: a clean workspace pays nothing, and a workspace refused on
+  // one document does not pay for the rest.
+  const wanted = new Set(diagnostics.map((diagnostic) => diagnostic.path))
+  const valueByPath = new Map<string, unknown>()
+  for (const source of sources) {
+    if (!wanted.has(source.path)) continue
+    try {
+      valueByPath.set(source.path, parse(source.source))
+    } catch {
+      // A source that will not parse is exactly one whose diagnostics belong
+      // to no subject, so failing to read it here is the right answer.
+    }
+  }
+  return diagnostics.map((diagnostic) => {
+    if (diagnostic.subjects !== undefined) return diagnostic
+    const subjects = subjectsForPointer(
+      diagnostic.pointer,
+      valueByPath.get(diagnostic.path),
+    )
+    return subjects.length === 0 ? diagnostic : { ...diagnostic, subjects }
+  })
 }
 
 function compileWorkspaceResolved(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -156,7 +156,10 @@ describe('YarraMate CLI', () => {
         '      "path": "test/fixtures/invalid/unknown-concept-kind.yaml",\n' +
         '      "pointer": "/concepts/0/kind",\n' +
         '      "line": 6,\n' +
-        '      "column": 11\n' +
+        '      "column": 11,\n' +
+        '      "subjects": [\n' +
+        '        "unknown-concept#mystery"\n' +
+        '      ]\n' +
         '    }\n' +
         '  ]\n' +
         '}\n',

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   compileWorkspace,
   compileWorkspaceWithProfileContext,
+  withDiagnosticSubjects,
 } from '../src/compiler.js'
 
 const fixture = (path: string): string =>
@@ -1936,5 +1937,115 @@ relationships: []
         'yarramate/policy@0.1#authentication-constraint',
       ),
     ).toBe(false)
+  })
+})
+
+// A diagnostic anchored at a subject now says which subject, derived once from
+// the pointer it already carried rather than by asking every rule to remember.
+// Absence is the signal that the diagnostic belongs somewhere other than the
+// canvas, so it must stay absent for the document- and workspace-level ones.
+describe('withDiagnosticSubjects', () => {
+  const workspaceWith = (documentBody: string) => [
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+${documentBody}`,
+    },
+  ]
+
+  const diagnosticsOf = (sources: readonly { path: string; source: string }[]) => {
+    const result = compileWorkspace(sources)
+    if (result.ok) throw new Error('expected the workspace to be refused')
+    return withDiagnosticSubjects(result.diagnostics, sources)
+  }
+
+  it('names the relationship a forbidden endpoint pairing was refused on', () => {
+    const diagnostics = diagnosticsOf(
+      workspaceWith(`concepts:
+  - id: comp
+    kind: applicationComponent
+    name: A component
+    status: current
+  - id: aim
+    kind: goal
+    name: A goal
+    status: current
+relationships:
+  - id: bad-edge
+    kind: assignment
+    from: comp
+    to: aim
+`),
+    )
+    const refusal = diagnostics.find((diagnostic) => diagnostic.code === 'YM404')
+    expect(refusal?.pointer).toBe('/relationships/0/kind')
+    expect(refusal?.subjects).toEqual(['main#bad-edge'])
+  })
+
+  it('names the concept an unknown kind was refused on', () => {
+    const diagnostics = diagnosticsOf(
+      workspaceWith(`concepts:
+  - id: fine
+    kind: applicationComponent
+    name: Fine
+    status: current
+  - id: mystery
+    kind: notAKindAtAll
+    name: Unknown kind
+    status: current
+relationships: []
+`),
+    )
+    const refusal = diagnostics.find((diagnostic) => diagnostic.code === 'YM401')
+    expect(refusal?.pointer).toBe('/concepts/1/kind')
+    expect(refusal?.subjects).toEqual(['main#mystery'])
+  })
+
+  it('leaves a whole-document refusal without subjects', () => {
+    const diagnostics = diagnosticsOf([
+      { path: 'architecture/main.yaml', source: 'format: yarramate/v1\nid: main\n' },
+    ])
+    expect(diagnostics.length).toBeGreaterThan(0)
+    for (const diagnostic of diagnostics) {
+      expect(diagnostic.subjects).toBeUndefined()
+    }
+  })
+
+  it('resolves the index against the document the diagnostic points into', () => {
+    // Two documents, each with its own `/concepts/0`: the subject must come
+    // from the one the diagnostic names, not from whichever parsed first.
+    const diagnostics = diagnosticsOf([
+      {
+        path: 'architecture/alpha.yaml',
+        source: `format: yarramate/v1
+id: alpha
+profile: yarramate/core@0.1
+concepts:
+  - id: alpha-one
+    kind: applicationComponent
+    name: Alpha one
+    status: current
+relationships: []
+`,
+      },
+      {
+        path: 'architecture/beta.yaml',
+        source: `format: yarramate/v1
+id: beta
+profile: yarramate/core@0.1
+concepts:
+  - id: beta-one
+    kind: notAKindAtAll
+    name: Beta one
+    status: current
+relationships: []
+`,
+      },
+    ])
+    const refusal = diagnostics.find((diagnostic) => diagnostic.code === 'YM401')
+    expect(refusal?.path).toBe('architecture/beta.yaml')
+    expect(refusal?.subjects).toEqual(['beta#beta-one'])
   })
 })


### PR DESCRIPTION
Wave 1's last item. Branched from main, independent of #217, #218 and #219.

A consumer that draws the model — a canvas badging the element a rule refused —
needs the subject, not a byte offset. The rules already knew it: YM404
interpolates both endpoint ids into its own message and then throws the
structure away into a string.

## What changes

Published results carry `subjects`, most relevant first, wherever a
diagnostic's pointer identifies one:

```json
{
  "severity": "error", "code": "YM404",
  "message": "Relationship \"assignment\" is not permitted from \"comp\" ...",
  "path": "architecture/main.yaml", "pointer": "/relationships/0/kind",
  "line": 17, "column": 11,
  "subjects": ["main#bad-edge"]
}
```

Derived in **one place** from the pointer the diagnostic already carried, so no
rule has to remember to name what it refused and none of the forty-odd
construction sites change.

## Why at the boundary, not in the compiler

`withDiagnosticSubjects` is applied where the result document is published, not
inside `compileWorkspace`. That keeps the compiler's diagnostics a pure
function of the model — and it is not only a layering preference. Enriching the
compile path broke **23 existing tests** that legitimately assert exact
compiler output, none of which had anything to say about subjects. At the
boundary, the only existing test that changes is the published CLI output,
which is exactly the contract this extends.

Only documents something was actually said about are parsed, so a clean
workspace pays nothing.

## Absence is the signal

Absence is meaningful and is not "not yet populated". Every diagnostic pointing
into `/concepts/<n>` or `/relationships/<n>` carries its subject, so the ones
that carry none are exactly the ones that belong to no subject: a YAML parse
failure, a whole-document schema violation, a projection's own definition, a
manifest.

That gives a UI a complete rule: subjects present → badge those elements;
subjects absent → route to the document lane, the view's properties, or a
workspace banner. Without it, a reviewer clicks Validate, sees failure, and
finds nothing marked anywhere.

Pointers are positional, so an insertion shifts every index below it. The
derivation runs against the parse that produced the diagnostic for exactly that
reason.

## Tests

Four new: a relationship-anchored refusal, a concept-anchored one, a
whole-document refusal that stays bare, and two documents that each have a
`/concepts/0` so the index is proved to resolve against the right one.

`pnpm verify` green: 72 files, 1223 passed, 1 skipped, self-check clean at 267
concepts / 375 relationships, LikeC4 validate clean.

## Note

`subjects` entries are `document#local-id` today. Wave 2's identity flattening
will change that form; the field itself is unaffected.
