### PR TITLE
feat(visual): connect two subjects without being able to draw a refused edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,21 @@
   `applyOperations` and compiled clean, with no filesystem involved anywhere
   now that Core is pure (#236).
 
+- A connection tool. Selecting a subject offers **Connect**; the next subject
+  named on the diagram becomes the target; the panel offers the relationship
+  kinds the ArchiMate 3.2 table permits between the two, and choosing one
+  stages an `add-relationship` into the source subject's document. Until now
+  the browser could only update a subject that already existed.
+  The reviewer cannot draw an edge `check` would refuse with `YM404`: the
+  palette is `permittedRelationshipKinds`, the same lookup the compiler
+  performs, and `draftRelationship` refuses a kind outside it even if a caller
+  offered one. Naming the source again backs out, because a subject related to
+  itself is a mis-click far more often than an intention. An empty palette can
+  only mean an endpoint outside the ArchiMate vocabulary, since a pair the
+  table knows always permits `association`, so the panel says that rather than
+  showing an empty list. Selection rather than dragging, so every step is a
+  state transition a test can make and a keyboard can reach (#237).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -102,6 +102,28 @@ recorded what those two backends mapped onto and why the obvious ELK choices
 were rejected; it is superseded here. A future layout mechanism is expected,
 and `presentation.layout` stays an enum so it has somewhere to land.
 
+### Connecting two subjects
+
+Selecting a subject offers **Connect**. The next subject named on the diagram
+becomes the target, and the panel then offers the relationship kinds the
+ArchiMate 3.2 table permits between the two, read through each endpoint's
+`coreKindLabel` so a model using a profile gets a palette rather than nothing.
+
+Choosing one stages an `add-relationship` into the *source* subject's document,
+with an id of the form `<from>-<kind>-<to>`, taking a numeric suffix if that is
+already taken. Nothing is written until the changeset is committed.
+
+The reviewer cannot draw an edge `check` would refuse with `YM404`: the palette
+is `permittedRelationshipKinds`, the same lookup the compiler performs, and
+`draftRelationship` refuses a kind outside it even if a caller offered one.
+Naming the source again backs out, since a subject related to itself is a
+mis-click far more often than an intention. A pair the table knows always
+permits `association`, so an empty palette means an endpoint outside the
+ArchiMate vocabulary, and the panel says so rather than showing an empty list.
+
+Selection is chosen over dragging deliberately: every step is a state
+transition a test can make and a keyboard can reach.
+
 ### Nesting
 
 `presentation.nesting` names the relationship kinds that draw as containment in

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -39,8 +39,10 @@ import {
   presentationActionsFor,
   viewNeedingApplication,
   visualWorkspaceReducer,
+  type ConnectionDraft,
   type SelectedDiagramSubject,
 } from "./workspace-state.js";
+import { ConnectionPanel } from "./connection-panel.js";
 
 /**
  * A drawing board, not a document: the diagram holds the workspace, one compact
@@ -335,6 +337,10 @@ const DiagramWorkspace = ({
   showLifecycle,
   showEvidence,
   showOwnership,
+  connection,
+  onConnectTarget,
+  onConnectCancel,
+  onConnectStage,
   onSelect,
   onClearFilter,
   onSaveLayout,
@@ -349,6 +355,10 @@ const DiagramWorkspace = ({
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
+  readonly connection: ConnectionDraft | null;
+  readonly onConnectTarget: (id: string) => void;
+  readonly onConnectCancel: () => void;
+  readonly onConnectStage: (operation: YarramateOperation) => void;
   readonly onSelect: (subject: SelectedDiagramSubject) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
@@ -386,6 +396,14 @@ const DiagramWorkspace = ({
         </div>
       ) : null}
       <div className="canvas">
+        {connection === null || state.model === null ? null : (
+          <ConnectionPanel
+            draft={connection}
+            graph={state.model.graph}
+            onStage={onConnectStage}
+            onCancel={onConnectCancel}
+          />
+        )}
         {state.model === null ? null : (
           <GraphCanvas
             graph={state.model.graph}
@@ -393,6 +411,13 @@ const DiagramWorkspace = ({
             onSelect={(id, type) => {
               const graph = state.model!.graph;
               if (type === "node") {
+                // While a relationship is being drawn, naming a subject means
+                // "connect to that", not "inspect that". Selection resumes as
+                // soon as the draft is resolved or cancelled.
+                if (connection !== null) {
+                  onConnectTarget(id);
+                  return;
+                }
                 const node = graph.nodes.find((n) => n.id === id);
                 if (node !== undefined)
                   onSelect(normalizeSelectedElement(node));
@@ -485,6 +510,7 @@ const SelectedSubjectInspector = ({
   expanded,
   onToggleDescription,
   onClear,
+  onConnect,
   onStageChange,
 }: {
   readonly subject: SelectedDiagramSubject;
@@ -493,6 +519,7 @@ const SelectedSubjectInspector = ({
   readonly expanded: boolean;
   readonly onToggleDescription: () => void;
   readonly onClear: () => void;
+  readonly onConnect: (from: string) => void;
   readonly onStageChange: (operation: YarramateOperation) => void;
 }) => {
   const node =
@@ -519,6 +546,15 @@ const SelectedSubjectInspector = ({
               : `${subject.sourceTitle} → ${subject.targetTitle}`}
           </h2>
         </div>
+        {subject.type === "element" ? (
+          <button
+            type="button"
+            className="subject-connect"
+            onClick={() => onConnect(subject.id)}
+          >
+            Connect
+          </button>
+        ) : null}
         <button type="button" className="subject-clear" onClick={onClear}>
           Clear
         </button>
@@ -560,6 +596,7 @@ const ConversationPanel = ({
   onChoice,
   onToggleDescription,
   onClearSubject,
+  onConnect,
   onDiscardChange,
   onStageChange,
   onClearChangeset,
@@ -576,6 +613,7 @@ const ConversationPanel = ({
   readonly onChoice: (optionId: string) => void;
   readonly onToggleDescription: () => void;
   readonly onClearSubject: () => void;
+  readonly onConnect: (from: string) => void;
   readonly onDiscardChange: (index: number) => void;
   readonly onStageChange: (operation: YarramateOperation) => void;
   readonly onClearChangeset: () => void;
@@ -618,6 +656,7 @@ const ConversationPanel = ({
             expanded={descriptionExpanded}
             onToggleDescription={onToggleDescription}
             onClear={onClearSubject}
+            onConnect={onConnect}
             onStageChange={onStageChange}
           />
         )}
@@ -971,6 +1010,14 @@ export const App = () => {
           direction={workspace.direction}
           nesting={workspace.nesting}
           notation={workspace.notation}
+          connection={workspace.connection}
+          onConnectTarget={(id) =>
+            dispatchWorkspace({ type: "connection.targeted", to: id })
+          }
+          onConnectCancel={() =>
+            dispatchWorkspace({ type: "connection.cancelled" })
+          }
+          onConnectStage={stageChange}
           showLifecycle={workspace.showLifecycle}
           showEvidence={workspace.showEvidence}
           showOwnership={workspace.showOwnership}
@@ -1003,6 +1050,9 @@ export const App = () => {
             dispatchWorkspace({ type: "description.toggled" })
           }
           onClearSubject={() => dispatchWorkspace({ type: "subject.cleared" })}
+          onConnect={(from) =>
+            dispatchWorkspace({ type: "connection.started", from })
+          }
           onDiscardChange={discardChange}
           onStageChange={stageChange}
           onClearChangeset={clearChangeset}

--- a/src/visual-app/connection-panel.tsx
+++ b/src/visual-app/connection-panel.tsx
@@ -1,0 +1,97 @@
+import type React from 'react'
+import type { CanvasGraph } from '../graph-projection.js'
+import type { YarramateOperation } from '../operations.js'
+import type { RelationshipKind } from '../profile.js'
+import {
+  connectableKinds,
+  draftRelationship,
+} from '../relationship-drafting.js'
+import type { ConnectionDraft } from './workspace-state.js'
+
+/**
+ * The connection tool: pick a source, pick a target, pick a kind.
+ *
+ * Every kind offered here comes from the ArchiMate relationship table, so the
+ * reviewer cannot draw an edge `check` would refuse with `YM404`
+ * (ADR 0097). Nothing filters the list by hand: `connectableKinds` is the same
+ * lookup the compiler performs, and `draftRelationship` refuses a kind that is
+ * not in it even if this panel somehow offered one.
+ *
+ * A pair the table knows always permits `association`, so an empty list here
+ * means an endpoint outside the ArchiMate vocabulary rather than a dead end,
+ * and the panel says which.
+ */
+export const ConnectionPanel = ({
+  draft,
+  graph,
+  onStage,
+  onCancel,
+}: {
+  readonly draft: ConnectionDraft
+  readonly graph: CanvasGraph
+  readonly onStage: (operation: YarramateOperation) => void
+  readonly onCancel: () => void
+}): React.ReactElement => {
+  const titleOf = (id: string): string =>
+    graph.nodes.find((node) => node.id === id)?.name ?? id
+
+  if (draft.to === null) {
+    return (
+      <section className="connection-panel" aria-label="Connect subjects">
+        <p className="connection-prompt">
+          Connecting from <strong>{titleOf(draft.from)}</strong>. Choose a
+          target on the diagram.
+        </p>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </section>
+    )
+  }
+
+  const target = draft.to
+  const kinds = connectableKinds(graph, draft.from, target)
+
+  return (
+    <section className="connection-panel" aria-label="Connect subjects">
+      <p className="connection-prompt">
+        <strong>{titleOf(draft.from)}</strong> to{' '}
+        <strong>{titleOf(target)}</strong>
+      </p>
+      {kinds.length === 0 ? (
+        <p className="connection-empty">
+          No relationship is defined between these kinds. One of them is
+          outside the ArchiMate vocabulary the table covers.
+        </p>
+      ) : (
+        <ul className="connection-kinds">
+          {kinds.map((kind: RelationshipKind) => (
+            <li key={kind}>
+              <button
+                type="button"
+                onClick={() => {
+                  const operation = draftRelationship(
+                    graph,
+                    draft.from,
+                    kind,
+                    target,
+                  )
+                  // Null here would mean this panel offered a kind the table
+                  // does not permit, which `connectableKinds` cannot produce.
+                  // Staging nothing is the safe reading of an impossible state.
+                  if (operation !== null) onStage(operation)
+                  onCancel()
+                }}
+              >
+                {kind}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </section>
+  )
+}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -360,6 +360,7 @@ body {
    box collapses, so the container is sized here rather than left to the
    canvas element it creates inside. */
 .canvas {
+  position: relative; /* containing block for .connection-panel */
   width: 100%;
   height: 100%;
   min-width: 0;
@@ -559,6 +560,46 @@ body {
 .subject-clear {
   margin-top: calc(var(--step) * 0.5);
   min-height: 28px;
+}
+
+.subject-connect {
+  margin-top: calc(var(--step) * 0.5);
+  margin-right: calc(var(--step) * 0.5);
+  min-height: 28px;
+}
+
+/* Sits over the canvas while a relationship is being drawn, so the diagram
+   stays visible: the reviewer is picking a target on it. */
+.connection-panel {
+  position: absolute;
+  z-index: 2;
+  top: calc(var(--step) * 1.5);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: min(560px, calc(100% - var(--step) * 4));
+  padding: calc(var(--step) * 1.5) calc(var(--step) * 2);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--sheet);
+  box-shadow: 0 2px 12px rgb(0 0 0 / 12%);
+}
+
+.connection-prompt {
+  margin: 0 0 calc(var(--step) * 1.5);
+}
+
+.connection-empty {
+  margin: 0 0 calc(var(--step) * 1.5);
+  color: var(--quiet);
+}
+
+.connection-kinds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(var(--step) * 0.75);
+  margin: 0 0 calc(var(--step) * 1.5);
+  padding: 0;
+  list-style: none;
 }
 
 .ledger {

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -29,6 +29,21 @@ export interface SelectedRelationship {
 
 export type SelectedDiagramSubject = SelectedElement | SelectedRelationship;
 
+/**
+ * A relationship being drawn. The source is chosen first and the target
+ * second, rather than dragged, so every step is a state transition a test can
+ * make and a keyboard can reach.
+ *
+ * The kinds on offer are NOT held here: they are a function of the two
+ * endpoints and the ArchiMate table, so they are derived on render by
+ * `connectableKinds`. Storing them would let a stale palette outlive the model
+ * frame it was computed from.
+ */
+export interface ConnectionDraft {
+  readonly from: string;
+  readonly to: string | null;
+}
+
 const optionalText = (value: string | null | undefined): string | null => {
   const text = value?.trim() ?? "";
   return text === "" ? null : text;
@@ -102,6 +117,8 @@ export interface VisualWorkspaceState {
    */
   readonly viewportWidth: number;
   readonly selectedSubject: SelectedDiagramSubject | null;
+  /** The relationship being drawn, or null when the tool is not in use. */
+  readonly connection: ConnectionDraft | null;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   readonly direction: "top-down" | "left-right";
@@ -129,6 +146,15 @@ export type VisualWorkspaceAction =
   | { readonly type: "conversation.resized"; readonly width: number }
   | { readonly type: "viewport.resized"; readonly viewportWidth: number }
   | { readonly type: "attention.received" }
+  | {
+      readonly type: "connection.started";
+      readonly from: string;
+    }
+  | {
+      readonly type: "connection.targeted";
+      readonly to: string;
+    }
+  | { readonly type: "connection.cancelled" }
   | {
       readonly type: "subject.selected";
       readonly subject: SelectedDiagramSubject;
@@ -297,6 +323,7 @@ export const createVisualWorkspaceState = (
   selectedSubject: null,
   descriptionExpanded: false,
   detailsOpen: false,
+  connection: null,
   direction: "top-down",
   nesting: DEFAULT_NESTING,
   layout: "layered",
@@ -364,6 +391,19 @@ export const visualWorkspaceReducer = (
           unread: state.conversation.unread + 1,
         },
       };
+    case "connection.started":
+      return { ...state, connection: { from: action.from, to: null } };
+    case "connection.targeted":
+      if (state.connection === null) return state;
+      // Naming the source again means "not that after all". A subject related
+      // to itself is a mis-click far more often than an intention, and the
+      // table would offer `association` for it regardless, so the gesture is
+      // better spent on the way out.
+      return action.to === state.connection.from
+        ? { ...state, connection: null }
+        : { ...state, connection: { ...state.connection, to: action.to } };
+    case "connection.cancelled":
+      return state.connection === null ? state : { ...state, connection: null };
     case "subject.selected":
       return {
         ...state,

--- a/test/connection-panel.test.ts
+++ b/test/connection-panel.test.ts
@@ -1,0 +1,120 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import { connectableKinds } from '../src/relationship-drafting.js'
+import { ConnectionPanel } from '../src/visual-app/connection-panel.js'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+/**
+ * What the panel puts on screen, which is the safety-critical half: a kind
+ * offered here is a kind the reviewer can land. What happens when one is
+ * clicked is `draftRelationship`, covered in `relationship-drafting.test.ts`
+ * by compiling every draft it produces, and the transitions around it are
+ * covered in `visual-workspace-state.test.ts`.
+ */
+const graphOf = (source: string): CanvasGraph => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return projectGraphForCanvas(result.graph, result.profileContext)
+}
+
+const graph = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+  - id: settle
+    kind: applicationFunction
+    name: Settle
+relationships: []
+`)
+
+const render = (draft: { from: string; to: string | null }) =>
+  renderToStaticMarkup(
+    createElement(ConnectionPanel, {
+      draft,
+      graph,
+      onStage: () => undefined,
+      onCancel: () => undefined,
+    }),
+  )
+
+describe('ConnectionPanel', () => {
+  it('names the source and asks for a target', () => {
+    const markup = render({ from: 'orders', to: null })
+
+    expect(markup).toContain('Orders')
+    expect(markup).toContain('Choose a target')
+    expect(markup).not.toContain('connection-kinds')
+  })
+
+  it('offers exactly what the table permits between the two', () => {
+    const markup = render({ from: 'orders', to: 'settle' })
+    const offered = connectableKinds(graph, 'orders', 'settle')
+
+    expect(offered.length).toBeGreaterThan(1)
+    for (const kind of offered) {
+      expect(markup, kind).toContain(`>${kind}<`)
+    }
+  })
+
+  it('offers no kind the table forbids between the two', () => {
+    const markup = render({ from: 'settle', to: 'orders' })
+    const offered = new Set(connectableKinds(graph, 'settle', 'orders'))
+    const everyKind = [
+      'access',
+      'aggregation',
+      'assignment',
+      'association',
+      'composition',
+      'flow',
+      'influence',
+      'realization',
+      'serving',
+      'specialization',
+      'triggering',
+    ]
+    const withheld = everyKind.filter((kind) => !offered.has(kind as never))
+
+    expect(withheld.length).toBeGreaterThan(0)
+    for (const kind of withheld) {
+      expect(markup, kind).not.toContain(`>${kind}<`)
+    }
+  })
+
+  it('says why there is nothing to offer rather than showing an empty list', () => {
+    // An endpoint outside the ArchiMate vocabulary has no row in the table. A
+    // pair the table knows always permits `association`, so an empty list can
+    // only mean this.
+    const outside: CanvasGraph = {
+      nodes: graph.nodes.map((node) =>
+        node.id === 'settle'
+          ? { ...node, coreKindLabel: 'somethingElse' }
+          : node,
+      ),
+      edges: graph.edges,
+    }
+    const markup = renderToStaticMarkup(
+      createElement(ConnectionPanel, {
+        draft: { from: 'orders', to: 'settle' },
+        graph: outside,
+        onStage: () => undefined,
+        onCancel: () => undefined,
+      }),
+    )
+
+    expect(markup).toContain('outside the ArchiMate vocabulary')
+    expect(markup).not.toContain('connection-kinds')
+  })
+
+  it('can always be backed out of', () => {
+    expect(render({ from: 'orders', to: null })).toContain('Cancel')
+    expect(render({ from: 'orders', to: 'settle' })).toContain('Cancel')
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -396,6 +396,78 @@ describe("visualWorkspaceReducer presentation", () => {
   });
 });
 
+describe("visualWorkspaceReducer connection", () => {
+  const workspaceState = createVisualWorkspaceState(1280);
+
+  const start = (from: string) =>
+    visualWorkspaceReducer(workspaceState, {
+      type: "connection.started",
+      from,
+    });
+
+  it("is not in use until it is started", () => {
+    expect(workspaceState.connection).toBeNull();
+  });
+
+  it("holds the source, and no target yet", () => {
+    expect(start("orders").connection).toEqual({ from: "orders", to: null });
+  });
+
+  it("takes a target", () => {
+    const next = visualWorkspaceReducer(start("orders"), {
+      type: "connection.targeted",
+      to: "billing",
+    });
+    expect(next.connection).toEqual({ from: "orders", to: "billing" });
+  });
+
+  it("treats naming the source again as backing out", () => {
+    // A subject related to itself is a mis-click far more often than an
+    // intention, and `association` would be offered for it regardless.
+    const next = visualWorkspaceReducer(start("orders"), {
+      type: "connection.targeted",
+      to: "orders",
+    });
+    expect(next.connection).toBeNull();
+  });
+
+  it("ignores a target when nothing is being drawn", () => {
+    const next = visualWorkspaceReducer(workspaceState, {
+      type: "connection.targeted",
+      to: "billing",
+    });
+    expect(next).toBe(workspaceState);
+  });
+
+  it("starting again replaces the draft rather than stacking one", () => {
+    const next = visualWorkspaceReducer(start("orders"), {
+      type: "connection.started",
+      from: "billing",
+    });
+    expect(next.connection).toEqual({ from: "billing", to: null });
+  });
+
+  it("cancels, and cancelling nothing changes nothing", () => {
+    expect(
+      visualWorkspaceReducer(start("orders"), { type: "connection.cancelled" })
+        .connection,
+    ).toBeNull();
+    expect(
+      visualWorkspaceReducer(workspaceState, { type: "connection.cancelled" }),
+    ).toBe(workspaceState);
+  });
+
+  it("does not hold the kinds on offer, which are a function of the endpoints", () => {
+    // Storing them would let a stale palette outlive the model frame it came
+    // from; `connectableKinds` derives them at render.
+    const next = visualWorkspaceReducer(start("orders"), {
+      type: "connection.targeted",
+      to: "billing",
+    });
+    expect(Object.keys(next.connection ?? {}).sort()).toEqual(["from", "to"]);
+  });
+});
+
 describe("visualWorkspaceReducer nesting", () => {
   const workspaceState = createVisualWorkspaceState(1280);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",
     "test/graph-canvas-nesting.test.ts",
+    "test/connection-panel.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/badges.test.ts",

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -29,6 +29,7 @@
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",
     "test/graph-canvas-nesting.test.ts",
+    "test/connection-panel.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/archimate-notation.test.ts"


### PR DESCRIPTION
## Summary

The browser could only ever **update** a subject that already existed. This adds
the first `add-*` it can stage — and the one the relationship table makes safe.

Select a subject → **Connect** → name a target on the diagram → pick from the
kinds ArchiMate permits between the two. Choosing one stages an
`add-relationship` into the source subject's document. Nothing is written until
the changeset is committed.

## The guarantee is not "the panel remembers to filter"

Two independent things would both have to be wrong for `YM404` to be reachable:

1. The palette **is** `permittedRelationshipKinds` — the same lookup the
   compiler performs, not a copy — read through each endpoint's `coreKindLabel`
   so a model using a profile gets a palette rather than nothing.
2. `draftRelationship` refuses a kind outside that set **even if a caller
   offered one**, and a test drives exactly that case.

#236 already compiles every draft the palette can produce. This change is the
surface on top of it.

## Three interaction decisions

**Selection, not dragging.** Every step is a state transition a test can make
and a keyboard can reach. Dragging would need either a new dependency or a
custom hit-test, and neither is testable the way this repo tests.

**The draft holds `{from, to}` and *not* the kinds.** They are a function of the
two endpoints and the table, so they are derived on render. Storing them would
let a stale palette outlive the model frame it came from.

**Naming the source again backs out.** A subject related to itself is a mis-click
far more often than an intention, and the table would offer `association` for it
regardless — so the gesture is better spent on the way out than on a useless
self-loop.

## An empty palette says why

A pair the table knows always permits `association`, so an empty list can only
mean an endpoint outside the ArchiMate vocabulary. The panel says that, rather
than showing an empty list and leaving the reviewer to guess whether the tool is
broken.

## Validation

`pnpm verify` exits 0: **78 files, 1289 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

Thirteen new tests. Eight on the reducer (source held, target taken, source-again
backs out, target ignored when nothing is being drawn, restart replaces rather
than stacks, cancel, and that the draft holds no palette). Five render the panel
via `renderToStaticMarkup` against real compiled graphs: it offers *exactly*
what the table permits, offers *none* of what it forbids, says why when there is
nothing to offer, and can always be backed out of.

`.canvas` becomes a containing block, which it had no reason to be until
something was positioned over it.

## Related issue

None. Wave 4 — the connection tool, completing the arc from #234 and #236.

## Contract impact

None to any published surface. New UI, new workspace-state actions, one CSS
rule. No schema, diagnostic, CLI or protocol change; the staged operation is the
existing `add-relationship`.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — UI over rules already decided in ADR 0097; no new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)