### PR TITLE
fix: YM302 says what became of a reference written the pre-1.0 way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,16 @@
   compiler would reject, and cannot hide a legal one either. `association` is
   always among the offered kinds, so no pair is a dead end (#234).
 
+- `YM302` says what became of a reference written the way ids read before 1.0.
+  Flattening subject ids is the change most likely to produce an unresolved
+  reference, and `<document>#<local>` is too far from `<local>` for an
+  edit-distance suggestion to reach, so the one migration everybody performs
+  got the one message that said nothing beyond the address it could not
+  resolve. It now names the cause and the id that exists. A reference whose
+  local part is also unknown gets no such hint, because a false one is worse
+  than none. The diagnostic also suggests a near miss now, which it never did
+  before: a plain typo was as silent as a migration (#235).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1727,7 +1727,29 @@ function compileWorkspaceResolved(
           diagnostics.push({
             severity: 'error',
             code: 'YM302',
-            message: `Unresolved concept reference "${reference}"`,
+            message: `Unresolved concept reference "${reference}"${(() => {
+              // A reference written the way ids read before 1.0 flattened them
+              // (ADR 0099) is not a typo, and the edit distance from
+              // `<document>#<local>` to `<local>` is usually past the
+              // suggestion threshold, so it would otherwise get no hint at all
+              // on the one change most likely to produce it.
+              const hash = reference.lastIndexOf('#')
+              if (hash !== -1) {
+                const local = reference.slice(hash + 1)
+                if (
+                  conceptByQualifiedId.has(qualifyReference(value.id, local))
+                ) {
+                  return `; a subject id carries no document prefix since 1.0, and "${local}" exists`
+                }
+              }
+              const suggestion = closestCandidate(
+                reference,
+                [...conceptByQualifiedId.keys()],
+              )
+              return suggestion === undefined
+                ? ''
+                : `; did you mean "${suggestion}"?`
+            })()}`,
             path: input.path,
             pointer,
             line: source.line,

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -819,6 +819,87 @@ relationships:
     })
   })
 
+  it('tells a reference written the pre-1.0 way what became of it', () => {
+    // The change most likely to produce an unresolved reference is 1.0
+    // flattening ids (ADR 0099), and `<document>#<local>` is too far from
+    // `<local>` for the edit-distance suggestion to reach. Without this the
+    // one migration everybody performs gets the one message that says nothing.
+    const source = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: alpha
+    kind: applicationComponent
+    name: Alpha
+  - id: beta
+    kind: applicationComponent
+    name: Beta
+relationships:
+  - id: edge
+    kind: serving
+    from: alpha
+    to: main#beta
+`
+    const result = compileWorkspace([{ path: 'main.yaml', source }])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      'Unresolved concept reference "main#beta"; a subject id carries no document prefix since 1.0, and "beta" exists',
+    ])
+  })
+
+  it('does not blame the prefix when the local part is unknown too', () => {
+    // A false hint is worse than none: this reference is wrong in a way
+    // flattening does not explain, so it gets the ordinary treatment.
+    const source = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: alpha
+    kind: applicationComponent
+    name: Alpha
+relationships:
+  - id: edge
+    kind: serving
+    from: alpha
+    to: main#nowhere
+`
+    const result = compileWorkspace([{ path: 'main.yaml', source }])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      'Unresolved concept reference "main#nowhere"',
+    ])
+  })
+
+  it('suggests a near miss, which this diagnostic never did before', () => {
+    const source = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: alpha
+    kind: applicationComponent
+    name: Alpha
+  - id: beta
+    kind: applicationComponent
+    name: Beta
+relationships:
+  - id: edge
+    kind: serving
+    from: alpha
+    to: bet
+`
+    const result = compileWorkspace([{ path: 'main.yaml', source }])
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics.map((d) => d.message)).toEqual([
+      'Unresolved concept reference "bet"; did you mean "beta"?',
+    ])
+  })
+
   it('reports a concept kind absent from the selected profile', () => {
     const result = compileWorkspace([
       {


### PR DESCRIPTION
## Summary

Found while surveying reference handling for the connection tool.

Flattening subject ids (ADR 0099) is **the change most likely to produce an
unresolved reference**, and `<document>#<local>` sits well past the
edit-distance threshold from `<local>`. So the one migration everybody performs
got the one message that said nothing beyond the address it could not resolve:

```
Unresolved concept reference "main#beta"
```

Now:

```
Unresolved concept reference "main#beta"; a subject id carries no document
prefix since 1.0, and "beta" exists
```

## The hint is withheld when it would be false

```
"main#beta"    -> ...no document prefix since 1.0, and "beta" exists
"other#beta"   -> ...no document prefix since 1.0, and "beta" exists
"main#missing" -> Unresolved concept reference "main#missing"     <- no hint
"bet"          -> ...did you mean "beta"?
"gamma"        -> Unresolved concept reference "gamma"
```

`main#missing` is wrong in a way flattening does not explain, so it gets the
ordinary treatment. A reference told the wrong reason is worse off than one
told nothing.

## YM302 had no suggestion at all

Worth calling out separately: this diagnostic never offered a near miss, while
the neighbouring `YM402` has done so all along. **A plain typo was exactly as
silent as a migration.** It now uses the same `closestCandidate` helper and the
same `; did you mean "X"?` phrasing.

## Why the explanation belongs at resolution

The document schema still admits the qualified shape — its `reference` pattern
is `^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:#...)?$` — so such a reference passes
validation and fails at resolution. That is where the reader meets it, so that
is where the explanation has to live.

## Validation

`pnpm verify` exits 0. Three new tests: the flattening hint, the withheld hint
when the local part is also unknown, and the near-miss suggestion. The two
existing YM302 tests pass unchanged, which confirms the new suggestion does not
fire on a reference that genuinely has no near neighbour.

## Related issue

None. Wave 4 survey work.

## Contract impact

A diagnostic message changes. `YM302`'s code, severity, path, pointer, line and
column are all unchanged; only the human-readable message gains a clause. No
schema, CLI or protocol change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — message wording only, no decision to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)