### PR TITLE
chore: report user-visible commits that wrote no changelog entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,17 @@ Keep changes narrowly scoped and explain:
 - any compatibility or migration effect;
 - whether generated output changed.
 
+A change a user would notice belongs in `CHANGELOG.md`, under the version
+being prepared, in the same pull request that makes it. A change nobody outside
+the repository can see does not. When a `feat`, `fix` or `perf` commit
+genuinely owes no entry, say why in the commit with a `Changelog: none`
+trailer, so the reason lives in the history rather than in someone's memory.
+
+Before tagging a release, `pnpm changelog:check` names every commit since the
+last tag that changed what a user sees and wrote no entry. It is a release
+backstop, not a per-pull-request gate: six changes once reached a release
+undocumented, one of them breaking, because nothing read the file.
+
 Generated files under `.yarramate-out/` and `dist/` are not committed.
 Acceptance, authorship, and review are provided by Git; do not add a parallel
 approval workflow.

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "self:check:likec4:output": "pnpm build && node dist/adapters/likec4-cli.js export-project --check .yarramate/likec4-project.yaml .yarramate-out/likec4 .yarramate/workspace.yaml",
     "validate": "pnpm self:export:likec4 && pnpm self:check:likec4:output && likec4 validate --no-layout .yarramate-out/likec4",
     "verify": "pnpm typecheck && pnpm build && pnpm test && pnpm self:check && pnpm validate",
+    "changelog:check": "node scripts/check-changelog.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.visual.json"
   },

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Reports every commit since a release that changed what a user sees and did
+// not write a CHANGELOG entry.
+//
+// Six of the nine pull requests merged into 1.0 wrote no entry, one of them
+// breaking, and nothing caught it: no test, no CI job and no script reads
+// CHANGELOG.md, so an entry can be skipped without anything failing until the
+// release notes are already published. This is the backstop, run before a tag
+// rather than on every pull request, where it costs one command and cannot
+// nag a refactor that legitimately has nothing to say.
+//
+// It asks whether the COMMIT touched CHANGELOG.md. That is the reliable test,
+// but on its own it convicts a change described later by a catch-up commit, so
+// a commit whose pull request is cited in the unreleased section is excused
+// too. Citation-matching is used ONLY to excuse, never to accuse: an entry
+// that cites the issue it closes rather than its pull request, or cites
+// nothing, simply fails to excuse and the commit is reported. The error runs
+// toward over-reporting, which a reader can dismiss, rather than toward the
+// silence that let six changes ship undocumented.
+//
+// Only `feat`, `fix` and `perf` are held to it, with or without a scope or a
+// breaking `!`. A `chore`, `ci`, `test`, `refactor`, `build`, `style` or
+// `docs` commit is exempt, since none of them changes what a user sees. A
+// subject outside conventional-commit form is reported, because a commit
+// nobody can classify is exactly the one worth a human glance. Genuine
+// exceptions say so in the message with a `Changelog: none` trailer, which
+// keeps the reason in the history rather than in an ignore list.
+//
+// Usage:
+//   node scripts/check-changelog.mjs [<since>]
+//
+// `since` defaults to the most recent tag. Exits 1 when anything is missing.
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// The repository is the working directory, not wherever this file happens to
+// live. `pnpm` runs a script from the package root, so the common invocation
+// is unchanged, and a test can point it at a repository built for the purpose
+// rather than at this one.
+const repositoryRoot = process.cwd()
+
+const git = (...args) =>
+  execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  }).trimEnd()
+
+// A type that changes what a user sees, so an entry is owed.
+const userVisible = /^(feat|fix|perf)(\([^)]*\))?!?:/
+// Every other conventional type, none of which a reader of the notes needs.
+const exempt = /^(chore|ci|test|refactor|build|style|docs|revert)(\([^)]*\))?!?:/
+
+const since = process.argv[2] ?? (() => {
+  try {
+    return git('describe', '--tags', '--abbrev=0')
+  } catch {
+    console.error(
+      'No tag to compare against. Name one explicitly:\n' +
+        '  node scripts/check-changelog.mjs <since>',
+    )
+    process.exit(2)
+  }
+})()
+
+let range
+try {
+  range = git('rev-parse', '--verify', `${since}^{commit}`)
+} catch {
+  console.error(`Not a commit this repository knows: ${since}`)
+  process.exit(2)
+}
+void range
+
+const commits = git(
+  'log',
+  '--no-merges',
+  // Fields separated by NUL and records by RS, because a body is free text
+  // that may be empty, may span lines, and may itself contain blank lines.
+  '--format=%x1e%H%x00%s%x00%b',
+  `${since}..HEAD`,
+)
+  .split('\x1e')
+  .filter((entry) => entry.trim() !== '')
+  .map((entry) => {
+    const [sha, subject, body] = entry.split('\0')
+    return { sha: sha.trim(), subject: subject ?? '', body: body ?? '' }
+  })
+
+if (commits.length === 0) {
+  console.log(`No commits since ${since}.`)
+  process.exit(0)
+}
+
+const touchesChangelog = (sha) =>
+  git('diff-tree', '--no-commit-id', '--name-only', '-r', sha, '--', 'CHANGELOG.md') !== ''
+
+// The section under the topmost `## ` heading: the version being prepared.
+const unreleasedSection = (() => {
+  let changelog
+  try {
+    changelog = readFileSync(resolve(repositoryRoot, 'CHANGELOG.md'), 'utf8')
+  } catch {
+    return ''
+  }
+  const headings = [...changelog.matchAll(/^## .*$/gm)]
+  if (headings.length === 0) return ''
+  const start = headings[0].index + headings[0][0].length
+  const end = headings[1]?.index ?? changelog.length
+  return changelog.slice(start, end)
+})()
+
+// A squash merge ends the subject with its pull request number.
+const citedInChangelog = (subject) => {
+  const pull = /\(#(\d+)\)\s*$/.exec(subject)
+  if (pull === null) return false
+  return new RegExp(`#${pull[1]}(?![0-9])`).test(unreleasedSection)
+}
+
+const waived = (body) => /^Changelog:\s*none\s*$/im.test(body)
+
+const missing = []
+const unclassified = []
+for (const commit of commits) {
+  if (
+    touchesChangelog(commit.sha) ||
+    citedInChangelog(commit.subject) ||
+    waived(commit.body)
+  ) {
+    continue
+  }
+  if (exempt.test(commit.subject)) continue
+  if (userVisible.test(commit.subject)) {
+    missing.push(commit)
+    continue
+  }
+  unclassified.push(commit)
+}
+
+const line = ({ sha, subject }) =>
+  `  ${sha.slice(0, 7)} ${subject.length > 68 ? `${subject.slice(0, 65)}...` : subject}`
+
+if (missing.length > 0) {
+  console.error('Missing a CHANGELOG entry:')
+  for (const commit of missing) console.error(line(commit))
+  console.error('')
+}
+if (unclassified.length > 0) {
+  console.error('Subject is not conventional-commit form, so nobody can tell:')
+  for (const commit of unclassified) console.error(line(commit))
+  console.error('')
+}
+
+const owed = missing.length + unclassified.length
+if (owed === 0) {
+  console.log(
+    `Every user-visible commit since ${since} has a CHANGELOG entry ` +
+      `(${commits.length} commit${commits.length === 1 ? '' : 's'} checked).`,
+  )
+  process.exit(0)
+}
+
+console.error(
+  `${owed} of ${commits.length} commits since ${since} wrote no entry.\n` +
+    'Write one, or record the reason in the commit with a `Changelog: none` trailer.',
+)
+process.exit(1)

--- a/test/check-changelog.test.ts
+++ b/test/check-changelog.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+const script = join(repositoryRoot, 'scripts/check-changelog.mjs')
+
+/**
+ * The guard that reports undocumented changes is itself a thing that can stop
+ * working without anyone noticing, which is the failure it exists to prevent.
+ * These run it against repositories built for the purpose rather than against
+ * this one, whose history would make every expectation a moving target.
+ */
+describe('check-changelog', () => {
+  let repository: string
+
+  const git = (...args: string[]) =>
+    execFileSync('git', args, { cwd: repository, encoding: 'utf8' })
+
+  const commit = (subject: string, body = '') => {
+    writeFileSync(join(repository, 'source.txt'), `${subject}\n`)
+    git('add', '-A')
+    git('commit', '-q', '-m', subject, ...(body === '' ? [] : ['-m', body]))
+  }
+
+  const writeChangelog = (contents: string) => {
+    writeFileSync(join(repository, 'CHANGELOG.md'), contents)
+    git('add', '-A')
+    git('commit', '-q', '-m', 'docs: changelog')
+  }
+
+  const run = (...args: string[]) =>
+    spawnSync(process.execPath, [script, ...args], {
+      cwd: repository,
+      encoding: 'utf8',
+    })
+
+  beforeEach(() => {
+    repository = mkdtempSync(join(tmpdir(), 'yarramate-changelog-guard-'))
+    git('init', '-q', '-b', 'main')
+    git('config', 'user.email', 'test@example.com')
+    git('config', 'user.name', 'Test')
+    writeFileSync(join(repository, 'CHANGELOG.md'), '# Changelog\n\n## 1.1.0\n')
+    commit('chore: first')
+    git('tag', 'v1.0.0')
+  })
+
+  afterEach(() => {
+    rmSync(repository, { recursive: true, force: true })
+  })
+
+  it('names a user-visible commit that wrote no entry', () => {
+    commit('feat: something a user sees (#42)')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Missing a CHANGELOG entry')
+    expect(result.stderr).toContain('feat: something a user sees (#42)')
+  })
+
+  it('accepts a commit that wrote its own entry', () => {
+    writeChangelog('# Changelog\n\n## 1.1.0\n\n- Something (#42).\n')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('has a CHANGELOG entry')
+  })
+
+  it('accepts a commit a later catch-up entry cites', () => {
+    commit('feat: something a user sees (#42)')
+    writeChangelog('# Changelog\n\n## 1.1.0\n\n- Written later (#42).\n')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(0)
+  })
+
+  it('does not accept a citation from an already released section', () => {
+    commit('feat: something a user sees (#42)')
+    writeChangelog('# Changelog\n\n## 1.1.0\n\n- Unrelated.\n\n## 1.0.0\n\n- Old (#42).\n')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('(#42)')
+  })
+
+  it('exempts a type that changes nothing a user sees', () => {
+    commit('test: cover the thing')
+    commit('refactor: move the thing')
+    commit('ci: run the thing')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(0)
+  })
+
+  it('honours a Changelog: none trailer on a user-visible commit', () => {
+    commit('fix: something internal (#43)', 'Changelog: none')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(0)
+  })
+
+  it('reports a subject nobody can classify', () => {
+    commit('made some changes')
+
+    const result = run('v1.0.0')
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('not conventional-commit form')
+    expect(result.stderr).toContain('made some changes')
+  })
+
+  it('refuses a reference the repository does not know', () => {
+    const result = run('v9.9.9')
+
+    expect(result.status).toBe(2)
+    expect(result.stderr).toContain('Not a commit this repository knows')
+  })
+
+  it('defaults to the most recent tag', () => {
+    commit('feat: after the tag (#42)')
+
+    const result = run()
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('since v1.0.0')
+  })
+})


### PR DESCRIPTION
## Summary

Six of the nine pull requests merged into 1.0 wrote no `CHANGELOG` entry, one
of them breaking, and nothing caught it until the release notes were being
read. `grep -rln CHANGELOG test/ src/ scripts/` returned nothing: no test, no CI
job and no script read the file, so an entry could be skipped without anything
failing. #224 added a checklist line, which is honour-system only. This is the
mechanical backstop.

```
$ pnpm changelog:check

Missing a CHANGELOG entry:
  7e8ca50 fix: accept an operation's document as the manifest names it (#221)
  a9418b7 feat: a published diagnostic names the subject it is about (#220)
  ...

6 of 9 commits since v0.23.1 wrote no entry.
Write one, or record the reason in the commit with a `Changelog: none` trailer.
```

## Why at release time, not on every pull request

A per-pull-request gate has to guess whether a refactor, a test-only change or
an internal fix owes an entry. It would be wrong often enough to be routinely
overridden, and a gate people reflexively bypass is worse than none. At release
time the same question is asked once, against the whole range, where the answer
actually matters and a human is already reading.

## What it asks

It asks whether the **commit** touched `CHANGELOG.md`, and additionally excuses
a commit whose pull request is cited in the unreleased section, so a catch-up
entry like #224's counts.

Citation matching is used **only to excuse, never to accuse**. An entry that
cites the issue it closes rather than its pull request, or cites nothing, simply
fails to excuse and the commit is reported. The error therefore runs toward
over-reporting, which a reader dismisses in a second, rather than toward the
silence that let six changes ship undocumented.

Only `feat`, `fix` and `perf` are held to it. A genuine exception carries a
`Changelog: none` trailer, keeping the reason in the history rather than in an
ignore list. A subject outside conventional-commit form is reported, because a
commit nobody can classify is exactly the one worth a glance.

## Validation

Against the history that motivated it, in both directions:

| run at | result |
|---|---|
| `110f4ed` (before #224) | exit 1, names **exactly** the six |
| `main` (after #224) | exit 0, clean |

So it distinguishes the two states it exists to tell apart, on real history
rather than on a fixture.

Nine tests drive it against repositories built for the purpose, since this
repository's own history would make every expectation a moving target. They
cover: a missing entry, a self-written entry, a catch-up citation, a citation
that must *not* count because it sits in an already-released section, exempt
types, the `Changelog: none` trailer, an unclassifiable subject, an unknown ref,
and the default-to-latest-tag path.

**Writing the tests found a real fault.** The record separator broke on any
commit with an empty body, which this repository's history happened to hide by
having bodies almost everywhere. An unverified guard that silently stops working
is the exact failure mode being fixed here, so the guard is itself guarded.

`pnpm verify` exits 0.

## Related issue

None. Found while preparing the held 1.0.0 tag.

## Contract impact

None. A development script, an npm script, and contributor documentation. No
native semantics, schema, graph interchange, diagnostic, CLI surface or adapter
boundary changes.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible. — repository tooling, not user-visible; committed as `chore:`, which the guard itself correctly exempts.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)