### PR TITLE
test(visual): bound the flaky visual-cli tests against a hang, not against load

### DIFF
--- a/test/visual-cli.test.ts
+++ b/test/visual-cli.test.ts
@@ -525,11 +525,16 @@ describe('descriptor confinement', () => {
     expect(refusalCodes(result)).toEqual(['YMVS401'])
   })
 
-  // Opening a FIFO for read blocks until a writer appears, so any finite bound
-  // proves the CLI refused instead of opening it. The bound is deliberately
-  // loose: a cold `visual-cli.js` start costs ~700ms on an idle machine and
-  // over 1s when the suite saturates every core, so a tight bound fails as a
-  // SIGTERM under load rather than reporting the invariant it guards.
+  // Opening a FIFO for read blocks until a writer appears, and no writer ever
+  // appears here, so a CLI that opened it would never exit at all. The bound
+  // separates refused from blocked-forever, which is the invariant; it does
+  // not separate fast from slow, and must never be read as a deadline. It is
+  // therefore set far past any start this can legitimately take: a cold
+  // `visual-cli.js` costs ~550ms idle and ~2.2s with every core three times
+  // oversubscribed, and a smaller runner under a full suite is slower again.
+  // An earlier 4s bound sat at less than twice the loaded cost and failed as a
+  // SIGTERM under load, reporting a timing accident as a breach of descriptor
+  // confinement (#222). Only a genuine hang pays the ceiling.
   it.runIf(process.platform !== 'win32')(
     'refuses a FIFO descriptor without waiting for a writer',
     () => {
@@ -542,7 +547,7 @@ describe('descriptor confinement', () => {
         {
           cwd: repositoryRoot,
           encoding: 'utf8',
-          timeout: 4000,
+          timeout: 30_000,
         },
       )
 
@@ -555,7 +560,7 @@ describe('descriptor confinement', () => {
         value: { diagnostics: [{ code: 'YMVS401' }] },
       })
     },
-    15_000,
+    60_000,
   )
 
   it('refuses a descriptor that is not JSON', async () => {
@@ -1263,9 +1268,18 @@ describe('runVisualStart', () => {
     process.platform !== 'win32' && process.getuid?.() !== 0
 
   /**
-   * A ceiling on the turns of the loop one teardown takes, measured in turns
-   * rather than milliseconds so a slow machine spends no longer here than a
-   * fast one: nothing in this test waits for a duration.
+   * A ceiling on the turns spent proving the teardown is still blocked,
+   * measured in turns rather than milliseconds so a slow machine spends no
+   * longer here than a fast one: nothing in this test waits for a duration.
+   *
+   * It bounds only the loop that proves a negative, where some finite effort
+   * has to stand in for "never". The loop that proves a positive - that a
+   * later signal does return - must not carry a ceiling of its own: exhausting
+   * one reports a machine too loaded to finish in the turns allowed as a
+   * teardown that never ran, which is how this test failed in CI (#222). That
+   * loop runs until the command returns and leans on the test timeout, the
+   * same way `observes the process signals when no source is injected` waits
+   * for its first line of output.
    */
   const teardownTurns = 5000
 
@@ -1323,11 +1337,7 @@ describe('runVisualStart', () => {
         // it, so the command is signalled every turn until it returns.
         await chmod(nativePath(started.sessionRoot), 0o700)
         let closed = await turn()
-        for (
-          let spin = 0;
-          closed === undefined && spin < teardownTurns;
-          spin += 1
-        ) {
+        while (closed === undefined) {
           foreground.signals.emit('SIGTERM')
           closed = await turn()
         }
@@ -1344,6 +1354,7 @@ describe('runVisualStart', () => {
         }
       }
     },
+    30_000,
   )
 
   it('observes the process signals when no source is injected', async () => {


### PR DESCRIPTION
## Summary

Closes #222.

`test/visual-cli.test.ts` failed intermittently with the failure moving between
two tests. Neither is a logic fault. Both tests prove something with a finite
bound, and both bounds sat close enough to the work they measured that a loaded
machine crossed them.

## The FIFO bound was being read as a deadline

Opening a FIFO with no writer blocks forever, so a CLI that opened it would
never exit. The bound exists to separate **refused** from **blocked-forever**.
It does not separate fast from slow, but 4000ms was doing exactly that.

Measured on this machine:

| condition | cold `visual-cli.js status` |
|---|---|
| idle | ~550ms |
| all 18 cores 3× oversubscribed | **~2.2s** |

So the old bound sat at under twice the loaded cost, on 18 cores. A smaller
runner under a full parallel suite is slower again. Crossing it kills the child
and asserts `expected 'SIGTERM' to be null` — the reported local failure.

Now 30s: far past any legitimate start, and paid only by a real hang.

## One ceiling was applied to two loops that prove opposite things

Counting turns rather than milliseconds was the right instinct and is kept. But
the test used a single `teardownTurns` for both loops:

- **Proving a negative** (the teardown is still blocked) *needs* a finite bound,
  because some finite effort has to stand in for "never". Kept.
- **Proving a positive** (a later signal does return) *must not* have one.
  Exhausting it reports a machine too loaded to finish in 5000 turns as a
  teardown that never ran — the CI failure, `expected undefined to match object
  { exitCode: 0 }`.

That loop now runs until the command returns and leans on the test timeout,
which is already the idiom two tests down:

```ts
while (stdout.length === 0) await new Promise(setImmediate)
```

The test gets an explicit 30s, since the file configures no `testTimeout` and
the 5s default is what let the turn ceiling be reached first.

## Validation

Both failure modes were **reproduced on demand** rather than reasoned about, by
shrinking each bound below the work it measures:

```
timeout: 4000 -> 300
  AssertionError: expected 'SIGTERM' to be null            <- the local failure

teardownTurns 5000 -> 1
  AssertionError: expected undefined to match object { exitCode: +0 }
                                                          <- the CI failure
```

Both are exactly the errors reported in #222, and neither reproduces with the
bounds corrected.

`pnpm verify` exits 0. The file was run 8 times consecutively: 70 passed each
time, 4.4–7.1s, so removing the ceiling introduces no hang and a passing run
never approaches either bound.

## Honest limitation

The underlying flake is load-dependent and I could not make the *unmodified*
tests fail on demand on an 18-core machine — the closest measurement is the
~2.2s at 3× saturation above, against the old 4s bound. The attribution rests
on that measurement plus the two exact reproductions, not on catching the
original tests failing.

## Related issue

#222.

## Contract impact

None. Test-only.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible. — not user-visible, test-only.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)