### PR TITLE
feat: a source store, and writes that land only against what was read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,21 @@
   `start` published, copied back verbatim: a native path is refused, and the
   argument is no longer resolved against the working directory (#208).
 
+- A `SourceStore` names where a workspace's sources come from and where they go
+  back to, exported as `createFileSystemStore` with `SourceStore`,
+  `StoredSource`, `PendingWrite`, `WriteConflict` and `WriteOutcome`
+  (ADR 0100). It is `list`, `read` and `writeAll`, and a revision is opaque
+  outside the store that minted it: a content hash here, an ETag or a
+  rowversion elsewhere, compared only for equality and only by its issuer.
+  There is no unconditional write, because a caller with nothing to state is
+  the caller that cannot detect a conflict; `expected: null` requires that the
+  document not exist yet. `writeAll` checks every expectation before moving a
+  byte, so a batch whose last document is stale does not leave its first one
+  rewritten, and each file lands whole through a staged write and a rename.
+  The batch as a whole is not atomic on a filesystem, which is stated rather
+  than implied. Nothing in the engine uses it yet: this is the seam, ahead of
+  the callers moving onto it (#230).
+
 - A LikeC4 project generated before 1.0 is regenerated rather than refused.
   Its marker records a comparison's endpoints in the qualified
   `<document>#<local>` form, which `subjectIdentity` no longer admits in either

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,3 +116,11 @@ export type {
   ProjectionLoadResult,
   ProjectionResult,
 } from './projection.js'
+export {
+  createFileSystemStore,
+  type PendingWrite,
+  type SourceStore,
+  type StoredSource,
+  type WriteConflict,
+  type WriteOutcome,
+} from './source-store.js'

--- a/src/source-store.ts
+++ b/src/source-store.ts
@@ -1,0 +1,225 @@
+import { createHash } from 'node:crypto'
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+
+/**
+ * Where a workspace's sources come from and where they go back to
+ * (ADR 0100).
+ *
+ * Core is a pure function from sources to sources and never holds one of
+ * these: a caller lists, reads, calls the pure function, and writes what it
+ * returns. That is what lets the same engine serve a filesystem, an object
+ * store and a database row without knowing which it is.
+ */
+export interface SourceStore {
+  /**
+   * Every path this store holds, for a manifest's patterns to match against.
+   * Relative to the store's root and separated by `/` whatever the platform
+   * writes, because a manifest's patterns are written that way.
+   */
+  list(): readonly string[]
+  /** The bytes, and an opaque statement of which bytes they are. */
+  read(path: string): StoredSource | undefined
+  /** All of them or none, each only if it still holds what was read. */
+  writeAll(writes: readonly PendingWrite[]): WriteOutcome
+}
+
+export interface StoredSource {
+  readonly source: string
+  /**
+   * Opaque outside the store that minted it. A filesystem store may use a
+   * content hash, S3 an ETag, git a blob sha, D1 a rowversion. Nothing parses
+   * one, orders two, or asks what it means; the only operation is equality,
+   * performed by the store that issued it.
+   */
+  readonly revision: string
+}
+
+export interface PendingWrite {
+  readonly path: string
+  readonly source: string
+  /**
+   * The revision this edit was made against, or `null` to require that the
+   * document does not exist yet. There is no way to write unconditionally:
+   * a caller with nothing to state is a caller that cannot detect a conflict.
+   */
+  readonly expected: string | null
+}
+
+export type WriteConflict =
+  /** Someone else wrote it after this edit was made. */
+  | { readonly path: string; readonly reason: 'changed' }
+  /** Expected to be new, but something is already there. */
+  | { readonly path: string; readonly reason: 'exists' }
+  /** Expected to be there, and is not. */
+  | { readonly path: string; readonly reason: 'missing' }
+
+export type WriteOutcome =
+  | { readonly ok: true; readonly revisions: ReadonlyMap<string, string> }
+  | { readonly ok: false; readonly conflicts: readonly WriteConflict[] }
+
+const digest = (source: string): string =>
+  createHash('sha256').update(source, 'utf8').digest('hex')
+
+const toPosix = (path: string): string =>
+  sep === '/' ? path : path.split(sep).join('/')
+
+/**
+ * A store over a directory, which is the manifest's own directory: a
+ * workspace's patterns are confined beneath it already (`YM701`), so listing
+ * everything under it enumerates the workspace and nothing else.
+ *
+ * Confinement is enforced here rather than in Core. `realpath` is a filesystem
+ * concept, and a store with no symlinks must not be asked to pretend it has
+ * them.
+ */
+export const createFileSystemStore = (root: string): SourceStore => {
+  const base = (() => {
+    const requested = resolve(root)
+    try {
+      // Resolved once, through the root's own links, so every later
+      // comparison has both sides in the same terms. Without this a platform
+      // that symlinks a parent of the root - macOS points /var at
+      // /private/var - makes every path under it look like an escape.
+      return realpathSync(requested)
+    } catch {
+      return requested
+    }
+  })()
+
+  const withinBase = (candidate: string): boolean =>
+    candidate === base || candidate.startsWith(`${base}${sep}`)
+
+  // Resolves a store path to an absolute one, refusing anything that would
+  // leave the root. A path is a store address, not a filesystem path, so a
+  // caller that builds one from a document id cannot reach outside by saying
+  // so.
+  const absoluteOf = (path: string): string => {
+    const absolute = resolve(base, path)
+    if (!withinBase(absolute)) {
+      throw new Error(`Path escapes the workspace root: ${path}`)
+    }
+    return absolute
+  }
+
+  const revisionOf = (absolute: string): string | undefined => {
+    try {
+      return digest(readFileSync(absolute, 'utf8'))
+    } catch {
+      return undefined
+    }
+  }
+
+  return {
+    list: () => {
+      const found: string[] = []
+      const walk = (directory: string): void => {
+        let entries
+        try {
+          entries = readdirSync(directory, { withFileTypes: true })
+        } catch {
+          return
+        }
+        for (const entry of entries) {
+          const absolute = join(directory, entry.name)
+          // A symlink is followed only where it lands inside the root, so a
+          // link out of the workspace neither lists nor reads.
+          let real
+          try {
+            real = realpathSync(absolute)
+          } catch {
+            continue
+          }
+          if (!withinBase(real)) continue
+          let stat
+          try {
+            stat = statSync(absolute)
+          } catch {
+            continue
+          }
+          if (stat.isDirectory()) walk(absolute)
+          else if (stat.isFile()) found.push(toPosix(relative(base, absolute)))
+        }
+      }
+      walk(base)
+      return found.sort()
+    },
+
+    read: (path) => {
+      let absolute
+      try {
+        absolute = absoluteOf(path)
+      } catch {
+        return undefined
+      }
+      let source
+      try {
+        source = readFileSync(absolute, 'utf8')
+      } catch {
+        return undefined
+      }
+      return { source, revision: digest(source) }
+    },
+
+    writeAll: (writes) => {
+      const conflicts: WriteConflict[] = []
+      const resolved = new Map<string, string>()
+      for (const write of writes) {
+        let absolute
+        try {
+          absolute = absoluteOf(write.path)
+        } catch {
+          conflicts.push({ path: write.path, reason: 'missing' })
+          continue
+        }
+        resolved.set(write.path, absolute)
+        const held = revisionOf(absolute)
+        if (write.expected === null) {
+          if (held !== undefined) {
+            conflicts.push({ path: write.path, reason: 'exists' })
+          }
+          continue
+        }
+        if (held === undefined) {
+          conflicts.push({ path: write.path, reason: 'missing' })
+          continue
+        }
+        if (held !== write.expected) {
+          conflicts.push({ path: write.path, reason: 'changed' })
+        }
+      }
+      // Every expectation is checked before any byte moves, so a batch whose
+      // last document is stale does not leave its first one rewritten.
+      if (conflicts.length > 0) return { ok: false, conflicts }
+
+      const revisions = new Map<string, string>()
+      for (const write of writes) {
+        const absolute = resolved.get(write.path)!
+        mkdirSync(dirname(absolute), { recursive: true })
+        // Each file lands whole: a reader sees the old bytes or the new ones,
+        // never a half-written document. The batch as a whole is not atomic on
+        // a filesystem, which ADR 0100 states rather than hides.
+        const staged = `${absolute}.yarramate-${randomUUID()}.tmp`
+        try {
+          writeFileSync(staged, write.source, 'utf8')
+          renameSync(staged, absolute)
+        } catch (error) {
+          rmSync(staged, { force: true })
+          throw error
+        }
+        revisions.set(write.path, digest(write.source))
+      }
+      return { ok: true, revisions }
+    },
+  }
+}

--- a/test/source-store.test.ts
+++ b/test/source-store.test.ts
@@ -1,0 +1,244 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createFileSystemStore } from '../src/source-store.js'
+
+describe('filesystem source store', () => {
+  let parent: string
+  let root: string
+
+  const write = (path: string, source: string) => {
+    const absolute = join(root, path)
+    mkdirSync(join(absolute, '..'), { recursive: true })
+    writeFileSync(absolute, source, 'utf8')
+  }
+
+  beforeEach(() => {
+    parent = mkdtempSync(join(tmpdir(), 'yarramate-source-store-'))
+    root = join(parent, 'workspace')
+    mkdirSync(root, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(parent, { recursive: true, force: true })
+  })
+
+  describe('list', () => {
+    it('names every file beneath the root, separated by slashes', () => {
+      write('workspace.yaml', 'a\n')
+      write('architecture/engine.yaml', 'b\n')
+      write('projections/one.yaml', 'c\n')
+
+      expect(createFileSystemStore(root).list()).toEqual([
+        'architecture/engine.yaml',
+        'projections/one.yaml',
+        'workspace.yaml',
+      ])
+    })
+
+    it('does not follow a link that leaves the root', () => {
+      write('inside.yaml', 'a\n')
+      writeFileSync(join(parent, 'outside.yaml'), 'b\n')
+      symlinkSync(join(parent, 'outside.yaml'), join(root, 'linked.yaml'))
+
+      expect(createFileSystemStore(root).list()).toEqual(['inside.yaml'])
+    })
+
+    it('is empty for a root that does not exist', () => {
+      expect(createFileSystemStore(join(parent, 'absent')).list()).toEqual([])
+    })
+  })
+
+  describe('read', () => {
+    it('returns the bytes and a revision that follows them', () => {
+      write('a.yaml', 'first\n')
+      const store = createFileSystemStore(root)
+
+      const before = store.read('a.yaml')
+      expect(before?.source).toBe('first\n')
+
+      write('a.yaml', 'second\n')
+      const after = store.read('a.yaml')
+
+      expect(after?.source).toBe('second\n')
+      expect(after?.revision).not.toBe(before?.revision)
+    })
+
+    it('gives one revision to identical bytes', () => {
+      write('a.yaml', 'same\n')
+      write('b.yaml', 'same\n')
+      const store = createFileSystemStore(root)
+
+      expect(store.read('a.yaml')?.revision).toBe(
+        store.read('b.yaml')?.revision,
+      )
+    })
+
+    it('is undefined for what is not there, and for what is outside', () => {
+      writeFileSync(join(parent, 'outside.yaml'), 'b\n')
+      const store = createFileSystemStore(root)
+
+      expect(store.read('absent.yaml')).toBeUndefined()
+      expect(store.read('../outside.yaml')).toBeUndefined()
+    })
+  })
+
+  describe('writeAll', () => {
+    it('writes every document when every expectation holds', () => {
+      write('a.yaml', 'one\n')
+      write('b.yaml', 'two\n')
+      const store = createFileSystemStore(root)
+      const a = store.read('a.yaml')!
+      const b = store.read('b.yaml')!
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'one changed\n', expected: a.revision },
+        { path: 'b.yaml', source: 'two changed\n', expected: b.revision },
+      ])
+
+      expect(outcome.ok).toBe(true)
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('one changed\n')
+      expect(readFileSync(join(root, 'b.yaml'), 'utf8')).toBe('two changed\n')
+    })
+
+    it('refuses the batch and writes nothing when one document moved', () => {
+      write('a.yaml', 'one\n')
+      write('b.yaml', 'two\n')
+      const store = createFileSystemStore(root)
+      const a = store.read('a.yaml')!
+      const b = store.read('b.yaml')!
+
+      // Someone else lands a write to the second document after both were read.
+      write('b.yaml', 'landed elsewhere\n')
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'one changed\n', expected: a.revision },
+        { path: 'b.yaml', source: 'two changed\n', expected: b.revision },
+      ])
+
+      expect(outcome).toEqual({
+        ok: false,
+        conflicts: [{ path: 'b.yaml', reason: 'changed' }],
+      })
+      // The point of checking everything first: the document that was still
+      // current is not left rewritten by a batch that did not land.
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('one\n')
+      expect(readFileSync(join(root, 'b.yaml'), 'utf8')).toBe(
+        'landed elsewhere\n',
+      )
+    })
+
+    it('reports every conflict, not only the first', () => {
+      write('a.yaml', 'one\n')
+      write('b.yaml', 'two\n')
+      const store = createFileSystemStore(root)
+      const stale = store.read('a.yaml')!.revision
+      write('a.yaml', 'moved\n')
+      write('b.yaml', 'moved\n')
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'x\n', expected: stale },
+        { path: 'b.yaml', source: 'y\n', expected: stale },
+      ])
+
+      expect(outcome.ok).toBe(false)
+      if (outcome.ok) return
+      expect(outcome.conflicts.map((conflict) => conflict.path)).toEqual([
+        'a.yaml',
+        'b.yaml',
+      ])
+    })
+
+    it('creates a document that was expected not to exist', () => {
+      const store = createFileSystemStore(root)
+
+      const outcome = store.writeAll([
+        { path: 'architecture/new.yaml', source: 'fresh\n', expected: null },
+      ])
+
+      expect(outcome.ok).toBe(true)
+      expect(readFileSync(join(root, 'architecture/new.yaml'), 'utf8')).toBe(
+        'fresh\n',
+      )
+    })
+
+    it('refuses to create over something already there', () => {
+      write('a.yaml', 'occupied\n')
+      const store = createFileSystemStore(root)
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'fresh\n', expected: null },
+      ])
+
+      expect(outcome).toEqual({
+        ok: false,
+        conflicts: [{ path: 'a.yaml', reason: 'exists' }],
+      })
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('occupied\n')
+    })
+
+    it('refuses to update something that has gone', () => {
+      write('a.yaml', 'here\n')
+      const store = createFileSystemStore(root)
+      const a = store.read('a.yaml')!
+      rmSync(join(root, 'a.yaml'))
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'x\n', expected: a.revision },
+      ])
+
+      expect(outcome).toEqual({
+        ok: false,
+        conflicts: [{ path: 'a.yaml', reason: 'missing' }],
+      })
+    })
+
+    it('refuses a path that would leave the root', () => {
+      writeFileSync(join(parent, 'outside.yaml'), 'safe\n')
+      const store = createFileSystemStore(root)
+
+      const outcome = store.writeAll([
+        { path: '../outside.yaml', source: 'reached\n', expected: null },
+      ])
+
+      expect(outcome.ok).toBe(false)
+      expect(readFileSync(join(parent, 'outside.yaml'), 'utf8')).toBe('safe\n')
+    })
+
+    it('returns revisions a later write can be made against', () => {
+      write('a.yaml', 'one\n')
+      const store = createFileSystemStore(root)
+      const first = store.writeAll([
+        { path: 'a.yaml', source: 'two\n', expected: store.read('a.yaml')!.revision },
+      ])
+
+      expect(first.ok).toBe(true)
+      if (!first.ok) return
+      const second = store.writeAll([
+        { path: 'a.yaml', source: 'three\n', expected: first.revisions.get('a.yaml')! },
+      ])
+
+      expect(second.ok).toBe(true)
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('three\n')
+    })
+
+    it('leaves no staging file behind', () => {
+      write('a.yaml', 'one\n')
+      const store = createFileSystemStore(root)
+      store.writeAll([
+        { path: 'a.yaml', source: 'two\n', expected: store.read('a.yaml')!.revision },
+      ])
+
+      expect(readdirSync(root)).toEqual(['a.yaml'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

First half of [ADR 0100](docs/adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md).
Introduces the seam; **nothing in the engine uses it yet**, so the interface can
be read on its own before every caller moves onto it.

```ts
interface SourceStore {
  list(): readonly string[]
  read(path: string): { source: string; revision: string } | undefined
  writeAll(writes: readonly PendingWrite[]): WriteOutcome
}
```

## Three decisions worth pausing on

**A revision is opaque outside its issuer.** A content hash here; an ETag, a
blob sha or a rowversion elsewhere. Nothing parses one, orders two, or asks what
it means. The only operation is equality, performed by the store that minted it.

**There is no unconditional write.** `expected` is required, and `null` means
"must not exist yet". A caller with nothing to state is exactly the caller that
cannot detect a conflict, so an optional precondition would be decoration —
the same argument ADR 0093 made for requiring `sourceDigests`.

**`writeAll` checks every expectation before it moves a byte.** A batch whose
last document is stale does not leave its first one rewritten. That is the
property the per-file `writeFileSync` loop it will replace could not offer, and
it has a test of its own:

```
expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('one\n')
// ^ the document that was still current is not left rewritten
//   by a batch that did not land
```

Each file lands whole through a staged write and a rename, so a reader sees the
old bytes or the new ones. **The batch as a whole is not atomic on a
filesystem** — ADR 0100 states that rather than hiding it, and the code says so
where it happens.

## Confinement belongs to the store

`realpath` is a filesystem concept, and a store with no symlinks must not be
asked to pretend it has them. A path is a store address, not a filesystem path:
one that would leave the root neither lists, reads, nor writes. Core keeps
`YM701` as a rule about the *shape* of a pattern.

## A bug worth recording

The first fifteen tests all failed. The root was compared against its own
realpath, so on any platform that symlinks a parent of the root — **macOS points
`/var` at `/private/var`, which is where `mkdtemp` puts things** — every path
under the root looked like an escape from it. The root is now resolved through
its own links once, so both sides of every later comparison are in the same
terms. Worth knowing before anyone writes a second store.

## Validation

`pnpm verify` exits 0. Fifteen tests cover: listing and slash separation, a link
out of the root, a missing root, revisions following content, identical bytes
sharing a revision, reads outside the root, a clean batch, a refused batch
leaving *both* files untouched, every conflict reported rather than the first,
creation, refusing to create over something present, refusing to update
something gone, refusing a path that escapes, chaining a returned revision into
the next write, and leaving no staging file behind.

## Related issue

None. ADR 0100, Wave 3 of the 1.0 arc.

## Contract impact

Additive. New exports from the package root: `createFileSystemStore` and the
`SourceStore`, `StoredSource`, `PendingWrite`, `WriteConflict` and
`WriteOutcome` types. No existing signature, diagnostic, schema or CLI
behaviour changes — the callers move in the next change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — ADR 0100, merged in #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)