### PR TITLE
test(visual): hold the coincidence a commit's pins depend on

### DIFF
--- a/docs/adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md
+++ b/docs/adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md
@@ -106,6 +106,24 @@ rule about the shape of a pattern. Containment against symlinks becomes the
 store's responsibility, because `realpathSync` is a filesystem concept that a
 D1 store has no analogue for and must not be asked to fake.
 
+> **Deferred, deliberately.** Resolution still globs the filesystem, and the
+> reason this is not a blocker only became clear once the rest had landed:
+> `applyOperations` takes an already-resolved `ResolvedWorkspace`, and that
+> type is exported, so an embedder over D1 builds its own and never asks Core
+> to match a pattern against anything. The split's remaining value is
+> uniformity, not capability.
+>
+> What it would cost is a pattern dialect decided and documented, and one has
+> never been named. `docs/WORKSPACES.md` describes what resolution *does* -
+> rejects `..`, expands to regular files, reports what matched nothing - but
+> never says what a pattern may contain; the schema constrains a pattern only
+> to a non-empty string; and every manifest reachable from this repository uses
+> nothing but `*`, with no `**`, `?`, `[` or `{` anywhere. So the dialect in
+> force is whatever `node:fs` `globSync` happens to support, undocumented and
+> untested past one wildcard. Naming it is a compatibility decision that
+> deserves its own change rather than a paragraph in this one, and it buys
+> uniformity rather than reach.
+
 **Two diagnostics, in the workspace range.** `YM704`: a document changed after
 this edit was staged, naming the document. `YM705`: a document expected not to
 exist already does. `YMVS312` and `YMVS313` remain the visual runtime's wire

--- a/src/adapters/visual/protocol.ts
+++ b/src/adapters/visual/protocol.ts
@@ -103,6 +103,17 @@ ajv.addSchema([
  * mints them for the initial model, the session server re-mints them on every
  * recompile and checks a commit's pins against the files on disk, and all three
  * are the same hash by construction rather than by three matching literals.
+ *
+ * There is a fourth, and it is not by construction. A commit's pins become the
+ * `expected` revisions a `SourceStore` compares before it writes (ADR 0100),
+ * and a store's revision is opaque: what `createFileSystemStore` mints happens
+ * to be this same sha256, which is the only reason a pin can be handed to it
+ * directly. The visual runtime only ever addresses a local filesystem, so that
+ * coincidence is safe today and a protocol version spent on carrying opaque
+ * revisions instead would buy nothing. It is held by a test rather than by a
+ * comment: `visual-protocol.test.ts` asserts the two agree, so a change to
+ * either side fails rather than silently making every commit's precondition
+ * unsatisfiable. That failure is when the protocol bump earns its cost.
  */
 export const digestOf = (source: string): string =>
   createHash('sha256').update(source).digest('hex')

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
+import { createFileSystemStore } from '../src/source-store.js'
 import {
+  digestOf,
   parseVisualBrowserInput,
   parseVisualDiagnosticResult,
   parseVisualEvent,
@@ -947,5 +952,32 @@ describe('fromWireFileUri', () => {
     // is refused rather than normalized: normalizing is what made two
     // distinct paths indistinguishable in the first place.
     expect(fromWireFileUri(uri)).toEqual({ ok: false, reason: 'noncanonical' })
+  })
+
+})
+
+describe('digestOf', () => {
+
+  /**
+   * A commit's pins become the `expected` revisions a store compares before it
+   * writes (ADR 0100). A store's revision is opaque, and this one is only
+   * usable as a pin because `createFileSystemStore` happens to mint the same
+   * sha256 `digestOf` does. That is a coincidence the runtime depends on, so
+   * it is asserted rather than assumed: if either side changes, this fails
+   * here instead of making every commit's precondition unsatisfiable in a way
+   * nothing would explain.
+   */
+  it('mints the revision the filesystem store does, which pins depend on', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-digest-pin-'))
+    try {
+      const source = 'format: yarramate/v1\nid: main\nconcepts: []\n'
+      writeFileSync(join(parent, 'main.yaml'), source, 'utf8')
+
+      expect(createFileSystemStore(parent).read('main.yaml')?.revision).toBe(
+        digestOf(source),
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

Closes the two threads left open by #231, both the way they were decided:
guard the coupling rather than bump the protocol, and record why the resolution
split is deferred rather than pending.

## The coupling

A commit's pins become the `expected` revisions a store compares before it
writes (ADR 0100). A store's revision is **opaque by design**. A pin can be
handed to one directly only because `createFileSystemStore` happens to mint the
same sha256 `digestOf` does:

```
digestOf    9222d2250d8844d3...
store rev   9222d2250d8844d3...
```

Nothing said so, and nothing would have noticed either side changing. Every
commit's precondition would simply have become unsatisfiable, with no diagnostic
pointing anywhere near the cause.

It is now asserted, and the assertion is not vacuous — changing `digestOf` to
sha512 fails it:

```
FAIL test/visual-protocol.test.ts > digestOf
  > mints the revision the filesystem store does, which pins depend on
AssertionError: expected '7174cd5243335e98…' to be '2bcde0b59c3b8f81…'
```

**No protocol version is spent.** The visual runtime only ever addresses a local
filesystem, so carrying opaque revisions over the wire would buy nothing today.
That failing test is when the v4→v5 bump earns its cost, and the comment beside
`digestOf` says so.

## Why the resolution split is deferred, not pending

ADR 0100 says manifest resolution splits, with the store listing and Core
matching. It still globs, and that reads as unfinished work. It is not, and the
reason only became clear once the rest had landed:

**`applyOperations` takes an already-resolved `ResolvedWorkspace`, and that type
is exported.** An embedder over D1 builds its own and never asks Core to match a
pattern against anything. The split buys uniformity, not reach.

What it would cost is a pattern dialect decided and documented, and one has
never been named:

- `docs/WORKSPACES.md` says what resolution *does* — rejects `..`, expands to
  regular files, reports what matched nothing — but never what a pattern may
  contain.
- The schema constrains a pattern only to a non-empty string.
- Every manifest reachable from this repository uses nothing but `*`. No `**`,
  `?`, `[` or `{` anywhere.

So the dialect in force is whatever `node:fs` `globSync` happens to support,
undocumented and untested past one wildcard. Naming it is a compatibility
decision that deserves its own change. ADR 0100 now records that rather than
leaving a reader to wonder.

## Validation

`pnpm verify` exits 0. `test/visual-protocol.test.ts`: 85 passed, 1 skipped
(pre-existing platform gate). The new test was confirmed to fail when the
coupling is broken.

## Related issue

None. Follows #231, ADR 0100.

## Contract impact

None. A test, a comment, and an ADR note. No protocol version, schema,
diagnostic or CLI change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible. — a test and an ADR note change nothing a user sees.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)