### PR TITLE
fix(visual): the app did not load, and adding a subject could never have worked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,26 @@
   that can reference a subject, and treating it as authoritative would block
   deletions that would land (#239).
 
+- **Fix.** The visual app did not load at all. `DEFAULT_NESTING` was defined in
+  `projection.ts`, which loads Ajv through `createRequire`, and importing that
+  one constant for its value put `(0, cre.createRequire)(import.meta.url)` in
+  the browser bundle, where it is not a function: the app failed to mount and
+  the page was blank. It had been broken since the constant was introduced,
+  through four subsequent merges, because every test runs in Node and a bundler
+  has no opinion about it. `NestingKind` and `DEFAULT_NESTING` now live in
+  `nesting.ts`, which imports nothing, and `projection.ts` re-exports them.
+  A test now walks every value import out of `src/visual-app` and fails on one
+  that reaches `node:`, naming the chain that got there.
+
+- **Fix.** Adding a subject could never have worked. The form offered each
+  kind's wire identity, `yarramate/core@0.1#applicationComponent`, where a
+  document names a kind the short way, so `apply` refused every commit with
+  `YM401 Unknown concept kind`. The editable inspector had always used the
+  short label; this form did not. The form also defaulted to the first kind
+  alphabetically, `andJunction`, so a reviewer who typed a name and pressed Add
+  made a junction by accident; it now asks for a kind and stays disabled until
+  it has one (#240).
+
 - `apply` accepts an operation's `document:` as the manifest names it. The
   address was resolved only against the working directory, so the
   manifest-relative form an author naturally writes was refused whenever the

--- a/src/nesting.ts
+++ b/src/nesting.ts
@@ -1,0 +1,14 @@
+/**
+ * What a view nests, kept in a module that imports nothing.
+ *
+ * These live apart from `projection.ts` because the browser needs the value,
+ * not only the type, and `projection.ts` reaches for `node:module` to load
+ * Ajv. A value import of it from `src/visual-app` therefore pulls
+ * `createRequire` into the browser bundle, where it is not a function and the
+ * whole app fails to mount (ADR 0101 introduced the constant; this is where it
+ * belongs). `projection.ts` re-exports both, so nothing else has to know.
+ */
+export type NestingKind = 'composition' | 'assignment'
+
+/** What a view nests when it does not say: the behaviour that shipped. */
+export const DEFAULT_NESTING: readonly NestingKind[] = ['composition']

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -66,14 +66,14 @@ export interface ProjectionDefinition {
 }
 
 /**
- * A relationship kind a view may draw as nesting. Closed here and in
- * `yarramate-projection.schema.json`; widening it is additive, because a view
- * opts in by naming a kind (ADR 0101).
+ * A relationship kind a view may draw as nesting, and the default. Defined in
+ * `./nesting.js`, which imports nothing, and re-exported here so a consumer
+ * that already reads projection types keeps finding them. The browser must
+ * import them from there rather than from here: this module reaches for
+ * `node:module` to load Ajv (ADR 0101).
  */
-export type NestingKind = 'composition' | 'assignment'
-
-/** What a view nests when it does not say: the behaviour that shipped. */
-export const DEFAULT_NESTING: readonly NestingKind[] = ['composition']
+export { DEFAULT_NESTING, type NestingKind } from './nesting.js'
+import type { NestingKind } from './nesting.js'
 
 export type ProjectionQuery = ProjectionDefinition['query']
 

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -18,7 +18,8 @@ import {
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import type { NestingKind, ProjectionQuery } from "../projection.js";
+import type { NestingKind } from "../nesting.js";
+import type { ProjectionQuery } from "../projection.js";
 import type { VisualRenderedModel } from "../adapters/visual/wire.js";
 import type { YarramateOperation } from "../operations.js";
 import type {

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -8,7 +8,7 @@ import type {
   CanvasNode,
   CanvasEdge,
 } from '../graph-projection.js'
-import { DEFAULT_NESTING, type NestingKind } from '../projection.js'
+import { DEFAULT_NESTING, type NestingKind } from '../nesting.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -31,7 +31,10 @@ export const SubjectDraftPanel = ({
   readonly onCancel: () => void
 }): React.ReactElement => {
   const [name, setName] = useState('')
-  const [kind, setKind] = useState(kinds[0]?.id ?? '')
+  // No default. The first kind alphabetically is `andJunction`, a plumbing
+  // construct nobody means to create, and a form that quietly picks one is a
+  // form that makes that subject by accident.
+  const [kind, setKind] = useState('')
   const [document, setDocument] = useState(defaultDocument)
 
   const proposed = name.trim() === '' ? null : proposeConceptId(graph, name)
@@ -41,7 +44,7 @@ export const SubjectDraftPanel = ({
       : draftConcept(
           graph,
           { name, kind, document },
-          kinds.map((option) => option.id),
+          kinds.map((option) => option.label),
         )
 
   return (
@@ -58,8 +61,12 @@ export const SubjectDraftPanel = ({
       <label className="subject-draft-field">
         <span>Kind</span>
         <select value={kind} onChange={(event) => setKind(event.target.value)}>
+          <option value="">Choose a kind</option>
           {kinds.map((option) => (
-            <option key={option.id} value={option.id}>
+            // The label, not the id: a document names a kind the short way and
+            // `apply` refuses the full identity as an unknown kind (`YM401`).
+            // `subject-form.tsx` has always done this; this form did not.
+            <option key={option.id} value={option.label}>
               {option.label}
             </option>
           ))}
@@ -81,7 +88,9 @@ export const SubjectDraftPanel = ({
       </label>
 
       <p className="subject-draft-id">
-        {name.trim() === '' ? (
+        {kind === '' ? (
+          'Choose a kind.'
+        ) : name.trim() === '' ? (
           'Give it a name.'
         ) : proposed === null ? (
           // The two names this cannot serve: nothing an id may be made of, and

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -3,7 +3,7 @@ import type {
   CanvasGraph,
   CanvasNode,
 } from "../graph-projection.js";
-import { DEFAULT_NESTING, type NestingKind } from "../projection.js";
+import { DEFAULT_NESTING, type NestingKind } from "../nesting.js";
 
 export type ConversationMode = "auto" | "open" | "closed";
 

--- a/test/concept-drafting.test.ts
+++ b/test/concept-drafting.test.ts
@@ -28,6 +28,28 @@ const graphOf = (source: string): CanvasGraph => {
 
 const graph = graphOf(DOCUMENT)
 
+const apply = (operations: readonly unknown[]) =>
+  applyOperations({
+    workspace: {
+      id: 'drafting',
+      documents: ['architecture/main.yaml'],
+      profiles: [],
+      projections: [],
+      adapterMappings: [],
+      evidence: [],
+      contracts: [],
+    },
+    sources: [{ path: 'architecture/main.yaml', source: DOCUMENT }],
+    operations: {
+      path: 'changeset.yaml',
+      source: stringify({
+        format: 'yarramate/operations/v1',
+        operations,
+      }),
+    },
+    manifestDirectory: '.yarramate',
+  })
+
 describe('proposeConceptId', () => {
   it('transliterates a name into an id a human can read in a diff', () => {
     expect(proposeConceptId(graph, 'Order Intake')).toBe('order-intake')
@@ -77,6 +99,44 @@ describe('proposeConceptId', () => {
 })
 
 describe('draftConcept', () => {
+  it('takes the short name a document uses, not the wire identity', () => {
+    // The other half of the bug in `subject-draft-panel.test.ts`. A model
+    // frame carries `{ id: 'yarramate/core@0.1#applicationComponent', label:
+    // 'applicationComponent' }`. A document names the kind the short way, and
+    // `apply` refuses the identity as `YM401 Unknown concept kind`, so the
+    // form must offer labels. This pins which of the two is the valid one.
+    const identity = 'yarramate/core@0.1#applicationComponent'
+
+    expect(
+      draftConcept(
+        graph,
+        { name: 'Thing', kind: identity, document: 'architecture/main.yaml' },
+        [identity],
+      ),
+    ).toMatchObject({ concept: { kind: identity } })
+
+    const viaIdentity = apply([
+      {
+        op: 'add-concept',
+        document: 'architecture/main.yaml',
+        concept: { id: 'thing', kind: identity, name: 'Thing' },
+      },
+    ])
+    expect(viaIdentity.ok).toBe(false)
+    if (!viaIdentity.ok) {
+      expect(viaIdentity.diagnostics.map((d) => d.code)).toContain('YM401')
+    }
+
+    const viaLabel = apply([
+      {
+        op: 'add-concept',
+        document: 'architecture/main.yaml',
+        concept: { id: 'thing', kind: 'applicationComponent', name: 'Thing' },
+      },
+    ])
+    expect(viaLabel.ok).toBe(true)
+  })
+
   it('refuses a kind outside the workspace vocabulary', () => {
     expect(
       draftConcept(graph, { name: 'Thing', kind: 'invented', document: 'architecture/main.yaml' }, KINDS),

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -34,8 +34,13 @@ const render = () =>
     createElement(SubjectDraftPanel, {
       graph,
       kinds: [
-        { id: 'applicationComponent', label: 'applicationComponent' },
-        { id: 'businessActor', label: 'businessActor' },
+        // id is the full identity the wire carries; label is the short name a
+        // document names. The two differ, which is the whole point.
+        {
+          id: 'yarramate/core@0.1#applicationComponent',
+          label: 'applicationComponent',
+        },
+        { id: 'yarramate/core@0.1#businessActor', label: 'businessActor' },
       ],
       documents: ['architecture/main.yaml', 'architecture/other.yaml'],
       defaultDocument: 'architecture/main.yaml',
@@ -59,9 +64,41 @@ describe('SubjectDraftPanel', () => {
     expect(markup).toContain('architecture/other.yaml')
   })
 
-  it('asks for a name before proposing anything', () => {
-    // The id is derived, so there is nothing to show until there is a name.
-    expect(render()).toContain('Give it a name')
+  /**
+   * The bug this exists for: the form offered `option.id`, the full kind
+   * identity, where a document names a kind the short way. Every Add was
+   * refused on commit with `YM401 Unknown concept kind`.
+   *
+   * This half asserts what the form puts in the DOM. The other half - that a
+   * short name is what `apply` accepts and an identity is not - is in
+   * `concept-drafting.test.ts`, because the engine cannot be imported here:
+   * `tsconfig.visual.json` lists what the browser program may see, and
+   * reaching past it is the same mistake in a different direction.
+   */
+  it('offers kind values a document accepts, never the full identity', () => {
+    const markup = render()
+    const values = [...markup.matchAll(/<option value="([^"]*)"/g)]
+      .map((match) => match[1]!)
+      .filter((value) => value !== '')
+
+    expect(values).toContain('applicationComponent')
+    expect(values.some((value) => value.includes('#'))).toBe(false)
+  })
+
+  it('picks no kind for the reviewer', () => {
+    // The first kind alphabetically is `andJunction`. A form that defaults to
+    // it makes junctions by accident.
+    const markup = render()
+    expect(markup).toContain('Choose a kind')
+    expect(markup).toContain('disabled')
+  })
+
+  it('shows guidance rather than an id until it has what it needs', () => {
+    // The id is derived, so there is nothing to show yet. An untouched form
+    // asks for the kind first, because that is what it now has no default for.
+    const markup = render()
+    expect(markup).toContain('Choose a kind')
+    expect(markup).not.toContain('Id:')
   })
 
   it('cannot be submitted while there is nothing to submit', () => {

--- a/test/visual-app-browser-safety.test.ts
+++ b/test/visual-app-browser-safety.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+const visualAppRoot = resolve(repositoryRoot, 'src/visual-app')
+
+/**
+ * The visual app is bundled for a browser. Anything it imports for its VALUE
+ * is bundled with it, so a value import of a module that reaches for `node:`
+ * puts a Node API in the browser, where it is not a function and the app fails
+ * to mount with nothing on screen.
+ *
+ * This is not hypothetical. `DEFAULT_NESTING` was defined in `projection.ts`,
+ * which loads Ajv through `createRequire`, and importing that one constant
+ * shipped `(0, cre.createRequire)(import.meta.url)` into the bundle. Every test
+ * passed, because vitest runs in Node, and `vite build` succeeded, because a
+ * bundler has no opinion about it. The app was broken for four merges.
+ *
+ * A type import is fine: it is erased before anything is bundled. The
+ * distinction between the two is the whole check.
+ */
+const sourceFiles = (directory: string): readonly string[] =>
+  readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry)
+    if (statSync(path).isDirectory()) return sourceFiles(path)
+    return /\.tsx?$/.test(path) && !path.endsWith('.d.ts') ? [path] : []
+  })
+
+/** Every `from '...'` whose binding is not entirely erased at build time. */
+const valueImports = (source: string): readonly string[] => {
+  const specifiers: string[] = []
+  const pattern = /import\s+([\s\S]*?)\s*from\s*['"]([^'"]+)['"]/g
+  for (const match of source.matchAll(pattern)) {
+    const clause = match[1] ?? ''
+    const specifier = match[2]
+    if (specifier === undefined) continue
+    const trimmed = clause.trim()
+    // `import type { ... }` and `import type X` are erased whole.
+    if (trimmed.startsWith('type ')) continue
+    // `import { type A, type B }` is erased too: every binding is a type.
+    const braced = /^\{([\s\S]*)\}$/.exec(trimmed)
+    if (braced !== undefined && braced !== null) {
+      const bindings = braced[1]!
+        .split(',')
+        .map((binding) => binding.trim())
+        .filter((binding) => binding !== '')
+      if (bindings.length > 0 && bindings.every((b) => b.startsWith('type '))) {
+        continue
+      }
+    }
+    specifiers.push(specifier)
+  }
+  return specifiers
+}
+
+const resolveLocal = (from: string, specifier: string): string | null => {
+  if (!specifier.startsWith('.')) return null
+  const base = resolve(dirname(from), specifier).replace(/\.js$/, '')
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+    try {
+      if (statSync(candidate).isFile()) return candidate
+    } catch {
+      // not that one
+    }
+  }
+  return null
+}
+
+const reachesNode = (entry: string): readonly string[] | null => {
+  const seen = new Set<string>()
+  const walk = (file: string, chain: readonly string[]): string[] | null => {
+    if (seen.has(file)) return null
+    seen.add(file)
+    const source = readFileSync(file, 'utf8')
+    if (/from\s*['"]node:/.test(source)) return [...chain, file]
+    for (const specifier of valueImports(source)) {
+      const next = resolveLocal(file, specifier)
+      if (next === null) continue
+      const found = walk(next, [...chain, file])
+      if (found !== null) return found
+    }
+    return null
+  }
+  return walk(entry, [])
+}
+
+describe('the visual app stays browser-safe', () => {
+  it('value-imports nothing that reaches node:', () => {
+    const offenders = sourceFiles(visualAppRoot)
+      .map((file) => ({ file, chain: reachesNode(file) }))
+      .filter((result) => result.chain !== null)
+      .map(({ file, chain }) =>
+        `${file.slice(repositoryRoot.length)} -> ${chain!
+          .slice(1)
+          .map((step) => step.slice(repositoryRoot.length))
+          .join(' -> ')}`,
+      )
+
+    expect(offenders).toEqual([])
+  })
+
+  it('can tell a value import from a type import', () => {
+    // The distinction this rests on, asserted rather than assumed.
+    expect(valueImports("import type { A } from './a.js'")).toEqual([])
+    expect(valueImports("import { type A } from './a.js'")).toEqual([])
+    expect(valueImports("import { type A, type B } from './a.js'")).toEqual([])
+    expect(valueImports("import { type A, B } from './a.js'")).toEqual([
+      './a.js',
+    ])
+    expect(valueImports("import { A } from './a.js'")).toEqual(['./a.js'])
+    expect(valueImports("import A from './a.js'")).toEqual(['./a.js'])
+    expect(valueImports("import * as A from './a.js'")).toEqual(['./a.js'])
+  })
+})


### PR DESCRIPTION
## Summary

Three defects, all found by opening the thing in a browser for the first time.
**Every one of them passed the full test suite.**

## 1. The app was blank

`DEFAULT_NESTING` lives in `projection.ts`, which loads Ajv through
`createRequire`. Importing that one constant **for its value** shipped this into
the browser bundle:

```js
Ire=(0,cre.createRequire)(import.meta.url)(`ajv/dist/2020.js`)
```

`createRequire` is not a function in a browser. Nothing mounted:

```
Uncaught TypeError: (0 , cre.createRequire) is not a function
```

It had been broken since the constant was introduced and **survived four merges
on top**, because vitest runs in Node and `vite build` has no opinion about it.

Every *other* visual-app import of `projection.ts` was already `import type`,
which is erased before bundling. That distinction was the whole bug.

`NestingKind` and `DEFAULT_NESTING` move to `nesting.ts`, which imports nothing.
`projection.ts` re-exports them, so nothing else changes.

**A test now walks every value import reachable from `src/visual-app` and fails
on one that reaches `node:`**, printing the chain. Reintroducing the bug gives:

```
src/visual-app/App.tsx -> src/visual-app/workspace-state.ts -> src/projection.ts
```

## 2. Adding a subject could never have landed

The form offered each kind's **wire identity** —
`yarramate/core@0.1#applicationComponent` — where a document names a kind the
short way. `apply` refused every commit:

```
YM401: Unknown concept kind "yarramate/core@0.1#applicationComponent"
```

The editable inspector **two files away** had always used `option.label`. This
form used `option.id`. Every unit test passed because they all fed short names
in by hand rather than taking what the form actually offers.

## 3. The default kind was `andJunction`

First alphabetically. A reviewer who typed a name and pressed Add made a
junction — a plumbing construct — by accident. There is no default now: the form
asks for a kind and stays disabled until it has one.

## The test for (2) is split deliberately

My first attempt imported `applyOperations` into the panel test. That test is
listed in `tsconfig.visual.json`, which is a **curated browser-safe boundary**,
so it dragged the Node-side engine into a `Bundler`-resolution program and broke
four unrelated files. Reaching past that boundary is the same mistake as (1) in
the other direction.

So the panel asserts what it puts in the DOM, and `concept-drafting.test.ts`
asserts which of the two values `apply` actually accepts.

## Validation

`pnpm verify` exits 0: **82 files, 1323 passed**, 1 skipped, self-check clean,
LikeC4 validate clean.

Both new guards were confirmed to fail when their bug is reintroduced.

Verified in a browser after fixing: the app mounts; the connection tool offers
exactly `access` and `association` between a behaviour and a passive-structure
subject, which is what ArchiMate permits; delete asks about the six
relationships it would take with it; and Add stages
`add-concept · order-intake · kind, name`.

## Related issue

None. Found reviewing #233–#239 in a browser.

## Contract impact

`NestingKind` and `DEFAULT_NESTING` move module, but `projection.ts` re-exports
both, so no published import path changes. No schema, diagnostic, CLI or
protocol change.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required. — defect fixes, no new decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)