### PR TITLE
feat(visual)!: ArchiMate is the notation, not a mode (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@
   at all if it finds a collision. Name any file that references subjects without
   being listed in the manifest, such as an adapter's project definition.
 
+- **Breaking.** One notation. The canvas draws ArchiMate, and `native` is
+  removed rather than demoted: `presentation.notation` admits `archimate`
+  alone, and a projection asking for `native` is refused rather than quietly
+  drawn as something else. The field stays an enum for the same reason
+  `layout` did when `radial` and `force` went, so a second notation has
+  somewhere to land (ADR 0087 is unchanged: notation is a rendering field with
+  no effect on the semantic model). Every node now carries its kind glyph and
+  takes its shape from its aspect, and every edge its line and arrows from its
+  core relationship kind, because none of that is a mode any more.
+  The notation picker and the direction toggle both leave the command strip.
+  The direction toggle goes because it had nothing left to do: ArchiMate's
+  layer bands only read top-down, so the canvas already pinned `elk.direction`
+  to `DOWN` and the control was inert whenever ArchiMate was on.
+  `presentation.direction` itself stays in the format, because the LikeC4
+  export reads it for its own `autoLayout` and draws no bands. A save now
+  carries a view's declared direction through untouched instead of writing the
+  canvas's own, which is what stops removing the control from silently
+  discarding a value the reviewer never saw; and a save writes no `notation` at
+  all rather than stamping the only one onto every projection it touches
+  (#250).
+
 - **Breaking.** One layout backend: `presentation.layout` admits only
   `layered`, and `presentation.seed` is gone (ADR 0086 carries a supersession
   note). `radial` (cytoscape `concentric`) and `force` (elk `stress` then

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -206,18 +206,33 @@ is meant to prevent.
 
 ### Presentation toggles
 
-Four presentation state fields ride alongside layout in `presentation`, saved via `view.save` and persisted in the projection document:
+Three presentation state fields ride alongside layout in `presentation`, saved via `view.save` and persisted in the projection document:
 
 - `showLifecycle` — renders a status badge (lifecycle: `planned` / `current` / `retired`) on each node's top-left, using the existing CSS tokens from `src/visual-app/styles.css`.
 - `showEvidence` — renders a checkmark badge on each node's bottom-left, only when the node has attestations (`hasAttestations: boolean`). Binary presence, never a graded state.
 - `showOwnership` — renders the owner's initials in a coloured circle on each node's bottom-right, hashing the owner ref onto a four-colour palette from `styles.css` (eucalyptus, ochre, cobalt, ink) deterministically and stably across reloads and machines. Colour is only informative here; initials identify the owner at a glance.
-- `notation` — toggles between `native` (the default) and `archimate` rendering mode (see below).
 
-None of these toggle a projection query or compose a `filter.query` event; toggling a checkbox dispatches `onTogglePresentation` and updates local state only. They are presentation, not semantic queries, so they save without consulting the model, reload without validating against the model, and appear in no changeset. View switching, layout changes, and direction changes all trigger a relayout; toggling a badge or notation does not (notation is applied at stylesheet render time, badges are derived from existing node data).
+None of these toggle a projection query or compose a `filter.query` event; toggling a checkbox dispatches `onTogglePresentation` and updates local state only. They are presentation, not semantic queries, so they save without consulting the model, reload without validating against the model, and appear in no changeset. Switching views triggers a relayout; toggling a badge does not, since badges are derived from existing node data.
 
-### ArchiMate notation mode
+### ArchiMate notation
 
-Under `notation === 'archimate'`, the stylesheet swaps node shapes by aspect (resolved from each concept kind's inheritance), applies line-notation conventions by core relationship kind (derived kinds resolve through lineage), and forces `layered` direction to `DOWN` with the direction toggle disabled and a reason shown (`"ArchiMate notation fixes direction to Top-Down."`). The direction pin is applied only at layout-config build time; nothing is overwritten in state, so switching back to `native` restores the projection's declared direction on the next layout.
+The canvas draws ArchiMate. The stylesheet shapes nodes by aspect (resolved
+from each concept kind's inheritance), applies line-notation conventions by
+core relationship kind (derived kinds resolve through lineage), draws each
+kind's glyph, and lays out `DOWN` because ArchiMate's layer bands only read
+top-down.
+
+This is not a mode: there is no picker and no second renderer to pick.
+`presentation.notation` stays in the projection format, admitting `archimate`
+alone, so a second notation has somewhere to land — the same reason
+`presentation.layout` stayed an enum when `radial` and `force` were removed. A
+projection asking for `native` is refused rather than quietly drawn as
+ArchiMate.
+
+`presentation.direction` also stays, and the canvas ignores it: the LikeC4
+export reads it for its own `autoLayout`, and that export draws no layer bands.
+A save carries a view's declared direction through untouched rather than
+dropping a value the canvas never offered to set.
 
 The kind colours, aspect shapes, glyphs, and relationship line styles are
 defined once in the published `yarramate/notation/archimate` module; this app

--- a/schema/yarramate-projection.schema.json
+++ b/schema/yarramate-projection.schema.json
@@ -149,7 +149,7 @@
           "type": "boolean"
         },
         "notation": {
-          "enum": ["native", "archimate"]
+          "enum": ["archimate"]
         }
       }
     },

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -51,6 +51,12 @@ export interface ProjectionDefinition {
     readonly title?: string
     readonly description?: string
     readonly layout?: 'layered'
+    /**
+     * Read by the LikeC4 export for its `autoLayout`, and by nothing else. The
+     * canvas draws ArchiMate, whose layer bands only read top-down, so it
+     * ignores this rather than offering a control that would tilt the bands
+     * away from what they mean.
+     */
     readonly direction?: 'top-down' | 'left-right'
     /**
      * The relationship kinds that draw as nesting in this view, in precedence
@@ -61,7 +67,13 @@ export interface ProjectionDefinition {
     readonly showLifecycle?: boolean
     readonly showEvidence?: boolean
     readonly showOwnership?: boolean
-    readonly notation?: 'native' | 'archimate'
+    /**
+     * The notation this view draws in. `archimate` is the only one, and the
+     * field is kept rather than dropped so a second notation has somewhere to
+     * land - the same reason `layout` stayed an enum when `radial` and `force`
+     * went (ADR 0086, ADR 0087).
+     */
+    readonly notation?: 'archimate'
   }
 }
 

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -96,16 +96,6 @@ const endTransitionStatus = (state: VisualAppState): string => {
   return "Ending conversation — preparing a handoff for the main agent.";
 };
 
-// ArchiMate notation pins `elk.direction` to `DOWN` when it builds a layered
-// config (`buildLayoutConfig`), and elk's direction is the only thing the
-// stored `direction` ever steers - so the strip reports Top-Down for that one
-// combination whatever is stored, and leaves every other one alone. Radial and
-// force never read a direction at all, so ArchiMate pins nothing there.
-const directionPinned = (
-  layout: "layered",
-  notation: "native" | "archimate",
-): boolean => layout === "layered" && notation === "archimate";
-
 const CommandStrip = ({
   state,
   connection,
@@ -113,14 +103,10 @@ const CommandStrip = ({
   conversationOpen,
   unread,
   layout,
-  direction,
   views,
   onToggleDetails,
   onToggleConversation,
-  onToggleDirection,
   onSelectLayout,
-  notation,
-  onSelectNotation,
   showLifecycle,
   showEvidence,
   showOwnership,
@@ -140,14 +126,10 @@ const CommandStrip = ({
   readonly conversationOpen: boolean;
   readonly unread: number;
   readonly layout: "layered";
-  readonly direction: "top-down" | "left-right";
   readonly views: readonly VisualViewSummary[];
   readonly onToggleDetails: () => void;
   readonly onToggleConversation: () => void;
   readonly onSelectLayout: (layout: "layered") => void;
-  readonly notation: "native" | "archimate";
-  readonly onSelectNotation: (notation: "native" | "archimate") => void;
-  readonly onToggleDirection: () => void;
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
@@ -202,8 +184,6 @@ const CommandStrip = ({
         activeViewId={state.activeView}
         query={state.activeFilter?.query ?? null}
         layout={layout}
-        direction={direction}
-        notation={notation}
         showLifecycle={showLifecycle}
         showEvidence={showEvidence}
         showOwnership={showOwnership}
@@ -212,30 +192,6 @@ const CommandStrip = ({
         onSave={onSaveView}
         onDismissNotice={onDismissSavedNotice}
       />
-      <select
-        aria-label="Notation"
-        value={notation}
-        onChange={(e) =>
-          onSelectNotation(e.currentTarget.value as "native" | "archimate")
-        }
-      >
-        <option value="native">Native</option>
-        <option value="archimate">ArchiMate</option>
-      </select>
-      <span className="direction-notice" role="status">
-        {directionPinned(layout, notation)
-          ? "ArchiMate notation fixes direction to Top-Down."
-          : ""}
-      </span>
-      <button
-        type="button"
-        onClick={onToggleDirection}
-        disabled={layout !== "layered" || notation === "archimate"}
-      >
-        {directionPinned(layout, notation) || direction === "top-down"
-          ? "Top-Down"
-          : "Left-Right"}
-      </button>
       <button
         type="button"
         aria-expanded={detailsOpen}
@@ -344,9 +300,7 @@ const DiagramWorkspace = ({
   selectedId,
   waiting,
   layout,
-  direction,
   nesting,
-  notation,
   showLifecycle,
   showEvidence,
   showOwnership,
@@ -367,9 +321,7 @@ const DiagramWorkspace = ({
   readonly selectedId: string | null;
   readonly waiting: string | null;
   readonly layout: "layered";
-  readonly direction: "top-down" | "left-right";
   readonly nesting: readonly NestingKind[];
-  readonly notation: "native" | "archimate";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
@@ -504,10 +456,8 @@ const DiagramWorkspace = ({
             }}
             matchedIds={state.activeFilter?.matchedIds ?? null}
             quickFilterText={state.quickFilterText}
-            direction={direction}
             nesting={nesting}
             faultedIds={faultedSubjects(state.commitDiagnostics ?? [])}
-            notation={notation}
             showLifecycle={showLifecycle}
             showEvidence={showEvidence}
             showOwnership={showOwnership}
@@ -1050,8 +1000,6 @@ export const App = () => {
         conversationOpen={conversationOpen}
         unread={workspace.conversation.unread}
         layout={workspace.layout}
-        direction={workspace.direction}
-        notation={workspace.notation}
         showLifecycle={workspace.showLifecycle}
         showEvidence={workspace.showEvidence}
         showOwnership={workspace.showOwnership}
@@ -1059,16 +1007,6 @@ export const App = () => {
         onToggleDetails={() => dispatchWorkspace({ type: "details.toggled" })}
         onToggleConversation={() =>
           dispatchWorkspace({ type: "conversation.toggled" })
-        }
-        onToggleDirection={() =>
-          dispatchWorkspace({
-            type: "direction.set",
-            direction:
-              workspace.direction === "top-down" ? "left-right" : "top-down",
-          })
-        }
-        onSelectNotation={(notation) =>
-          dispatchWorkspace({ type: "notation.set", notation })
         }
         onSelectLayout={(layout) =>
           dispatchWorkspace({ type: "layout.set", layout })
@@ -1095,9 +1033,7 @@ export const App = () => {
           selectedId={workspace.selectedSubject?.id ?? null}
           waiting={waiting}
           layout={workspace.layout}
-          direction={workspace.direction}
           nesting={workspace.nesting}
-          notation={workspace.notation}
           connection={workspace.connection}
           onConnectTarget={(id) =>
             dispatchWorkspace({ type: "connection.targeted", to: id })

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -76,9 +76,9 @@ function withWrapPoints(text: string): string {
 // ELK layout options: extends base layout with elk-specific config not in
 // cytoscape's types. `nodeLayoutOptions` is cytoscape-elk's only per-node hook
 // (`makeNode` calls it for every node and assigns the result to that node's
-// ELK `layoutOptions`). `elk.direction` is optional because the `force`
-// backend (elk's `stress` algorithm) ignores direction entirely - only
-// `layered` sets it.
+// ELK `layoutOptions`). `elk.direction` stays optional on the type because it
+// describes elk's option bag rather than this canvas's use of it: `layered`
+// reads it, other algorithms ignore it entirely.
 interface ElkLayoutOptions extends Record<string, unknown> {
   name: 'elk'
   elk: {
@@ -146,6 +146,7 @@ const ELK_SPACING: Record<string, unknown> = {
 // Shared by the full-graph layout effect and the visible-subgraph relayout
 // that runs on view switch, so both always agree on algorithm and direction.
 //
+//
 // One backend. `radial` (cytoscape `concentric`) and `force` (elk `stress`
 // then `sporeOverlap`) were measured against `layered` on every view of the
 // contact-update journey and lost on all three counts that matter: edge
@@ -154,20 +155,18 @@ const ELK_SPACING: Record<string, unknown> = {
 // `force` ever read went with them - the projection schema had required a
 // seed of every view that declared a layout at all, for one backend's benefit.
 //
-// `elk.direction` is read only by `layered`. Under ArchiMate notation it is
-// pinned to `DOWN` regardless of `direction`: ArchiMate's layer bands only
-// read top-down, so a left-right run would draw bands corresponding to
-// nothing. The pin is applied here, at config-build time, and nowhere else -
-// stored `direction` is never overwritten, so returning to native notation
-// restores whatever direction the reviewer declared.
-export function buildLayoutConfig(
-  direction: 'top-down' | 'left-right',
-  notation: 'native' | 'archimate' = 'native',
-): cytoscape.LayoutOptions {
+// `elk.direction` is read only by `layered`, and it is `DOWN`: ArchiMate's
+// layer bands only read top-down, so a left-right run would draw bands
+// corresponding to nothing. This used to be a pin applied over a reviewer's
+// stored `direction`, kept so that returning to native notation restored what
+// they declared. There is no native notation to return to, so the pin is now
+// simply the value. `presentation.direction` stays in the projection format:
+// the LikeC4 export reads it for its own `autoLayout`, which is not drawing
+// ArchiMate bands and has no reason to be held top-down.
+export function buildLayoutConfig(): cytoscape.LayoutOptions {
   const elk: ElkLayoutOptions['elk'] = {
     algorithm: 'layered',
-    'elk.direction':
-      notation === 'archimate' ? 'DOWN' : direction === 'top-down' ? 'DOWN' : 'RIGHT',
+    'elk.direction': 'DOWN',
     ...ELK_SPACING,
   }
   const config: ElkLayoutOptions = {
@@ -203,7 +202,7 @@ interface BadgeStyleArrays {
 }
 
 const BADGE_SIZE = 12
-// Kind icon top-left (ArchiMate notation only), lifecycle top-right, evidence
+// Kind icon top-left, lifecycle top-right, evidence
 // bottom-left, ownership bottom-right - each corner gets at most one image, so
 // none ever overlap on a single node. Plan Task 10 named the top-right slot for
 // the icon, but Task 5 had already spent that corner on the lifecycle chip
@@ -214,21 +213,18 @@ const BADGE_SIZE = 12
 // dimmed "maybe" state. Ownership requires both owner (non-null) and derived
 // ownerInitials (non-null), since ownerInitialsOf filters out malformed local
 // ids that leave no words (e.g., "###" or a bare document prefix). The kind
-// icon is an ArchiMate element glyph, so it draws only under that notation, and
-// only for a kind the catalogue maps - an unmapped kind leaves the slot empty.
+// icon draws for any kind the catalogue maps - an unmapped kind leaves the
+// slot empty.
 function badgeLayersFor(
   ele: NodeSingular,
   showLifecycle: boolean,
   showEvidence: boolean,
   showOwnership: boolean,
-  notation: 'native' | 'archimate',
 ): BadgeLayer[] {
   const layers: BadgeLayer[] = []
-  if (notation === 'archimate') {
-    const icon = kindIconUriOf(String(ele.data('kindLabel')))
-    if (icon !== null) {
-      layers.push({ image: icon, positionX: '0%', positionY: '0%', size: ICON_SIZE })
-    }
+  const icon = kindIconUriOf(String(ele.data('kindLabel')))
+  if (icon !== null) {
+    layers.push({ image: icon, positionX: '0%', positionY: '0%', size: ICON_SIZE })
   }
   const status: unknown = ele.data('status')
   if (showLifecycle && isLifecycleStatus(status)) {
@@ -265,20 +261,19 @@ function badgeLayersFor(
 // Stylesheet entries match StylesheetStyle shape (selector + style properties)
 // `showLifecycle`/`showEvidence`/`showOwnership` are parameters, not module
 // state, so the mount effect that builds a fresh cytoscape instance and a
-// future toggle effect (Task 7 wires the checkboxes to `GraphCanvasProps`;
-// Task 11 passes notation mode the same way) both call this with whatever is
-// current instead of racing a shared mutable stylesheet.
+// future toggle effect (Task 7 wires the checkboxes to `GraphCanvasProps`)
+// both call this with whatever is current instead of racing a shared mutable
+// stylesheet.
 export function buildStylesheet(
   showLifecycle: boolean,
   showEvidence: boolean,
   showOwnership: boolean,
-  notation: 'native' | 'archimate',
 ): cytoscape.StylesheetJsonBlock[] {
   // Cytoscape re-evaluates every mapper on each style recalculation - a single
   // selection change re-runs all seven over every node - and rebuilding the
   // percent-encoded SVG payloads that often is pure waste. Which images a node
-  // gets is a pure function of five data fields (the three toggles and the
-  // notation mode are fixed for this stylesheet's lifetime), so keying on those
+  // gets is a pure function of five data fields (the three toggles are fixed
+  // for this stylesheet's lifetime), so keying on those
   // per recalculation into one per distinct badge combination on the graph.
   // Cytoscape only reads these arrays, so nodes sharing a combination share
   // one set.
@@ -290,7 +285,7 @@ export function buildStylesheet(
       `\u0000${String(ele.data('kindLabel'))}`
     const cached = badgeStyleCache.get(key)
     if (cached !== undefined) return cached
-    const layers = badgeLayersFor(ele, showLifecycle, showEvidence, showOwnership, notation)
+    const layers = badgeLayersFor(ele, showLifecycle, showEvidence, showOwnership)
     const built: BadgeStyleArrays = {
       images: layers.map((layer) => layer.image),
       positionsX: layers.map((layer) => layer.positionX),
@@ -435,15 +430,15 @@ export function buildStylesheet(
     },
   ]
 
-  if (notation !== 'archimate') return baseStylesheet
-
-  // ArchiMate notation mode (Task 11): node shape by `aspect` (Task 8) and
-  // relationship line/arrow treatment by `coreKindLabel` - the edge's
-  // resolved core-vocabulary kind (Task 11), not its raw `kindLabel`, so a
-  // derived kind (e.g. `implements` -> `realization`) renders through its
-  // lineage identically to the core kind it inherits from. Appended after
-  // `baseStylesheet` rather than folded in, so `notation === 'native'`
-  // returns the exact same array untouched.
+  // ArchiMate is the notation this canvas draws in, so what follows is not a
+  // mode: node shape by `aspect` and relationship line/arrow treatment by
+  // `coreKindLabel` - the edge's resolved core-vocabulary kind, not its raw
+  // `kindLabel`, so a derived kind (e.g. `implements` -> `realization`)
+  // renders through its lineage identically to the core kind it inherits
+  // from. Kept appended to `baseStylesheet` rather than folded into it: the
+  // base carries what any notation would need (labels, selection, compound
+  // containers) and these rules carry what ArchiMate specifically says, which
+  // is the seam a second notation would attach at.
   // Node shapes: one rule per `ASPECT_SHAPES` entry, translating the
   // notation module's ShapeMeta into cytoscape node style. Passive
   // structure's top accent band and composite's dashed border are decoded
@@ -774,12 +769,8 @@ export function applyFilter(
 // the nodes it left overlapping. With `layered` the only backend a layout run
 // cannot still be in flight when the next one is requested, so none of that
 // apparatus has anything left to guard.
-function runLayout(
-  eles: Core | CollectionReturnValue,
-  direction: 'top-down' | 'left-right',
-  notation: 'native' | 'archimate' = 'native',
-): void {
-  eles.layout(buildLayoutConfig(direction, notation)).run()
+function runLayout(eles: Core | CollectionReturnValue): void {
+  eles.layout(buildLayoutConfig()).run()
 }
 
 
@@ -790,15 +781,9 @@ function runLayout(
 // each view a fresh, compact layout instead. cytoscape-elk's own `fit: true`
 // default re-frames the viewport to the result, so no separate fit call is
 // needed; `layout()` is a no-op on an empty visible collection, so callers
-// never need to guard against "the new view matched nothing". `notation`
-// defaults to `'native'` so a caller that has never heard of ArchiMate
-// notation gets the direction mapping it always did.
-export function relayoutVisible(
-  cy: Core,
-  direction: 'top-down' | 'left-right',
-  notation: 'native' | 'archimate' = 'native',
-): void {
-  runLayout(cy.elements(':visible'), direction, notation)
+// never need to guard against "the new view matched nothing".
+export function relayoutVisible(cy: Core): void {
+  runLayout(cy.elements(':visible'))
 }
 
 // `dragfree` fires once per drag (unlike `position`, which fires on every
@@ -884,7 +869,6 @@ interface GraphCanvasProps {
   readonly onSelect: (id: string, type: 'node' | 'edge') => void
   readonly matchedIds: readonly string[] | null
   readonly quickFilterText: string
-  readonly direction: 'top-down' | 'left-right'
   /** What draws as nesting in this view, in precedence order (ADR 0101). */
   readonly nesting: readonly NestingKind[]
   /** Subjects a diagnostic named, marked so a failure is visible where it is. */
@@ -892,7 +876,6 @@ interface GraphCanvasProps {
   readonly showLifecycle: boolean
   readonly showEvidence: boolean
   readonly showOwnership: boolean
-  readonly notation: 'native' | 'archimate'
   readonly activeViewId: string
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
@@ -914,7 +897,6 @@ export function GraphCanvas({
   onSelect,
   matchedIds,
   quickFilterText,
-  direction,
   nesting,
   faultedIds,
   activeViewId,
@@ -923,7 +905,6 @@ export function GraphCanvas({
   showLifecycle,
   showEvidence,
   showOwnership,
-  notation,
 }: GraphCanvasProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<Core | null>(null)
@@ -931,8 +912,6 @@ export function GraphCanvas({
   const isInitialSyncRef = useRef(true)
   const isInitialPresentationSyncRef = useRef(true)
   const activeViewIdRef = useRef(activeViewId)
-  const directionRef = useRef(direction)
-  const notationRef = useRef(notation)
   const pendingViewFitRef = useRef(false)
   const matchedIdsRef = useRef(matchedIds)
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
@@ -981,7 +960,7 @@ export function GraphCanvas({
       // `showLifecycle`/`showEvidence`/`showOwnership` seed the stylesheet the
       // mount builds; the effect below re-applies it to the live instance on
       // every later toggle, without remounting or re-laying-out.
-      style: buildStylesheet(showLifecycle, showEvidence, showOwnership, notation),
+      style: buildStylesheet(showLifecycle, showEvidence, showOwnership),
       wheelSensitivity: 0.1,
       layout: { name: 'null' },
     })
@@ -1070,17 +1049,15 @@ export function GraphCanvas({
       isInitialPresentationSyncRef.current = false
       return
     }
-    cyRef.current.style(buildStylesheet(showLifecycle, showEvidence, showOwnership, notation))
-  }, [showLifecycle, showEvidence, showOwnership, notation])
+    cyRef.current.style(buildStylesheet(showLifecycle, showEvidence, showOwnership))
+  }, [showLifecycle, showEvidence, showOwnership])
 
-  // Update elements whenever the graph itself changes, laying out with the
-  // current layout and direction. Deliberately NOT keyed on `layout`/
-  // `direction` - a full remove/re-add + unscoped layout over every element
-  // (not just what's currently visible) on every toggle would blow away the
-  // filtered/view-scoped canvas and reintroduce the sprawl a view switch
-  // once had. Layout/direction-only changes are handled by the pending-fit
-  // effect below, which reruns `relayoutVisible` scoped to what's actually
-  // shown.
+  // Update elements whenever the graph itself changes. Keyed on the graph and
+  // nothing else: a full remove/re-add plus an unscoped layout over every
+  // element (not just what is currently visible) would blow away the
+  // filtered, view-scoped canvas and reintroduce the sprawl a view switch once
+  // had. A view switch is handled by the pending-fit effect below, which
+  // reruns `relayoutVisible` scoped to what is actually shown.
   useEffect(() => {
     if (!cyRef.current) return
 
@@ -1092,7 +1069,7 @@ export function GraphCanvas({
       cyRef.current.add(elements)
     }
 
-    runLayout(cyRef.current, direction, notation)
+    runLayout(cyRef.current)
   }, [graph])
 
   // Mark every subject a diagnostic named. Runs on its own rather than with
@@ -1121,33 +1098,21 @@ export function GraphCanvas({
     }
   }, [selectedId, graph])
 
-  // Arms a pending fit whenever the active view, layout backend, layout
-  // direction, notation mode, or seed changes. Notation belongs here because
-  // `buildLayoutConfig` pins `elk.direction: 'DOWN'` under `archimate` - the
-  // stylesheet effect above swaps node shapes on the live instance
-  // immediately, so without a matching relayout an archimate toggle would
-  // leave ArchiMate shapes sitting in the native direction's geometry. Seed
-  // belongs here for the same reason: under `force` it is layout input, so a
-  // reviewer who declares a new seed has to see the placement it produces.
+  // Arms a pending fit when the active view changes. It used to arm on layout
+  // direction and notation too, because both fed `buildLayoutConfig` and a
+  // notation swap would otherwise leave ArchiMate shapes sitting in the native
+  // direction's geometry. Neither is a variable any more: there is one
+  // notation and one direction, so the view is the only thing left that can
+  // change what the layout should be.
   // Declared before the filter-apply effect below - same-phase effects commit
   // in source order, so a view switch whose filter result lands in the very
   // same render (e.g. clearing back to "All") is still armed in time for that
   // commit.
   useEffect(() => {
-    const viewChanged = activeViewId !== activeViewIdRef.current
-    const directionChanged = direction !== directionRef.current
-    const notationChanged = notation !== notationRef.current
-    if (
-      !viewChanged &&
-      !directionChanged &&
-      !notationChanged
-    )
-      return
+    if (activeViewId === activeViewIdRef.current) return
     activeViewIdRef.current = activeViewId
-    directionRef.current = direction
-    notationRef.current = notation
     pendingViewFitRef.current = true
-  }, [activeViewId, direction, notation])
+  }, [activeViewId])
 
   // Apply structural filter (matchedIds) and quick-filter narrowing, then,
   // only once a pending view-switch relayout is armed and its filter result
@@ -1158,8 +1123,8 @@ export function GraphCanvas({
     if (!cyRef.current) return
     applyFilter(cyRef.current, matchedIds, quickFilterText)
     // A structural filter result lands in a later commit than the view id that
-    // asked for it. The arming effect above fires only on a view / direction /
-    // notation change, so on a session's first paint the one layout that runs
+    // asked for it. The arming effect above fires only on a view change, so on
+    // a session's first paint the one layout that runs
     // is computed over every element - including the ones the filter is about
     // to hide - and the survivors are left spread across a layout built for a
     // graph that is no longer on screen, so it sprawls. Measured on the
@@ -1177,9 +1142,9 @@ export function GraphCanvas({
     matchedIdsRef.current = matchedIds
     if (pendingViewFitRef.current || matchedChanged) {
       pendingViewFitRef.current = false
-      relayoutVisible(cyRef.current, direction, notation)
+      relayoutVisible(cyRef.current)
     }
-  }, [matchedIds, quickFilterText, graph, direction, notation])
+  }, [matchedIds, quickFilterText, graph])
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
 }

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -11,19 +11,14 @@ export interface SaveViewControlProps {
   readonly activeViewId: string;
   readonly query: ProjectionQuery | null;
   readonly layout: "layered";
-  readonly direction: "top-down" | "left-right";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
-  readonly notation: "native" | "archimate";
   readonly pendingSave: boolean;
   readonly notice: boolean;
   readonly onSave: (payload: VisualViewSavePayload) => void;
   readonly onDismissNotice: () => void;
 }
-
-// (no module-level seed constant: the seed a save writes is the one the canvas
-// laid the view out with, held in workspace state - see `workspace-state.ts`.)
 
 export interface BuildPayloadParams {
   readonly id: string | undefined;
@@ -31,11 +26,17 @@ export interface BuildPayloadParams {
   readonly description: string;
   readonly query: ProjectionQuery | null;
   readonly layout: "layered";
-  readonly direction: "top-down" | "left-right";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
-  readonly notation: "native" | "archimate";
+  /**
+   * Whatever the view being overwritten already declared, carried through
+   * rather than restated. The canvas has no direction control - it draws
+   * ArchiMate, which is top-down by construction - but the LikeC4 export reads
+   * `presentation.direction`, so a save that simply omitted it would quietly
+   * drop a value the reviewer never saw and cannot have meant to discard.
+   */
+  readonly carriedDirection: "top-down" | "left-right" | undefined;
 }
 
 /** Pure translation from the form's local state to the wire payload — no
@@ -48,11 +49,10 @@ export const buildPayload = ({
   description,
   query,
   layout,
-  direction,
   showLifecycle,
   showEvidence,
   showOwnership,
-  notation,
+  carriedDirection,
 }: BuildPayloadParams): VisualViewSavePayload => ({
   ...(id === undefined ? {} : { id }),
   title,
@@ -60,16 +60,15 @@ export const buildPayload = ({
   query: query ?? {},
   presentation: {
     layout,
-    direction,
+    ...(carriedDirection === undefined ? {} : { direction: carriedDirection }),
     showLifecycle,
     showEvidence,
     showOwnership,
-    notation,
   },
 });
 
 /**
- * Saves the reviewer's current filter and layout direction as a named
+ * Saves the reviewer's current filter and presentation as a named
  * projection document. "Save" overwrites whatever view is active — behind a
  * confirm dialog, since that is destructive — and "Save As New" always
  * creates a fresh one, which the server can never collide with a
@@ -80,11 +79,9 @@ export function SaveViewControl({
   activeViewId,
   query,
   layout,
-  direction,
   showLifecycle,
   showEvidence,
   showOwnership,
-  notation,
   pendingSave,
   notice,
   onSave,
@@ -121,11 +118,13 @@ export function SaveViewControl({
       description,
       query,
       layout,
-      direction,
       showLifecycle,
       showEvidence,
       showOwnership,
-      notation,
+      // Overwriting carries the view's own direction; a brand new view has
+      // none to carry, and the export's own default applies.
+      carriedDirection:
+        id === undefined ? undefined : activeView?.presentation?.direction,
     });
 
   const submit = (id: string | undefined) => {

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -133,7 +133,6 @@ export interface VisualWorkspaceState {
   readonly pendingDeletion: string | null;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
-  readonly direction: "top-down" | "left-right";
   /**
    * What draws as nesting in the active view, in precedence order (ADR 0101).
    * A view that says nothing keeps `DEFAULT_NESTING`, which is composition
@@ -144,13 +143,6 @@ export interface VisualWorkspaceState {
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
-  readonly notation: "native" | "archimate";
-  /**
-   * The seed the canvas lays `force` out with, and the one a save writes back
-   * as `presentation.seed`. Only `force` reads it - `layered` is deterministic
-   * and elk ignores the seed outright, `radial` is not elk-based at all (see
-   * `docs/VISUAL-ADAPTER.md`).
-   */
 }
 
 export type VisualWorkspaceAction =
@@ -179,10 +171,6 @@ export type VisualWorkspaceAction =
   | { readonly type: "description.toggled" }
   | { readonly type: "details.toggled" }
   | {
-      readonly type: "direction.set";
-      readonly direction: "top-down" | "left-right";
-    }
-  | {
       readonly type: "nesting.set";
       readonly nesting: readonly NestingKind[];
     }
@@ -190,7 +178,6 @@ export type VisualWorkspaceAction =
       readonly type: "layout.set";
       readonly layout: "layered";
     }
-  | { readonly type: "notation.set"; readonly notation: "native" | "archimate" }
   | {
       readonly type: "presentation.toggled";
       readonly flag: "showLifecycle" | "showEvidence" | "showOwnership";
@@ -206,9 +193,8 @@ export type VisualWorkspaceAction =
 // A view switch adopts the view's own presentation: a field the view
 // declares replaces whatever the workspace currently shows; a field it
 // leaves unset keeps the workspace's current value untouched. Returns the
-// `direction.set`/`layout.set` actions to dispatch, in declaration order,
-// so App.tsx has nothing left to decide - it only has to dispatch what
-// comes back.
+// actions to dispatch, in declaration order, so App.tsx has nothing left to
+// decide - it only has to dispatch what comes back.
 const sameNesting = (
   left: readonly NestingKind[],
   right: readonly NestingKind[],
@@ -220,22 +206,16 @@ export const presentationActionsFor = (
   presentation:
     | {
         readonly layout?: "layered";
-        readonly direction?: "top-down" | "left-right";
         readonly nesting?: readonly NestingKind[];
-        readonly notation?: "native" | "archimate";
         readonly showLifecycle?: boolean;
         readonly showEvidence?: boolean;
         readonly showOwnership?: boolean;
-        readonly seed?: string;
       }
     | undefined,
 ): readonly VisualWorkspaceAction[] => {
   const actions: VisualWorkspaceAction[] = [];
   if (presentation?.layout !== undefined) {
     actions.push({ type: "layout.set", layout: presentation.layout });
-  }
-  if (presentation?.direction !== undefined) {
-    actions.push({ type: "direction.set", direction: presentation.direction });
   }
   // A view that omits `nesting` is restored to the default rather than left
   // holding the previous view's vocabulary: switching views must not carry a
@@ -244,9 +224,6 @@ export const presentationActionsFor = (
     type: "nesting.set",
     nesting: presentation?.nesting ?? DEFAULT_NESTING,
   });
-  if (presentation?.notation !== undefined) {
-    actions.push({ type: "notation.set", notation: presentation.notation });
-  }
   if (presentation?.showLifecycle !== undefined) {
     actions.push({
       type: "presentation.toggled",
@@ -276,7 +253,7 @@ export const presentationActionsFor = (
 // one the server named (`initialView`, also what a reload restores) - and
 // only the first ever ran through the picker's handler, so a session opened
 // on a view rendered the whole graph under workspace defaults and ignored
-// the layout, notation and seed that view declares. Both routes move the
+// the presentation that view declares. Both routes move the
 // same `activeView` field, so the decision belongs here, keyed on what has
 // actually been applied rather than on where the id came from. A view's query
 // travels over the socket, but the opening snapshot arrives over HTTP before
@@ -342,7 +319,6 @@ export const createVisualWorkspaceState = (
   connection: null,
   draftingSubject: false,
   pendingDeletion: null,
-  direction: "top-down",
   nesting: DEFAULT_NESTING,
   layout: "layered",
   showLifecycle: true,
@@ -351,11 +327,6 @@ export const createVisualWorkspaceState = (
   // `yarramate/ownership/owner` claims, so every chip would render
   // identically - uniform noise until real ownership diversity exists.
   showOwnership: false,
-  notation: "native",
-  // A view that declares no seed of its own lays out under this one, and a
-  // save of such a view writes it back - `presentation.seed` is required
-  // wherever `presentation.layout` is (`schema/yarramate-projection.schema.json`),
-  // so there is no "unset" to round-trip.
 });
 
 export const visualWorkspaceReducer = (
@@ -462,8 +433,6 @@ export const visualWorkspaceReducer = (
         : { ...state, descriptionExpanded: !state.descriptionExpanded };
     case "details.toggled":
       return { ...state, detailsOpen: !state.detailsOpen };
-    case "direction.set":
-      return { ...state, direction: action.direction };
     case "nesting.set":
       // Restating the same vocabulary is not a change. Every view states one,
       // so without this a view switch would produce a new state object each
@@ -473,8 +442,6 @@ export const visualWorkspaceReducer = (
         : { ...state, nesting: action.nesting };
     case "layout.set":
       return { ...state, layout: action.layout };
-    case "notation.set":
-      return { ...state, notation: action.notation };
     case "presentation.toggled":
       return { ...state, [action.flag]: action.value };
     case "model.replaced": {

--- a/test/badges.test.ts
+++ b/test/badges.test.ts
@@ -65,9 +65,8 @@ describe('buildStylesheet badge layers', () => {
     showLifecycle: boolean,
     showEvidence: boolean,
     showOwnership: boolean,
-    notation: 'native' | 'archimate' = 'native',
   ): cytoscape.StylesheetStyle =>
-    buildStylesheet(showLifecycle, showEvidence, showOwnership, notation).find(
+    buildStylesheet(showLifecycle, showEvidence, showOwnership).find(
       (block): block is cytoscape.StylesheetStyle =>
         'style' in block && block.selector === 'node' && 'background-image' in block.style,
     )!
@@ -81,9 +80,8 @@ describe('buildStylesheet badge layers', () => {
     showEvidence: boolean,
     showOwnership: boolean,
     data: Record<string, unknown>,
-    notation: 'native' | 'archimate',
   ): T => {
-    const rule = nodeRule(showLifecycle, showEvidence, showOwnership, notation)
+    const rule = nodeRule(showLifecycle, showEvidence, showOwnership)
     const style = rule.style as cytoscape.Css.Node
     const mapper = style[property] as (ele: { data: (key: string) => unknown }) => T
     return mapper({ data: (key) => data[key] })
@@ -94,21 +92,19 @@ describe('buildStylesheet badge layers', () => {
     showEvidence: boolean,
     showOwnership: boolean,
     data: Record<string, unknown>,
-    notation: 'native' | 'archimate' = 'native',
   ): string[] =>
-    mapperFor<string[]>('background-image', showLifecycle, showEvidence, showOwnership, data, notation)
+    mapperFor<string[]>('background-image', showLifecycle, showEvidence, showOwnership, data)
 
   const sizesFor = (
     showLifecycle: boolean,
     showEvidence: boolean,
     showOwnership: boolean,
     data: Record<string, unknown>,
-    notation: 'native' | 'archimate' = 'native',
   ): number[] =>
-    mapperFor<number[]>('background-width', showLifecycle, showEvidence, showOwnership, data, notation)
+    mapperFor<number[]>('background-width', showLifecycle, showEvidence, showOwnership, data)
 
   it('draws a background-color rule for every LAYER_COLORS key', () => {
-    const sheet = buildStylesheet(false, false, false, 'native')
+    const sheet = buildStylesheet(false, false, false)
     for (const layer of Object.keys(LAYER_COLORS)) {
       const rule = sheet.find(
         (block): block is cytoscape.StylesheetStyle =>
@@ -153,19 +149,21 @@ describe('buildStylesheet badge layers', () => {
         false,
         false,
         { status: 'current', kindLabel: 'applicationComponent' },
-        'archimate',
       ),
     ).toEqual([kindIconUriOf('applicationComponent'), LIFECYCLE_BADGE_URI.current])
   })
 
-  it('draws no kind icon under native notation', () => {
+  it('draws the kind icon with every badge off, because it is not a badge', () => {
+    // The three presentation flags gate the three badges. The kind icon is the
+    // notation itself, so it draws whatever they say - there is no longer a
+    // notation for it to be absent from.
     expect(
-      layersFor(false, false, false, { kindLabel: 'applicationComponent' }, 'native'),
-    ).toEqual([])
+      layersFor(false, false, false, { kindLabel: 'applicationComponent' }),
+    ).toEqual([kindIconUriOf('applicationComponent')])
   })
 
   it('leaves the icon slot empty for a kind the catalogue does not map', () => {
-    expect(layersFor(false, false, false, { kindLabel: 'notAKind' }, 'archimate')).toEqual([])
+    expect(layersFor(false, false, false, { kindLabel: 'notAKind' })).toEqual([])
   })
 
   it('sizes the kind icon and the badges independently', () => {
@@ -177,7 +175,6 @@ describe('buildStylesheet badge layers', () => {
         true,
         false,
         { status: 'current', hasAttestations: true, kindLabel: 'applicationComponent' },
-        'archimate',
       ),
     ).toEqual([ICON_SIZE, 12, 12])
   })

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -9,6 +9,7 @@ import {
   registerDragSave,
   relayoutVisible,
 } from '../src/visual-app/graph-canvas.js'
+import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -224,25 +225,18 @@ const countOverlappingPairs = (cy: cytoscape.Core): number => {
 describe('buildLayoutConfig', () => {
   it('lays out with zero overlapping node bounding boxes', async () => {
     const cy = buildLayoutFixture()
-    await runLayout(cy, buildLayoutConfig('top-down'))
+    await runLayout(cy, buildLayoutConfig())
     expect(countOverlappingPairs(cy)).toBe(0)
   })
 
-  it('archimate notation pins direction to DOWN regardless of the stored direction', () => {
-    const archimate = buildLayoutConfig('left-right', 'archimate') as unknown as {
-      elk: Record<string, unknown>
-    }
-    expect(archimate.elk['elk.direction']).toBe('DOWN')
-
-    const native = buildLayoutConfig('left-right', 'native') as unknown as {
-      elk: Record<string, unknown>
-    }
-    expect(native.elk['elk.direction']).toBe('RIGHT')
-
-    const nativeTopDown = buildLayoutConfig('top-down', 'native') as unknown as {
-      elk: Record<string, unknown>
-    }
-    expect(nativeTopDown.elk['elk.direction']).toBe('DOWN')
+  // ArchiMate's layer bands only read top-down, so the canvas lays out DOWN
+  // and takes no direction to be told otherwise. `presentation.direction`
+  // survives in the projection format for the LikeC4 export, which draws no
+  // bands, and this config is deliberately blind to it.
+  it('lays out DOWN, and takes nothing that could say otherwise', () => {
+    const config = buildLayoutConfig() as unknown as { elk: Record<string, unknown> }
+    expect(config.elk['elk.direction']).toBe('DOWN')
+    expect(buildLayoutConfig.length).toBe(0)
   })
 
   // `layered` is the only backend, so a layout run is one synchronous elk
@@ -251,7 +245,7 @@ describe('buildLayoutConfig', () => {
   // guard that `force` needed.
   it('relayouts the visible subgraph in one synchronous pass', () => {
     const cy = buildHubFixture()
-    relayoutVisible(cy, 'top-down')
+    relayoutVisible(cy)
     expect(buildPositionMap(cy.nodes()).size ?? Object.keys(buildPositionMap(cy.nodes())).length)
       .toBeGreaterThan(0)
   })
@@ -274,7 +268,7 @@ describe('buildStylesheet ArchiMate notation', () => {
   }
 
   it('renders a realization edge as a dotted line with a hollow target triangle', () => {
-    const style = edgeRule(buildStylesheet(false, false, false, 'archimate'), 'realization')
+    const style = edgeRule(buildStylesheet(false, false, false), 'realization')
     expect(style['line-style']).toBe('dotted')
     expect(style['source-arrow-shape']).toBe('none')
     expect(style['target-arrow-shape']).toBe('triangle')
@@ -282,7 +276,7 @@ describe('buildStylesheet ArchiMate notation', () => {
   })
 
   it('resolves a derived development kind to its core lineage style via coreKindLabel, not kindLabel', () => {
-    const sheet = buildStylesheet(false, false, false, 'archimate')
+    const sheet = buildStylesheet(false, false, false)
     const cy = cytoscape({
       headless: true,
       styleEnabled: true,
@@ -343,7 +337,7 @@ describe('buildStylesheet ArchiMate notation', () => {
       return cytoscape({
         headless: true,
         styleEnabled: true,
-        style: buildStylesheet(true, true, true, 'archimate'),
+        style: buildStylesheet(true, true, true),
         elements: [node('container'), node('child', 'container'), node('leaf')],
       })
     }
@@ -379,9 +373,19 @@ describe('buildStylesheet ArchiMate notation', () => {
     })
   })
 
-  it('adds no ArchiMate rules under native notation', () => {
-    const native = buildStylesheet(true, true, true, 'native')
-    expect(native.some((block) => block.selector.startsWith('edge[coreKindLabel'))).toBe(false)
-    expect(native.some((block) => block.selector.startsWith('node[aspect'))).toBe(false)
+  // There is no longer a notation to switch off, so the shape and arrow rules
+  // are not a mode the stylesheet can be built without. A build that dropped
+  // them would draw every kind as an undifferentiated box and every
+  // relationship with the same line, which is what this asserts cannot happen.
+  it('always carries the ArchiMate shape and arrow rules', () => {
+    const sheet = buildStylesheet(true, true, true)
+    expect(sheet.filter((block) => block.selector.startsWith('node[aspect')))
+      .toHaveLength(Object.keys(ASPECT_SHAPES).length)
+    expect(sheet.filter((block) => block.selector.startsWith('edge[coreKindLabel')))
+      .toHaveLength(RELATIONSHIP_NOTATION.length)
+
+    const bare = buildStylesheet(false, false, false)
+    expect(bare.filter((block) => block.selector.startsWith('node[aspect')))
+      .toHaveLength(Object.keys(ASPECT_SHAPES).length)
   })
 })

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -170,7 +170,7 @@ describe('relayoutVisible', () => {
     const visibleBefore = { ...cy.getElementById('node1').position() }
     const settled = new Promise<void>((resolve) => cy.one('layoutstop', () => resolve()))
 
-    relayoutVisible(cy, 'top-down')
+    relayoutVisible(cy)
     await settled
 
     expect(cy.getElementById('node3').position()).toEqual(hiddenBefore)
@@ -180,6 +180,6 @@ describe('relayoutVisible', () => {
   it('is a safe no-op when nothing is visible', () => {
     const cy = buildPositionedCy()
     applyFilter(cy, [], '')
-    expect(() => relayoutVisible(cy, 'top-down')).not.toThrow()
+    expect(() => relayoutVisible(cy)).not.toThrow()
   })
 })

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -705,16 +705,6 @@ query:
   })
 
   it('round-trips notation through a saved projection document', () => {
-    const withNative = loadProjection({
-      path: 'native.projection.yaml',
-      source: `format: yarramate/projection/v1
-id: notation-test
-version: "1.0"
-query: {}
-presentation:
-  notation: native
-`,
-    })
     const withArchimate = loadProjection({
       path: 'archimate.projection.yaml',
       source: `format: yarramate/projection/v1
@@ -725,13 +715,30 @@ presentation:
   notation: archimate
 `,
     })
-    expect(withNative.ok).toBe(true)
     expect(withArchimate.ok).toBe(true)
-    if (!withNative.ok || !withArchimate.ok) return
-    expect(withNative.projection.presentation?.notation).toBe('native')
+    if (!withArchimate.ok) return
     expect(withArchimate.projection.presentation?.notation).toBe('archimate')
-    expect(canonicalProjection(withNative.projection).presentation?.notation).toBe('native')
     expect(canonicalProjection(withArchimate.projection).presentation?.notation).toBe('archimate')
+  })
+
+  // `native` was a renderer, and it is gone. The field stays so a second
+  // notation has somewhere to land, which is only worth anything if naming a
+  // notation that does not exist is refused rather than quietly drawn as
+  // ArchiMate.
+  it('refuses a projection that asks for a notation nothing renders', () => {
+    const withNative = loadProjection({
+      path: 'native.projection.yaml',
+      source: `format: yarramate/projection/v1
+id: notation-test
+version: "1.0"
+query: {}
+presentation:
+  notation: native
+`,
+    })
+    expect(withNative.ok).toBe(false)
+    if (withNative.ok) return
+    expect(withNative.diagnostics[0]?.pointer).toBe('/presentation/notation')
   })
 
   it('rejects unknown notation values in schema validation', () => {

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -12,11 +12,10 @@ describe('buildPayload', () => {
       description: 'desc',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
-      notation: 'native',
     })
 
     expect(payload).toEqual({
@@ -30,7 +29,6 @@ describe('buildPayload', () => {
         showLifecycle: true,
         showEvidence: true,
         showOwnership: false,
-        notation: 'native',
       },
     })
   })
@@ -42,11 +40,10 @@ describe('buildPayload', () => {
       description: 'desc',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: false,
       showEvidence: true,
       showOwnership: true,
-      notation: 'native',
     })
 
     expect(payload.presentation?.showLifecycle).toBe(false)
@@ -61,11 +58,10 @@ describe('buildPayload', () => {
       description: 'desc',
       query,
       layout: 'layered',
-      direction: 'left-right',
+      carriedDirection: 'left-right',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
-      notation: 'native',
     })
 
     expect(payload).not.toHaveProperty('id')
@@ -79,7 +75,6 @@ describe('buildPayload', () => {
         showLifecycle: true,
         showEvidence: true,
         showOwnership: false,
-        notation: 'native',
       },
     })
   })
@@ -91,11 +86,10 @@ describe('buildPayload', () => {
       description: 'Exact description',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
-      notation: 'native',
     })
 
     expect(payload.title).toBe('Exact Title')
@@ -111,11 +105,10 @@ describe('buildPayload', () => {
       description: 'desc',
       query: null,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: false,
       showOwnership: false,
-      notation: 'native',
     })
 
     expect(payload.query).toEqual({})
@@ -128,11 +121,10 @@ describe('buildPayload', () => {
       description: 'A layout round-trip test',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: false,
       showOwnership: false,
-      notation: 'native',
     })
 
     expect(payload.presentation?.layout).toBe('layered')
@@ -143,21 +135,42 @@ describe('buildPayload', () => {
     expect(payload.presentation?.direction).toBe('top-down')
   })
 
-  it('carries notation through to presentation', () => {
+  // ArchiMate is the only notation, so a save writes no `notation` at all
+  // rather than stamping the same value onto every projection it touches. A
+  // view that declares one by hand keeps it; nothing here mints one.
+  it('writes no notation, because there is only one', () => {
     const payload = buildPayload({
       id: 'view-id',
-      title: 'ArchiMate View',
-      description: 'An archimate test',
+      title: 'A View',
+      description: 'A test',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
-      notation: 'archimate',
     })
 
-    expect(payload.presentation?.notation).toBe('archimate')
+    expect(payload.presentation?.notation).toBeUndefined()
+  })
+
+  // The canvas has no direction control, so a save must carry through what the
+  // view already declared. Dropping it would discard a value the LikeC4 export
+  // reads and the reviewer never saw.
+  it('omits direction entirely when there is none to carry', () => {
+    const payload = buildPayload({
+      id: undefined,
+      title: 'A New View',
+      description: 'A test',
+      query,
+      layout: 'layered',
+      carriedDirection: undefined,
+      showLifecycle: true,
+      showEvidence: true,
+      showOwnership: false,
+    })
+
+    expect(payload.presentation).not.toHaveProperty('direction')
   })
 
   // The seed the canvas actually laid this view out with is what a save must
@@ -169,11 +182,10 @@ describe('buildPayload', () => {
       description: 'A reviewer-chosen seed',
       query,
       layout: 'layered',
-      direction: 'top-down',
+      carriedDirection: 'top-down',
       showLifecycle: true,
       showEvidence: true,
       showOwnership: false,
-      notation: 'native',
     })
 
   })

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -2,7 +2,6 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { VisualAppState } from '../src/visual-app/state.js'
-import type * as WorkspaceState from '../src/visual-app/workspace-state.js'
 
 const session = vi.hoisted(() => {
   const baseState: VisualAppState = {
@@ -62,39 +61,6 @@ vi.mock('../src/visual-app/session-client.js', () => ({
     end: vi.fn(),
   }),
 }))
-
-// The command strip's layout control lives on local `useReducer` workspace
-// state, not `VisualAppState` - so a render test that wants to see the
-// direction button disabled under a non-`layered` backend has to override
-// the reducer's initial value the same way `session` overrides session state
-// above, rather than driving it through props the App component doesn't have.
-// `notationOverride` follows the same pattern for the ArchiMate direction pin,
-// and `directionOverride` for a stored direction the pin has to override in
-// the label without touching what is stored.
-const workspace = vi.hoisted(() => ({
-  layoutOverride: undefined as 'layered' | 'radial' | 'force' | undefined,
-  notationOverride: undefined as 'native' | 'archimate' | undefined,
-  directionOverride: undefined as 'top-down' | 'left-right' | undefined,
-}))
-
-vi.mock('../src/visual-app/workspace-state.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof WorkspaceState>()
-  return {
-    ...actual,
-    createVisualWorkspaceState: (viewportWidth: number) => ({
-      ...actual.createVisualWorkspaceState(viewportWidth),
-      ...(workspace.layoutOverride === undefined
-        ? {}
-        : { layout: workspace.layoutOverride }),
-      ...(workspace.notationOverride === undefined
-        ? {}
-        : { notation: workspace.notationOverride }),
-      ...(workspace.directionOverride === undefined
-        ? {}
-        : { direction: workspace.directionOverride }),
-    }),
-  }
-})
 
 import { App } from '../src/visual-app/App.js'
 
@@ -262,72 +228,25 @@ describe('visual conversation rendering', () => {
   })
 })
 
-describe('layout control', () => {
-  beforeEach(() => {
-    workspace.layoutOverride = undefined
-    workspace.notationOverride = undefined
-    workspace.directionOverride = undefined
-  })
-
-  afterAll(() => {
-    workspace.layoutOverride = undefined
-    workspace.notationOverride = undefined
-    workspace.directionOverride = undefined
-  })
-
-  it('enables the direction button under the default layered backend', () => {
-    workspace.layoutOverride = undefined
+// ArchiMate is the notation and it lays out top-down, so neither a notation
+// picker nor a direction toggle has anything to offer. Asserted on the rendered
+// markup rather than on state, because a control is gone when it stops being
+// drawn - a reducer with no field behind it would still pass a state assertion
+// while the strip carried a dead button.
+describe('command strip', () => {
+  it('offers no notation picker', () => {
     const markup = renderSession()
 
-    expect(markup).toContain('<button type="button">Top-Down</button>')
+    expect(markup).not.toContain('aria-label="Notation"')
+    expect(markup).not.toContain('>ArchiMate<')
+    expect(markup).not.toContain('>Native<')
   })
 
-  it.each(['radial', 'force'] as const)(
-    'disables the direction button under %s',
-    (layout) => {
-      workspace.layoutOverride = layout
-      const markup = renderSession()
-
-      expect(markup).toContain('<button type="button" disabled="">Top-Down</button>')
-    },
-  )
-
-  it('disables the direction button and shows the reason under archimate notation', () => {
-    workspace.layoutOverride = undefined
-    workspace.notationOverride = 'archimate'
+  it('offers no direction control, and no notice explaining one', () => {
     const markup = renderSession()
 
-    expect(markup).toContain('<button type="button" disabled="">Top-Down</button>')
-    expect(markup).toContain(
-      '<span class="direction-notice" role="status">ArchiMate notation fixes direction to Top-Down.</span>',
-    )
-  })
-
-  it('shows no direction notice under native notation', () => {
-    workspace.layoutOverride = undefined
-    workspace.notationOverride = 'native'
-    const markup = renderSession()
-
-    expect(markup).toContain('<span class="direction-notice" role="status"></span>')
-  })
-
-  it('reports the pinned direction while archimate makes a stored left-right inert', () => {
-    workspace.notationOverride = 'archimate'
-    workspace.directionOverride = 'left-right'
-    const markup = renderSession()
-
-    // The canvas laid out DOWN, so the strip cannot advertise the stored value.
-    expect(markup).toContain('<button type="button" disabled="">Top-Down</button>')
-  })
-
-  it('keeps the stored direction and drops the notice where archimate pins nothing', () => {
-    workspace.layoutOverride = 'radial'
-    workspace.notationOverride = 'archimate'
-    workspace.directionOverride = 'left-right'
-    const markup = renderSession()
-
-    // Radial never reads a direction, so the pin is not what disabled this.
-    expect(markup).toContain('<button type="button" disabled="">Left-Right</button>')
-    expect(markup).toContain('<span class="direction-notice" role="status"></span>')
+    expect(markup).not.toContain('Top-Down')
+    expect(markup).not.toContain('Left-Right')
+    expect(markup).not.toContain('direction-notice')
   })
 })

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -297,26 +297,35 @@ describe("visualWorkspaceReducer layout", () => {
     expect(workspaceState.layout).toBe("layered");
   });
 
-  it("carries the layout through layout.set without touching direction", () => {
+  it("carries the layout through layout.set", () => {
     const next = visualWorkspaceReducer(workspaceState, {
       type: "layout.set",
       layout: "layered",
     });
     expect(next.layout).toBe("layered");
-    expect(next.direction).toBe(workspaceState.direction);
   });
 
-  it("adopts a selected view declared layout and direction", () => {
+  it("adopts a selected view declared layout", () => {
+    const actions = presentationActionsFor({ layout: "layered" });
+    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
+    expect(next.layout).toBe("layered");
+  });
+
+  // A view may still declare `direction` - the LikeC4 export reads it - and
+  // the canvas must take no notice: it draws ArchiMate, which is top-down by
+  // construction, and there is no control for a declared direction to move.
+  it("ignores a direction a view declares", () => {
     const actions = presentationActionsFor({
       layout: "layered",
       direction: "left-right",
-    });
-    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next.layout).toBe("layered");
-    expect(next.direction).toBe("left-right");
+    } as Parameters<typeof presentationActionsFor>[0]);
+    expect(actions).toEqual([
+      { type: "layout.set", layout: "layered" },
+      { type: "nesting.set", nesting: ["composition"] },
+    ]);
   });
 
-  it("leaves layout and direction untouched when a view declares neither", () => {
+  it("leaves layout untouched when a view declares none", () => {
     const actions = presentationActionsFor({});
     const next = actions.reduce(visualWorkspaceReducer, workspaceState);
     expect(next).toBe(workspaceState);
@@ -590,42 +599,6 @@ describe("visualWorkspaceReducer nesting", () => {
       nesting: ["composition"],
     });
     expect(next).toBe(workspaceState);
-  });
-});
-
-describe("visualWorkspaceReducer notation", () => {
-  const workspaceState = createVisualWorkspaceState(1280);
-
-  it("starts with native notation", () => {
-    expect(workspaceState.notation).toBe("native");
-  });
-
-  it("sets notation on notation.set", () => {
-    const next = visualWorkspaceReducer(workspaceState, {
-      type: "notation.set",
-      notation: "archimate",
-    });
-    expect(next.notation).toBe("archimate");
-  });
-
-  it("adopts a selected view declared notation", () => {
-    const actions = presentationActionsFor({ notation: "archimate" });
-    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next.notation).toBe("archimate");
-  });
-
-  it("leaves notation untouched when a view declares none", () => {
-    const actions = presentationActionsFor({});
-    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
-    expect(next).toBe(workspaceState);
-  });
-
-  it("adopts only the notation field a view actually declares", () => {
-    const actions = presentationActionsFor({ notation: "archimate" });
-    expect(actions).toEqual([
-      { type: "nesting.set", nesting: ["composition"] },
-      { type: "notation.set", notation: "archimate" },
-    ]);
   });
 });
 


### PR DESCRIPTION
Closes #250. First of the eight in #244.

## What changed

The canvas drew ArchiMate only when asked, and undifferentiated boxes
otherwise. Now shape follows aspect, every node carries its kind glyph, and
every edge takes its line and arrows from its core relationship kind, because
none of that is a mode any more.

`buildStylesheet`'s `if (notation !== 'archimate') return baseStylesheet` early
return is gone, and with it the mode plumbing through `badgeLayersFor`,
`buildLayoutConfig`, `runLayout`, `relayoutVisible`, the workspace reducer and
the command strip. **`buildLayoutConfig` now takes no arguments at all.**

## Breaking

`presentation.notation` admits `archimate` alone. A projection asking for
`native` is refused rather than quietly drawn as something else — there is a
test asserting the refusal lands on `/presentation/notation`, because a field
kept for a renderer that does not exist is worse than no field.

It stays an enum for the reason `layout` did when `radial` and `force` went
(#219): a second notation needs somewhere to land. ADR 0087 is untouched.

## The one that nearly went wrong

I had removed `presentation.direction` too, on the reasoning that ArchiMate
pins `elk.direction: 'DOWN'` so nothing reads it. Then the Node typecheck
failed on `likec4-export.ts:475`:

```ts
`    autoLayout ${projection.presentation?.direction === 'top-down' ? 'TopBottom' : 'LeftRight'}`
```

**The LikeC4 export reads it, and draws no layer bands, so left-right is
legitimate there.** `direction` stays in the format; only the canvas control
goes.

That has a consequence worth stating: with no control, a save had nothing to
write for `direction`, so overwriting a view would have **silently dropped** a
value the reviewer never saw and could not have meant to discard. `buildPayload`
now carries the view's declared direction through untouched, with a test for it.
A save also stops writing `notation` at all rather than stamping the only one
onto every projection it touches.

## Also

Three dead references #219 left behind, all in code this change touches: a doc
comment for a `seed` state field that no longer exists, a `seed?` parameter
nothing reads, and render tests driving `radial` and `force` through a mock.

**Noticed, not fixed:** a save does not write `presentation.nesting` either, so
overwriting a view drops it. That is the same shape of bug but predates this
change and has its own fix (write it, not carry it), so it is left alone.

## Verification

`pnpm verify` exits 0 (83 files, 1329 tests). `changelog:check` exits 0. The
repo's own 22 projections still check, so nothing here declared a refused value.

Opened in a browser, which is the only place most of this is visible:

| | drawn |
|---|---|
| `goal` (motivation) | octagon, lilac, target glyph |
| `businessProcess`, `capability` (behavior) | rounded rectangle |
| `applicationComponent`, `node` (active structure) | rectangle |
| `realization` | dotted, hollow triangle |
| `triggering` | solid, filled triangle |
| `serving` | solid, open vee |

A view declaring `direction: left-right` still lays out top-down. The strip
carries no notation picker and no direction control; `Conversation` and `End`
remain, since those belong to #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
