### PR TITLE
feat!: applyOperations is pure, and a batch lands by compare-and-swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,26 @@
   once any control was touched: more than twice as wide for the same twenty
   nodes. Relaying out when the matched set changes closes it (#219).
 
+- **Breaking.** `applyOperations` is a pure function from sources to sources
+  (ADR 0100). It takes an `ApplyInput` - the resolved workspace, every source
+  that workspace resolves to, the operations document, and where the manifest
+  sits - and returns the documents it changed rather than writing them. It
+  reads no file and writes none. `landOperations(store, input)` is the
+  composition both callers use: read the workspace through a `SourceStore`,
+  apply, and write back only what still holds what was read. Both are exported,
+  with `ApplyInput` and `ApplyOutcome`, so an engine embedded over D1 or an
+  object store can be handed its own sources.
+  This closes a gap ADR 0093 left open. The visual runtime pinned a digest per
+  document and refused a batch whose pin no longer matched, but the check sat
+  in the adapter and the write sat in Core with a whole workspace compile
+  between them, so a write landing in that window was overwritten by a batch
+  that had already proved it was current. The pin stays, unchanged, along with
+  `YMVS312` and `YMVS313`; the store's comparison now runs immediately before
+  the bytes land, so nothing can move in between. New `YM704` refuses a batch
+  whose document changed or was removed after it was staged, and `YM705` one
+  that expected to create a document already there. `apply` from a terminal,
+  which had no precondition at all, now has this one (#231).
+
 - **Breaking.** Relationship endpoints are validated against the ArchiMate
   3.2 relationship table (ADR 0097), vendored from Archi's `relationships.xml`
   (MIT) and regenerated into a zero-import module a test keeps honest. The

--- a/docs/adr/0057-writes-land-as-one-validated-batch.md
+++ b/docs/adr/0057-writes-land-as-one-validated-batch.md
@@ -2,6 +2,14 @@
 
 Status: accepted
 
+> Extended in 1.0 by
+> [ADR 0100](0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md):
+> the batch is still staged in memory, compiled whole and rejected whole, but
+> it no longer ends in a loop of `writeFileSync`. `applyOperations` returns the
+> documents it changed and a store writes them, checking every expectation
+> before it moves a byte. What this ADR called atomic was true up to that last
+> loop, which could leave the first document rewritten when the third failed.
+
 The validated-write surface was one operation per invocation: safe — it
 structurally cannot emit aspect violations — but expensive in an agent
 loop, where eight `add`/`connect` calls meant eight turns of re-fed

--- a/docs/adr/0093-a-commit-states-what-it-was-staged-against.md
+++ b/docs/adr/0093-a-commit-states-what-it-was-staged-against.md
@@ -2,6 +2,17 @@
 
 Status: accepted
 
+> Joined in 1.0 by
+> [ADR 0100](0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md).
+> The pin described here is about the reviewer's view: whether the value on
+> screen is still the value on disk. It stays, unchanged, along with `YMVS312`
+> and `YMVS313`. What it could not do is close the gap between the digest that
+> satisfied it and the write that acted on it, which spanned a whole workspace
+> compile: a write landing in that window was overwritten by a batch that had
+> already proved it was current. The store's own comparison now runs
+> immediately before the bytes land, so both checks apply and the window is no
+> longer open.
+
 The visual runtime stages mechanical edits in the browser and lands them as one
 batch through `yarramate apply` (ADR 0084). Until now the commit handler read
 the workspace from disk at commit time and applied the batch to whatever it

--- a/docs/adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md
+++ b/docs/adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md
@@ -1,6 +1,6 @@
 # Sources come from a store, and a batch lands by compare-and-swap
 
-Status: proposed
+Status: accepted
 
 Core reads and writes the filesystem directly. `applyOperations` calls
 `readFileSync` in four places and ends in a loop of `writeFileSync`;

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -12,7 +12,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
-import { basename, extname, join, resolve, sep } from "node:path";
+import { basename, extname, join, relative, resolve, sep } from "node:path";
 import type { Duplex } from "node:stream";
 import { fileURLToPath } from "node:url";
 import Ajv2020Module from "ajv/dist/2020.js";
@@ -70,7 +70,11 @@ import {
   type ResolvedProfileContext,
   type SemanticGraph,
 } from "../../compiler.js";
-import { applyOperations } from "../../apply-command.js";
+import {
+  landOperations,
+  posixDirectoryOf,
+} from "../../apply-command.js";
+import { createFileSystemStore } from "../../source-store.js";
 import { projectGraphForCanvas } from "../../graph-projection.js";
 import { kindLabelOf } from "../../kind-label.js";
 import {
@@ -1440,10 +1444,36 @@ export const startVisualServer = async (
           format: "yarramate/operations/v1",
           operations: event.payload.operations,
         });
-        const outcome = applyOperations(
-          { path: "changeset.yaml", source: operationsSource },
+        // The pin check above is about the reviewer's view: whether the value
+        // on screen is still the value on disk. What follows is about the
+        // bytes: Core is handed the sources, returns the ones it changed, and
+        // the store writes them only if each still holds what Core was shown
+        // (ADR 0100). That second check is what closes the window the pin
+        // check alone left open, which used to span a whole workspace compile
+        // between the digest that satisfied it and the write that acted on it.
+        const loadedWorkspace = loadWorkspaceManifest(
           { path: manifestPath, source: readFileSync(manifestPath, "utf8") },
           options.cwd,
+        );
+        if (!loadedWorkspace.ok) {
+          sendFrame(socket, {
+            kind: "apply-result",
+            result: { ok: false, diagnostics: loadedWorkspace.diagnostics },
+          });
+          return;
+        }
+        const outcome = landOperations(
+          createFileSystemStore(options.cwd),
+          {
+            workspace: loadedWorkspace.workspace,
+            operations: {
+              path: "changeset.yaml",
+              source: operationsSource,
+            },
+            manifestDirectory: posixDirectoryOf(
+              relative(options.cwd, manifestPath),
+            ),
+          },
         );
         if (!outcome.ok) {
           // Nothing landed: forward Core's diagnostics verbatim (ADR 0062)

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { resolve, sep } from 'node:path'
 import {
   isMap,
   isScalar,
@@ -31,7 +31,24 @@ import {
   scanSubjectReferences,
   type SubjectReferenceGroup,
 } from './subject-references.js'
-import { loadWorkspaceManifest } from './workspace.js'
+import {
+  loadWorkspaceManifest,
+  type ResolvedWorkspace,
+} from './workspace.js'
+import {
+  createFileSystemStore,
+  type SourceStore,
+} from './source-store.js'
+
+/**
+ * The directory part of a workspace path, in the `/`-separated terms a
+ * manifest is written in rather than the platform's.
+ */
+export const posixDirectoryOf = (path: string): string => {
+  const normalised = path.split(sep).join('/')
+  const cut = normalised.lastIndexOf('/')
+  return cut === -1 ? '' : normalised.slice(0, cut)
+}
 import operationsSchema from '../schema/yarramate-operations.schema.json' with {
   type: 'json',
 }
@@ -471,7 +488,16 @@ const removeCollectionItem = (
 // ---------------------------------------------------------------------------
 
 export type ApplyOutcome =
-  | { readonly ok: true; readonly result: YarramateApplyResult }
+  | {
+      readonly ok: true
+      /**
+       * The documents this batch changed, for the caller to write. Core
+       * returns them rather than writing them, so the store's comparison is
+       * the last thing that happens before bytes land (ADR 0100).
+       */
+      readonly sources: readonly WorkspaceSource[]
+      readonly result: YarramateApplyResult
+    }
   | { readonly ok: false; readonly diagnostics: readonly Diagnostic[] }
 
 // The programmatic core, split out of the CLI wrapper below so a long-lived
@@ -482,19 +508,42 @@ export type ApplyOutcome =
 // back onto whatever authored the operation. No shell-out, no temp files,
 // no process access, no module-level mutable state: safe to call
 // repeatedly and concurrently against different workspaces.
+/**
+ * Everything `applyOperations` is allowed to know. The workspace is already
+ * resolved and the sources are already read, because Core does not reach for
+ * either (ADR 0100).
+ */
+export interface ApplyInput {
+  /** The workspace this batch is addressed to, already resolved. */
+  readonly workspace: ResolvedWorkspace
+  /** Every source that workspace resolves to, keyed by its manifest path. */
+  readonly sources: readonly WorkspaceSource[]
+  /** The operations document itself. */
+  readonly operations: WorkspaceSource
+  /**
+   * Where the manifest sits relative to the paths in `workspace`, so an
+   * operation may address a document the way the manifest names it as well as
+   * the way the workspace lists it (#216). String arithmetic, not a lookup.
+   */
+  readonly manifestDirectory: string
+}
+
 export const applyOperations = (
-  operations: WorkspaceSource,
-  workspace: WorkspaceSource,
-  cwd: string,
+  input: ApplyInput,
 ): ApplyOutcome => {
+  const { workspace: resolvedWorkspace, operations } = input
+  // Every source the workspace resolves to, by its manifest path. Core reads
+  // nothing: what is not here does not exist as far as this function is
+  // concerned, which is what lets the same code serve a filesystem, an object
+  // store and a database row (ADR 0100).
+  const held = new Map(
+    input.sources.map((source) => [source.path, source.source]),
+  )
+  const sourceOf = (path: string): string => held.get(path) ?? ''
   const failed = (diagnostics: readonly Diagnostic[]): ApplyOutcome => ({
     ok: false,
     diagnostics,
   })
-  const loadedWorkspace = loadWorkspaceManifest(workspace, cwd)
-  if (!loadedWorkspace.ok) return failed(loadedWorkspace.diagnostics)
-  const resolvedWorkspace = loadedWorkspace.workspace
-
   const loadedOperations = loadSourceDocument<OperationsDocument>(
     operations,
     validateOperations,
@@ -509,14 +558,14 @@ export const applyOperations = (
   // Documents are addressed by their manifest paths; an operation aimed
   // anywhere else is rejected before anything is touched.
   const workspaceDocuments = new Map(
-    resolvedWorkspace.documents.map((path) => [resolve(cwd, path), path]),
+    resolvedWorkspace.documents.map((path): [string, string] => [path, path]),
   )
   // Overlay entries live in the workspace's evidence documents, addressed the
   // same way. The two sets stay apart: a concept operation aimed at an
   // overlay — or an observation aimed at a compiler document — is rejected
   // before anything is touched.
   const workspaceEvidence = new Map(
-    resolvedWorkspace.evidence.map((path) => [resolve(cwd, path), path]),
+    resolvedWorkspace.evidence.map((path): [string, string] => [path, path]),
   )
   // A rename re-points references, and references live in four kinds of file,
   // so the write set is wider than the two above. Projections and adapter
@@ -524,7 +573,6 @@ export const applyOperations = (
   // along by a rename — but they are written, so they carry their manifest
   // path for the touched-document list and their group for the walker.
   const referenceFiles: ReadonlyArray<{
-    readonly absolute: string
     readonly path: string
     readonly group: SubjectReferenceGroup
   }> = (
@@ -535,10 +583,10 @@ export const applyOperations = (
       ['adapter-mapping', resolvedWorkspace.adapterMappings],
     ] as ReadonlyArray<readonly [SubjectReferenceGroup, readonly string[]]>
   ).flatMap(([group, paths]) =>
-    paths.map((path) => ({ absolute: resolve(cwd, path), path, group })),
+    paths.map((path) => ({ path, group })),
   )
   const referenceFileOf = new Map(
-    referenceFiles.map((file) => [file.absolute, file]),
+    referenceFiles.map((file) => [file.path, file]),
   )
   const candidates = new Map<string, string>()
   const counts = {
@@ -587,13 +635,25 @@ export const applyOperations = (
   // (#216). Both readings are tried, and only a path that actually names a
   // document of this workspace is accepted, so admitting the second form
   // cannot make an address ambiguous.
-  const manifestDirectory = dirname(resolve(cwd, workspace.path))
+  // Both readings an author may write, as workspace paths. #216 accepted the
+  // manifest-relative form; expressing it as arithmetic rather than as a
+  // second resolution against the working directory is what ADR 0100 said this
+  // seam was the place to collapse.
+  const joinPosix = (base: string, path: string): string => {
+    const segments = base === '' || base === '.' ? [] : base.split('/')
+    for (const segment of path.split('/')) {
+      if (segment === '' || segment === '.') continue
+      if (segment === '..') segments.pop()
+      else segments.push(segment)
+    }
+    return segments.join('/')
+  }
   for (const [index, operation] of operationList.entries()) {
     const overlay = operation.op.endsWith('-observation')
     const known = overlay ? workspaceEvidence : workspaceDocuments
     const readings = [
-      resolve(manifestDirectory, operation.document),
-      resolve(cwd, operation.document),
+      joinPosix(input.manifestDirectory, operation.document),
+      joinPosix('', operation.document),
     ]
     const absolute = readings.find((reading) => known.has(reading)) ?? readings[1]!
     const manifestPath = known.get(absolute)
@@ -620,7 +680,7 @@ export const applyOperations = (
     }
     let source = candidates.get(absolute)
     if (source === undefined) {
-      source = readFileSync(absolute, 'utf8')
+      source = sourceOf(absolute)
     }
     if (operation.op === 'add-concept') {
       source = appendCollectionItem(
@@ -715,7 +775,7 @@ export const applyOperations = (
       // in the same batch reads the first one's result.
       for (const file of referenceFiles) {
         const before =
-          candidates.get(file.absolute) ?? readFileSync(file.absolute, 'utf8')
+          candidates.get(file.path) ?? sourceOf(file.path)
         const rewrite = rewriteSubjectReferences(before, file.group, rename)
         if (!rewrite.ok) {
           return failed([
@@ -729,7 +789,7 @@ export const applyOperations = (
           ])
         }
         if (rewrite.source !== before) {
-          candidates.set(file.absolute, rewrite.source)
+          candidates.set(file.path, rewrite.source)
         }
       }
       // The target document's own declaration moved in that same walk, so the
@@ -925,11 +985,10 @@ export const applyOperations = (
       readonly field: string
     }
     const staged = resolvedWorkspace.documents.map((path) => {
-      const absolute = resolve(cwd, path)
       return {
-        absolute,
+        absolute: path,
         value: parseDocument(
-          candidates.get(absolute) ?? readFileSync(absolute, 'utf8'),
+          candidates.get(path) ?? sourceOf(path),
         ).toJSON() as {
           readonly id?: string
           readonly concepts?: readonly ConceptFields[]
@@ -1015,10 +1074,9 @@ export const applyOperations = (
   const compilation = compileWorkspace(
     [...resolvedWorkspace.profiles, ...resolvedWorkspace.documents].map(
       (path) => {
-        const absolute = resolve(cwd, path)
         return {
           path,
-          source: candidates.get(absolute) ?? readFileSync(absolute, 'utf8'),
+          source: candidates.get(path) ?? sourceOf(path),
         }
       },
     ),
@@ -1048,7 +1106,7 @@ export const applyOperations = (
   if (renames.length > 0) {
     const movedFrom = new Map(renames.map(({ from, index }) => [from, index]))
     const residue = referenceFiles.flatMap((file) => {
-      const source = candidates.get(file.absolute)
+      const source = candidates.get(file.path)
       if (source === undefined) return []
       return scanSubjectReferences(source, file.group)
         .hits.filter((hit) => movedFrom.has(hit.address))
@@ -1068,7 +1126,7 @@ export const applyOperations = (
   // rewrite that produced an unreadable address is caught here rather than by
   // the next command to read the file.
   for (const file of referenceFiles) {
-    const source = candidates.get(file.absolute)
+    const source = candidates.get(file.path)
     if (source === undefined) continue
     if (file.group === 'projection') {
       const loaded = loadProjection({ path: file.path, source })
@@ -1079,20 +1137,97 @@ export const applyOperations = (
     }
   }
 
-  for (const [absolute, source] of candidates) {
-    writeFileSync(absolute, source, 'utf8')
-  }
-  const touched = [...candidates.keys()]
-    .map((absolute) => referenceFileOf.get(absolute)!.path)
-    .sort()
+  // Nothing is written. The caller pairs each of these with the revision it
+  // read and hands the batch to a store, which is where the comparison that
+  // decides whether it lands belongs (ADR 0100).
+  const written = [...candidates]
+    .map(([path, source]) => ({ path, source }))
+    .sort((left, right) => (left.path < right.path ? -1 : 1))
+  const touched = written.map((source) => source.path)
   return {
     ok: true,
+    sources: written,
     result: {
       format: 'yarramate/apply-result/v1',
       workspace: resolvedWorkspace.id,
       applied: counts,
       documents: touched,
     },
+  }
+}
+
+
+/**
+ * Reads a workspace through a store, applies a batch, and writes what changed
+ * back only if every document still holds what was read (ADR 0100).
+ *
+ * This is the composition Core deliberately does not perform: `applyOperations`
+ * is a pure function, and the comparison that decides whether a batch lands
+ * belongs to the store. Both callers - the CLI and the visual session server -
+ * go through here so the precondition exists in one place rather than being
+ * remembered twice.
+ */
+export const landOperations = (
+  store: SourceStore,
+  input: {
+    readonly workspace: ResolvedWorkspace
+    readonly operations: WorkspaceSource
+    readonly manifestDirectory: string
+  },
+): ApplyOutcome => {
+  const revisions = new Map<string, string>()
+  const sources: WorkspaceSource[] = []
+  for (const path of [
+    ...input.workspace.documents,
+    ...input.workspace.projections,
+    ...input.workspace.evidence,
+    ...input.workspace.adapterMappings,
+  ]) {
+    const stored = store.read(path)
+    if (stored === undefined) continue
+    revisions.set(path, stored.revision)
+    sources.push({ path, source: stored.source })
+  }
+
+  const outcome = applyOperations({
+    workspace: input.workspace,
+    sources,
+    operations: input.operations,
+    manifestDirectory: input.manifestDirectory,
+  })
+  if (!outcome.ok) return outcome
+  if (outcome.sources.length === 0) return outcome
+
+  // A document Core rewrote must still hold what Core was shown. One it
+  // created must still not be there. There is no third case: a batch that
+  // vouches for nothing would buy back the unconditional write by omission.
+  const written = store.writeAll(
+    outcome.sources.map((source) => ({
+      path: source.path,
+      source: source.source,
+      expected: revisions.get(source.path) ?? null,
+    })),
+  )
+  if (written.ok) return outcome
+
+  return {
+    ok: false,
+    diagnostics: written.conflicts.map((conflict) => ({
+      severity: 'error' as const,
+      code: conflict.reason === 'exists' ? 'YM705' : 'YM704',
+      message:
+        conflict.reason === 'exists'
+          ? `Document "${conflict.path}" already exists; this batch expected to create it`
+          : conflict.reason === 'missing'
+            ? `Document "${conflict.path}" no longer exists; this batch was staged against it`
+            : `Document "${conflict.path}" changed after this batch was staged`,
+      path: input.operations.path,
+      // The conflict is about the batch rather than about any one line of it:
+      // the operation that named the document is not what went wrong.
+      pointer: '/',
+      line: 1,
+      column: 1,
+    })),
   }
 }
 
@@ -1128,11 +1263,24 @@ export function runApplyCommand(
       resolve(cwd, operationsPath),
       'utf8',
     )
-    const outcome = applyOperations(
-      { path: operationsPath, source: operationsSource },
+    const loadedWorkspace = loadWorkspaceManifest(
       { path: workspacePath, source: manifestSource },
       cwd,
     )
+    if (!loadedWorkspace.ok) {
+      return {
+        exitCode: 1,
+        stdout: json
+          ? diagnosticJson(loadedWorkspace.diagnostics)
+          : humanDiagnostics(loadedWorkspace.diagnostics),
+        stderr: '',
+      }
+    }
+    const outcome = landOperations(createFileSystemStore(cwd), {
+      workspace: loadedWorkspace.workspace,
+      operations: { path: operationsPath, source: operationsSource },
+      manifestDirectory: posixDirectoryOf(workspacePath),
+    })
     if (!outcome.ok) {
       return {
         exitCode: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,3 +124,10 @@ export {
   type WriteConflict,
   type WriteOutcome,
 } from './source-store.js'
+export {
+  applyOperations,
+  landOperations,
+  posixDirectoryOf,
+  type ApplyInput,
+  type ApplyOutcome,
+} from './apply-command.js'

--- a/test/apply-operations.test.ts
+++ b/test/apply-operations.test.ts
@@ -2,12 +2,35 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { applyOperations } from '../src/apply-command.js'
+import {
+  applyOperations,
+  landOperations,
+  posixDirectoryOf,
+} from '../src/apply-command.js'
+import { createFileSystemStore } from '../src/source-store.js'
+import { loadWorkspaceManifest } from '../src/workspace.js'
+import type { WorkspaceSource } from '../src/compiler.js'
+import type { SourceStore } from '../src/source-store.js'
 
-// Coverage for the programmatic core: every test here calls `applyOperations`
-// directly with in-memory sources, the way the visual session server calls it.
-// The CLI-shaped behaviour — argv parsing, `--json` formatting, the manifest
-// precheck — stays covered by `apply-command.test.ts`, unchanged.
+// Coverage for the programmatic core. `applyOperations` itself is pure and
+// reads nothing (ADR 0100), so these drive it through `landOperations`, which
+// is the composition both real callers use: read the workspace through a
+// store, apply, and write back only what still holds what was read.
+// The CLI-shaped behaviour - argv parsing, `--json` formatting, the manifest
+// precheck - stays covered by `apply-command.test.ts`, unchanged.
+const landBatch = (
+  operations: WorkspaceSource,
+  workspace: WorkspaceSource,
+  cwd: string,
+) => {
+  const loaded = loadWorkspaceManifest(workspace, cwd)
+  if (!loaded.ok) return { ok: false as const, diagnostics: loaded.diagnostics }
+  return landOperations(createFileSystemStore(cwd), {
+    workspace: loaded.workspace,
+    operations,
+    manifestDirectory: posixDirectoryOf(workspace.path),
+  })
+}
 
 const document = `format: yarramate/v1
 id: main
@@ -40,6 +63,111 @@ operations:
       status: planned
 `
 
+describe('applyOperations is pure, and a batch lands by compare-and-swap', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'yarramate-apply-cas-'))
+    mkdirSync(join(cwd, 'architecture'))
+    writeFileSync(join(cwd, 'architecture/main.yaml'), document, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  const resolved = () => {
+    const loaded = loadWorkspaceManifest(
+      { path: 'workspace.yaml', source: manifest },
+      cwd,
+    )
+    if (!loaded.ok) throw new Error(JSON.stringify(loaded.diagnostics))
+    return loaded.workspace
+  }
+
+  it('returns the documents it changed and writes none of them', () => {
+    const workspace = resolved()
+    const before = readFileSync(join(cwd, 'architecture/main.yaml'), 'utf8')
+
+    const outcome = applyOperations({
+      workspace,
+      sources: workspace.documents.map((path) => ({
+        path,
+        source: readFileSync(join(cwd, path), 'utf8'),
+      })),
+      operations: { path: 'operations.yaml', source: batch },
+      manifestDirectory: '',
+    })
+
+    if (!outcome.ok) throw new Error(JSON.stringify(outcome.diagnostics))
+    expect(outcome.sources.map((source) => source.path)).toEqual([
+      'architecture/main.yaml',
+    ])
+    expect(outcome.sources[0]!.source).not.toBe(before)
+    // The whole point: Core produced new bytes and touched no disk.
+    expect(readFileSync(join(cwd, 'architecture/main.yaml'), 'utf8')).toBe(
+      before,
+    )
+  })
+
+  it('refuses the batch as YM704 when a document moved between read and write', () => {
+    // A store that lets another writer land the instant Core has been shown
+    // the sources. The revision handed out is the one read before the race,
+    // which is exactly the situation a real concurrent writer creates - and
+    // the window that used to hold a whole workspace compile.
+    const inner = createFileSystemStore(cwd)
+    let raced = false
+    const racing: SourceStore = {
+      list: () => inner.list(),
+      read: (path) => {
+        const held = inner.read(path)
+        if (!raced && held !== undefined) {
+          raced = true
+          writeFileSync(
+            join(cwd, 'architecture/main.yaml'),
+            `${document}# landed elsewhere\n`,
+            'utf8',
+          )
+        }
+        return held
+      },
+      writeAll: (writes) => inner.writeAll(writes),
+    }
+
+    const outcome = landOperations(racing, {
+      workspace: resolved(),
+      operations: { path: 'operations.yaml', source: batch },
+      manifestDirectory: '',
+    })
+
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) return
+    expect(outcome.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'YM704',
+    ])
+    expect(outcome.diagnostics[0]!.message).toContain(
+      'architecture/main.yaml',
+    )
+    // Refused means refused: the other writer's bytes are still there.
+    expect(readFileSync(join(cwd, 'architecture/main.yaml'), 'utf8')).toContain(
+      '# landed elsewhere',
+    )
+  })
+
+  it('lands when nothing moved underneath it', () => {
+    const outcome = landOperations(createFileSystemStore(cwd), {
+      workspace: resolved(),
+      operations: { path: 'operations.yaml', source: batch },
+      manifestDirectory: '',
+    })
+
+    expect(outcome.ok).toBe(true)
+    expect(readFileSync(join(cwd, 'architecture/main.yaml'), 'utf8')).not.toBe(
+      document,
+    )
+  })
+})
+
 describe('applyOperations', () => {
   let cwd: string
 
@@ -54,7 +182,7 @@ describe('applyOperations', () => {
   })
 
   it('applies a batch atomically and returns the apply-result payload', () => {
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: batch },
       { path: 'workspace.yaml', source: manifest },
       cwd,
@@ -91,7 +219,7 @@ operations:
     concept:
       id: user
 `
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: invalidBatch },
       { path: 'workspace.yaml', source: manifest },
       cwd,
@@ -109,7 +237,7 @@ operations:
       'architecture/main.yaml',
       'architecture/other.yaml',
     )
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: outOfScope },
       { path: 'workspace.yaml', source: manifest },
       cwd,
@@ -134,7 +262,7 @@ operations:
       from: user
       to: missing-target
 `
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: brokenBatch },
       { path: 'workspace.yaml', source: manifest },
       cwd,
@@ -154,7 +282,7 @@ operations:
       'architecture/main.yaml',
       'architecture/other.yaml',
     )
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: outOfScope },
       { path: 'workspace.yaml', source: manifest },
       cwd,
@@ -170,12 +298,12 @@ operations:
       mkdirSync(join(other, 'architecture'))
       writeFileSync(join(other, 'architecture/main.yaml'), document, 'utf8')
 
-      const first = applyOperations(
+      const first = landBatch(
         { path: 'operations.yaml', source: batch },
         { path: 'workspace.yaml', source: manifest },
         cwd,
       )
-      const second = applyOperations(
+      const second = landBatch(
         { path: 'operations.yaml', source: batch },
         { path: 'workspace.yaml', source: manifest },
         other,
@@ -313,7 +441,7 @@ describe('applyOperations rename', () => {
   })
 
   const apply = (source: string) =>
-    applyOperations(
+    landBatch(
       { path: 'operations.yaml', source },
       { path: 'workspace.yaml', source: renameManifest },
       cwd,
@@ -512,7 +640,7 @@ concepts:
 relationships: []
 `
     writeFileSync(join(cwd, 'architecture/other.yaml'), other, 'utf8')
-    const outcome = applyOperations(
+    const outcome = landBatch(
       { path: 'operations.yaml', source: renameBatch('platform', 'platform-team') },
       {
         path: 'workspace.yaml',


### PR DESCRIPTION
## Summary

Second half of ADR 0100, which becomes **accepted**. Follows #230, which added
the store and nothing that used it.

```ts
applyOperations(input: ApplyInput): ApplyOutcome   // reads nothing, writes nothing
landOperations(store, input): ApplyOutcome         // the composition both callers use
```

`applyOperations` takes the resolved workspace, every source it resolves to, and
the operations document, and returns the documents it changed.
`landOperations` reads through a store, applies, and writes back only what still
holds what was read. Both are exported, with `ApplyInput` and `ApplyOutcome`, so
an engine embedded over D1 or an object store can be handed its own sources.

## It closes a real gap, not just a layering one

ADR 0093 made the visual runtime pin a digest per document. But the check sat in
the adapter and the write sat in Core, with a whole workspace compile between
them:

```
digestOf(readFileSync(...))     <- precondition satisfied here
   ... 267 concepts, 375 relationships compiled ...
writeFileSync(...)              <- bytes land here
```

A write landing in that window was overwritten by a batch that had **already
proved it was current**.

**Both checks now apply, and they are about different things.** The pin is about
the reviewer's *view* — whether the value on screen is still the value on disk.
It stays exactly as it was, along with `YMVS312` and `YMVS313`. The store's
comparison is about the *bytes*, and runs immediately before they land. Nothing
can move in between.

The test drives it with a store that lets another writer land the instant Core
has been shown the sources:

```
expect(outcome.diagnostics.map(d => d.code)).toEqual(['YM704'])
// refused means refused: the other writer's bytes are still there
expect(readFileSync(...)).toContain('# landed elsewhere')
```

`apply` from a terminal had no precondition at all, and now has this one.

## New diagnostics

- **`YM704`** — a document changed or was removed after the batch was staged.
- **`YM705`** — a batch expected to create a document that is already there.

## Also collapsed

The two document addressings #216 accepted are now string arithmetic over
workspace paths rather than two resolutions against a working directory. #216's
own note said this seam would be the place to collapse them.

## What is deliberately NOT in this change

**Manifest resolution still globs.** ADR 0100 said resolution splits, with the
store listing and Core matching. Splitting it needs a pattern dialect decided
and *documented* — `docs/WORKSPACES.md` has never named one, the schema
constrains patterns only to non-empty strings, and every manifest reachable here
uses nothing but `*`. So the current dialect is whatever `node:fs` `globSync`
happens to support, undocumented and untested beyond one wildcard. Naming it is
a compatibility decision with its own edge, and it does not belong bundled into
this one.

## Validation

`pnpm verify` exits 0: **74 files, 1245 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

The 9 existing `applyOperations` tests were migrated to drive `landOperations`
and all pass unchanged, which is the useful signal: the composition behaves as
the old direct-to-disk function did. Three tests are new — Core returning
changed bytes while the file on disk is untouched, the race above, and a clean
landing.

ADR 0057 and ADR 0093 get the notes ADR 0100 promised, now that the mechanism
has actually moved.

## Related issue

None. ADR 0100, Wave 3 of the 1.0 arc.

## Contract impact

**Breaking.** `applyOperations` changes signature and no longer writes. New
exports: `applyOperations`, `landOperations`, `posixDirectoryOf`, `ApplyInput`,
`ApplyOutcome`. New diagnostics `YM704` and `YM705`. `apply` gains a refusal
when its documents moved underneath it. No schema, graph interchange or CLI
argument change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — ADR 0100, merged in #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)