### PR TITLE
feat(visual): delete from the canvas, and take the relationships with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,21 @@
   thing. Adding and connecting are alternatives rather than layers, so a click
   on the diagram always belongs to exactly one of them (#238).
 
+- Deleting from the canvas, which completes the four motions the write surface
+  has had since ADR 0069 and the canvas had none of. **Delete** on a selected
+  subject or relationship asks first, because this is the one motion that
+  removes authored text.
+  Deleting a subject stages every relationship naming it in the same batch.
+  `apply` will not remove a subject something still references and evaluates
+  that against the post-batch state, so the two go together or neither does;
+  composing that batch is the point, since a reviewer would otherwise have to
+  find every relationship touching the subject by hand and the canvas already
+  knows them. The confirmation names what else still holds the subject, an
+  `owner` or a `supersedes` or a constraint, and warns rather than refuses: the
+  list is derived from what a canvas holds, a canvas does not hold everything
+  that can reference a subject, and treating it as authoritative would block
+  deletions that would land (#239).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -102,6 +102,25 @@ recorded what those two backends mapped onto and why the obvious ELK choices
 were rejected; it is superseded here. A future layout mechanism is expected,
 and `presentation.layout` stays an enum so it has somewhere to land.
 
+### Deleting
+
+**Delete** on a selected subject or relationship asks first, because this is the
+one motion that removes authored text.
+
+Deleting a subject takes every relationship naming it in the same batch.
+`apply` will not remove a subject something still references, and it evaluates
+that against the post-batch state (ADR 0069), so the two go together or neither
+does. Composing that batch is the point: a reviewer would otherwise have to find
+every relationship touching the subject by hand, and the canvas already knows
+them.
+
+The confirmation states what else still names the subject: an `owner`, a
+`distinctFrom`, a `supersedes`, a constraint or a reference. It **warns rather
+than refuses**. That list is derived from what a canvas holds, and a canvas does
+not hold everything that can reference a subject, so treating it as
+authoritative would block deletions that would actually land. `apply` is the
+gate.
+
 ### Adding a subject
 
 **Add subject** opens a form over the canvas: a name, a kind, and the document

--- a/src/deletion-drafting.ts
+++ b/src/deletion-drafting.ts
@@ -1,0 +1,152 @@
+import type { CanvasGraph } from './graph-projection.js'
+import type { YarramateOperation } from './operations.js'
+
+/**
+ * Drafting a deletion, the last of the four motions the write surface has
+ * (ADR 0069) and the last the canvas could not make.
+ *
+ * `apply` refuses to delete a subject anything still references, and evaluates
+ * that against the post-batch state, so a subject and the relationships naming
+ * it land as one atomic motion when they go together. Composing that batch is
+ * the useful part: a reviewer deleting one subject would otherwise have to
+ * find every relationship touching it by hand, and a canvas already knows them.
+ */
+
+/** A reference that would still hold the subject after its relationships go. */
+export interface DeletionBlocker {
+  /** The subject doing the referencing. */
+  readonly by: string
+  /** Which of its fields names the target. */
+  readonly field: 'owner' | 'distinctFrom' | 'supersedes' | 'constraint' | 'reference'
+}
+
+/**
+ * What would still refuse the deletion once every relationship naming the
+ * subject is deleted with it.
+ *
+ * Relationships are absent by construction: they are deleted in the same
+ * batch. What remains is the reference kinds a batch cannot resolve on the
+ * reviewer's behalf, because removing them changes what another subject says
+ * rather than removing something that only existed to join two things.
+ */
+export const deletionBlockers = (
+  graph: CanvasGraph,
+  id: string,
+): readonly DeletionBlocker[] => {
+  const blockers: DeletionBlocker[] = []
+  for (const node of graph.nodes) {
+    if (node.id === id) continue
+    if (node.owner === id) blockers.push({ by: node.id, field: 'owner' })
+    if (node.distinctFrom.includes(id)) {
+      blockers.push({ by: node.id, field: 'distinctFrom' })
+    }
+    if (node.supersedes.includes(id)) {
+      blockers.push({ by: node.id, field: 'supersedes' })
+    }
+    if (node.constraints.some((constraint) => constraint.ref === id)) {
+      blockers.push({ by: node.id, field: 'constraint' })
+    }
+    if (node.references.some((reference) => reference.ref === id)) {
+      blockers.push({ by: node.id, field: 'reference' })
+    }
+  }
+  return blockers
+}
+
+/**
+ * The operations that remove a subject, or a relationship, from the model.
+ *
+ * Deleting a subject takes every relationship naming it along, which is what
+ * makes the batch land at all. Each operation names the document the thing was
+ * actually authored in, so a relationship stored apart from its endpoints is
+ * still spliced out of its own file.
+ *
+ * Empty when the id is not in the graph. Blockers are NOT consulted here: a
+ * caller that wants to warn asks {@link deletionBlockers}, and one that goes
+ * ahead anyway is refused by `apply` rather than by a second opinion here.
+ */
+export const draftDeletion = (
+  graph: CanvasGraph,
+  id: string,
+): readonly YarramateOperation[] => {
+  const edge = graph.edges.find((candidate) => candidate.id === id)
+  if (edge !== undefined) {
+    return [
+      {
+        op: 'delete-relationship',
+        document: edge.document,
+        relationship: { id: edge.id },
+      },
+    ]
+  }
+
+  const node = graph.nodes.find((candidate) => candidate.id === id)
+  if (node === undefined) return []
+
+  const touching = graph.edges.filter(
+    (candidate) => candidate.from === id || candidate.to === id,
+  )
+  return [
+    ...touching.map(
+      (candidate): YarramateOperation => ({
+        op: 'delete-relationship',
+        document: candidate.document,
+        relationship: { id: candidate.id },
+      }),
+    ),
+    { op: 'delete-concept', document: node.document, concept: { id: node.id } },
+  ]
+}
+
+/**
+ * What a reviewer is about to do, in a sentence, for the confirmation.
+ *
+ * Blockers are stated rather than used to disable the confirmation. The list
+ * is derived from what a canvas holds, and a canvas does not hold everything
+ * that can reference a subject - an evidence overlay is not in the graph - so
+ * treating it as authoritative would refuse deletions that would actually
+ * land. `apply` is the gate; this is a warning.
+ */
+export const describeDeletion = (
+  graph: CanvasGraph,
+  id: string,
+): string | null => {
+  const edge = graph.edges.find((candidate) => candidate.id === id)
+  if (edge !== undefined) {
+    return `Delete the ${edge.kindLabel} relationship from "${
+      graph.nodes.find((node) => node.id === edge.from)?.name ?? edge.from
+    }" to "${
+      graph.nodes.find((node) => node.id === edge.to)?.name ?? edge.to
+    }"?`
+  }
+
+  const node = graph.nodes.find((candidate) => candidate.id === id)
+  if (node === undefined) return null
+
+  const touching = graph.edges.filter(
+    (candidate) => candidate.from === id || candidate.to === id,
+  ).length
+  const blockers = deletionBlockers(graph, id)
+
+  const head =
+    touching === 0
+      ? `Delete "${node.name}"?`
+      : `Delete "${node.name}" and the ${touching} ${
+          touching === 1 ? 'relationship that names' : 'relationships that name'
+        } it?`
+
+  if (blockers.length === 0) return head
+  // By name, because the reviewer is reading a diagram of names.
+  const named = [
+    ...new Set(
+      blockers.map(
+        (blocker) =>
+          graph.nodes.find((candidate) => candidate.id === blocker.by)?.name ??
+          blocker.by,
+      ),
+    ),
+  ]
+  const shown = named.slice(0, 3)
+  const rest = named.length > shown.length ? ' and others' : ''
+  return `${head} It is still named by ${shown.join(', ')}${rest}, so this may be refused.`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,3 +137,9 @@ export {
   proposeRelationshipId,
 } from './relationship-drafting.js'
 export { draftConcept, proposeConceptId } from './concept-drafting.js'
+export {
+  deletionBlockers,
+  describeDeletion,
+  draftDeletion,
+  type DeletionBlocker,
+} from './deletion-drafting.js'

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -44,6 +44,8 @@ import {
 } from "./workspace-state.js";
 import { ConnectionPanel } from "./connection-panel.js";
 import { SubjectDraftPanel } from "./subject-draft-panel.js";
+import { ConfirmDialog } from "./confirm-dialog.js";
+import { describeDeletion, draftDeletion } from "../deletion-drafting.js";
 
 /**
  * A drawing board, not a document: the diagram holds the workspace, one compact
@@ -345,6 +347,8 @@ const DiagramWorkspace = ({
   draftingSubject,
   onDraftSubject,
   onDraftSubjectClose,
+  pendingDeletion,
+  onDeletionDismiss,
   onSelect,
   onClearFilter,
   onSaveLayout,
@@ -366,6 +370,8 @@ const DiagramWorkspace = ({
   readonly draftingSubject: boolean;
   readonly onDraftSubject: () => void;
   readonly onDraftSubjectClose: () => void;
+  readonly pendingDeletion: string | null;
+  readonly onDeletionDismiss: () => void;
   readonly onSelect: (subject: SelectedDiagramSubject) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
@@ -430,6 +436,29 @@ const DiagramWorkspace = ({
             }
             onStage={onConnectStage}
             onCancel={onDraftSubjectClose}
+          />
+        )}
+        {pendingDeletion === null || state.model === null ? null : (
+          <ConfirmDialog
+            title="Delete"
+            message={
+              describeDeletion(state.model.graph, pendingDeletion) ??
+              "That subject is no longer on the diagram."
+            }
+            confirmLabel="Delete"
+            cancelLabel="Keep"
+            onConfirm={() => {
+              // One batch: a subject and the relationships naming it have to
+              // go together or `apply` refuses the lot (ADR 0069).
+              for (const operation of draftDeletion(
+                state.model!.graph,
+                pendingDeletion,
+              )) {
+                onConnectStage(operation);
+              }
+              onDeletionDismiss();
+            }}
+            onCancel={onDeletionDismiss}
           />
         )}
         {connection === null || state.model === null ? null : (
@@ -547,6 +576,7 @@ const SelectedSubjectInspector = ({
   onToggleDescription,
   onClear,
   onConnect,
+  onDelete,
   onStageChange,
 }: {
   readonly subject: SelectedDiagramSubject;
@@ -556,6 +586,7 @@ const SelectedSubjectInspector = ({
   readonly onToggleDescription: () => void;
   readonly onClear: () => void;
   readonly onConnect: (from: string) => void;
+  readonly onDelete: (id: string) => void;
   readonly onStageChange: (operation: YarramateOperation) => void;
 }) => {
   const node =
@@ -591,6 +622,13 @@ const SelectedSubjectInspector = ({
             Connect
           </button>
         ) : null}
+        <button
+          type="button"
+          className="subject-delete"
+          onClick={() => onDelete(subject.id)}
+        >
+          Delete
+        </button>
         <button type="button" className="subject-clear" onClick={onClear}>
           Clear
         </button>
@@ -633,6 +671,7 @@ const ConversationPanel = ({
   onToggleDescription,
   onClearSubject,
   onConnect,
+  onDelete,
   onDiscardChange,
   onStageChange,
   onClearChangeset,
@@ -650,6 +689,7 @@ const ConversationPanel = ({
   readonly onToggleDescription: () => void;
   readonly onClearSubject: () => void;
   readonly onConnect: (from: string) => void;
+  readonly onDelete: (id: string) => void;
   readonly onDiscardChange: (index: number) => void;
   readonly onStageChange: (operation: YarramateOperation) => void;
   readonly onClearChangeset: () => void;
@@ -693,6 +733,7 @@ const ConversationPanel = ({
             onToggleDescription={onToggleDescription}
             onClear={onClearSubject}
             onConnect={onConnect}
+            onDelete={onDelete}
             onStageChange={onStageChange}
           />
         )}
@@ -1061,6 +1102,10 @@ export const App = () => {
           onDraftSubjectClose={() =>
             dispatchWorkspace({ type: "subject.draft.closed" })
           }
+          pendingDeletion={workspace.pendingDeletion}
+          onDeletionDismiss={() =>
+            dispatchWorkspace({ type: "deletion.dismissed" })
+          }
           showLifecycle={workspace.showLifecycle}
           showEvidence={workspace.showEvidence}
           showOwnership={workspace.showOwnership}
@@ -1096,6 +1141,7 @@ export const App = () => {
           onConnect={(from) =>
             dispatchWorkspace({ type: "connection.started", from })
           }
+          onDelete={(id) => dispatchWorkspace({ type: "deletion.asked", id })}
           onDiscardChange={discardChange}
           onStageChange={stageChange}
           onClearChangeset={clearChangeset}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -593,6 +593,12 @@ body {
   color: var(--quiet);
 }
 
+.subject-delete {
+  margin-top: calc(var(--step) * 0.5);
+  margin-right: calc(var(--step) * 0.5);
+  min-height: 28px;
+}
+
 .subject-draft-open {
   position: absolute;
   z-index: 2;

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -125,6 +125,12 @@ export interface VisualWorkspaceState {
    * not workspace state anyone else needs.
    */
   readonly draftingSubject: boolean;
+  /**
+   * The subject or relationship a deletion has been asked for, held until the
+   * reviewer confirms. Deleting is the one motion that removes authored text,
+   * so it is the one that asks first.
+   */
+  readonly pendingDeletion: string | null;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   readonly direction: "top-down" | "left-right";
@@ -163,6 +169,8 @@ export type VisualWorkspaceAction =
   | { readonly type: "connection.cancelled" }
   | { readonly type: "subject.draft.opened" }
   | { readonly type: "subject.draft.closed" }
+  | { readonly type: "deletion.asked"; readonly id: string }
+  | { readonly type: "deletion.dismissed" }
   | {
       readonly type: "subject.selected";
       readonly subject: SelectedDiagramSubject;
@@ -333,6 +341,7 @@ export const createVisualWorkspaceState = (
   detailsOpen: false,
   connection: null,
   draftingSubject: false,
+  pendingDeletion: null,
   direction: "top-down",
   nesting: DEFAULT_NESTING,
   layout: "layered",
@@ -423,6 +432,19 @@ export const visualWorkspaceReducer = (
       return { ...state, draftingSubject: true, connection: null };
     case "subject.draft.closed":
       return state.draftingSubject ? { ...state, draftingSubject: false } : state;
+    case "deletion.asked":
+      // Asking puts the other tools away: a confirmation is the only thing
+      // that should be able to take the next click.
+      return {
+        ...state,
+        pendingDeletion: action.id,
+        connection: null,
+        draftingSubject: false,
+      };
+    case "deletion.dismissed":
+      return state.pendingDeletion === null
+        ? state
+        : { ...state, pendingDeletion: null };
     case "subject.selected":
       return {
         ...state,

--- a/test/deletion-drafting.test.ts
+++ b/test/deletion-drafting.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { stringify } from 'yaml'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import { projectGraphForCanvas } from '../src/graph-projection.js'
+import { deletionBlockers, draftDeletion } from '../src/deletion-drafting.js'
+import { applyOperations } from '../src/apply-command.js'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+const DOCUMENT = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+  - id: billing
+    kind: applicationComponent
+    name: Billing
+  - id: ledger
+    kind: dataObject
+    name: Ledger
+relationships:
+  - id: orders-serving-billing
+    kind: serving
+    from: orders
+    to: billing
+  - id: billing-access-ledger
+    kind: access
+    from: billing
+    to: ledger
+`
+
+const graphOf = (source: string): CanvasGraph => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return projectGraphForCanvas(result.graph, result.profileContext)
+}
+
+const graph = graphOf(DOCUMENT)
+
+const apply = (operations: readonly unknown[], source = DOCUMENT) =>
+  applyOperations({
+    workspace: {
+      id: 'deleting',
+      documents: ['architecture/main.yaml'],
+      profiles: [],
+      projections: [],
+      adapterMappings: [],
+      evidence: [],
+      contracts: [],
+    },
+    sources: [{ path: 'architecture/main.yaml', source }],
+    operations: {
+      path: 'changeset.yaml',
+      source: stringify({
+        format: 'yarramate/operations/v1',
+        operations,
+      }),
+    },
+    manifestDirectory: '.yarramate',
+  })
+
+describe('draftDeletion', () => {
+  it('is empty for an id the graph does not hold', () => {
+    expect(draftDeletion(graph, 'absent')).toEqual([])
+  })
+
+  it('removes a relationship on its own', () => {
+    expect(draftDeletion(graph, 'orders-serving-billing')).toEqual([
+      {
+        op: 'delete-relationship',
+        document: 'architecture/main.yaml',
+        relationship: { id: 'orders-serving-billing' },
+      },
+    ])
+  })
+
+  it('takes every relationship naming a subject along with it', () => {
+    // Without this the delete is simply refused: `apply` will not remove a
+    // subject something still references.
+    const operations = draftDeletion(graph, 'billing')
+
+    expect(operations.map((operation) => operation.op)).toEqual([
+      'delete-relationship',
+      'delete-relationship',
+      'delete-concept',
+    ])
+  })
+
+  /**
+   * The property: what the canvas composes actually lands. ADR 0069 evaluates
+   * integrity against the post-batch state, which is what lets a subject and
+   * its relationships go together at all.
+   */
+  it('composes a batch that applies and leaves a workspace that compiles', () => {
+    const outcome = apply(draftDeletion(graph, 'billing'))
+
+    expect(outcome.ok ? [] : outcome.diagnostics.map((d) => d.code)).toEqual([])
+    if (!outcome.ok) return
+
+    const after = graphOf(outcome.sources[0]!.source)
+    expect(after.nodes.map((node) => node.id).sort()).toEqual([
+      'ledger',
+      'orders',
+    ])
+    expect(after.edges).toEqual([])
+  })
+
+  it('deletes every subject in turn without leaving a workspace that fails', () => {
+    for (const node of graph.nodes) {
+      const outcome = apply(draftDeletion(graph, node.id))
+      expect(
+        outcome.ok ? [] : outcome.diagnostics.map((d) => d.code),
+        `deleting ${node.id}`,
+      ).toEqual([])
+      if (!outcome.ok) continue
+      const after = graphOf(outcome.sources[0]!.source)
+      expect(after.nodes.map((candidate) => candidate.id)).not.toContain(
+        node.id,
+      )
+    }
+  })
+})
+
+describe('deletionBlockers', () => {
+  it('finds nothing when only relationships hold the subject', () => {
+    // Those go in the same batch, so they are not blockers.
+    expect(deletionBlockers(graph, 'billing')).toEqual([])
+  })
+
+  it('names the subject and the field that would still refuse it', () => {
+    const held = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: alice
+    kind: businessActor
+    name: Alice
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+    owner: alice
+relationships: []
+`)
+
+    expect(deletionBlockers(held, 'alice')).toEqual([
+      { by: 'orders', field: 'owner' },
+    ])
+  })
+
+  it('a blocked deletion is refused by apply, which is the real gate', () => {
+    // The blocker list is a warning the canvas can show; it is not the rule.
+    const source = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: alice
+    kind: businessActor
+    name: Alice
+  - id: orders
+    kind: applicationComponent
+    name: Orders
+    owner: alice
+relationships: []
+`
+    const held = graphOf(source)
+    const outcome = apply(draftDeletion(held, 'alice'), source)
+
+    expect(outcome.ok).toBe(false)
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -507,6 +507,46 @@ describe("visualWorkspaceReducer subject draft", () => {
   });
 });
 
+describe("visualWorkspaceReducer deletion", () => {
+  const workspaceState = createVisualWorkspaceState(1280);
+
+  it("holds what was asked for until it is answered", () => {
+    const asked = visualWorkspaceReducer(workspaceState, {
+      type: "deletion.asked",
+      id: "orders",
+    });
+    expect(asked.pendingDeletion).toBe("orders");
+    expect(
+      visualWorkspaceReducer(asked, { type: "deletion.dismissed" })
+        .pendingDeletion,
+    ).toBeNull();
+  });
+
+  it("dismissing when nothing was asked changes nothing", () => {
+    expect(
+      visualWorkspaceReducer(workspaceState, { type: "deletion.dismissed" }),
+    ).toBe(workspaceState);
+  });
+
+  it("puts the other tools away, so only the confirmation takes the next click", () => {
+    const connecting = visualWorkspaceReducer(workspaceState, {
+      type: "connection.started",
+      from: "orders",
+    });
+    const drafting = visualWorkspaceReducer(connecting, {
+      type: "subject.draft.opened",
+    });
+    const asked = visualWorkspaceReducer(drafting, {
+      type: "deletion.asked",
+      id: "orders",
+    });
+
+    expect(asked.connection).toBeNull();
+    expect(asked.draftingSubject).toBe(false);
+    expect(asked.pendingDeletion).toBe("orders");
+  });
+});
+
 describe("visualWorkspaceReducer nesting", () => {
   const workspaceState = createVisualWorkspaceState(1280);
 


### PR DESCRIPTION
## Summary

The write surface has had four motions since ADR 0069 — assert, enrich, retract,
delete — and the canvas had none of the last one. **Delete** on a selected
subject or relationship asks first, because this is the one motion that removes
authored text.

## The batch is the point

`apply` will not remove a subject something still references, and it evaluates
integrity against the **post-batch** state. So a subject and the relationships
naming it land as one atomic motion, or not at all.

A reviewer deleting one subject would otherwise have to find every relationship
touching it by hand. The canvas already knows them, so it composes the batch:

```
delete-relationship  orders-serving-billing
delete-relationship  billing-access-ledger
delete-concept       billing
```

A test deletes **every subject in the fixture in turn** and confirms each batch
applies and leaves a workspace that still compiles.

## The blocker list warns, it does not refuse

The confirmation names what else still holds the subject — an `owner`, a
`distinctFrom`, a `supersedes`, a constraint, a reference:

```
Delete "Alice"? It is still named by Orders, so this may be refused.
```

**Deliberately advice rather than a gate.** That list is derived from what a
canvas holds, and a canvas does not hold everything that can reference a subject
— an evidence overlay is not in the graph. Treating an incomplete list as
authoritative would block deletions that would actually land, so `apply` stays
the gate. A test covers exactly that: a blocked deletion is refused *by apply*.

## Wording was worth testing

The message is built by a pure function, and two things were wrong until the
values were checked rather than the shape:

- "the 1 relationship that **name** it" — singular and plural now differ.
- blockers were named by **id** (`orders`) in a diagram the reviewer is reading
  by **name** (`Orders`).

## Validation

`pnpm verify` exits 0: **81 files, 1318 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

Eleven new tests: the composed batch and its ordering, deleting every subject in
turn, a relationship deleted alone, an unknown id, the blocker cases, the
apply-is-the-gate case, and the three state transitions including
asking-puts-the-other-tools-away.

## Related issue

None. Wave 4 — this completes CRUD on the canvas.

## Contract impact

Additive. Four new exports (`draftDeletion`, `deletionBlockers`,
`describeDeletion`, `DeletionBlocker`). New UI and two workspace-state actions.
No schema, diagnostic, CLI or protocol change; the staged operations are the
existing `delete-concept` and `delete-relationship`.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — UI over ADR 0069's existing contract; no new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)