### PR TITLE
fix(likec4): regenerate a project generated before 1.0 rather than refusing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@
   `start` published, copied back verbatim: a native path is refused, and the
   argument is no longer resolved against the working directory (#208).
 
+- A LikeC4 project generated before 1.0 is regenerated rather than refused.
+  Its marker records a comparison's endpoints in the qualified
+  `<document>#<local>` form, which `subjectIdentity` no longer admits in either
+  marker version, so `export-project` and `export-project --check` rejected it
+  as "not a YarraMate-generated project" - a message about the wrong thing,
+  since the directory is one we wrote and the ids in it are recorded metadata
+  rather than addresses anything resolves. Continuous integration never saw
+  this, checking out clean with no prior output directory, so it fired only for
+  people who already used the tool, on their first command after upgrading.
+  Such a marker is now accepted where an existing project is read, exactly as a
+  marker written before output digests existed is, and the next write upgrades
+  it with nothing for the reader to do. `--check` reports the project stale and
+  safe to regenerate, which is the truth it always had (#225).
+
 ## 0.23.0
 
 - Interrogation: `has-linkage`, `exists-linkage` (`direction` includes

--- a/src/adapters/likec4-cli.ts
+++ b/src/adapters/likec4-cli.ts
@@ -52,6 +52,39 @@ const validateGeneratedProjectMarker = new Ajv2020({
 const validateGeneratedProjectV2Marker = new Ajv2020({
   allErrors: true,
 }).compile(generatedProjectV2Schema)
+// A marker written before 1.0 flattened subject ids records a comparison's
+// endpoints in the qualified `<document>#<local>` form, which `subjectIdentity`
+// no longer admits in either marker version. Such a marker is still one of
+// ours: those ids are recorded metadata, not addresses anything resolves, and
+// regeneration rewrites them flat. So it is accepted where an existing project
+// is read, exactly as a marker written before output digests existed is, and
+// the upgrade happens on the next write with nothing for the reader to do.
+// Each variant is derived from its own schema rather than copied, so a change
+// to either cannot leave its variant behind: only the one pattern is relaxed.
+const preFlattenSubjectIdentity =
+  '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:#[a-z][a-z0-9]*(?:-[a-z0-9]+)*)?$'
+const preFlattenVariant = (schema: {
+  readonly $id: string
+  readonly $defs: {
+    readonly subjectIdentity: { readonly pattern: string }
+  }
+}): Readonly<Record<string, unknown>> => ({
+  ...schema,
+  $id: `${schema.$id}/pre-flatten-subject-ids`,
+  $defs: {
+    ...schema.$defs,
+    subjectIdentity: {
+      ...schema.$defs.subjectIdentity,
+      pattern: preFlattenSubjectIdentity,
+    },
+  },
+})
+const validateGeneratedProjectPreFlattenMarker = new Ajv2020({
+  allErrors: true,
+}).compile(preFlattenVariant(generatedProjectSchema))
+const validateGeneratedProjectV2PreFlattenMarker = new Ajv2020({
+  allErrors: true,
+}).compile(preFlattenVariant(generatedProjectV2Schema))
 const generatedFileNames = [
   'likec4.config.json',
   'model.likec4',
@@ -402,7 +435,9 @@ const readGeneratedProjectMarker = (
     return undefined
   }
   return validateGeneratedProjectMarker(marker) ||
-    validateGeneratedProjectV2Marker(marker)
+    validateGeneratedProjectV2Marker(marker) ||
+    validateGeneratedProjectPreFlattenMarker(marker) ||
+    validateGeneratedProjectV2PreFlattenMarker(marker)
     ? (marker as Readonly<Record<string, unknown>>)
     : undefined
 }

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2348,6 +2348,131 @@ views:
     }
   })
 
+  it('accepts a v1 marker whose comparison predates flattened subject ids', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-preflatten-v1-'),
+    )
+    const project = join(parent, 'governed-change')
+    const exportArgs = [
+      'export-project',
+      'test/fixtures/valid/governed-change.projection.yaml',
+      'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+      project,
+      'test/fixtures/valid/governed-change.workspace.yaml',
+    ]
+    const checkArgs = ['export-project', '--check', ...exportArgs.slice(1)]
+    try {
+      expect(runLikeC4Cli(exportArgs, repositoryRoot).exitCode).toBe(0)
+      const markerPath = join(project, 'yarramate.generated.json')
+      const marker = JSON.parse(
+        readFileSync(markerPath, 'utf8'),
+      ) as Record<string, unknown>
+      expect(marker['format']).toBe('yarramate/likec4-generated-project/v1')
+      writeFileSync(
+        markerPath,
+        `${JSON.stringify(
+          {
+            ...marker,
+            comparison: {
+              from: 'evolution#adapter-foundation',
+              to: 'evolution#state-foundation',
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      expect(runLikeC4Cli(checkArgs, repositoryRoot)).toEqual({
+        exitCode: 0,
+        stdout: 'Generated LikeC4 output: fresh\n',
+        stderr: '',
+      })
+      expect(runLikeC4Cli(exportArgs, repositoryRoot)).toEqual({
+        exitCode: 0,
+        stdout: `Updated LikeC4 project at ${project}\n`,
+        stderr: '',
+      })
+      expect(
+        JSON.parse(readFileSync(markerPath, 'utf8')) as Record<
+          string,
+          unknown
+        >,
+      ).not.toHaveProperty('comparison')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts a v2 marker whose comparison predates flattened subject ids', () => {
+    const parent = mkdtempSync(
+      join(tmpdir(), 'yarramate-likec4-preflatten-v2-'),
+    )
+    const project = join(parent, 'governed-change')
+    const exportArgs = [
+      'export-project',
+      'test/fixtures/valid/governed-change.projection.yaml',
+      'test/fixtures/valid/governed-change.likec4-mapping.yaml',
+      project,
+      'test/fixtures/valid/governed-change.workspace.yaml',
+    ]
+    const checkArgs = ['export-project', '--check', ...exportArgs.slice(1)]
+    try {
+      expect(runLikeC4Cli(exportArgs, repositoryRoot).exitCode).toBe(0)
+      const markerPath = join(project, 'yarramate.generated.json')
+      const marker = JSON.parse(
+        readFileSync(markerPath, 'utf8'),
+      ) as Record<string, unknown>
+      // The bytes a pre-flatten multi-view export left behind: the same owned
+      // files and digests, addressed by the qualified ids of the time.
+      writeFileSync(
+        markerPath,
+        `${JSON.stringify(
+          {
+            format: 'yarramate/likec4-generated-project/v2',
+            project: 'governed-change@1.0',
+            mapping: 'governed-change-likec4@1.0',
+            views: [
+              { id: 'index', projection: 'governed-change@1.0' },
+              {
+                projection: 'state-engine-change@1.0',
+                comparison: {
+                  from: 'evolution#adapter-foundation',
+                  to: 'evolution#state-foundation',
+                },
+              },
+            ],
+            files: marker['files'],
+            digests: marker['digests'],
+            inputDigests: marker['inputDigests'],
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      expect(runLikeC4Cli(checkArgs, repositoryRoot)).toEqual({
+        exitCode: 0,
+        stdout: 'Generated LikeC4 output: fresh\n',
+        stderr: '',
+      })
+      expect(runLikeC4Cli(exportArgs, repositoryRoot)).toEqual({
+        exitCode: 0,
+        stdout: `Updated LikeC4 project at ${project}\n`,
+        stderr: '',
+      })
+      const rewritten = JSON.parse(
+        readFileSync(markerPath, 'utf8'),
+      ) as Record<string, unknown>
+      expect(rewritten['format']).toBe(
+        'yarramate/likec4-generated-project/v1',
+      )
+      expect(rewritten).not.toHaveProperty('views')
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
   it('atomically replaces each owned file during regeneration', () => {
     const parent = mkdtempSync(
       join(tmpdir(), 'yarramate-likec4-atomic-update-'),


### PR DESCRIPTION
## Summary

Closes #225.

A LikeC4 project generated before 1.0 flattened subject ids is refused on the
first command after upgrading:

```
Output directory exists but is not a YarraMate-generated project: /…/.yarramate-out/likec4
```

The message is about the wrong thing. The directory *is* one we wrote. Its
marker records a comparison's endpoints in the qualified `<document>#<local>`
form, `subjectIdentity` no longer admits that, so `readGeneratedProjectMarker`
returns `undefined` and both callers fall through to the generic "not ours"
branch.

Those ids are recorded metadata, not addresses anything resolves, and
regeneration rewrites them flat.

## Both marker versions are affected

Worth stating because the first cut of this fix only covered v2. v1 carries
`comparison` at the top level, v2 carries it per view, and **both `$ref` the
same `subjectIdentity` definition**, so a single-projection export is refused
exactly as a multi-view one is. Each is covered, and each relaxed variant is
derived from its own schema rather than copied, so a later change to either
cannot leave its variant behind.

## Why accept rather than improve the message

The codebase already answers this exact question, two functions away:

```ts
// Markers written before output digests existed are accepted once and
// upgraded on regeneration.
if (marker['digests'] === undefined) return undefined
```

A marker predating a schema change is the same situation and now gets the same
treatment: accepted where an existing project is read, upgraded on the next
write, nothing for the reader to do.

## Why it matters more than the diff suggests

CI never sees it. A clean checkout has no prior output directory, so the guard
never runs there. It fires only for people who already use the tool, which is
exactly the population upgrading to 1.0, on their first command after upgrading.

## Validation

`pnpm verify` exits 0: 72 files, 1218 passed, 1 skipped, self-check clean,
LikeC4 validate clean.

Two new tests, one per marker version. Both were confirmed to fail without the
fix, with precisely the reported error:

```
AssertionError: expected { exitCode: 2, … } to deeply equal { exitCode: +0, … }
+ "stderr": "Output directory exists but is not a YarraMate-generated project: …"
```

Reproduced end to end against the real pre-flatten `.yarramate-out/likec4` that
surfaced this, not only against synthesised markers. Before, `pnpm validate`
failed at exit 2. After:

```
Generated LikeC4 output: stale
Reason:
- input changed: .yarramate/architecture/engine.yaml
  …
- model source changed
Safe to regenerate: yes
```

and regenerating rewrites the marker flat:

```
"comparison": { "from": "adapter-foundation", "to": "state-foundation" }
```

with `pnpm validate` then green.

## Related issue

#225.

## Contract impact

Widens what an existing on-disk marker may contain for it to be recognised as
ours. No change to what is written: a fresh marker is byte-identical to before,
and the flat pattern still governs everything produced. No native semantics,
graph interchange, diagnostic, or CLI surface change.

## Note

The `CHANGELOG.md` entry here will conflict with #224, which rewrites the same
section. #224 is docs-only; merge it first and this branch needs one trivial
resolution.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)