### PR TITLE
feat(visual): make a subject, not only relate two that exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,22 @@
   showing an empty list. Selection rather than dragging, so every step is a
   state transition a test can make and a keyboard can reach (#237).
 
+- Adding a subject. **Add subject** opens a form over the canvas taking a name,
+  a kind and a document, and stages an `add-concept`. The kinds are the
+  workspace's own vocabulary, already sent with every model frame, so nothing
+  in the browser decides what a workspace may contain; the document defaults to
+  the selected subject's and any declared document may be chosen. Until now the
+  canvas could connect two subjects but not bring one into existence.
+  The id is derived from the name rather than asked for, and shown before the
+  subject lands: an id is a stable address a human reads in a diff, a reviewer
+  thinking about a name writes worse ids than a transliteration does, and a
+  derived address the author never saw is one nobody agreed to. `Order Intake
+  (v2)` becomes `order-intake-v2`. Two kinds of name are refused rather than
+  mangled: one no id can be made of, and one that would start with a digit,
+  since `2FA Gateway` would otherwise become `fa-gateway` and stop naming the
+  thing. Adding and connecting are alternatives rather than layers, so a click
+  on the diagram always belongs to exactly one of them (#238).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -102,6 +102,28 @@ recorded what those two backends mapped onto and why the obvious ELK choices
 were rejected; it is superseded here. A future layout mechanism is expected,
 and `presentation.layout` stays an enum so it has somewhere to land.
 
+### Adding a subject
+
+**Add subject** opens a form over the canvas: a name, a kind, and the document
+to write it into. The kinds are the workspace's own vocabulary, sent with every
+model frame, so nothing in the browser decides what a workspace may contain.
+The document defaults to the selected subject's, or the first the workspace
+declares, and any declared document may be chosen.
+
+The id is *derived* from the name rather than asked for, and shown before the
+subject lands. An id is a stable address a human reads in a diff, and a
+reviewer thinking about a name writes worse ids than a transliteration of the
+name does; showing it first keeps a derived address from being one nobody
+agreed to. `Order Intake (v2)` becomes `order-intake-v2`, and a name already
+taken steps to a numeric suffix.
+
+Two kinds of name are refused rather than mangled: one an id cannot be made of
+at all, and one that would start with a digit. `2FA Gateway` would otherwise
+become `fa-gateway`, an id that no longer names the thing.
+
+Adding and connecting are alternatives rather than layers: starting one puts
+the other away, so a click on the diagram always belongs to exactly one of them.
+
 ### Connecting two subjects
 
 Selecting a subject offers **Connect**. The next subject named on the diagram

--- a/src/concept-drafting.ts
+++ b/src/concept-drafting.ts
@@ -1,0 +1,86 @@
+import type { CanvasGraph } from './graph-projection.js'
+import type { YarramateOperation } from './operations.js'
+
+/**
+ * Drafting a new subject, the counterpart to `relationship-drafting.ts`.
+ *
+ * A canvas can connect two subjects but could not make one, which left the
+ * editor able to describe relationships between things it had no way to bring
+ * into existence. These functions are pure and hold no React, so what an
+ * editor would produce can be compiled rather than asserted about.
+ */
+
+/** What `yarramate-document.schema.json` accepts as an id. */
+const ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+
+/**
+ * A kebab-case id derived from a name, unique across the graph, or `null` when
+ * the name yields nothing an id may be made of.
+ *
+ * Deriving rather than asking is the point: an id is a stable address a human
+ * reads in a diff, and asking a reviewer to invent one while they are thinking
+ * about a name produces worse ids than a transliteration of the name does.
+ * Returning null rather than a placeholder keeps a subject called `"???"` from
+ * landing as `subject-1`, which nothing could later be traced back from.
+ */
+export const proposeConceptId = (
+  graph: CanvasGraph,
+  name: string,
+): string | null => {
+  const base = name
+    .normalize('NFKD')
+    // The marks NFKD split off, dropped rather than treated as boundaries:
+    // otherwise every accent becomes a hyphen and "Ünïcodé" reads as
+    // "u-ni-code".
+    .replace(/[\u0300-\u036f]/g, '')
+    // Anything else that is not a letter or digit becomes a boundary, so
+    // "Order Intake (v2)" reads as "order-intake-v2".
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+  // An id starts with a letter. Dropping a leading digit would turn "2FA
+  // Gateway" into "fa-gateway", an id that no longer names the thing, so this
+  // is a name an id cannot be made of and the caller is told so.
+  if (base === '' || !ID_PATTERN.test(base)) return null
+
+  const taken = new Set([
+    ...graph.nodes.map((node) => node.id),
+    ...graph.edges.map((edge) => edge.id),
+  ])
+  if (!taken.has(base)) return base
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}`
+    if (!taken.has(candidate)) return candidate
+  }
+}
+
+/**
+ * The operation that lands a new subject, or `null` when the draft is one no
+ * document could accept.
+ *
+ * `kinds` is the vocabulary the workspace's profile actually offers. Refusing
+ * a kind outside it here, rather than trusting the caller's palette, is the
+ * same posture `draftRelationship` takes: the guarantee has to hold for any
+ * caller, not only one that filtered first.
+ */
+export const draftConcept = (
+  graph: CanvasGraph,
+  input: {
+    readonly name: string
+    readonly kind: string
+    readonly document: string
+  },
+  kinds: readonly string[],
+): YarramateOperation | null => {
+  if (input.document === '') return null
+  if (!kinds.includes(input.kind)) return null
+  const name = input.name.trim()
+  if (name === '') return null
+  const id = proposeConceptId(graph, name)
+  if (id === null) return null
+  return {
+    op: 'add-concept',
+    document: input.document,
+    concept: { id, kind: input.kind, name },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,3 +136,4 @@ export {
   draftRelationship,
   proposeRelationshipId,
 } from './relationship-drafting.js'
+export { draftConcept, proposeConceptId } from './concept-drafting.js'

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -43,6 +43,7 @@ import {
   type SelectedDiagramSubject,
 } from "./workspace-state.js";
 import { ConnectionPanel } from "./connection-panel.js";
+import { SubjectDraftPanel } from "./subject-draft-panel.js";
 
 /**
  * A drawing board, not a document: the diagram holds the workspace, one compact
@@ -341,6 +342,9 @@ const DiagramWorkspace = ({
   onConnectTarget,
   onConnectCancel,
   onConnectStage,
+  draftingSubject,
+  onDraftSubject,
+  onDraftSubjectClose,
   onSelect,
   onClearFilter,
   onSaveLayout,
@@ -359,6 +363,9 @@ const DiagramWorkspace = ({
   readonly onConnectTarget: (id: string) => void;
   readonly onConnectCancel: () => void;
   readonly onConnectStage: (operation: YarramateOperation) => void;
+  readonly draftingSubject: boolean;
+  readonly onDraftSubject: () => void;
+  readonly onDraftSubjectClose: () => void;
   readonly onSelect: (subject: SelectedDiagramSubject) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
@@ -396,6 +403,35 @@ const DiagramWorkspace = ({
         </div>
       ) : null}
       <div className="canvas">
+        {state.model === null ? null : (
+          <button
+            type="button"
+            className="subject-draft-open"
+            onClick={onDraftSubject}
+          >
+            Add subject
+          </button>
+        )}
+        {!draftingSubject || state.model === null ? null : (
+          <SubjectDraftPanel
+            graph={state.model.graph}
+            kinds={state.model.vocabulary.conceptKinds}
+            documents={state.model.documents}
+            defaultDocument={
+              // Near what the reviewer is looking at: the selected subject's
+              // document, or the first the workspace declares.
+              (selectedId === null
+                ? undefined
+                : state.model.graph.nodes.find(
+                    (node) => node.id === selectedId,
+                  )?.document) ??
+              state.model.documents[0] ??
+              ""
+            }
+            onStage={onConnectStage}
+            onCancel={onDraftSubjectClose}
+          />
+        )}
         {connection === null || state.model === null ? null : (
           <ConnectionPanel
             draft={connection}
@@ -1018,6 +1054,13 @@ export const App = () => {
             dispatchWorkspace({ type: "connection.cancelled" })
           }
           onConnectStage={stageChange}
+          draftingSubject={workspace.draftingSubject}
+          onDraftSubject={() =>
+            dispatchWorkspace({ type: "subject.draft.opened" })
+          }
+          onDraftSubjectClose={() =>
+            dispatchWorkspace({ type: "subject.draft.closed" })
+          }
           showLifecycle={workspace.showLifecycle}
           showEvidence={workspace.showEvidence}
           showOwnership={workspace.showOwnership}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -593,6 +593,47 @@ body {
   color: var(--quiet);
 }
 
+.subject-draft-open {
+  position: absolute;
+  z-index: 2;
+  top: calc(var(--step) * 1.5);
+  right: calc(var(--step) * 1.5);
+  min-height: 28px;
+}
+
+.subject-draft-panel {
+  position: absolute;
+  z-index: 3;
+  top: calc(var(--step) * 1.5);
+  right: calc(var(--step) * 1.5);
+  width: min(340px, calc(100% - var(--step) * 4));
+  padding: calc(var(--step) * 1.5) calc(var(--step) * 2);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--sheet);
+  box-shadow: 0 2px 12px rgb(0 0 0 / 12%);
+}
+
+.subject-draft-field {
+  display: block;
+  margin-bottom: calc(var(--step) * 1.5);
+}
+
+.subject-draft-field > span {
+  display: block;
+  margin-bottom: calc(var(--step) * 0.5);
+}
+
+.subject-draft-field > input,
+.subject-draft-field > select {
+  width: 100%;
+}
+
+.subject-draft-id {
+  margin: 0 0 calc(var(--step) * 1.5);
+  color: var(--quiet);
+}
+
 .connection-kinds {
   display: flex;
   flex-wrap: wrap;

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -1,0 +1,113 @@
+import type React from 'react'
+import { useState } from 'react'
+import type { CanvasGraph } from '../graph-projection.js'
+import type { YarramateOperation } from '../operations.js'
+import { draftConcept, proposeConceptId } from '../concept-drafting.js'
+import type { VisualKindOption } from '../adapters/visual/protocol-contract.js'
+
+/**
+ * Making a subject, the counterpart to the connection tool.
+ *
+ * The kinds come from the workspace's own profile, sent with every model
+ * frame, so nothing here decides what a workspace may contain. The id is
+ * derived from the name rather than asked for: an id is a stable address a
+ * human reads in a diff, and a reviewer thinking about a name writes worse ids
+ * than a transliteration of the name does. It is shown before landing, because
+ * a derived address the author never saw is one nobody agreed to.
+ */
+export const SubjectDraftPanel = ({
+  graph,
+  kinds,
+  documents,
+  defaultDocument,
+  onStage,
+  onCancel,
+}: {
+  readonly graph: CanvasGraph
+  readonly kinds: readonly VisualKindOption[]
+  readonly documents: readonly string[]
+  readonly defaultDocument: string
+  readonly onStage: (operation: YarramateOperation) => void
+  readonly onCancel: () => void
+}): React.ReactElement => {
+  const [name, setName] = useState('')
+  const [kind, setKind] = useState(kinds[0]?.id ?? '')
+  const [document, setDocument] = useState(defaultDocument)
+
+  const proposed = name.trim() === '' ? null : proposeConceptId(graph, name)
+  const operation =
+    proposed === null
+      ? null
+      : draftConcept(
+          graph,
+          { name, kind, document },
+          kinds.map((option) => option.id),
+        )
+
+  return (
+    <section className="subject-draft-panel" aria-label="Add a subject">
+      <label className="subject-draft-field">
+        <span>Name</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </label>
+
+      <label className="subject-draft-field">
+        <span>Kind</span>
+        <select value={kind} onChange={(event) => setKind(event.target.value)}>
+          {kinds.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="subject-draft-field">
+        <span>Document</span>
+        <select
+          value={document}
+          onChange={(event) => setDocument(event.target.value)}
+        >
+          {documents.map((path) => (
+            <option key={path} value={path}>
+              {path}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <p className="subject-draft-id">
+        {name.trim() === '' ? (
+          'Give it a name.'
+        ) : proposed === null ? (
+          // The two names this cannot serve: nothing an id may be made of, and
+          // one that would start with a digit.
+          'That name makes no id. An id starts with a letter and is made of letters, digits and hyphens.'
+        ) : (
+          <>
+            Id: <code>{proposed}</code>
+          </>
+        )}
+      </p>
+
+      <button
+        type="button"
+        disabled={operation === null}
+        onClick={() => {
+          if (operation === null) return
+          onStage(operation)
+          onCancel()
+        }}
+      >
+        Add
+      </button>
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </section>
+  )
+}

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -119,6 +119,12 @@ export interface VisualWorkspaceState {
   readonly selectedSubject: SelectedDiagramSubject | null;
   /** The relationship being drawn, or null when the tool is not in use. */
   readonly connection: ConnectionDraft | null;
+  /**
+   * Whether the add-a-subject form is open. Only the openness lives here: the
+   * fields belong to the form while it is on screen, and a half-typed name is
+   * not workspace state anyone else needs.
+   */
+  readonly draftingSubject: boolean;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   readonly direction: "top-down" | "left-right";
@@ -155,6 +161,8 @@ export type VisualWorkspaceAction =
       readonly to: string;
     }
   | { readonly type: "connection.cancelled" }
+  | { readonly type: "subject.draft.opened" }
+  | { readonly type: "subject.draft.closed" }
   | {
       readonly type: "subject.selected";
       readonly subject: SelectedDiagramSubject;
@@ -324,6 +332,7 @@ export const createVisualWorkspaceState = (
   descriptionExpanded: false,
   detailsOpen: false,
   connection: null,
+  draftingSubject: false,
   direction: "top-down",
   nesting: DEFAULT_NESTING,
   layout: "layered",
@@ -392,7 +401,11 @@ export const visualWorkspaceReducer = (
         },
       };
     case "connection.started":
-      return { ...state, connection: { from: action.from, to: null } };
+      return {
+        ...state,
+        connection: { from: action.from, to: null },
+        draftingSubject: false,
+      };
     case "connection.targeted":
       if (state.connection === null) return state;
       // Naming the source again means "not that after all". A subject related
@@ -404,6 +417,12 @@ export const visualWorkspaceReducer = (
         : { ...state, connection: { ...state.connection, to: action.to } };
     case "connection.cancelled":
       return state.connection === null ? state : { ...state, connection: null };
+    case "subject.draft.opened":
+      // The two tools are alternatives, not layers: opening one puts the other
+      // away rather than leaving two half-finished drafts on screen.
+      return { ...state, draftingSubject: true, connection: null };
+    case "subject.draft.closed":
+      return state.draftingSubject ? { ...state, draftingSubject: false } : state;
     case "subject.selected":
       return {
         ...state,

--- a/test/concept-drafting.test.ts
+++ b/test/concept-drafting.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import { stringify } from 'yaml'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import { draftConcept, proposeConceptId } from '../src/concept-drafting.js'
+import { applyOperations } from '../src/apply-command.js'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+const DOCUMENT = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+relationships: []
+`
+
+const KINDS = ['applicationComponent', 'applicationService', 'businessActor']
+
+const graphOf = (source: string): CanvasGraph => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return projectGraphForCanvas(result.graph, result.profileContext)
+}
+
+const graph = graphOf(DOCUMENT)
+
+describe('proposeConceptId', () => {
+  it('transliterates a name into an id a human can read in a diff', () => {
+    expect(proposeConceptId(graph, 'Order Intake')).toBe('order-intake')
+    expect(proposeConceptId(graph, 'Order Intake (v2)')).toBe('order-intake-v2')
+    expect(proposeConceptId(graph, '  Spaced   Out  ')).toBe('spaced-out')
+  })
+
+  it('steps past an id already taken', () => {
+    expect(proposeConceptId(graph, 'Orders')).toBe('orders-2')
+  })
+
+  it('drops the marks an accent decomposes into rather than hyphenating them', () => {
+    // Asserting the pattern alone let this through as "u-ni-code-name".
+    expect(proposeConceptId(graph, 'Ünïcodé Name')).toBe('unicode-name')
+  })
+
+  it('refuses a name it cannot make an id of, rather than inventing one', () => {
+    // A placeholder id nothing could be traced back from is worse than asking
+    // the reviewer for a different name.
+    expect(proposeConceptId(graph, '???')).toBeNull()
+    expect(proposeConceptId(graph, '   ')).toBeNull()
+    expect(proposeConceptId(graph, '\u65e5\u672c\u8a9e')).toBeNull()
+  })
+
+  it('refuses a leading digit rather than silently dropping it', () => {
+    // "2FA Gateway" -> "fa-gateway" would be an id that no longer names the
+    // thing. An id must start with a letter, so this is a name it cannot be
+    // made of, and the caller is told rather than handed a mangled one.
+    expect(proposeConceptId(graph, '2FA Gateway')).toBeNull()
+    expect(proposeConceptId(graph, '123')).toBeNull()
+  })
+
+  it('always produces something the document schema accepts', () => {
+    const pattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+    for (const name of [
+      'Orders',
+      'Order Intake (v2)',
+      'ACME  Billing',
+      'a',
+      'trailing---hyphens---',
+    ]) {
+      const id = proposeConceptId(graph, name)
+      if (id === null) continue
+      expect(id, name).toMatch(pattern)
+    }
+  })
+})
+
+describe('draftConcept', () => {
+  it('refuses a kind outside the workspace vocabulary', () => {
+    expect(
+      draftConcept(graph, { name: 'Thing', kind: 'invented', document: 'architecture/main.yaml' }, KINDS),
+    ).toBeNull()
+  })
+
+  it('refuses a draft with nothing to name it or nowhere to put it', () => {
+    expect(
+      draftConcept(graph, { name: '', kind: 'applicationComponent', document: 'architecture/main.yaml' }, KINDS),
+    ).toBeNull()
+    expect(
+      draftConcept(graph, { name: 'Thing', kind: 'applicationComponent', document: '' }, KINDS),
+    ).toBeNull()
+  })
+
+  /**
+   * The property, driven through: whatever the form produces is applied and
+   * compiled, so anything the editor could land already has a passing `check`
+   * behind it. No filesystem, because Core is pure since ADR 0100.
+   */
+  it('produces a concept that applies and compiles, for every kind offered', () => {
+    let drafted = 0
+    for (const kind of KINDS) {
+      const operation = draftConcept(
+        graph,
+        { name: `New ${kind}`, kind, document: 'architecture/main.yaml' },
+        KINDS,
+      )
+      expect(operation, kind).not.toBeNull()
+      if (operation === null) continue
+      drafted += 1
+
+      const outcome = applyOperations({
+        workspace: {
+          id: 'drafting',
+          documents: ['architecture/main.yaml'],
+          profiles: [],
+          projections: [],
+          adapterMappings: [],
+          evidence: [],
+          contracts: [],
+        },
+        sources: [{ path: 'architecture/main.yaml', source: DOCUMENT }],
+        operations: {
+          path: 'changeset.yaml',
+          source: stringify({
+            format: 'yarramate/operations/v1',
+            operations: [operation],
+          }),
+        },
+        manifestDirectory: '.yarramate',
+      })
+
+      expect(
+        outcome.ok ? [] : outcome.diagnostics.map((d) => d.code),
+        `${kind} did not apply`,
+      ).toEqual([])
+    }
+    expect(drafted).toBe(KINDS.length)
+  })
+
+  it('lands a subject the connection tool can then reach', () => {
+    // The two halves meet: a subject made here is an endpoint there.
+    const operation = draftConcept(
+      graph,
+      { name: 'Billing', kind: 'applicationComponent', document: 'architecture/main.yaml' },
+      KINDS,
+    )
+    expect(operation).not.toBeNull()
+    if (operation === null) return
+
+    const outcome = applyOperations({
+      workspace: {
+        id: 'drafting',
+        documents: ['architecture/main.yaml'],
+        profiles: [],
+        projections: [],
+        adapterMappings: [],
+        evidence: [],
+        contracts: [],
+      },
+      sources: [{ path: 'architecture/main.yaml', source: DOCUMENT }],
+      operations: {
+        path: 'changeset.yaml',
+        source: stringify({
+          format: 'yarramate/operations/v1',
+          operations: [operation],
+        }),
+      },
+      manifestDirectory: '.yarramate',
+    })
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) return
+
+    const after = graphOf(outcome.sources[0]!.source)
+    expect(after.nodes.map((node) => node.id)).toContain('billing')
+  })
+})

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -1,0 +1,74 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import { SubjectDraftPanel } from '../src/visual-app/subject-draft-panel.js'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+/**
+ * What the form puts on screen. What it produces when submitted is
+ * `draftConcept`, covered in `concept-drafting.test.ts` by compiling every
+ * draft it makes.
+ */
+const graphOf = (source: string): CanvasGraph => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return projectGraphForCanvas(result.graph, result.profileContext)
+}
+
+const graph = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+relationships: []
+`)
+
+const render = () =>
+  renderToStaticMarkup(
+    createElement(SubjectDraftPanel, {
+      graph,
+      kinds: [
+        { id: 'applicationComponent', label: 'applicationComponent' },
+        { id: 'businessActor', label: 'businessActor' },
+      ],
+      documents: ['architecture/main.yaml', 'architecture/other.yaml'],
+      defaultDocument: 'architecture/main.yaml',
+      onStage: () => undefined,
+      onCancel: () => undefined,
+    }),
+  )
+
+describe('SubjectDraftPanel', () => {
+  it('offers the workspace vocabulary rather than a list of its own', () => {
+    const markup = render()
+
+    expect(markup).toContain('applicationComponent')
+    expect(markup).toContain('businessActor')
+  })
+
+  it('offers every document the workspace declares', () => {
+    const markup = render()
+
+    expect(markup).toContain('architecture/main.yaml')
+    expect(markup).toContain('architecture/other.yaml')
+  })
+
+  it('asks for a name before proposing anything', () => {
+    // The id is derived, so there is nothing to show until there is a name.
+    expect(render()).toContain('Give it a name')
+  })
+
+  it('cannot be submitted while there is nothing to submit', () => {
+    expect(render()).toContain('disabled')
+  })
+
+  it('can always be backed out of', () => {
+    expect(render()).toContain('Cancel')
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -468,6 +468,45 @@ describe("visualWorkspaceReducer connection", () => {
   });
 });
 
+describe("visualWorkspaceReducer subject draft", () => {
+  const workspaceState = createVisualWorkspaceState(1280);
+
+  it("is closed until it is opened", () => {
+    expect(workspaceState.draftingSubject).toBe(false);
+    expect(
+      visualWorkspaceReducer(workspaceState, { type: "subject.draft.opened" })
+        .draftingSubject,
+    ).toBe(true);
+  });
+
+  it("closing a form that is not open changes nothing", () => {
+    expect(
+      visualWorkspaceReducer(workspaceState, { type: "subject.draft.closed" }),
+    ).toBe(workspaceState);
+  });
+
+  it("the two tools are alternatives, not layers", () => {
+    // Opening one puts the other away, rather than leaving two half-finished
+    // drafts on screen with no way to tell which a click belongs to.
+    const connecting = visualWorkspaceReducer(workspaceState, {
+      type: "connection.started",
+      from: "orders",
+    });
+    const drafting = visualWorkspaceReducer(connecting, {
+      type: "subject.draft.opened",
+    });
+    expect(drafting.connection).toBeNull();
+    expect(drafting.draftingSubject).toBe(true);
+
+    const backToConnecting = visualWorkspaceReducer(drafting, {
+      type: "connection.started",
+      from: "orders",
+    });
+    expect(backToConnecting.draftingSubject).toBe(false);
+    expect(backToConnecting.connection).toEqual({ from: "orders", to: null });
+  });
+});
+
 describe("visualWorkspaceReducer nesting", () => {
   const workspaceState = createVisualWorkspaceState(1280);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "test/graph-canvas-layout.test.ts",
     "test/graph-canvas-nesting.test.ts",
     "test/connection-panel.test.ts",
+    "test/subject-draft-panel.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/badges.test.ts",

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -30,6 +30,7 @@
     "test/graph-canvas-layout.test.ts",
     "test/graph-canvas-nesting.test.ts",
     "test/connection-panel.test.ts",
+    "test/subject-draft-panel.test.ts",
     "test/changeset-tray.test.ts",
     "test/subject-form.test.ts",
     "test/archimate-notation.test.ts"


### PR DESCRIPTION
## Summary

The canvas could connect two subjects but had no way to bring one into
existence — able to describe relationships between things it could not make.

**Add subject** opens a form over the canvas: a name, a kind, a document. It
stages an `add-concept`.

The kinds are the workspace's own vocabulary, which **every model frame has
carried all along and nothing consumed**. Nothing in the browser decides what a
workspace may contain, and `draftConcept` refuses a kind outside that list even
if a caller offered one — the same posture `draftRelationship` takes.

## The id is derived, and shown before it lands

An id is a stable address a human reads in a diff. A reviewer thinking about a
*name* writes worse ids than a transliteration of the name does, so it is
derived. But a derived address the author never saw is one nobody agreed to, so
the form shows it first.

```
"Order Intake (v2)"     -> order-intake-v2
"Orders"  (taken)       -> orders-2
```

## Two names refused rather than mangled — both caught late

I had asserted only that the derived id *matched the id pattern*. Both of these
passed that and were still wrong:

```
"Ünïcodé Name" -> "u-ni-code-name"
```
NFKD splits an accent into a letter plus a combining mark, and the mark then
read as a word boundary. Marks are dropped now: `unicode-name`.

```
"2FA Gateway"  -> "fa-gateway"
```
A leading digit was silently stripped to satisfy the pattern, leaving an id that
**no longer names the thing**. Such a name is now refused and the form says why.

The tests pin the produced values, not just the shape. That is the lesson worth
keeping: a pattern assertion proves an id is *legal*, never that it is *right*.

## One interaction rule

Adding and connecting are **alternatives, not layers**. Starting one puts the
other away, so a click on the diagram always belongs to exactly one of them.
Only the form's openness is workspace state — a half-typed name is not something
anyone else needs.

## Validation

`pnpm verify` exits 0: **80 files, 1307 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

Eighteen new tests. Ten on the drafting functions, including one that applies a
drafted concept and confirms the connection tool can then reach it as an
endpoint — the two halves meeting. Five render the form. Three cover the
alternatives-not-layers rule.

## Related issue

None. Wave 4 — CRUD and the kind palette, which turned out to be one piece of
work.

## Contract impact

Additive. Two new exports (`draftConcept`, `proposeConceptId`). New UI and two
workspace-state actions. No schema, diagnostic, CLI or protocol change; the
staged operation is the existing `add-concept`.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — UI over the existing operations contract; no new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)