### PR TITLE
feat: draft a relationship the compiler will accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,22 @@
   than none. The diagnostic also suggests a near miss now, which it never did
   before: a plain typo was as silent as a migration (#235).
 
+- Drafting a relationship between two subjects on a canvas, as pure functions:
+  `connectableKinds`, `proposeRelationshipId` and `draftRelationship`. The
+  first returns what the ArchiMate table permits between two rendered nodes,
+  read through each one's core kind so a model using a profile gets a palette
+  rather than nothing. The second proposes `<from>-<kind>-<to>`, which reads as
+  the sentence the relationship makes and is already a valid id, stepping to a
+  numeric suffix on collision because the id is authored text a human reads in
+  a diff. The third returns the `add-relationship` operation, into the source
+  subject's document, and returns `null` for a kind the table does not permit
+  rather than trusting the caller to have filtered first - the guarantee has to
+  hold for any caller, not only a careful one.
+  These hold no React, so what an editor would produce is compiled rather than
+  asserted about: every kind the palette offers is drafted, applied through
+  `applyOperations` and compiled clean, with no filesystem involved anywhere
+  now that Core is pure (#236).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,3 +131,8 @@ export {
   type ApplyInput,
   type ApplyOutcome,
 } from './apply-command.js'
+export {
+  connectableKinds,
+  draftRelationship,
+  proposeRelationshipId,
+} from './relationship-drafting.js'

--- a/src/relationship-drafting.ts
+++ b/src/relationship-drafting.ts
@@ -1,0 +1,113 @@
+import type { CanvasGraph } from './graph-projection.js'
+import type { YarramateOperation } from './operations.js'
+import type { RelationshipKind } from './profile.js'
+import {
+  isCoreConceptKindId,
+  permittedRelationshipKinds,
+} from './relationship-matrix.js'
+
+/**
+ * Drafting a relationship between two subjects already on a canvas.
+ *
+ * The point of doing this here rather than in the editor is that an editor
+ * offering exactly {@link connectableKinds} cannot draw an edge `check` would
+ * refuse with `YM404`, and that guarantee is about the ArchiMate table and the
+ * compiler agreeing rather than about any user interface. These functions are
+ * pure and hold no React, so the property can be tested by compiling what they
+ * produce.
+ *
+ * Everything here reads the rendered graph, which is what a canvas has, rather
+ * than the compiled model, which it does not.
+ */
+
+/**
+ * The relationship kinds ArchiMate permits from one subject to another, sorted
+ * so a palette is stable between renders.
+ *
+ * Empty when either endpoint is unknown to the graph, or when its kind does not
+ * resolve to a core one - an extension kind outside the ArchiMate vocabulary
+ * has no row in the table, and guessing a row for it would be inventing
+ * permission the compiler never granted. `association` is in every non-empty
+ * answer, so a pair the table knows is never a dead end.
+ */
+export const connectableKinds = (
+  graph: CanvasGraph,
+  fromId: string,
+  toId: string,
+): readonly RelationshipKind[] => {
+  const from = graph.nodes.find((node) => node.id === fromId)
+  const to = graph.nodes.find((node) => node.id === toId)
+  if (from === undefined || to === undefined) return []
+  // The table is keyed on core kinds, which is why a canvas node carries the
+  // core ancestor of the kind it was authored as.
+  if (
+    !isCoreConceptKindId(from.coreKindLabel) ||
+    !isCoreConceptKindId(to.coreKindLabel)
+  ) {
+    return []
+  }
+  return [
+    ...permittedRelationshipKinds(from.coreKindLabel, to.coreKindLabel),
+  ].sort()
+}
+
+/**
+ * An id for a new relationship, unique across the graph.
+ *
+ * `<from>-<kind>-<to>` reads as the sentence the relationship makes and is
+ * already valid: a subject id is lowercase and hyphenated, and every core
+ * relationship kind is a single lowercase word. A collision takes a numeric
+ * suffix rather than a hash, because the id is authored text a human will read
+ * in a diff.
+ */
+export const proposeRelationshipId = (
+  graph: CanvasGraph,
+  fromId: string,
+  kind: RelationshipKind,
+  toId: string,
+): string => {
+  const taken = new Set([
+    ...graph.nodes.map((node) => node.id),
+    ...graph.edges.map((edge) => edge.id),
+  ])
+  const base = `${fromId}-${kind}-${toId}`
+  if (!taken.has(base)) return base
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}`
+    if (!taken.has(candidate)) return candidate
+  }
+}
+
+/**
+ * The operation that lands a drafted relationship, or `null` when the draft is
+ * one the table does not permit.
+ *
+ * Refusing here rather than trusting the caller is what makes the guarantee
+ * hold for any caller, not only for an editor that remembered to filter its
+ * palette first.
+ *
+ * The relationship is written into the *source* subject's document. A
+ * relationship has to live somewhere, both endpoints are equally defensible,
+ * and the source is where a reader looking for what this thing does would go
+ * first.
+ */
+export const draftRelationship = (
+  graph: CanvasGraph,
+  fromId: string,
+  kind: RelationshipKind,
+  toId: string,
+): YarramateOperation | null => {
+  if (!connectableKinds(graph, fromId, toId).includes(kind)) return null
+  const from = graph.nodes.find((node) => node.id === fromId)
+  if (from === undefined) return null
+  return {
+    op: 'add-relationship',
+    document: from.document,
+    relationship: {
+      id: proposeRelationshipId(graph, fromId, kind, toId),
+      kind,
+      from: fromId,
+      to: toId,
+    },
+  }
+}

--- a/test/relationship-drafting.test.ts
+++ b/test/relationship-drafting.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import {
+  connectableKinds,
+  draftRelationship,
+  proposeRelationshipId,
+} from '../src/relationship-drafting.js'
+import { applyOperations } from '../src/apply-command.js'
+import { stringify } from 'yaml'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+const DOCUMENT = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+  - id: billing
+    kind: applicationComponent
+    name: Billing
+  - id: settle
+    kind: applicationFunction
+    name: Settle
+  - id: ledger
+    kind: dataObject
+    name: Ledger
+relationships:
+  - id: orders-serving-billing
+    kind: serving
+    from: orders
+    to: billing
+`
+
+const graphOf = (source: string): CanvasGraph => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return projectGraphForCanvas(result.graph, result.profileContext)
+}
+
+const graph = graphOf(DOCUMENT)
+
+describe('connectableKinds', () => {
+  it('offers what the table permits, sorted, with association always present', () => {
+    const kinds = connectableKinds(graph, 'orders', 'settle')
+
+    expect(kinds).toContain('assignment')
+    expect(kinds).toContain('association')
+    expect([...kinds]).toEqual([...kinds].sort())
+  })
+
+  it('is empty for an endpoint the graph does not hold', () => {
+    expect(connectableKinds(graph, 'orders', 'absent')).toEqual([])
+    expect(connectableKinds(graph, 'absent', 'orders')).toEqual([])
+  })
+
+  it('reads the core kind, not the authored one', () => {
+    // A profile kind has no row in the table; its core ancestor does. Without
+    // this the palette would be empty for every model that uses a profile.
+    const result = compileWorkspaceWithProfileContext([
+      {
+        path: 'architecture/profile.yaml',
+        source: `format: yarramate/profile/v1
+id: yarramate/development
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: microservice
+    name: Microservice
+    parent: yarramate/core@0.1#applicationComponent
+relationshipKinds: []
+`,
+      },
+      {
+        path: 'architecture/main.yaml',
+        source: `format: yarramate/v1
+id: main
+profile: yarramate/development@1.0
+concepts:
+  - id: orders
+    kind: microservice
+    name: Orders
+  - id: settle
+    kind: applicationFunction
+    name: Settle
+relationships: []
+`,
+      },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const derived = projectGraphForCanvas(result.graph, result.profileContext)
+
+    expect(
+      derived.nodes.find((node) => node.id === 'orders')?.kindLabel,
+    ).toBe('microservice')
+    expect(connectableKinds(derived, 'orders', 'settle')).toContain(
+      'assignment',
+    )
+  })
+})
+
+describe('proposeRelationshipId', () => {
+  it('reads as the sentence the relationship makes', () => {
+    expect(proposeRelationshipId(graph, 'orders', 'assignment', 'settle')).toBe(
+      'orders-assignment-settle',
+    )
+  })
+
+  it('steps past an id already taken', () => {
+    // `orders-serving-billing` is already in the document.
+    expect(proposeRelationshipId(graph, 'orders', 'serving', 'billing')).toBe(
+      'orders-serving-billing-2',
+    )
+  })
+
+  it('produces an id the document schema accepts', () => {
+    const pattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+    for (const kind of connectableKinds(graph, 'orders', 'settle')) {
+      expect(
+        proposeRelationshipId(graph, 'orders', kind, 'settle'),
+      ).toMatch(pattern)
+    }
+  })
+})
+
+describe('draftRelationship', () => {
+  it('refuses a kind the table does not permit, whatever the caller believes', () => {
+    // Not filtered by a palette first: the guarantee has to hold for any
+    // caller, not only a careful one.
+    expect(draftRelationship(graph, 'settle', 'composition', 'orders')).toBeNull()
+  })
+
+  it('writes into the source subject document', () => {
+    const operation = draftRelationship(graph, 'orders', 'assignment', 'settle')
+    expect(operation).toMatchObject({
+      op: 'add-relationship',
+      document: 'architecture/main.yaml',
+      relationship: { kind: 'assignment', from: 'orders', to: 'settle' },
+    })
+  })
+
+  /**
+   * The property the whole connection tool rests on, driven all the way
+   * through: whatever the palette offers is drafted, applied, and compiled.
+   * Anything the editor could produce therefore already has a passing `check`
+   * behind it.
+   */
+  it('produces a relationship that applies and compiles, for every kind offered', () => {
+    const pairs: ReadonlyArray<readonly [string, string]> = [
+      ['orders', 'settle'],
+      ['orders', 'billing'],
+      ['settle', 'ledger'],
+      ['orders', 'ledger'],
+    ]
+    let drafted = 0
+
+    for (const [from, to] of pairs) {
+      for (const kind of connectableKinds(graph, from, to)) {
+        const operation = draftRelationship(graph, from, kind, to)
+        expect(operation, `${from} -${kind}-> ${to}`).not.toBeNull()
+        if (operation === null) continue
+        drafted += 1
+
+        // No filesystem anywhere: `applyOperations` is pure since ADR 0100, so
+        // the workspace is stated directly and this stays a test about what a
+        // draft compiles to.
+        const outcome = applyOperations({
+          workspace: {
+            id: 'drafting',
+            documents: ['architecture/main.yaml'],
+            profiles: [],
+            projections: [],
+            adapterMappings: [],
+            evidence: [],
+            contracts: [],
+          },
+          sources: [{ path: 'architecture/main.yaml', source: DOCUMENT }],
+          operations: {
+            path: 'changeset.yaml',
+            source: stringify({
+              format: 'yarramate/operations/v1',
+              operations: [operation],
+            }),
+          },
+          manifestDirectory: '.yarramate',
+        })
+
+        expect(
+          outcome.ok ? [] : outcome.diagnostics.map((d) => d.code),
+          `${from} -${kind}-> ${to} did not apply`,
+        ).toEqual([])
+      }
+    }
+
+    // Not passing by drafting nothing. A floor rather than the exact count,
+    // which is a property of the ArchiMate table and not of this test.
+    expect(drafted).toBeGreaterThan(12)
+  })
+})


### PR DESCRIPTION
## Summary

The connection tool's logic, as pure functions with **no React in them** — so
what an editor would produce can be *compiled* rather than asserted about.

```ts
connectableKinds(graph, from, to)            // what the table permits
proposeRelationshipId(graph, from, kind, to) // "orders-assignment-settle"
draftRelationship(graph, from, kind, to)     // the add-relationship, or null
```

## Three decisions worth naming

**The palette reads the core kind, not the authored one.** A profile kind has no
row in the ArchiMate table; its core ancestor does. Without that step the
palette would be empty for every model that uses a profile — which is most of
them. Empty is also the honest answer for an endpoint the graph does not hold,
or a kind outside the ArchiMate vocabulary, because guessing a row would invent
permission the compiler never granted.

**The id reads as the sentence the relationship makes.** `<from>-<kind>-<to>` is
already valid: a subject id is lowercase and hyphenated, and every core
relationship kind is a single lowercase word. A collision steps to a numeric
suffix rather than a hash, because this is authored text a human reads in a
diff.

**`draftRelationship` refuses rather than trusting its caller.** It returns
`null` for a kind the table does not permit, even though a well-behaved editor
would have filtered its palette first. The guarantee has to hold for *any*
caller, not only a careful one, and a test drives exactly that case.

The relationship is written into the **source** subject's document. It has to
live somewhere, both endpoints are equally defensible, and the source is where a
reader looking for what this thing does would go first.

## The property, driven all the way through

Every kind the palette offers is drafted, applied through `applyOperations`, and
compiled clean — 18 of them across four pairs, with a floor asserted so it
cannot pass by drafting nothing.

**No filesystem is involved anywhere.** That is only possible because ADR 0100
made `applyOperations` pure; this is the first test written *against* that seam
rather than around it.

## Two things I caught while writing it

Both were mine, and both are fixed:

- The test had a `loadWorkspaceManifest` call whose result was discarded — but
  it still hit the disk, and failed with `ENOENT: /nowhere`. Deleted; the pure
  seam means the workspace can just be stated.
- The derived-kind test had a `.replace()` chain that converted the derived kind
  *away* before asserting on it, so it proved nothing. It now compiles a real
  profile with a `microservice` kind and checks the palette resolves through
  lineage.

## Validation

`pnpm verify` exits 0: **77 files, 1276 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

## Related issue

None. Wave 4, the connection tool's logic. The UI is the next piece and holds no
decisions of its own now.

## Contract impact

Additive. Three new exports from the package root. No schema, diagnostic, CLI or
protocol change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — new functions over existing rules; the drawing decision was ADR 0101 and the table is ADR 0097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)