### PR TITLE
feat(visual): a view says what nesting means in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,29 @@
   it with nothing for the reader to do. `--check` reports the project stale and
   safe to regenerate, which is the truth it always had (#225).
 
+- A view says what nesting means in it. `presentation.nesting` names the
+  relationship kinds that draw as containment, in precedence order (ADR 0101),
+  defaulting to `[composition]` - the behaviour that shipped, now stated rather
+  than assumed - with `[]` drawing everything as a line. `assignment` may now
+  nest, so a component's functions and processes draw inside it the way
+  ArchiMate renders them, instead of scattering as lines the reader
+  reconstructs edge by edge.
+  Nesting was widened this way rather than outright because a nested box
+  carries no label saying how it got there: with two kinds nesting, an inner
+  box means either "is a part of" or "is behaviour performed by" and nothing on
+  screen separates them. Declaring the vocabulary makes that a choice rather
+  than an accident, and a view naming one kind has no ambiguity to resolve. A
+  child claimed by two kinds nests under the earlier-listed one; two claims at
+  the same precedence naming different parents stay undecidable and draw
+  unnested with every claim still a line, as does a nesting cycle, which a
+  mixed vocabulary can form where composition alone could not. Assignment never
+  nests a service whatever the view says, because a service is the promise the
+  layer above consumes and burying it inside its provider inverts what it is
+  for; that declines to draw a containment rather than to accept the model,
+  since the ArchiMate 3.2 table permits the relationship. Unlike the
+  presentation toggles, a view that declares no nesting is restored to the
+  default rather than inheriting the previous view's (#233).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -102,6 +102,45 @@ recorded what those two backends mapped onto and why the obvious ELK choices
 were rejected; it is superseded here. A future layout mechanism is expected,
 and `presentation.layout` stays an enum so it has somewhere to land.
 
+### Nesting
+
+`presentation.nesting` names the relationship kinds that draw as containment in
+this view, in precedence order
+([ADR 0101](adr/0101-a-view-says-what-nesting-means-in-it.md)):
+
+```yaml
+presentation:
+  nesting: [composition, assignment]
+```
+
+It defaults to `[composition]`, which is the behaviour that shipped before a
+view could say. `[]` draws every relationship as a line.
+
+A nested box carries no label saying how it got there, so a view that nests two
+kinds has accepted that an inner box means either "is a part of" or "is
+behaviour performed by". Declaring the vocabulary is what makes that a choice
+rather than an accident: a view listing one kind has no ambiguity to resolve.
+
+A child claimed by two kinds nests under the earlier-listed one. Two claims at
+the same precedence naming different parents stay undecidable: the child draws
+at top level and every claim stays drawn as a line, so the conflict stays
+visible rather than being silently resolved. The same is true of a nesting
+cycle, which a mixed vocabulary can form where composition alone could not.
+
+Assignment never nests a service, whatever the view says. A service is the
+promise the layer above consumes, so burying it inside the thing that exposes
+it inverts what it is for. This declines to *draw* a containment, not to accept
+the model: `applicationComponent -assignment-> applicationService` is permitted
+by the ArchiMate 3.2 table and stays drawn as a line. Composition is
+unaffected, because a composed service is a part.
+
+Unlike the toggles below, `nesting` is restored to the default by a view that
+does not declare it, rather than carried across. The toggles are things a
+reviewer changes on screen, so their choice should survive a view switch;
+nesting has no control and is a property of the view, and inheriting one view's
+containment meaning into a view that never asked for it is the ambiguity this
+is meant to prevent.
+
 ### Presentation toggles
 
 Four presentation state fields ride alongside layout in `presentation`, saved via `view.save` and persisted in the projection document:

--- a/docs/adr/0101-a-view-says-what-nesting-means-in-it.md
+++ b/docs/adr/0101-a-view-says-what-nesting-means-in-it.md
@@ -1,0 +1,108 @@
+# A view says what nesting means in it
+
+Status: accepted
+
+Drawing one box inside another is the most compact thing a diagram can say, and
+until now the canvas said it in exactly one circumstance: a `composition` edge
+consumed into cytoscape's parent field, decided by
+`resolveCompositionParents` and written down nowhere. Other relationships that
+ArchiMate conventionally nests, `assignment` above all, drew as lines.
+
+This ADR makes the nestable set a property of the view rather than of the
+renderer, and settles what a nested box is allowed to mean.
+
+## Why
+
+**Assignment is worth nesting.** A component's functions and processes happen
+*inside* it, and drawing them inside it is how ArchiMate itself renders that.
+Left as lines they scatter across the canvas, and the reader reconstructs
+containment edge by edge.
+
+**But nesting two relationships in one view makes containment ambiguous.** A
+nested box carries no label saying how it got there. If both `composition` and
+`assignment` nest, an inner box means either "is a part of" or "is behaviour
+performed by", and nothing on screen distinguishes them. This is the real flaw
+in nested notation, and it is the reason the set could not simply be widened.
+
+**The renderer is the wrong place to decide.** Which relationships should nest
+depends on what the view is for: a structural decomposition wants
+`composition`, a behavioural allocation wants `assignment`, and a view that
+wants both is accepting the ambiguity knowingly. That is an authoring
+judgement, and every other such judgement in a projection already lives under
+`presentation`.
+
+## Decided
+
+**`presentation.nesting` names the relationship kinds that nest in this view,
+in precedence order.**
+
+```yaml
+presentation:
+  nesting: [composition, assignment]
+```
+
+It defaults to `[composition]`, which is exactly today's behaviour, now stated
+rather than assumed. `[]` turns nesting off and draws every relationship as a
+line.
+
+**Ambiguity is removed by declaration, not by decoration.** A view that lists
+one kind has no ambiguity to resolve: every nested box in it means that one
+thing, and the view can say so once. A view that lists two has accepted the
+trade knowingly, which is a different thing from stumbling into it. Marking
+each nested child with the relationship that placed it is deliberately not
+attempted here: it competes for the corners that already carry the kind glyph
+and the lifecycle badge, and no view yet exists where the ambiguity has been
+measured rather than imagined.
+
+**Precedence decides a child claimed more than once.** A child claimed by both
+a `composition` and an `assignment` nests under the composition, because
+`composition` is listed first. Two claims at the *same* rank naming *different*
+parents remain undecidable and fall through to the existing unnest-and-warn
+path unchanged: the child draws at top level and every claim stays drawn as a
+line, so the conflict stays visible rather than being silently resolved.
+
+**Assignment never nests a service.** A service is the promise a layer above
+consumes; burying it inside the thing that exposes it inverts what it is for.
+This is a *drawing* rule, not a validity one, and the distinction matters:
+`applicationComponent -assignment-> applicationService` is permitted by the
+ArchiMate 3.2 table this repository validates against (ADR 0097), so the model
+is correct and only the rendering declines to collapse it. Composition is
+unaffected: a composed service is a part, and parts nest.
+
+## Consequences
+
+**Nothing changes for a view that says nothing.** The default is the behaviour
+that shipped, so every existing projection renders as it did.
+
+**`YM501` still does not cover this.** It rejects one `(from, to)` pair
+declaring both composition and aggregation. It does not reject two different
+relationships of the same kind naming one `to`, nor a nesting chain that loops,
+and cytoscape's single-parent field can represent neither. Both remain
+modelling anomalies this layer surfaces by unnesting rather than resolving.
+
+**The cycle walk now spans the whole nestable set.** A composition into an
+assignment into a composition is a cycle that could not previously be
+constructed. The existing walk already handles it, because it follows
+`parentOf` rather than any one relationship kind.
+
+## Rejected
+
+**Aggregation in the nestable set.** ArchiMate nests it, and a `grouping`
+aggregating its members is the obvious candidate. It is left out because it
+answers a question nobody asked here, and adding a kind to the set later is
+purely additive: a view opts in by naming it. The parked question was
+assignment, and this ADR answers that one.
+
+**Marking each nested child with the relationship that placed it.** The honest
+fix for a view that nests two kinds, and deferred rather than rejected. The
+corners of a node already carry the kind glyph and the lifecycle badge, so this
+needs notation invented rather than borrowed, and inventing it before a view
+exists that needs it would be guessing at the shape of a problem.
+
+**Inferring the nestable set from the kinds present.** A renderer that decides
+for itself makes the same view draw differently as the model grows, which is
+exactly the property `presentation` exists to prevent.
+
+**Nesting by relationship kind globally rather than per view.** One setting for
+the whole workspace makes the structural view and the allocation view fight
+over one answer, and neither is wrong.

--- a/schema/yarramate-projection.schema.json
+++ b/schema/yarramate-projection.schema.json
@@ -132,6 +132,13 @@
         "direction": {
           "enum": ["top-down", "left-right"]
         },
+        "nesting": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["composition", "assignment"]
+          }
+        },
         "showLifecycle": {
           "type": "boolean"
         },

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -52,12 +52,28 @@ export interface ProjectionDefinition {
     readonly description?: string
     readonly layout?: 'layered'
     readonly direction?: 'top-down' | 'left-right'
+    /**
+     * The relationship kinds that draw as nesting in this view, in precedence
+     * order (ADR 0101). Absent means `['composition']`, which is the behaviour
+     * that shipped before a view could say; `[]` draws everything as a line.
+     */
+    readonly nesting?: readonly NestingKind[]
     readonly showLifecycle?: boolean
     readonly showEvidence?: boolean
     readonly showOwnership?: boolean
     readonly notation?: 'native' | 'archimate'
   }
 }
+
+/**
+ * A relationship kind a view may draw as nesting. Closed here and in
+ * `yarramate-projection.schema.json`; widening it is additive, because a view
+ * opts in by naming a kind (ADR 0101).
+ */
+export type NestingKind = 'composition' | 'assignment'
+
+/** What a view nests when it does not say: the behaviour that shipped. */
+export const DEFAULT_NESTING: readonly NestingKind[] = ['composition']
 
 export type ProjectionQuery = ProjectionDefinition['query']
 
@@ -117,6 +133,7 @@ export function canonicalProjection(
             ...(presentation.description === undefined ? {} : { description: presentation.description }),
             ...(presentation.layout === undefined ? {} : { layout: presentation.layout }),
             ...(presentation.direction === undefined ? {} : { direction: presentation.direction }),
+            ...(presentation.nesting === undefined ? {} : { nesting: presentation.nesting }),
             ...(presentation.showLifecycle === undefined ? {} : { showLifecycle: presentation.showLifecycle }),
             ...(presentation.showEvidence === undefined ? {} : { showEvidence: presentation.showEvidence }),
             ...(presentation.showOwnership === undefined ? {} : { showOwnership: presentation.showOwnership }),
@@ -406,6 +423,9 @@ export function evaluateProjection(
             ...(projection.presentation.direction === undefined
               ? {}
               : { direction: projection.presentation.direction }),
+            ...(projection.presentation.nesting === undefined
+              ? {}
+              : { nesting: projection.presentation.nesting }),
             ...(projection.presentation.showLifecycle === undefined
               ? {}
               : { showLifecycle: projection.presentation.showLifecycle }),

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -18,7 +18,7 @@ import {
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import type { ProjectionQuery } from "../projection.js";
+import type { NestingKind, ProjectionQuery } from "../projection.js";
 import type { VisualRenderedModel } from "../adapters/visual/wire.js";
 import type { YarramateOperation } from "../operations.js";
 import type {
@@ -330,6 +330,7 @@ const DiagramWorkspace = ({
   waiting,
   layout,
   direction,
+  nesting,
   notation,
   showLifecycle,
   showEvidence,
@@ -343,6 +344,7 @@ const DiagramWorkspace = ({
   readonly waiting: string | null;
   readonly layout: "layered";
   readonly direction: "top-down" | "left-right";
+  readonly nesting: readonly NestingKind[];
   readonly notation: "native" | "archimate";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
@@ -403,6 +405,7 @@ const DiagramWorkspace = ({
             matchedIds={state.activeFilter?.matchedIds ?? null}
             quickFilterText={state.quickFilterText}
             direction={direction}
+            nesting={nesting}
             notation={notation}
             showLifecycle={showLifecycle}
             showEvidence={showEvidence}
@@ -966,6 +969,7 @@ export const App = () => {
           waiting={waiting}
           layout={workspace.layout}
           direction={workspace.direction}
+          nesting={workspace.nesting}
           notation={workspace.notation}
           showLifecycle={workspace.showLifecycle}
           showEvidence={workspace.showEvidence}

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -8,6 +8,7 @@ import type {
   CanvasNode,
   CanvasEdge,
 } from '../graph-projection.js'
+import { DEFAULT_NESTING, type NestingKind } from '../projection.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -487,6 +488,27 @@ export function buildStylesheet(
 // rendered edge like every other relationship kind. Composition edges that
 // are consumed into nesting are never also drawn as a line.
 const COMPOSITION_RELATIONSHIP_KIND = 'yarramate/core@0.1#composition'
+const ASSIGNMENT_RELATIONSHIP_KIND = 'yarramate/core@0.1#assignment'
+
+// A view names which relationships nest, in precedence order (ADR 0101). The
+// short names a projection is authored in resolve to the kind identities the
+// graph carries here, in one place, so the schema's vocabulary and the
+// canvas's cannot drift.
+const NESTING_KIND_IDS: Readonly<Record<NestingKind, string>> = {
+  composition: COMPOSITION_RELATIONSHIP_KIND,
+  assignment: ASSIGNMENT_RELATIONSHIP_KIND,
+}
+
+/**
+ * Assignment nests internal behaviour, never a service. A service is the
+ * promise the layer above consumes, so burying it inside the thing that
+ * exposes it inverts what it is for. This declines to *draw* a nesting, not to
+ * accept the model: `applicationComponent -assignment-> applicationService` is
+ * permitted by the ArchiMate 3.2 table (ADR 0097) and stays drawn as a line.
+ * Composition is unaffected, because a composed service is a part.
+ */
+const nestsAsAssignment = (edge: CanvasEdge, kindOf: (id: string) => string) =>
+  !kindOf(edge.to).endsWith('Service')
 
 // The compiler's YM501 rule only rejects the same (from, to) pair declaring
 // both composition and aggregation - it does not reject two different
@@ -499,14 +521,28 @@ const COMPOSITION_RELATIONSHIP_KIND = 'yarramate/core@0.1#composition'
 // composition edge naming them stays drawn as a regular edge, so the
 // conflicting claims stay visible on the canvas instead of one silently
 // winning.
-function resolveCompositionParents(edges: readonly CanvasEdge[]): {
+export function resolveNestingParents(
+  edges: readonly CanvasEdge[],
+  nesting: readonly NestingKind[],
+  kindOf: (id: string) => string
+): {
   readonly parentOf: ReadonlyMap<string, string>
   readonly consumedEdgeIds: ReadonlySet<string>
 } {
-  const compositionEdges = edges.filter((edge) => edge.kind === COMPOSITION_RELATIONSHIP_KIND)
+  // Precedence is the order the view listed: a child claimed by a composition
+  // and by an assignment nests under the composition.
+  const rankOf = new Map(
+    nesting.map((kind, rank) => [NESTING_KIND_IDS[kind], rank])
+  )
+  const nestingEdges = edges.filter(
+    (edge) =>
+      rankOf.has(edge.kind) &&
+      (edge.kind !== ASSIGNMENT_RELATIONSHIP_KIND ||
+        nestsAsAssignment(edge, kindOf))
+  )
 
   const claimsByChild = new Map<string, CanvasEdge[]>()
-  for (const edge of compositionEdges) {
+  for (const edge of nestingEdges) {
     const claims = claimsByChild.get(edge.to)
     if (claims === undefined) {
       claimsByChild.set(edge.to, [edge])
@@ -517,11 +553,17 @@ function resolveCompositionParents(edges: readonly CanvasEdge[]): {
 
   const parentOf = new Map<string, string>()
   for (const [child, claims] of claimsByChild) {
-    if (claims.length === 1) {
-      parentOf.set(child, claims[0]!.from)
+    // Only claims at the best rank compete. Two of them naming different
+    // parents stays undecidable and falls through to unnest-and-warn, which is
+    // the behaviour composition alone already had.
+    const best = Math.min(...claims.map((claim) => rankOf.get(claim.kind)!))
+    const winners = claims.filter((claim) => rankOf.get(claim.kind) === best)
+    const parents = new Set(winners.map((claim) => claim.from))
+    if (parents.size === 1) {
+      parentOf.set(child, winners[0]!.from)
     } else {
       console.warn(
-        `Composition conflict: "${child}" is claimed as a part by ${claims.length} different wholes (${claims.map((claim) => claim.from).join(', ')}) - rendering it unnested; every claim stays drawn as a regular edge.`
+        `Nesting conflict: "${child}" is claimed by ${parents.size} different parents at the same precedence (${winners.map((claim) => `${claim.kindLabel} from ${claim.from}`).join(', ')}) - rendering it unnested; every claim stays drawn as a regular edge.`
       )
     }
   }
@@ -547,12 +589,12 @@ function resolveCompositionParents(edges: readonly CanvasEdge[]): {
     }
   }
   if (cycleMembers.size > 0) {
-    console.warn(`Composition cycle detected among: ${[...cycleMembers].join(', ')} - rendering them unnested.`)
+    console.warn(`Nesting cycle detected among: ${[...cycleMembers].join(', ')} - rendering them unnested.`)
     for (const id of cycleMembers) parentOf.delete(id)
   }
 
   const consumedEdgeIds = new Set<string>()
-  for (const edge of compositionEdges) {
+  for (const edge of nestingEdges) {
     if (parentOf.get(edge.to) === edge.from) consumedEdgeIds.add(edge.id)
   }
 
@@ -560,8 +602,18 @@ function resolveCompositionParents(edges: readonly CanvasEdge[]): {
 }
 
 // Convert CanvasGraph nodes and edges to cytoscape ElementDefinition format
-function graphToElements(graph: CanvasGraph): ElementDefinition[] {
-  const { parentOf, consumedEdgeIds } = resolveCompositionParents(graph.edges)
+function graphToElements(
+  graph: CanvasGraph,
+  nesting: readonly NestingKind[]
+): ElementDefinition[] {
+  // A node's own kind decides whether an assignment may nest it, so the lookup
+  // is built once here rather than searched per edge.
+  const kindById = new Map(graph.nodes.map((node) => [node.id, node.kind]))
+  const { parentOf, consumedEdgeIds } = resolveNestingParents(
+    graph.edges,
+    nesting,
+    (id) => kindById.get(id) ?? ''
+  )
 
   const nodeElements = graph.nodes.map((node): ElementDefinition => {
     const parent = parentOf.get(node.id)
@@ -820,6 +872,8 @@ interface GraphCanvasProps {
   readonly matchedIds: readonly string[] | null
   readonly quickFilterText: string
   readonly direction: 'top-down' | 'left-right'
+  /** What draws as nesting in this view, in precedence order (ADR 0101). */
+  readonly nesting: readonly NestingKind[]
   readonly showLifecycle: boolean
   readonly showEvidence: boolean
   readonly showOwnership: boolean
@@ -846,6 +900,7 @@ export function GraphCanvas({
   matchedIds,
   quickFilterText,
   direction,
+  nesting,
   activeViewId,
   savedPositions,
   onSaveLayout,
@@ -906,7 +961,7 @@ export function GraphCanvas({
 
     const cy = cytoscape({
       container: containerRef.current,
-      elements: graphToElements(graph),
+      elements: graphToElements(graph, nesting),
       // `showLifecycle`/`showEvidence`/`showOwnership` seed the stylesheet the
       // mount builds; the effect below re-applies it to the live instance on
       // every later toggle, without remounting or re-laying-out.
@@ -1016,7 +1071,7 @@ export function GraphCanvas({
     if (isInitialSyncRef.current) {
       isInitialSyncRef.current = false
     } else {
-      const elements = graphToElements(graph)
+      const elements = graphToElements(graph, nesting)
       cyRef.current.elements().remove()
       cyRef.current.add(elements)
     }

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -3,6 +3,7 @@ import type {
   CanvasGraph,
   CanvasNode,
 } from "../graph-projection.js";
+import { DEFAULT_NESTING, type NestingKind } from "../projection.js";
 
 export type ConversationMode = "auto" | "open" | "closed";
 
@@ -104,6 +105,12 @@ export interface VisualWorkspaceState {
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   readonly direction: "top-down" | "left-right";
+  /**
+   * What draws as nesting in the active view, in precedence order (ADR 0101).
+   * A view that says nothing keeps `DEFAULT_NESTING`, which is composition
+   * alone - the behaviour that shipped before a view could say.
+   */
+  readonly nesting: readonly NestingKind[];
   readonly layout: "layered";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
@@ -134,6 +141,10 @@ export type VisualWorkspaceAction =
       readonly direction: "top-down" | "left-right";
     }
   | {
+      readonly type: "nesting.set";
+      readonly nesting: readonly NestingKind[];
+    }
+  | {
       readonly type: "layout.set";
       readonly layout: "layered";
     }
@@ -156,11 +167,19 @@ export type VisualWorkspaceAction =
 // `direction.set`/`layout.set` actions to dispatch, in declaration order,
 // so App.tsx has nothing left to decide - it only has to dispatch what
 // comes back.
+const sameNesting = (
+  left: readonly NestingKind[],
+  right: readonly NestingKind[],
+): boolean =>
+  left.length === right.length &&
+  left.every((kind, index) => kind === right[index]);
+
 export const presentationActionsFor = (
   presentation:
     | {
         readonly layout?: "layered";
         readonly direction?: "top-down" | "left-right";
+        readonly nesting?: readonly NestingKind[];
         readonly notation?: "native" | "archimate";
         readonly showLifecycle?: boolean;
         readonly showEvidence?: boolean;
@@ -176,6 +195,13 @@ export const presentationActionsFor = (
   if (presentation?.direction !== undefined) {
     actions.push({ type: "direction.set", direction: presentation.direction });
   }
+  // A view that omits `nesting` is restored to the default rather than left
+  // holding the previous view's vocabulary: switching views must not carry a
+  // containment meaning across into one that never asked for it.
+  actions.push({
+    type: "nesting.set",
+    nesting: presentation?.nesting ?? DEFAULT_NESTING,
+  });
   if (presentation?.notation !== undefined) {
     actions.push({ type: "notation.set", notation: presentation.notation });
   }
@@ -272,6 +298,7 @@ export const createVisualWorkspaceState = (
   descriptionExpanded: false,
   detailsOpen: false,
   direction: "top-down",
+  nesting: DEFAULT_NESTING,
   layout: "layered",
   showLifecycle: true,
   showEvidence: true,
@@ -356,6 +383,13 @@ export const visualWorkspaceReducer = (
       return { ...state, detailsOpen: !state.detailsOpen };
     case "direction.set":
       return { ...state, direction: action.direction };
+    case "nesting.set":
+      // Restating the same vocabulary is not a change. Every view states one,
+      // so without this a view switch would produce a new state object each
+      // time and every identity-based memo downstream would miss.
+      return sameNesting(state.nesting, action.nesting)
+        ? state
+        : { ...state, nesting: action.nesting };
     case "layout.set":
       return { ...state, layout: action.layout };
     case "notation.set":

--- a/test/graph-canvas-nesting.test.ts
+++ b/test/graph-canvas-nesting.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveNestingParents } from '../src/visual-app/graph-canvas.js'
+import type { CanvasEdge } from '../src/graph-projection.js'
+import type { NestingKind } from '../src/projection.js'
+
+const COMPOSITION = 'yarramate/core@0.1#composition'
+const ASSIGNMENT = 'yarramate/core@0.1#assignment'
+
+const edge = (
+  id: string,
+  kind: string,
+  from: string,
+  to: string,
+): CanvasEdge =>
+  ({
+    id,
+    localId: id,
+    document: 'main.yaml',
+    kind,
+    kindLabel: kind.split('#')[1]!,
+    coreKindLabel: kind.split('#')[1]!,
+    from,
+    to,
+    name: null,
+    description: null,
+    mode: null,
+    content: null,
+    status: null,
+    references: [],
+  }) as unknown as CanvasEdge
+
+// The kinds a child may be, which is what decides whether an assignment is
+// allowed to swallow it.
+const kinds: Record<string, string> = {
+  component: 'applicationComponent',
+  otherComponent: 'applicationComponent',
+  behaviour: 'applicationFunction',
+  service: 'applicationService',
+  part: 'applicationComponent',
+}
+const kindOf = (id: string) => kinds[id] ?? 'applicationComponent'
+
+const resolve = (edges: readonly CanvasEdge[], nesting: readonly NestingKind[]) =>
+  resolveNestingParents(edges, nesting, kindOf)
+
+describe('nesting is what the view says it is (ADR 0101)', () => {
+  it('nests a composition and leaves an assignment as a line by default', () => {
+    const edges = [
+      edge('e1', COMPOSITION, 'component', 'part'),
+      edge('e2', ASSIGNMENT, 'component', 'behaviour'),
+    ]
+
+    const { parentOf, consumedEdgeIds } = resolve(edges, ['composition'])
+
+    expect(parentOf.get('part')).toBe('component')
+    expect(parentOf.has('behaviour')).toBe(false)
+    expect([...consumedEdgeIds]).toEqual(['e1'])
+  })
+
+  it('nests an assignment when the view asks for it', () => {
+    const edges = [edge('e1', ASSIGNMENT, 'component', 'behaviour')]
+
+    const { parentOf, consumedEdgeIds } = resolve(edges, [
+      'composition',
+      'assignment',
+    ])
+
+    expect(parentOf.get('behaviour')).toBe('component')
+    expect([...consumedEdgeIds]).toEqual(['e1'])
+  })
+
+  it('never nests a service by assignment, even when asked', () => {
+    // Permitted by the ArchiMate 3.2 table, so the model is correct; this
+    // declines to draw it as containment, not to accept it.
+    const edges = [edge('e1', ASSIGNMENT, 'component', 'service')]
+
+    const { parentOf, consumedEdgeIds } = resolve(edges, [
+      'composition',
+      'assignment',
+    ])
+
+    expect(parentOf.has('service')).toBe(false)
+    expect(consumedEdgeIds.size).toBe(0)
+  })
+
+  it('still nests a service that is composed, because a part is a part', () => {
+    const edges = [edge('e1', COMPOSITION, 'component', 'service')]
+
+    const { parentOf } = resolve(edges, ['composition', 'assignment'])
+
+    expect(parentOf.get('service')).toBe('component')
+  })
+
+  it('gives the earlier-listed kind precedence over the later one', () => {
+    const edges = [
+      edge('e1', ASSIGNMENT, 'otherComponent', 'behaviour'),
+      edge('e2', COMPOSITION, 'component', 'behaviour'),
+    ]
+
+    const { parentOf, consumedEdgeIds } = resolve(edges, [
+      'composition',
+      'assignment',
+    ])
+
+    expect(parentOf.get('behaviour')).toBe('component')
+    // The losing claim is not consumed, so it stays drawn as a line.
+    expect([...consumedEdgeIds]).toEqual(['e2'])
+  })
+
+  it('leaves two claims at the same rank undecided, and says so', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const edges = [
+        edge('e1', COMPOSITION, 'component', 'part'),
+        edge('e2', COMPOSITION, 'otherComponent', 'part'),
+      ]
+
+      const { parentOf, consumedEdgeIds } = resolve(edges, ['composition'])
+
+      expect(parentOf.has('part')).toBe(false)
+      expect(consumedEdgeIds.size).toBe(0)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Nesting conflict'),
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('nests nothing when the view asks for nothing', () => {
+    const edges = [
+      edge('e1', COMPOSITION, 'component', 'part'),
+      edge('e2', ASSIGNMENT, 'component', 'behaviour'),
+    ]
+
+    const { parentOf, consumedEdgeIds } = resolve(edges, [])
+
+    expect(parentOf.size).toBe(0)
+    expect(consumedEdgeIds.size).toBe(0)
+  })
+
+  it('unnests a cycle that only a mixed vocabulary could form', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      // component composes behaviour, behaviour is assigned back to component:
+      // impossible while only one kind nested, and a cycle cytoscape cannot
+      // render.
+      const edges = [
+        edge('e1', COMPOSITION, 'component', 'behaviour'),
+        edge('e2', ASSIGNMENT, 'behaviour', 'component'),
+      ]
+
+      const { parentOf } = resolve(edges, ['composition', 'assignment'])
+
+      expect(parentOf.size).toBe(0)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Nesting cycle'),
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -321,9 +321,18 @@ describe("visualWorkspaceReducer layout", () => {
     expect(next).toBe(workspaceState);
   });
 
+  // `nesting` is the one field a view always states, declared or not. The
+  // others are things a reviewer can toggle on screen, so leaving one unset
+  // rightly keeps their choice across a view switch. Nesting has no control:
+  // it is a property of the view, and carrying one view's containment meaning
+  // into a view that never asked for it is exactly the ambiguity ADR 0101
+  // exists to prevent, so an undeclaring view is restored to the default.
   it("adopts only the field a view actually declares", () => {
     const actions = presentationActionsFor({ layout: "layered" });
-    expect(actions).toEqual([{ type: "layout.set", layout: "layered" }]);
+    expect(actions).toEqual([
+      { type: "layout.set", layout: "layered" },
+      { type: "nesting.set", nesting: ["composition"] },
+    ]);
   });
 });
 
@@ -380,8 +389,55 @@ describe("visualWorkspaceReducer presentation", () => {
   it("adopts only the presentation flag a view actually declares", () => {
     const actions = presentationActionsFor({ showOwnership: true });
     expect(actions).toEqual([
+      { type: "nesting.set", nesting: ["composition"] },
       { type: "presentation.toggled", flag: "showOwnership", value: true },
     ]);
+  });
+});
+
+describe("visualWorkspaceReducer nesting", () => {
+  const workspaceState = createVisualWorkspaceState(1280);
+
+  it("starts at composition alone, the behaviour that shipped", () => {
+    expect(workspaceState.nesting).toEqual(["composition"]);
+  });
+
+  it("adopts the vocabulary a view declares", () => {
+    const actions = presentationActionsFor({
+      nesting: ["composition", "assignment"],
+    });
+    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
+    expect(next.nesting).toEqual(["composition", "assignment"]);
+  });
+
+  it("restores the default when the next view declares none", () => {
+    // The point of ADR 0101: a view that never asked for assignment nesting
+    // must not inherit it from the view before, or its nested boxes mean
+    // something nothing on screen explains.
+    const nested = presentationActionsFor({
+      nesting: ["composition", "assignment"],
+    }).reduce(visualWorkspaceReducer, workspaceState);
+    expect(nested.nesting).toEqual(["composition", "assignment"]);
+
+    const plain = presentationActionsFor({}).reduce(
+      visualWorkspaceReducer,
+      nested,
+    );
+    expect(plain.nesting).toEqual(["composition"]);
+  });
+
+  it("honours a view that turns nesting off entirely", () => {
+    const actions = presentationActionsFor({ nesting: [] });
+    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
+    expect(next.nesting).toEqual([]);
+  });
+
+  it("treats restating the same vocabulary as no change at all", () => {
+    const next = visualWorkspaceReducer(workspaceState, {
+      type: "nesting.set",
+      nesting: ["composition"],
+    });
+    expect(next).toBe(workspaceState);
   });
 });
 
@@ -414,7 +470,10 @@ describe("visualWorkspaceReducer notation", () => {
 
   it("adopts only the notation field a view actually declares", () => {
     const actions = presentationActionsFor({ notation: "archimate" });
-    expect(actions).toEqual([{ type: "notation.set", notation: "archimate" }]);
+    expect(actions).toEqual([
+      { type: "nesting.set", nesting: ["composition"] },
+      { type: "notation.set", notation: "archimate" },
+    ]);
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "test/filter-panel.test.ts",
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",
+    "test/graph-canvas-nesting.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/badges.test.ts",

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -28,6 +28,7 @@
     "test/filter-panel.test.ts",
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",
+    "test/graph-canvas-nesting.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/archimate-notation.test.ts"


### PR DESCRIPTION
## Summary

Answers the parked assignment-nesting question with
[ADR 0101](docs/adr/0101-a-view-says-what-nesting-means-in-it.md).

Drawing one box inside another is the most compact thing a diagram can say, and
until now the canvas said it in exactly one circumstance: a `composition` edge
consumed into cytoscape's parent field, decided by the renderer and **written
down nowhere**. Assignment, which ArchiMate conventionally nests, drew as lines,
so a component's functions and processes scattered across the canvas.

```yaml
presentation:
  nesting: [composition, assignment]
```

Defaults to `[composition]` — the behaviour that shipped, now stated rather than
assumed. `[]` draws everything as a line.

## Why this needed deciding rather than just widening

**A nested box carries no label saying how it got there.** With two kinds
nesting, an inner box means either "is a part of" or "is behaviour performed by",
and nothing on screen separates them. That is the real flaw in nested notation
and the reason the set could not simply be enlarged.

Declaring the vocabulary per view makes that a knowing trade rather than an
accident, and **a view naming one kind has no ambiguity to resolve at all**.

Marking each nested child with the relationship that placed it is the honest fix
for a view that nests two, and is *deferred rather than rejected*: the corners
already carry the kind glyph and the lifecycle badge, so it needs notation
invented rather than borrowed, and no view yet exists where the ambiguity has
been measured rather than imagined.

## Assignment never nests a service

A service is the promise the layer above consumes, so burying it inside the thing
that exposes it inverts what it is for.

This declines to **draw** a containment, not to accept the model.
`applicationComponent -assignment-> applicationService` **is permitted** by the
ArchiMate 3.2 table this repository validates against (ADR 0097) — I checked the
generated table rather than assuming — so the model is correct and only the
rendering declines to collapse it. Composition is unaffected: a composed service
is a part, and parts nest.

## One deviation, deliberate

`nesting` is the one presentation field a view **always** states. The others
(`direction`, `notation`, the badge toggles) are things a reviewer changes on
screen, so leaving one unset rightly keeps their choice across a view switch.
Nesting has no control and is a property of the view — inheriting one view's
containment meaning into a view that never asked for it is exactly the ambiguity
this exists to prevent.

Three existing tests asserted the "emit only what is declared" contract and now
record the exception with its reason. Restating the same vocabulary returns the
same state object, so identity-based memos downstream still hold.

## Validation

`pnpm verify` exits 0: **75 files, 1259 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

Thirteen new tests. Eight on the resolver: default nests composition and leaves
assignment as a line; assignment nests when asked; a service is never nested by
assignment; a *composed* service still nests; precedence picks the
earlier-listed kind and leaves the loser drawn; same-rank conflict unnests and
warns; an empty vocabulary nests nothing; and a cycle only a mixed vocabulary
could form is unnested. Five on the view state, including the reset-on-switch
behaviour above.

## Related issue

None. Wave 4, and the parked nesting decision the ledger carried.

## Contract impact

Additive. New optional `presentation.nesting` in
`yarramate-projection.schema.json`, new `NestingKind` and `DEFAULT_NESTING`
exports. No existing projection renders differently, because the default is the
behaviour that shipped. No diagnostic, CLI or protocol change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — ADR 0101, in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)