### PR TITLE
fix(visual): a subject you create appears on the canvas that created it (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,32 @@
   at all if it finds a collision. Name any file that references subjects without
   being listed in the manifest, such as an adapter's project definition.
 
+- **Fix.** A subject you create appears on the canvas that created it. A filter
+  is resolved against the model the server held when it was asked, and a landed
+  commit replaces that model. Nothing re-asked, so the matched set went on
+  describing the graph as it was: the subject the reviewer had just made was
+  not in it, and the canvas hides every element the matched set does not name.
+  The commit reported `Committed - 1 file`, the bytes landed, and the diagram
+  did not change. It needed no unusual view and no stale projection, only a
+  filter resolved once, which is every view a session opens on; the one case it
+  never reached was an unfiltered canvas. Confirmed against a view whose query
+  genuinely matches the new subject, where navigating away and back revealed
+  it: same view, same query, same model, only the re-asking differed.
+  The browser now re-asks its standing filter off the `model` frame that
+  invalidated it. That is a consequence of a frame arriving rather than of a
+  render, so it lives beside the rest of the frame handling as a pure function
+  (`filterToReresolve`) instead of in an effect: the same frame that
+  invalidates a matched set is the thing that asks for a new one. Only a
+  `model` frame qualifies, since a `filter-result` is the answer and re-asking
+  off it would never stop. Whichever query is standing is the one re-asked,
+  under the source that asked for it, so a reviewer holding their own filter
+  does not have the view's query put back underneath them and a chat-issued
+  narrowing does not start reporting itself as the reviewer's own (#251).
+  The test that missed this asserted on `state.model.graph`, which was correct
+  the whole time. What was wrong is what the canvas *draws*, which is that
+  graph narrowed by the matched set, so the canvas is what the new tests
+  assert on.
+
 - **Breaking.** One notation. The canvas draws ArchiMate, and `native` is
   removed rather than demoted: `presentation.notation` admits `archimate`
   alone, and a projection asking for `native` is refused rather than quietly

--- a/src/visual-app/session-client.tsx
+++ b/src/visual-app/session-client.tsx
@@ -12,6 +12,7 @@ import type { YarramateOperation } from '../operations.js'
 import {
   canReconnect,
   initialVisualAppState,
+  filterToReresolve,
   visualAppActionsForFrame,
   visualAppReducer,
   visualAppSnapshotFrom,
@@ -41,7 +42,7 @@ export interface VisualSession {
   readonly ask: (text: string) => void
   readonly choose: (optionId: string) => void
   readonly navigate: (viewId: string) => void
-  readonly filter: (query: ProjectionQuery, origin?: 'view' | 'panel') => void
+  readonly filter: (query: ProjectionQuery, origin?: 'view' | 'panel' | 'chat') => void
   readonly clearFilter: () => void
   readonly setQuickFilterText: (text: string) => void
   readonly saveView: (payload: VisualViewSavePayload) => void
@@ -68,7 +69,7 @@ export const useVisualSession = (): VisualSession => {
   // the reason the browser last asked, so a result can be told apart from a
   // named view being applied. Panel is the honest default: an unsolicited
   // result is not a view this browser can claim to be showing.
-  const filterOriginRef = useRef<'view' | 'panel'>('panel')
+  const filterOriginRef = useRef<'view' | 'panel' | 'chat'>('panel')
 
   useEffect(() => {
     let stopped = false
@@ -117,6 +118,25 @@ export const useVisualSession = (): VisualSession => {
           filterOriginRef.current,
         ))
           dispatch(action)
+        // A landed commit replaces the model, which invalidates the matched
+        // set every filter result described. Asking again here, off the frame
+        // that invalidated it, is what keeps a subject the reviewer just
+        // created from being hidden by a matched set resolved before it
+        // existed. `stateRef` holds the state before this frame's actions
+        // commit, which is exactly right: the standing filter is the one that
+        // needs re-asking, not one this frame produced.
+        const stale = filterToReresolve(frame, stateRef.current)
+        if (stale !== null) {
+          filterOriginRef.current = stale.source
+          socket.send(
+            JSON.stringify(
+              visualBrowserInputFor(
+                { kind: 'filter', query: stale.query },
+                stateRef.current,
+              ),
+            ),
+          )
+        }
       })
       socket.addEventListener('close', () => {
         setConnected(false)
@@ -192,7 +212,7 @@ export const useVisualSession = (): VisualSession => {
   )
 
   const filter = useCallback(
-    (query: ProjectionQuery, origin: 'view' | 'panel' = 'panel') => {
+    (query: ProjectionQuery, origin: 'view' | 'panel' | 'chat' = 'panel') => {
       filterOriginRef.current = origin
       send({ kind: 'filter', query })
     },

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -810,6 +810,47 @@ export const visualBrowserInputFor = (
 };
 
 /**
+ * The filter to ask again once a frame has been applied, or `null`.
+ *
+ * A filter is resolved against the model the server held when it was asked,
+ * and a landed commit replaces that model. Nothing re-asks on its own, so
+ * `matchedIds` goes on describing the graph as it was: a subject the reviewer
+ * just created is not in it, and the canvas hides every element the matched
+ * set does not name. The commit reports success and the diagram does not
+ * change. That needs no unusual view and no stale projection - only a filter
+ * that was resolved once, which is every view a session opens on.
+ *
+ * This is a consequence of a frame arriving rather than of a render, which is
+ * why it lives here beside `visualAppActionsForFrame` and not in an effect:
+ * the same `model` frame that invalidates the matched set is the thing that
+ * has to ask for a new one.
+ *
+ * Only a `model` frame qualifies. A `filter-result` is the answer to this
+ * question and must never re-ask it, or a session would ask forever.
+ *
+ * The query re-asked is whichever one is standing, under the source that asked
+ * for it: a reviewer holding a panel filter must not have the active view's
+ * query put back underneath them, and a chat-issued filter must not start
+ * reporting itself as the reviewer's own.
+ */
+export const filterToReresolve = (
+  frame: VisualServerFrame,
+  state: VisualAppState,
+): {
+  readonly query: ProjectionQuery;
+  readonly source: "view" | "panel" | "chat";
+} | null => {
+  if (frame.kind !== "model") return null;
+  // No filter standing is "everything is drawn", which a new subject joins by
+  // existing. There is nothing to re-ask.
+  if (state.activeFilter === null) return null;
+  return {
+    query: state.activeFilter.query,
+    source: state.activeFilter.source,
+  };
+};
+
+/**
  * One server frame as the actions it means. Translation is pure so the socket
  * owns nothing but the socket.
  *
@@ -820,7 +861,7 @@ export const visualBrowserInputFor = (
  */
 export const visualAppActionsForFrame = (
   frame: VisualServerFrame,
-  filterOrigin: "view" | "panel" = "panel",
+  filterOrigin: "view" | "panel" | "chat" = "panel",
 ): readonly VisualAppAction[] => {
   switch (frame.kind) {
     case "ready":

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -183,3 +183,49 @@ describe('relayoutVisible', () => {
     expect(() => relayoutVisible(cy)).not.toThrow()
   })
 })
+
+// What the canvas DRAWS, which is the model graph narrowed by the matched set,
+// not the model graph. Every test that asserted on the model graph passed while
+// this was broken: the graph was right, and the reviewer saw nothing.
+describe('a subject the model has just gained', () => {
+  /** The graph after a commit landed a new subject, as a `model` frame carries it. */
+  const cyAfterCommit = () => {
+    const cy = buildCy()
+    cy.add({
+      data: {
+        id: 'payment-gateway',
+        label: 'Payment Gateway',
+        kindLabel: 'applicationComponent',
+      },
+      group: 'nodes',
+    })
+    return cy
+  }
+
+  it('is hidden by a matched set resolved before it existed', () => {
+    // The defect, stated as the canvas states it. `matchedIds` was resolved
+    // against the graph as it was; nothing re-asked; the new subject is not in
+    // it, so it is drawn nowhere despite the commit having landed.
+    const cy = cyAfterCommit()
+    applyFilter(cy, ['node1', 'node2'], '')
+
+    expect(cy.getElementById('payment-gateway').visible()).toBe(false)
+    expect(visibleIds(cy)).not.toContain('payment-gateway')
+  })
+
+  it('is drawn once the matched set is asked for again', () => {
+    const cy = cyAfterCommit()
+    applyFilter(cy, ['node1', 'node2', 'payment-gateway'], '')
+
+    expect(cy.getElementById('payment-gateway').visible()).toBe(true)
+  })
+
+  it('is drawn with no structural filter standing at all', () => {
+    // Unfiltered is the one case the defect never reached: `null` means draw
+    // everything, and a new subject joins by existing.
+    const cy = cyAfterCommit()
+    applyFilter(cy, null, '')
+
+    expect(cy.getElementById('payment-gateway').visible()).toBe(true)
+  })
+})

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -12,6 +12,7 @@ import {
   RECONNECT_WINDOW_MS,
   VISUAL_END_NOTICE,
   canReconnect,
+  filterToReresolve,
   initialVisualAppState,
   visualAppActionsForFrame,
   visualAppReducer,
@@ -1607,5 +1608,76 @@ describe("visualAppReducer view save", () => {
     });
     expect(reloaded.pendingViewSave).toBe(null);
     expect(reloaded.viewSaveNotice).toBe(false);
+  });
+});
+
+describe("filterToReresolve", () => {
+  /**
+   * The defect this exists to close: a filter is resolved against the model
+   * the server held when it was asked, and a landed commit replaces that
+   * model. Nothing re-asked, so the matched set went on describing the graph
+   * as it was, and the canvas hid the subject the reviewer had just created.
+   * The commit reported success and the diagram did not change.
+   */
+  const standing = (
+    source: "view" | "panel" | "chat",
+    matchedIds: readonly string[] = ["checkout"],
+  ): VisualAppState => ({
+    ...initialVisualAppState,
+    activeFilter: {
+      query: { kinds: ["yarramate/core@0.1#applicationComponent"] },
+      matchedIds,
+      source,
+    },
+  });
+
+  const modelFrame: VisualServerFrame = { kind: "model", model: model("all") };
+
+  it("asks the standing view query again when a model replaces the old one", () => {
+    expect(filterToReresolve(modelFrame, standing("view"))).toEqual({
+      query: { kinds: ["yarramate/core@0.1#applicationComponent"] },
+      source: "view",
+    });
+  });
+
+  it.each(["panel", "chat"] as const)(
+    "re-asks a %s filter under the source that asked for it",
+    (source) => {
+      // A reviewer holding their own filter must not have the active view's
+      // query put back underneath them, and a chat-issued narrowing must not
+      // start reporting itself as the reviewer's own.
+      expect(filterToReresolve(modelFrame, standing(source))?.source).toBe(source);
+    },
+  );
+
+  it("has nothing to re-ask when no filter is standing", () => {
+    // Unfiltered draws everything, which a new subject joins by existing.
+    expect(filterToReresolve(modelFrame, initialVisualAppState)).toBeNull();
+  });
+
+  it("never re-asks off a filter result, which is the answer to the question", () => {
+    // The guard against asking forever: this frame is what a re-ask produces.
+    expect(
+      filterToReresolve(
+        {
+          kind: "filter-result",
+          result: {
+            query: { kinds: ["yarramate/core@0.1#applicationComponent"] },
+            matchedIds: ["checkout", "payment-gateway"],
+          },
+        },
+        standing("view"),
+      ),
+    ).toBeNull();
+  });
+
+  it("re-asks off nothing but a model", () => {
+    for (const frame of [
+      { kind: "accepted", sequence: 1 },
+      { kind: "rejected", reason: "nope" },
+      { kind: "closing", reason: "user-ended" },
+    ] as unknown as VisualServerFrame[]) {
+      expect(filterToReresolve(frame, standing("view"))).toBeNull();
+    }
   });
 });

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -1538,6 +1538,55 @@ relationships: []
     await closeSocket(socket)
   })
 
+  it('answers the same query differently once a commit has landed', async () => {
+    // The other half of "a subject you create appears on the canvas that
+    // created it". The browser re-asks its standing filter off the `model`
+    // frame a commit produces (`filterToReresolve`); this is the server side
+    // of that exchange, and the reason re-asking is not merely tidy: the
+    // answer to an identical query changes, so a matched set resolved once is
+    // wrong from the moment a commit lands.
+    await plantEditableWorkspace()
+    const visual = await startVisualFixture()
+    const { socket, state: ready } = await openBrowser(visual)
+    const model = modelOf(ready)
+
+    const query = { kinds: ['yarramate/core@0.1#applicationComponent'] } as const
+    const asked = (): VisualBrowserInput => ({
+      type: 'filter.query',
+      lastAcknowledgedSequence: 0,
+      payload: { query },
+    })
+
+    send(socket, asked())
+    const before = await nextFrame(socket, 'filter-result')
+    expect([...before.result.matchedIds].sort()).toEqual(['checkout', 'ledger'])
+
+    const operation = draftConcept(
+      model.graph,
+      {
+        name: 'Payment Gateway',
+        kind: 'applicationComponent',
+        document: ENGINE,
+      },
+      paletteOf(ready),
+    )
+    commit(socket, staged(ready, operation!))
+    expect(await nextFrame(socket, 'apply-result')).toMatchObject({
+      result: { ok: true },
+    })
+    await nextFrame(socket, 'model')
+
+    // The identical query, asked again.
+    send(socket, asked())
+    const after = await nextFrame(socket, 'filter-result')
+    expect([...after.result.matchedIds].sort()).toEqual([
+      'checkout',
+      'ledger',
+      'payment-gateway',
+    ])
+    await closeSocket(socket)
+  })
+
   it('marks the subject at fault, not the one a deletion shifted past', async () => {
     await plantEditableWorkspace()
     const visual = await startVisualFixture()


### PR DESCRIPTION
Addresses the defect half of #251. Second of the eight in #244.

## The defect

Add a subject, commit. The tray says **`Committed · 1 file`**, the bytes land,
and **the canvas does not change.**

A filter is resolved against the model the server held when it was asked, and a
landed commit replaces that model. Nothing re-asked, so `matchedIds` went on
describing the graph as it was. `graph-canvas.tsx:696` hides every element the
matched set does not name, so the subject the reviewer had just made was drawn
nowhere.

It needed no unusual view and no stale projection, only a filter resolved once
— which is every view a session opens on. The one case it never reached was an
unfiltered canvas, where `matchedIds` is `null` and everything is drawn.

Confirmed not to be the projection's fault: on a view whose query is
`kinds: [applicationComponent]`, which genuinely matches the new subject, it was
still hidden. Navigating away to **All (unfiltered)** and back to the same view
revealed it. Same view, same query, same model — only the re-asking differed.

## The fix, and why it is not an effect

The browser re-asks its standing filter off the `model` frame that invalidated
it.

I first wrote this as a `useEffect` keyed on `state.model`. That was wrong in a
way worth naming: the re-ask is caused by **a frame arriving**, not by a render.
Moving it beside the rest of the frame handling as a pure function
(`filterToReresolve`) made it both more honest and testable — a React effect
firing over a WebSocket is exactly what this repo has no test environment for.

Two guards fall out of the shape:

- **Only a `model` frame qualifies.** A `filter-result` is the answer to this
  question, so re-asking off one would never stop.
- **The query re-asked is whichever is standing, under the source that asked for
  it.** A reviewer holding a panel filter must not have the view's query put
  back underneath them, and a chat-issued narrowing must not start reporting
  itself as the reviewer's own. `filter`'s origin widens to admit `chat` for
  that.

It is also deliberately narrower than re-applying the view, which would
re-dispatch the view's declared presentation and snap back any badge the
reviewer had toggled since.

## Tests

No single test spans React, a socket and cytoscape, so there are three, each on
a real seam:

1. **`filterToReresolve`** — the decision, including that it never fires off a
   `filter-result`. Reverting the fix fails exactly these three.
2. **The server answers an identical query differently once a commit lands** —
   real server, real commit: `[checkout, ledger]` before, `[checkout, ledger,
   payment-gateway]` after. This is why re-asking is necessary, not merely tidy.
3. **What the canvas DRAWS** — the one the suite never had. Every existing test
   asserted on `state.model.graph`, which was correct the whole time; what was
   wrong is that graph narrowed by the matched set. Including #243's own
   end-to-end test, which passed throughout.

The wiring itself is verified in a browser, which is the only place React and a
WebSocket meet. Add subject → commit → `payment-gateway` draws, laid out
alongside the other two.

## Not closed by this

**#251 stays open for its second half.** A projection that enumerates
`subjects:` still never gains the new id, so re-asking correctly returns a set
that correctly excludes it. That is 8 of this repo's 22 projections. The answer
is the design's staged view operation (`view "X" · +subject`), which is a
feature — protocol, server, tray — rather than a fix, and is filed separately.

## Verification

`pnpm verify` exits 0 (83 files, 1339 tests). `changelog:check` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
