### PR TITLE
Right-click menus, and the view/model split they have to teach (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## 1.0.0
 
+- **Added.** Right-click menus on a subject, a relationship, the empty canvas
+  and a row in the rail. Every one of them obeys one rule: **operations that
+  edit the view are separated from operations that edit the model**, under
+  named headings, with anything model-destructive last, behind a firm rule, in
+  `--failure`. Removing a subject from a view rewrites one projection and
+  leaves every other view alone; deleting it from the model takes every
+  relationship naming it and changes every view that drew it, and rendered as
+  neighbours in a flat list the second is one slip away from someone who meant
+  the first. Deleting still goes through the confirmation the side panel
+  already used, so the menu adds a way to ask and no way to skip being asked.
+  What a menu offers is a pure function of the model (`contextMenuFor`)
+  returning intents rather than callbacks, so what a right-click puts on screen
+  is something a test can read.
+
+- **Fix.** Re-typing a relationship offers only the kinds the endpoint pairing
+  permits. The properties form offered the profile's whole relationship
+  vocabulary, so turning `applicationComponent --serving--> businessActor`
+  into a `composition` was one click away and the `YM404` only arrived at
+  commit - while the connection tool two files over had always narrowed to
+  `connectableKinds`. The same narrowing now covers the form and the new menu,
+  and the kind an edge already carries is always offered, because a model
+  authored outside this editor is not the editor's to silently rewrite.
+
+- **Added.** `VisualKindOption` carries `coreLabel`, the core-profile kind an
+  option descends from, resolved through the profile's declared lineage exactly
+  as a canvas subject gets its own `coreKindLabel`. Without it a browser could
+  read a palette but not judge it: the ArchiMate table is keyed on core kinds,
+  so an extension kind had to be offered unchecked, and this repo's own
+  `implements` was offered on every edge including the pairings where the
+  `realization` it descends from is refused. It is now offered exactly where
+  that ancestor is permitted.
+
 - **Added.** The saved views and the whole model are a tree in a left rail,
   replacing the flat `<select>` that sat in the command strip. That control
   held every view at one level and could do nothing to a view but open it; a

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -165,6 +165,35 @@ ArchiMate vocabulary, and the panel says so rather than showing an empty list.
 Selection is chosen over dragging deliberately: every step is a state
 transition a test can make and a keyboard can reach.
 
+### Right-click menus
+
+Four things carry a menu — a subject, a relationship, the empty canvas, and a
+row in the rail — and one rule runs through all four: **operations that edit
+the view are separated from operations that edit the model.** The groups are
+named, view before model, and anything model-destructive sits last, behind a
+firm rule, drawn in `--failure`.
+
+The rule is not decoration. Removing a subject from a view rewrites one
+projection and leaves every other view alone; deleting it from the model takes
+every relationship naming it and changes every view that drew it. Rendered as
+neighbours in a flat list, the second is one slip away from someone who meant
+the first. Delete still asks through the same confirmation the side panel uses,
+so a menu adds a way to ask and no way to skip being asked.
+
+`Change kind` on a relationship offers only what the endpoint pairing permits,
+which is the guarantee the connection tool already gave a new edge, given to
+one that exists. An extension kind is judged by the core kind it descends from,
+read off `VisualKindOption.coreLabel`; a kind whose lineage never reaches the
+ArchiMate table has no row to judge it against and is offered rather than
+refused on a guess. The kind an edge already carries is always offered, because
+a model authored outside this editor is not the editor's to silently rewrite.
+
+What a menu contains is a pure function of the model (`contextMenuFor`), and
+its items name intents rather than carrying callbacks, so what a right-click
+puts on screen is something a test can read. It is rebuilt on every render
+rather than captured when it opened: a commit landing underneath an open menu
+redraws it instead of leaving items pointing at a subject that has gone.
+
 ### Nesting
 
 `presentation.nesting` names the relationship kinds that draw as containment in

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -166,6 +166,17 @@ export interface VisualViewSummary {
 export interface VisualKindOption {
   readonly id: string;
   readonly label: string;
+  /**
+   * The nearest core-profile kind this one descends from, as a label — the
+   * same resolution `CanvasNode.coreKindLabel` and `CanvasEdge.coreKindLabel`
+   * carry, for a kind nothing has been authored with yet.
+   *
+   * Without it a browser can read a palette but cannot judge it: the ArchiMate
+   * table is keyed on core kinds, so an editor offering an extension kind has
+   * no way to ask whether the pairing permits what that kind descends from,
+   * and can put a `YM404` one click away. Equal to `label` for a core kind.
+   */
+  readonly coreLabel: string;
 }
 
 export interface VisualFilterQueryPayload {

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -83,6 +83,7 @@ import {
   loadWorkspaceManifest,
   type ResolvedWorkspace,
 } from "../../workspace.js";
+import type { VisualKindOption } from "./protocol-contract.js";
 import type {
   VisualRenderedModel,
   VisualServerFrame,
@@ -747,12 +748,23 @@ export const startVisualServer = async (
         graph: compiled.graph,
         profileContext: compiled.profileContext,
       };
-      const conceptKinds = [
-        ...compiled.profileContext.conceptKindLineages.keys(),
-      ].map((id) => ({ id, label: kindLabelOf(id) }));
-      const relationshipKinds = [
-        ...compiled.profileContext.relationshipKindLineages.keys(),
-      ].map((id) => ({ id, label: kindLabelOf(id) }));
+      // `[0]` is the nearest declared ancestor, the same reading
+      // `projectGraphForCanvas` gives an authored subject its `coreKindLabel`.
+      // A kind with no lineage IS a core kind and stands for itself.
+      const optionsFrom = (
+        lineages: ReadonlyMap<string, readonly string[]>,
+      ): readonly VisualKindOption[] =>
+        [...lineages.keys()].map((id) => ({
+          id,
+          label: kindLabelOf(id),
+          coreLabel: kindLabelOf(lineages.get(id)?.[0] ?? id),
+        }));
+      const conceptKinds = optionsFrom(
+        compiled.profileContext.conceptKindLineages,
+      );
+      const relationshipKinds = optionsFrom(
+        compiled.profileContext.relationshipKindLineages,
+      );
       rendered = {
         authority: rendered.authority,
         initialView: rendered.initialView,

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -47,6 +47,13 @@ import { ConnectionPanel } from "./connection-panel.js";
 import { faultedSubjects } from "./faults.js";
 import { SubjectDraftPanel } from "./subject-draft-panel.js";
 import { ConfirmDialog } from "./confirm-dialog.js";
+import { ContextMenu } from "./context-menu.js";
+import {
+  contextMenuFor,
+  type ContextMenuIntent,
+  type ContextMenuTarget,
+} from "./context-menu-model.js";
+import { stageRelationshipScalarChange } from "./subject-form.js";
 import { describeDeletion, draftDeletion } from "../deletion-drafting.js";
 
 /**
@@ -310,6 +317,7 @@ const DiagramWorkspace = ({
   pendingDeletion,
   onDeletionDismiss,
   onSelect,
+  onCanvasMenu,
   onClearFilter,
   onSaveLayout,
 }: {
@@ -331,6 +339,13 @@ const DiagramWorkspace = ({
   readonly pendingDeletion: string | null;
   readonly onDeletionDismiss: () => void;
   readonly onSelect: (subject: SelectedDiagramSubject) => void;
+  readonly onCanvasMenu: (
+    target: {
+      readonly type: "node" | "edge" | "canvas";
+      readonly id: string | null;
+    },
+    position: { readonly x: number; readonly y: number },
+  ) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
 }) => {
@@ -450,6 +465,7 @@ const DiagramWorkspace = ({
                   onSelect(normalizeSelectedRelationship(edge, nodeTitles));
               }
             }}
+            onContextMenu={onCanvasMenu}
             matchedIds={state.activeFilter?.matchedIds ?? null}
             quickFilterText={state.quickFilterText}
             nesting={nesting}
@@ -994,6 +1010,111 @@ export const App = () => {
     "--conversation-width": `${workspace.conversation.width}px`,
   } as CSSProperties;
 
+  const openMenu = (
+    target: ContextMenuTarget,
+    position: { readonly x: number; readonly y: number },
+  ) =>
+    dispatchWorkspace({
+      type: "menu.opened",
+      target,
+      x: position.x,
+      y: position.y,
+    });
+
+  // The menu is rebuilt from the live model on every render rather than
+  // captured when it opened, so a commit landing underneath it cannot leave
+  // items pointing at a subject that has gone.
+  const menuGroups =
+    workspace.contextMenu === null
+      ? []
+      : contextMenuFor(workspace.contextMenu.target, {
+          graph: state.model?.graph ?? null,
+          relationshipKinds: state.model?.vocabulary.relationshipKinds ?? [],
+          activeViewId: state.activeView,
+          filtered: state.activeFilter !== null,
+        });
+
+  /**
+   * Every menu item ends here. The menu itself decides nothing about what an
+   * item does; it names an intent, and this is the single place that turns one
+   * into the dispatch, filter or staged operation it already had a name for.
+   */
+  const runIntent = (intent: ContextMenuIntent) => {
+    const graph = state.model?.graph ?? null;
+    switch (intent.type) {
+      case "subject.inspect": {
+        const node = graph?.nodes.find(
+          (candidate) => candidate.id === intent.id,
+        );
+        if (node === undefined) return;
+        dispatchWorkspace({
+          type: "subject.selected",
+          subject: normalizeSelectedElement(node),
+        });
+        return;
+      }
+      case "relationship.inspect": {
+        const edge = graph?.edges.find(
+          (candidate) => candidate.id === intent.id,
+        );
+        if (edge === undefined || graph === null) return;
+        dispatchWorkspace({
+          type: "subject.selected",
+          subject: normalizeSelectedRelationship(
+            edge,
+            new Map(graph.nodes.map((node) => [node.id, node.name] as const)),
+          ),
+        });
+        return;
+      }
+      case "subject.connect":
+        dispatchWorkspace({ type: "connection.started", from: intent.from });
+        return;
+      case "subject.delete":
+      case "relationship.delete":
+        // Both go through the same confirmation the side panel already uses:
+        // `draftDeletion` composes the batch and knows an edge from a node.
+        dispatchWorkspace({ type: "deletion.asked", id: intent.id });
+        return;
+      case "relationship.retype": {
+        const edge = graph?.edges.find(
+          (candidate) => candidate.id === intent.id,
+        );
+        if (edge === undefined) return;
+        for (const operation of stageRelationshipScalarChange(
+          edge.document,
+          edge.localId,
+          "kind",
+          edge.kindLabel,
+          intent.kind,
+        )) {
+          stageChange(operation);
+        }
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
+      case "canvas.draft-subject":
+        dispatchWorkspace({ type: "subject.draft.opened" });
+        return;
+      case "view.open":
+        navigate(intent.id);
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      case "view.clear":
+        clearFilter();
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      case "view.new":
+        // Same two motions the rail's own new-view button makes: a new view
+        // starts from the whole model, and the form seeds itself from what is
+        // active, so clearing first is what makes its fields blank.
+        clearFilter();
+        setSaveViewOpen(true);
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+    }
+  };
+
   return (
     <main className="visual-shell" style={shellStyle}>
       <CommandStrip
@@ -1068,6 +1189,14 @@ export const App = () => {
               subject: normalizeSelectedElement(node),
             });
           }}
+          onRowMenu={(row, position) =>
+            openMenu(
+              row.kind === "view"
+                ? { kind: "view-row", id: row.id }
+                : { kind: "model-row", id: row.id },
+              position,
+            )
+          }
         />
         <DiagramWorkspace
           state={state}
@@ -1099,6 +1228,16 @@ export const App = () => {
           showOwnership={workspace.showOwnership}
           onSelect={(subject) =>
             dispatchWorkspace({ type: "subject.selected", subject })
+          }
+          onCanvasMenu={(target, position) =>
+            openMenu(
+              target.type === "node"
+                ? { kind: "subject", id: target.id ?? "" }
+                : target.type === "edge"
+                  ? { kind: "relationship", id: target.id ?? "" }
+                  : { kind: "canvas" },
+              position,
+            )
           }
           onClearFilter={clearFilter}
           onSaveLayout={saveLayout}
@@ -1138,6 +1277,17 @@ export const App = () => {
           onCommitChangeset={commitChangeset}
         />
       </div>
+      {/* At the shell, not inside the canvas or the rail: a menu opened on the
+          last row of the rail has to be able to hang past the rail's edge. */}
+      {workspace.contextMenu === null ? null : (
+        <ContextMenu
+          groups={menuGroups}
+          x={workspace.contextMenu.x}
+          y={workspace.contextMenu.y}
+          onChoose={runIntent}
+          onDismiss={() => dispatchWorkspace({ type: "menu.dismissed" })}
+        />
+      )}
     </main>
   );
 };

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -1,0 +1,333 @@
+/**
+ * What a right-click offers, as data.
+ *
+ * Four things can be right-clicked — a subject, a relationship, the empty
+ * canvas, a row in the rail — and one rule runs through all four: **operations
+ * that edit the view are separated from operations that edit the model.**
+ *
+ * The rule is not decoration. Removing a subject from a view rewrites one
+ * projection and leaves every other view alone; deleting it from the model
+ * takes every relationship naming it and changes every view that drew it.
+ * Rendered as neighbours in a flat list, the second is one slip away from
+ * someone who meant the first. So the groups are labelled, they are ordered
+ * view-before-model, and anything model-destructive sits last, behind a rule,
+ * in `--failure`.
+ *
+ * Items carry an INTENT rather than a callback. A closure cannot be compared,
+ * so a menu built from closures is a menu no test can read; a discriminated
+ * union can be asserted on exactly, and the shell has nothing left to decide
+ * but which reducer to hand it to. `presentationActionsFor` returns actions
+ * for the same reason.
+ *
+ * Pure, and outside any component, because this repo renders React through
+ * `renderToStaticMarkup` and has no DOM test environment.
+ */
+import type { CanvasGraph } from "../graph-projection.js";
+import type { VisualKindOption } from "../adapters/visual/protocol-contract.js";
+import { relationshipKindOffer } from "./relationship-kind-options.js";
+
+/** The id of the "All subjects" row, which is the absence of a view. */
+export const ALL_SUBJECTS_VIEW = "";
+
+export type ContextMenuTarget =
+  | { readonly kind: "subject"; readonly id: string }
+  | { readonly kind: "relationship"; readonly id: string }
+  | { readonly kind: "canvas" }
+  | { readonly kind: "view-row"; readonly id: string }
+  | { readonly kind: "model-row"; readonly id: string };
+
+export type ContextMenuIntent =
+  | { readonly type: "subject.inspect"; readonly id: string }
+  | { readonly type: "subject.connect"; readonly from: string }
+  | { readonly type: "subject.delete"; readonly id: string }
+  | { readonly type: "relationship.inspect"; readonly id: string }
+  | {
+      readonly type: "relationship.retype";
+      readonly id: string;
+      readonly kind: string;
+    }
+  | { readonly type: "relationship.delete"; readonly id: string }
+  | { readonly type: "canvas.draft-subject" }
+  | { readonly type: "view.open"; readonly id: string }
+  | { readonly type: "view.clear" }
+  | { readonly type: "view.new" };
+
+/** Which half of the split an operation belongs to. */
+export type ContextMenuScope = "view" | "model";
+
+export interface ContextMenuItem {
+  /** Stable across renders and readable in a test. */
+  readonly key: string;
+  readonly label: string;
+  readonly intent: ContextMenuIntent;
+  /** Marked as the value already in force, for a group that names a choice. */
+  readonly current?: true;
+}
+
+export interface ContextMenuGroup {
+  readonly key: string;
+  readonly scope: ContextMenuScope;
+  /** The heading, or null for a group that needs no name. */
+  readonly label: string | null;
+  /**
+   * Whether this group removes authored text. Exactly one group per menu may
+   * say so, it is always last, and it is the group that draws in `--failure`.
+   */
+  readonly destructive: boolean;
+  readonly items: readonly ContextMenuItem[];
+}
+
+export interface ContextMenuContext {
+  readonly graph: CanvasGraph | null;
+  readonly relationshipKinds: readonly VisualKindOption[];
+  /** The view the canvas is showing, or `ALL_SUBJECTS_VIEW`. */
+  readonly activeViewId: string;
+  /** Whether anything at all is narrowing the canvas right now. */
+  readonly filtered: boolean;
+}
+
+const NEW_VIEW: ContextMenuItem = {
+  key: "view.new",
+  label: "New view…",
+  intent: { type: "view.new" },
+};
+
+const SHOW_ALL: ContextMenuItem = {
+  key: "view.clear",
+  label: "Show all subjects",
+  intent: { type: "view.clear" },
+};
+
+const deleteGroup = (
+  intent: ContextMenuIntent,
+  label: string,
+): ContextMenuGroup => ({
+  key: "delete",
+  scope: "model",
+  label: null,
+  destructive: true,
+  items: [{ key: "delete", label, intent }],
+});
+
+const subjectMenu = (
+  id: string,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  const node = context.graph?.nodes.find((candidate) => candidate.id === id);
+  if (node === undefined) return [];
+  return [
+    {
+      key: "model",
+      scope: "model",
+      label: "Model",
+      destructive: false,
+      items: [
+        {
+          key: "inspect",
+          label: "Properties",
+          intent: { type: "subject.inspect", id },
+        },
+        {
+          key: "connect",
+          label: "Connect from here…",
+          intent: { type: "subject.connect", from: id },
+        },
+      ],
+    },
+    deleteGroup({ type: "subject.delete", id }, "Delete from model…"),
+  ];
+};
+
+const relationshipMenu = (
+  id: string,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  const graph = context.graph;
+  const edge = graph?.edges.find((candidate) => candidate.id === id);
+  if (graph === null || graph === undefined || edge === undefined) return [];
+
+  // The whole point of the change-kind group: it is built from the table, so a
+  // menu cannot draw an edge the compiler would refuse.
+  const offer = relationshipKindOffer(
+    graph,
+    { from: edge.from, to: edge.to },
+    context.relationshipKinds,
+    edge.kindLabel,
+  );
+
+  const groups: ContextMenuGroup[] = [
+    {
+      key: "model",
+      scope: "model",
+      label: "Model",
+      destructive: false,
+      items: [
+        {
+          key: "inspect",
+          label: "Properties",
+          intent: { type: "relationship.inspect", id },
+        },
+      ],
+    },
+  ];
+
+  // A group of one is the kind it already has and nothing to change it to;
+  // a heading over a single unclickable choice teaches nothing.
+  if (offer.options.length > 1) {
+    groups.push({
+      key: "kind",
+      scope: "model",
+      label: "Change kind",
+      destructive: false,
+      items: offer.options.map((option) => ({
+        key: `kind:${option.label}`,
+        label: option.label,
+        intent: {
+          type: "relationship.retype" as const,
+          id,
+          kind: option.label,
+        },
+        ...(option.label === edge.kindLabel ? { current: true as const } : {}),
+      })),
+    });
+  }
+
+  groups.push(
+    deleteGroup({ type: "relationship.delete", id }, "Delete from model…"),
+  );
+  return groups;
+};
+
+const canvasMenu = (
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  if (context.graph === null) return [];
+  return [
+    {
+      key: "view",
+      scope: "view",
+      label: "View",
+      destructive: false,
+      items: context.filtered ? [NEW_VIEW, SHOW_ALL] : [NEW_VIEW],
+    },
+    {
+      key: "model",
+      scope: "model",
+      label: "Model",
+      destructive: false,
+      items: [
+        {
+          key: "add",
+          label: "Add subject…",
+          intent: { type: "canvas.draft-subject" },
+        },
+      ],
+    },
+  ];
+};
+
+const viewRowMenu = (
+  id: string,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => [
+  {
+    key: "view",
+    scope: "view",
+    label: "View",
+    destructive: false,
+    items: [
+      id === ALL_SUBJECTS_VIEW
+        ? SHOW_ALL
+        : {
+            key: "view.open",
+            label: "Open view",
+            intent: { type: "view.open", id },
+            ...(id === context.activeViewId ? { current: true as const } : {}),
+          },
+      NEW_VIEW,
+    ],
+  },
+];
+
+const modelRowMenu = (
+  id: string,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  const node = context.graph?.nodes.find((candidate) => candidate.id === id);
+  if (node === undefined) return [];
+  return [
+    {
+      key: "model",
+      scope: "model",
+      label: "Model",
+      destructive: false,
+      items: [
+        {
+          key: "inspect",
+          label: "Properties",
+          intent: { type: "subject.inspect", id },
+        },
+      ],
+    },
+    deleteGroup({ type: "subject.delete", id }, "Delete from model…"),
+  ];
+};
+
+/**
+ * The menu for a target, already ordered: view groups first, model groups
+ * after them, and the destructive group last of all.
+ *
+ * Empty when the target has gone — a commit can replace the model between the
+ * right-click and the render, and a menu over a subject that no longer exists
+ * should not be drawn rather than drawn with dead items.
+ */
+export const contextMenuFor = (
+  target: ContextMenuTarget,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  switch (target.kind) {
+    case "subject":
+      return subjectMenu(target.id, context);
+    case "relationship":
+      return relationshipMenu(target.id, context);
+    case "canvas":
+      return canvasMenu(context);
+    case "view-row":
+      return viewRowMenu(target.id, context);
+    case "model-row":
+      return modelRowMenu(target.id, context);
+  }
+};
+
+export interface MenuPlacement {
+  readonly left: number;
+  readonly top: number;
+}
+
+/**
+ * Where the menu is drawn, given where the pointer was.
+ *
+ * A menu opened near the right or bottom edge would otherwise run off the
+ * viewport with no scrollbar to reach it, which is how a right-click on the
+ * last row of a rail loses its own delete item. Flipping to the other side of
+ * the pointer keeps the menu beside what was clicked rather than over it;
+ * clamping to zero is the last resort for a menu taller than the window.
+ */
+export const placeMenu = (
+  pointer: { readonly x: number; readonly y: number },
+  size: { readonly width: number; readonly height: number },
+  viewport: { readonly width: number; readonly height: number },
+): MenuPlacement => ({
+  left: Math.max(
+    0,
+    pointer.x + size.width <= viewport.width
+      ? pointer.x
+      : Math.min(pointer.x - size.width, viewport.width - size.width),
+  ),
+  top: Math.max(
+    0,
+    pointer.y + size.height <= viewport.height
+      ? pointer.y
+      : Math.min(pointer.y - size.height, viewport.height - size.height),
+  ),
+});

--- a/src/visual-app/context-menu.tsx
+++ b/src/visual-app/context-menu.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  placeMenu,
+  type ContextMenuGroup,
+  type ContextMenuIntent,
+} from "./context-menu-model.js";
+
+/**
+ * The menu itself: a positioned list of buttons over whatever was right-clicked.
+ *
+ * It decides nothing. `contextMenuFor` has already said which groups exist, in
+ * which order, and which one removes authored text; this draws that and reports
+ * the intent that was chosen. The one thing it computes is where to sit, and
+ * that is `placeMenu`, which is pure and tested — the measurement it needs
+ * (`getBoundingClientRect`) is the only reason any of this is in an effect.
+ *
+ * Buttons in lists, not an ARIA `menu`, for the same reason the rail is not an
+ * ARIA `tree`: a real menu widget owes the reviewer roving focus and typeahead,
+ * and this repo has no DOM test environment to hold that behaviour honest.
+ * What it does owe — Escape closes, a click outside closes, focus lands inside
+ * so a keyboard can reach the items — is small enough to be right by reading.
+ */
+
+export interface ContextMenuProps {
+  readonly groups: readonly ContextMenuGroup[];
+  readonly x: number;
+  readonly y: number;
+  readonly onChoose: (intent: ContextMenuIntent) => void;
+  readonly onDismiss: () => void;
+}
+
+export function ContextMenu({
+  groups,
+  x,
+  y,
+  onChoose,
+  onDismiss,
+}: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  // Offscreen until measured: a menu painted at the pointer and then moved is
+  // a menu that visibly jumps on every right-click near an edge.
+  const [placement, setPlacement] = useState<{
+    readonly left: number;
+    readonly top: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    const element = menuRef.current;
+    if (element === null) return;
+    const box = element.getBoundingClientRect();
+    setPlacement(
+      placeMenu(
+        { x, y },
+        { width: box.width, height: box.height },
+        { width: window.innerWidth, height: window.innerHeight },
+      ),
+    );
+    element.focus();
+  }, [x, y, groups]);
+
+  useEffect(() => {
+    const keyed = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onDismiss();
+    };
+    // Pointerdown, not click: a menu that survives until mouseup sits over the
+    // thing the next click was aimed at.
+    const pointed = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        menuRef.current !== null &&
+        target instanceof Node &&
+        menuRef.current.contains(target)
+      ) {
+        return;
+      }
+      onDismiss();
+    };
+    window.addEventListener("keydown", keyed);
+    window.addEventListener("pointerdown", pointed, true);
+    // A right-click elsewhere opens its own menu; this one must not linger
+    // beside it, and the canvas suppresses the native menu rather than this.
+    window.addEventListener("contextmenu", pointed, true);
+    window.addEventListener("resize", onDismiss);
+    return () => {
+      window.removeEventListener("keydown", keyed);
+      window.removeEventListener("pointerdown", pointed, true);
+      window.removeEventListener("contextmenu", pointed, true);
+      window.removeEventListener("resize", onDismiss);
+    };
+  }, [onDismiss]);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      role="dialog"
+      aria-label="Actions"
+      tabIndex={-1}
+      style={
+        placement === null
+          ? { left: 0, top: 0, visibility: "hidden" }
+          : { left: `${placement.left}px`, top: `${placement.top}px` }
+      }
+    >
+      {groups.map((group) => (
+        <div
+          key={group.key}
+          className={`context-menu-group context-menu-${group.scope}${
+            group.destructive ? " context-menu-destructive" : ""
+          }`}
+        >
+          {group.label === null ? null : (
+            <p className="context-menu-heading">{group.label}</p>
+          )}
+          <ul>
+            {group.items.map((item) => (
+              <li key={item.key}>
+                <button
+                  type="button"
+                  className="context-menu-item"
+                  aria-current={item.current === true ? "true" : undefined}
+                  onClick={() => onChoose(item.intent)}
+                >
+                  <span className="context-menu-tick" aria-hidden>
+                    {item.current === true ? "•" : ""}
+                  </span>
+                  <span className="context-menu-label">{item.label}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -867,6 +867,15 @@ interface GraphCanvasProps {
   readonly graph: CanvasGraph
   readonly selectedId: string | null
   readonly onSelect: (id: string, type: 'node' | 'edge') => void
+  /**
+   * A right-click on the canvas, reported in VIEWPORT coordinates because the
+   * menu is positioned against the window rather than against this container.
+   * `id` is null for the background.
+   */
+  readonly onContextMenu: (
+    target: { readonly type: 'node' | 'edge' | 'canvas'; readonly id: string | null },
+    position: { readonly x: number; readonly y: number },
+  ) => void
   readonly matchedIds: readonly string[] | null
   readonly quickFilterText: string
   /** What draws as nesting in this view, in precedence order (ADR 0101). */
@@ -895,6 +904,7 @@ export function GraphCanvas({
   graph,
   selectedId,
   onSelect,
+  onContextMenu,
   matchedIds,
   quickFilterText,
   nesting,
@@ -909,6 +919,7 @@ export function GraphCanvas({
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<Core | null>(null)
   const onSelectRef = useRef(onSelect)
+  const onContextMenuRef = useRef(onContextMenu)
   const isInitialSyncRef = useRef(true)
   const isInitialPresentationSyncRef = useRef(true)
   const activeViewIdRef = useRef(activeViewId)
@@ -932,6 +943,10 @@ export function GraphCanvas({
   useEffect(() => {
     onSelectRef.current = onSelect
   }, [onSelect])
+
+  useEffect(() => {
+    onContextMenuRef.current = onContextMenu
+  }, [onContextMenu])
 
   // Keep onSaveLayoutRef up-to-date for the drag-save handler
   useEffect(() => {
@@ -977,6 +992,48 @@ export function GraphCanvas({
     cy.on('tap', 'edge', (evt) => {
       const edgeId = evt.target.id()
       onSelectRef.current(edgeId, 'edge')
+    })
+
+    // Right-click. Cytoscape reports its own rendered position, which is
+    // relative to this container; the menu is positioned against the window,
+    // so the native event's client coordinates are the ones that place it.
+    // A `cxttap` with no original event (a synthetic emit, as a test or a
+    // console driver produces) falls back to the container's own origin plus
+    // the rendered position, which is the same point by another route.
+    const pointerOf = (evt: cytoscape.EventObject) => {
+      const original = evt.originalEvent as MouseEvent | undefined
+      if (original !== undefined && original !== null) {
+        return { x: original.clientX, y: original.clientY }
+      }
+      const box = cy.container()?.getBoundingClientRect()
+      const rendered = evt.renderedPosition as
+        | { x: number; y: number }
+        | undefined
+      return {
+        x: (box?.left ?? 0) + (rendered?.x ?? 0),
+        y: (box?.top ?? 0) + (rendered?.y ?? 0),
+      }
+    }
+
+    cy.on('cxttap', 'node', (evt) => {
+      onContextMenuRef.current(
+        { type: 'node', id: evt.target.id() },
+        pointerOf(evt),
+      )
+    })
+
+    cy.on('cxttap', 'edge', (evt) => {
+      onContextMenuRef.current(
+        { type: 'edge', id: evt.target.id() },
+        pointerOf(evt),
+      )
+    })
+
+    cy.on('cxttap', (evt) => {
+      // Cytoscape fires the unfiltered handler for elements too, so the
+      // background is the case where the target IS the core instance.
+      if (evt.target !== cy) return
+      onContextMenuRef.current({ type: 'canvas', id: null }, pointerOf(evt))
     })
 
     // Drag-end → debounced layout save with full position snapshot
@@ -1146,5 +1203,14 @@ export function GraphCanvas({
     }
   }, [matchedIds, quickFilterText, graph])
 
-  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+  // The browser's own menu is suppressed here rather than on `window`: every
+  // other surface in this application should keep the one the platform gives
+  // it, and only the canvas has a menu of its own to put in its place.
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: '100%' }}
+      onContextMenu={(event) => event.preventDefault()}
+    />
+  )
 }

--- a/src/visual-app/relationship-kind-options.ts
+++ b/src/visual-app/relationship-kind-options.ts
@@ -1,0 +1,77 @@
+/**
+ * Which relationship kinds an editor may offer for an edge that already exists.
+ *
+ * `connectableKinds` answers this for an edge being drawn, and the guarantee it
+ * carries is that a palette built from it cannot produce an edge `check` would
+ * refuse with `YM404`. Re-typing an edge is the same question asked of the same
+ * table, and until now nothing asked it: the properties form offered the whole
+ * vocabulary, so `applicationComponent --composition--> businessActor` was one
+ * click away and the refusal only arrived at commit.
+ *
+ * An extension kind has no row of its own in the ArchiMate table, so it is
+ * judged by the core kind it descends from — `VisualKindOption.coreLabel`,
+ * which the session server resolves through the profile's declared lineage
+ * exactly as a canvas edge gets its own `coreKindLabel`. That field exists
+ * because of this: without it the browser could read a palette but not judge
+ * it, and every extension kind would have to be offered unchecked, which is a
+ * `YM404` one click away in a menu whose whole point is that it cannot produce
+ * one.
+ *
+ * The kind the edge already has is always offered, even when the table would
+ * refuse it. A model authored outside this editor is not the editor's to
+ * silently rewrite, and a select whose current value is missing from its own
+ * options renders blank.
+ *
+ * Pure, and outside any component, for the reason `view-tree-model.ts` is:
+ * this repo renders React through `renderToStaticMarkup` and has no DOM test
+ * environment, so logic inside a component is logic no test can reach.
+ */
+import type { CanvasGraph } from "../graph-projection.js";
+import type { VisualKindOption } from "../adapters/visual/protocol-contract.js";
+import { connectableKinds } from "../relationship-drafting.js";
+import { CORE_RELATIONSHIP_KINDS } from "../relationship-matrix.js";
+
+export interface RelationshipKindOffer {
+  /** What may be chosen, in vocabulary order. */
+  readonly options: readonly VisualKindOption[];
+  /**
+   * Whether the ArchiMate table narrowed the list. False when either endpoint
+   * sits outside the core vocabulary, which is the one case where the whole
+   * vocabulary is offered because nothing here can judge it.
+   */
+  readonly narrowed: boolean;
+}
+
+export const relationshipKindOffer = (
+  graph: CanvasGraph,
+  /**
+   * The endpoints as they stand, which is not always what the edge was
+   * authored with: a staged `from` change moves the row of the table this
+   * question is asked against, and the kind offered next has to follow it.
+   */
+  endpoints: { readonly from: string; readonly to: string },
+  vocabulary: readonly VisualKindOption[],
+  currentKindLabel: string,
+): RelationshipKindOffer => {
+  const permitted = new Set<string>(
+    connectableKinds(graph, endpoints.from, endpoints.to),
+  );
+  // Empty means the table has no row for this pairing — an endpoint outside the
+  // core vocabulary. Offering nothing would make the kind uneditable, which is
+  // a worse answer than the one this module cannot give.
+  if (permitted.size === 0) return { options: vocabulary, narrowed: false };
+
+  const core = new Set<string>(CORE_RELATIONSHIP_KINDS);
+  return {
+    options: vocabulary.filter(
+      (option) =>
+        permitted.has(option.coreLabel) ||
+        // A `coreLabel` the core vocabulary does not know is a kind whose
+        // lineage never reaches the table at all. There is no row to judge it
+        // against, so it is offered rather than refused on a guess.
+        !core.has(option.coreLabel) ||
+        option.label === currentKindLabel,
+    ),
+    narrowed: true,
+  };
+};

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1699,3 +1699,98 @@ body {
   padding: 0.25rem 0.6rem;
   cursor: pointer;
 }
+
+/* ---- Context menus (#247) --------------------------------------------- */
+/* The rule the menus have to teach is drawn, not just ordered: a labelled
+   group per scope, a firm rule before anything model-destructive, and
+   `--failure` on the item that removes authored text. */
+
+.context-menu {
+  position: fixed;
+  z-index: 1100;
+  min-width: 184px;
+  max-width: 280px;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: calc(var(--step) * 0.5) 0;
+  background: var(--sheet);
+  border: 1px solid var(--rule-firm);
+  border-radius: 2px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+}
+
+.context-menu:focus {
+  outline: none;
+}
+
+.context-menu ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.context-menu-group + .context-menu-group {
+  margin-top: calc(var(--step) * 0.5);
+  padding-top: calc(var(--step) * 0.5);
+  border-top: 1px solid var(--rule);
+}
+
+/* The one rule that is not decoration: the boundary a slip must not cross. */
+.context-menu-destructive {
+  margin-top: calc(var(--step) * 0.5);
+  padding-top: calc(var(--step) * 0.5);
+  border-top: 1px solid var(--rule-firm);
+}
+
+.context-menu-heading {
+  margin: 0;
+  padding: calc(var(--step) * 0.5) calc(var(--step) * 1.5);
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--step) * 0.75);
+  width: 100%;
+  padding: 0.3rem calc(var(--step) * 1.5);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  color: var(--ink);
+  background: none;
+  border: 0;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.context-menu-item:hover {
+  background: color-mix(in oklab, var(--cobalt) 10%, transparent);
+}
+
+.context-menu-destructive .context-menu-item {
+  color: var(--failure);
+}
+
+.context-menu-destructive .context-menu-item:hover {
+  background: color-mix(in oklab, var(--failure) 12%, transparent);
+}
+
+.context-menu-tick {
+  flex: none;
+  width: 8px;
+  font-family: var(--utility);
+  font-size: 12px;
+  color: var(--cobalt);
+}
+
+.context-menu-label {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/visual-app/subject-form.tsx
+++ b/src/visual-app/subject-form.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { kindLabelOf } from '../kind-label.js'
+import { relationshipKindOffer } from './relationship-kind-options.js'
 import type { CanvasEdge, CanvasNode } from '../graph-projection.js'
 import type { VisualRenderedModel } from '../adapters/visual/wire.js'
 import type { VisualKindOption } from '../adapters/visual/protocol-contract.js'
@@ -784,11 +785,22 @@ export const RelationshipForm = ({ edge, model, operations, onStageChange }: Rel
   const document = edge.document
   const id = edge.localId
   const stage = (ops: readonly YarramateOperation[]) => ops.forEach(onStageChange)
-  const kindOptions = model.vocabulary.relationshipKinds.map((option) => ({
+  const currentKind = kindLabelFor(effective.kind, model.vocabulary.relationshipKinds)
+  // The same guarantee `connectableKinds` gives the connection tool, given to
+  // the edge that already exists: this select offered the whole vocabulary, so
+  // re-typing `applicationComponent --composition--> businessActor` was one
+  // click away and `YM404` only arrived at commit. Endpoints come from
+  // `effective`, not from the edge, so a staged `from` change moves the row of
+  // the table this is asked against.
+  const kindOptions = relationshipKindOffer(
+    model.graph,
+    { from: effective.from, to: effective.to },
+    model.vocabulary.relationshipKinds,
+    currentKind,
+  ).options.map((option) => ({
     value: option.label,
     label: option.label,
   }))
-  const currentKind = kindLabelFor(effective.kind, model.vocabulary.relationshipKinds)
   // Endpoints are refs, not addresses: `qualifyReference` leaves an already
   // qualified ref alone, so writing the canvas id keeps a cross-document
   // endpoint unambiguous instead of guessing which document to read it in.

--- a/src/visual-app/view-tree.tsx
+++ b/src/visual-app/view-tree.tsx
@@ -74,13 +74,31 @@ function LayerSwatch({ layer }: { readonly layer: string | null }) {
   );
 }
 
+/**
+ * A right-click on a row, in viewport coordinates. The rail reports which row
+ * was hit and nothing about what the menu should say — `contextMenuFor` owns
+ * that, and a rail that also decided it would be a second place to change.
+ */
+export type TreeRowMenu = (
+  row: { readonly kind: "view" | "subject"; readonly id: string },
+  position: { readonly x: number; readonly y: number },
+) => void;
+
+const menuHandler =
+  (row: { readonly kind: "view" | "subject"; readonly id: string }, onMenu: TreeRowMenu) =>
+  (event: { preventDefault: () => void; clientX: number; clientY: number }) => {
+    event.preventDefault();
+    onMenu(row, { x: event.clientX, y: event.clientY });
+  };
+
 interface ViewRowProps {
   readonly row: ViewTreeRow;
   readonly depth: 1 | 2;
   readonly onSelect: (id: string) => void;
+  readonly onMenu: TreeRowMenu;
 }
 
-function ViewRow({ row, depth, onSelect }: ViewRowProps) {
+function ViewRow({ row, depth, onSelect, onMenu }: ViewRowProps) {
   return (
     <li>
       <button
@@ -93,6 +111,7 @@ function ViewRow({ row, depth, onSelect }: ViewRowProps) {
         title={row.title}
         aria-current={row.active ? "true" : undefined}
         onClick={() => onSelect(row.id)}
+        onContextMenu={menuHandler({ kind: "view", id: row.id }, onMenu)}
       >
         <ViewGlyph />
         <span className="tree-label">{row.title}</span>
@@ -140,6 +159,7 @@ export interface ViewTreeProps {
   readonly onClearView: () => void;
   readonly onNewView: () => void;
   readonly onSelectSubject: (id: string) => void;
+  readonly onRowMenu: TreeRowMenu;
 }
 
 export function ViewTree({
@@ -155,6 +175,7 @@ export function ViewTree({
   onClearView,
   onNewView,
   onSelectSubject,
+  onRowMenu,
 }: ViewTreeProps) {
   const tree = buildViewTree({
     views,
@@ -233,6 +254,7 @@ export function ViewTree({
                   }`}
                   aria-current={showingAll ? "true" : undefined}
                   onClick={onClearView}
+                  onContextMenu={menuHandler({ kind: "view", id: "" }, onRowMenu)}
                 >
                   <ViewGlyph />
                   <span className="tree-label">{ALL_SUBJECTS_LABEL}</span>
@@ -246,6 +268,7 @@ export function ViewTree({
                 row={row}
                 depth={1}
                 onSelect={onSelectView}
+                onMenu={onRowMenu}
               />
             ))}
             {tree.folders.map((folder) => {
@@ -269,6 +292,7 @@ export function ViewTree({
                           row={row}
                           depth={2}
                           onSelect={onSelectView}
+                          onMenu={onRowMenu}
                         />
                       ))}
                     </ul>
@@ -314,6 +338,10 @@ export function ViewTree({
                             }`}
                             title={`${subject.name} — ${subject.kindLabel}`}
                             onClick={() => onSelectSubject(subject.id)}
+                            onContextMenu={menuHandler(
+                              { kind: "subject", id: subject.id },
+                              onRowMenu,
+                            )}
                           >
                             <LayerSwatch layer={subject.layer} />
                             <span className="tree-label">{subject.name}</span>

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -4,6 +4,7 @@ import type {
   CanvasNode,
 } from "../graph-projection.js";
 import { DEFAULT_NESTING, type NestingKind } from "../nesting.js";
+import type { ContextMenuTarget } from "./context-menu-model.js";
 
 export type ConversationMode = "auto" | "open" | "closed";
 
@@ -148,6 +149,18 @@ export interface VisualWorkspaceState {
    * A view that says nothing keeps `DEFAULT_NESTING`, which is composition
    * alone - the behaviour that shipped before a view could say.
    */
+  /**
+   * The open context menu: what was right-clicked and where the pointer was,
+   * or null. The menu's CONTENTS are not held here — `contextMenuFor` derives
+   * them from the model on every render, so a commit that lands while a menu
+   * is open redraws it instead of leaving stale items over a subject that is
+   * no longer there.
+   */
+  readonly contextMenu: {
+    readonly target: ContextMenuTarget;
+    readonly x: number;
+    readonly y: number;
+  } | null;
   readonly nesting: readonly NestingKind[];
   readonly layout: "layered";
   readonly showLifecycle: boolean;
@@ -180,6 +193,13 @@ export type VisualWorkspaceAction =
   | { readonly type: "subject.cleared" }
   | { readonly type: "description.toggled" }
   | { readonly type: "details.toggled" }
+  | {
+      readonly type: "menu.opened";
+      readonly target: ContextMenuTarget;
+      readonly x: number;
+      readonly y: number;
+    }
+  | { readonly type: "menu.dismissed" }
   | { readonly type: "tree.filtered"; readonly filterText: string }
   | { readonly type: "tree.toggled"; readonly key: string }
   | {
@@ -332,6 +352,7 @@ export const createVisualWorkspaceState = (
   connection: null,
   draftingSubject: false,
   pendingDeletion: null,
+  contextMenu: null,
   nesting: DEFAULT_NESTING,
   layout: "layered",
   showLifecycle: true,
@@ -393,11 +414,25 @@ export const visualWorkspaceReducer = (
           unread: state.conversation.unread + 1,
         },
       };
+    // A menu is dismissed by everything it can lead to, and by the commit that
+    // can take its target away, rather than by a blanket rule over every
+    // action: a reviewer who right-clicks and then reads an agent's reply
+    // should still find the menu where they left it.
+    case "menu.opened":
+      return {
+        ...state,
+        contextMenu: { target: action.target, x: action.x, y: action.y },
+      };
+    case "menu.dismissed":
+      return state.contextMenu === null
+        ? state
+        : { ...state, contextMenu: null };
     case "connection.started":
       return {
         ...state,
         connection: { from: action.from, to: null },
         draftingSubject: false,
+        contextMenu: null,
       };
     case "connection.targeted":
       if (state.connection === null) return state;
@@ -413,7 +448,12 @@ export const visualWorkspaceReducer = (
     case "subject.draft.opened":
       // The two tools are alternatives, not layers: opening one puts the other
       // away rather than leaving two half-finished drafts on screen.
-      return { ...state, draftingSubject: true, connection: null };
+      return {
+        ...state,
+        draftingSubject: true,
+        connection: null,
+        contextMenu: null,
+      };
     case "subject.draft.closed":
       return state.draftingSubject ? { ...state, draftingSubject: false } : state;
     case "deletion.asked":
@@ -424,6 +464,7 @@ export const visualWorkspaceReducer = (
         pendingDeletion: action.id,
         connection: null,
         draftingSubject: false,
+        contextMenu: null,
       };
     case "deletion.dismissed":
       return state.pendingDeletion === null
@@ -435,6 +476,7 @@ export const visualWorkspaceReducer = (
         conversation: { ...state.conversation, mode: "open", unread: 0 },
         selectedSubject: action.subject,
         descriptionExpanded: false,
+        contextMenu: null,
       };
     case "subject.cleared":
       return state.selectedSubject === null
@@ -474,8 +516,14 @@ export const visualWorkspaceReducer = (
     case "presentation.toggled":
       return { ...state, [action.flag]: action.value };
     case "model.replaced": {
-      const held = state.selectedSubject;
-      if (held === null) return state;
+      // A menu is anchored to a pointer position over a subject that may not
+      // have survived the commit. `contextMenuFor` would return an empty menu
+      // for a target that is gone, so nothing stale is ever drawn — but a menu
+      // floating over a canvas that just redrew under it is its own confusion.
+      const base =
+        state.contextMenu === null ? state : { ...state, contextMenu: null };
+      const held = base.selectedSubject;
+      if (held === null) return base;
       const graph = action.graph;
       const survivor =
         graph === null
@@ -487,8 +535,8 @@ export const visualWorkspaceReducer = (
       // survives it - re-read the same id rather than closing the inspector
       // under them. Only a subject the commit actually removed is dropped.
       return survivor === null
-        ? { ...state, selectedSubject: null, descriptionExpanded: false }
-        : { ...state, selectedSubject: survivor };
+        ? { ...base, selectedSubject: null, descriptionExpanded: false }
+        : { ...base, selectedSubject: survivor };
     }
   }
 };

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -39,8 +39,13 @@ const render = () =>
         {
           id: 'yarramate/core@0.1#applicationComponent',
           label: 'applicationComponent',
+          coreLabel: 'applicationComponent',
         },
-        { id: 'yarramate/core@0.1#businessActor', label: 'businessActor' },
+        {
+          id: 'yarramate/core@0.1#businessActor',
+          label: 'businessActor',
+          coreLabel: 'businessActor',
+        },
       ],
       documents: ['architecture/main.yaml', 'architecture/other.yaml'],
       defaultDocument: 'architecture/main.yaml',

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -1,0 +1,383 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ContextMenu } from "../src/visual-app/context-menu.js";
+import type { CanvasEdge, CanvasGraph, CanvasNode } from "../src/graph-projection.js";
+import type { VisualKindOption } from "../src/adapters/visual/protocol-contract.js";
+import {
+  contextMenuFor,
+  placeMenu,
+  type ContextMenuContext,
+  type ContextMenuGroup,
+} from "../src/visual-app/context-menu-model.js";
+import { relationshipKindOffer } from "../src/visual-app/relationship-kind-options.js";
+
+const node = (overrides: Partial<CanvasNode> = {}): CanvasNode => ({
+  id: "api",
+  localId: "api",
+  kind: "yarramate/core@0.1#applicationComponent",
+  kindLabel: "applicationComponent",
+  coreKindLabel: "applicationComponent",
+  document: "main.yaml",
+  layer: "application",
+  aspect: null,
+  name: "API",
+  description: null,
+  aka: [],
+  status: null,
+  owner: null,
+  distinctFrom: [],
+  supersedes: [],
+  constraints: [],
+  references: [],
+  presentIn: [],
+  attestations: [],
+  ...overrides,
+});
+
+const edge = (overrides: Partial<CanvasEdge> = {}): CanvasEdge => ({
+  id: "api-serving-ui",
+  localId: "api-serving-ui",
+  document: "main.yaml",
+  kind: "yarramate/core@0.1#serving",
+  kindLabel: "serving",
+  coreKindLabel: "serving",
+  from: "api",
+  to: "ui",
+  name: null,
+  description: null,
+  mode: null,
+  content: null,
+  status: null,
+  references: [],
+  presentIn: [],
+  ...overrides,
+});
+
+/**
+ * A different row of the table on purpose: `applicationComponent ->
+ * businessActor` permits association, flow, serving and triggering, and
+ * refuses composition. Two application components would have permitted
+ * composition, and a narrowing that removes nothing proves nothing.
+ */
+const reviewer = node({
+  id: "ui",
+  localId: "ui",
+  name: "Reviewer",
+  kind: "yarramate/core@0.1#businessActor",
+  kindLabel: "businessActor",
+  coreKindLabel: "businessActor",
+  layer: "business",
+});
+
+const graph: CanvasGraph = {
+  nodes: [node(), reviewer],
+  edges: [edge()],
+};
+
+/** A core kind stands for itself; an extension names what it descends from. */
+const kind = (label: string, coreLabel: string = label): VisualKindOption => ({
+  id: `yarramate/core@0.1#${label}`,
+  label,
+  coreLabel,
+});
+
+const VOCABULARY: readonly VisualKindOption[] = [
+  kind("association"),
+  kind("serving"),
+  kind("triggering"),
+  kind("composition"),
+];
+
+const context = (
+  overrides: Partial<ContextMenuContext> = {},
+): ContextMenuContext => ({
+  graph,
+  relationshipKinds: VOCABULARY,
+  activeViewId: "",
+  filtered: false,
+  ...overrides,
+});
+
+const labels = (groups: readonly ContextMenuGroup[]): readonly string[] =>
+  groups.flatMap((group) => group.items.map((item) => item.label));
+
+describe("the view/model split every menu has to teach", () => {
+  it("never puts a model group before a view group", () => {
+    for (const target of [
+      { kind: "subject", id: "api" },
+      { kind: "relationship", id: "api-serving-ui" },
+      { kind: "canvas" },
+      { kind: "view-row", id: "current" },
+      { kind: "model-row", id: "api" },
+    ] as const) {
+      const groups = contextMenuFor(target, context({ filtered: true }));
+      const lastView = groups.findLastIndex((group) => group.scope === "view");
+      const firstModel = groups.findIndex((group) => group.scope === "model");
+      if (lastView === -1 || firstModel === -1) continue;
+      expect(lastView, `${target.kind} orders view before model`).toBeLessThan(
+        firstModel,
+      );
+    }
+  });
+
+  it("puts the destructive group last, alone, and only once", () => {
+    for (const target of [
+      { kind: "subject", id: "api" },
+      { kind: "relationship", id: "api-serving-ui" },
+      { kind: "model-row", id: "api" },
+    ] as const) {
+      const groups = contextMenuFor(target, context());
+      const destructive = groups.filter((group) => group.destructive);
+      expect(destructive).toHaveLength(1);
+      expect(groups[groups.length - 1]?.destructive).toBe(true);
+      // A rule the reviewer can slip past is no rule: one item behind it.
+      expect(destructive[0]?.items).toHaveLength(1);
+    }
+  });
+
+  it("gives a view row nothing that edits the model", () => {
+    const groups = contextMenuFor({ kind: "view-row", id: "current" }, context());
+    expect(groups.every((group) => group.scope === "view")).toBe(true);
+    expect(groups.some((group) => group.destructive)).toBe(false);
+    expect(labels(groups)).toEqual(["Open view", "New view…"]);
+  });
+});
+
+describe("what each menu offers", () => {
+  it("offers the canvas a view group and a model group", () => {
+    const groups = contextMenuFor({ kind: "canvas" }, context());
+    expect(groups.map((group) => group.label)).toEqual(["View", "Model"]);
+    expect(labels(groups)).toEqual(["New view…", "Add subject…"]);
+  });
+
+  it("offers to show all only while something is narrowing the canvas", () => {
+    expect(labels(contextMenuFor({ kind: "canvas" }, context()))).not.toContain(
+      "Show all subjects",
+    );
+    expect(
+      labels(contextMenuFor({ kind: "canvas" }, context({ filtered: true }))),
+    ).toContain("Show all subjects");
+  });
+
+  it("marks the view already open", () => {
+    const groups = contextMenuFor(
+      { kind: "view-row", id: "current" },
+      context({ activeViewId: "current" }),
+    );
+    expect(groups[0]?.items[0]?.current).toBe(true);
+  });
+
+  it("gives the all-subjects row the clearing item, not an open", () => {
+    const groups = contextMenuFor({ kind: "view-row", id: "" }, context());
+    expect(labels(groups)).toEqual(["Show all subjects", "New view…"]);
+  });
+
+  it("draws nothing for a target the model no longer holds", () => {
+    // A commit can replace the model between the right-click and the render.
+    expect(contextMenuFor({ kind: "subject", id: "gone" }, context())).toEqual([]);
+    expect(
+      contextMenuFor({ kind: "relationship", id: "gone" }, context()),
+    ).toEqual([]);
+    expect(
+      contextMenuFor({ kind: "canvas" }, context({ graph: null })),
+    ).toEqual([]);
+  });
+
+  it("names the intent rather than carrying a callback", () => {
+    const groups = contextMenuFor({ kind: "subject", id: "api" }, context());
+    expect(groups.flatMap((group) => group.items.map((item) => item.intent)))
+      .toEqual([
+        { type: "subject.inspect", id: "api" },
+        { type: "subject.connect", from: "api" },
+        { type: "subject.delete", id: "api" },
+      ]);
+  });
+});
+
+describe("a menu cannot draw an edge the compiler would refuse", () => {
+  it("offers only kinds the endpoint pairing permits", () => {
+    const groups = contextMenuFor(
+      { kind: "relationship", id: "api-serving-ui" },
+      context(),
+    );
+    const kinds = groups.find((group) => group.key === "kind");
+    expect(kinds).toBeDefined();
+    // `composition` between two application components is refused by the
+    // ArchiMate table, so the menu must not be able to produce it.
+    expect(kinds!.items.map((item) => item.label)).not.toContain("composition");
+    expect(kinds!.items.map((item) => item.label)).toContain("serving");
+  });
+
+  it("marks the kind the edge already has", () => {
+    const groups = contextMenuFor(
+      { kind: "relationship", id: "api-serving-ui" },
+      context(),
+    );
+    const kinds = groups.find((group) => group.key === "kind");
+    const current = kinds!.items.filter((item) => item.current === true);
+    expect(current.map((item) => item.label)).toEqual(["serving"]);
+  });
+
+  it("drops the change-kind group when there is no other kind to pick", () => {
+    const groups = contextMenuFor(
+      { kind: "relationship", id: "api-serving-ui" },
+      context({ relationshipKinds: [kind("serving")] }),
+    );
+    expect(groups.some((group) => group.key === "kind")).toBe(false);
+  });
+});
+
+describe("relationshipKindOffer", () => {
+  it("keeps the kind the edge already has, even when the table refuses it", () => {
+    // A model authored outside this editor is not the editor's to rewrite,
+    // and a select whose current value is missing renders blank.
+    const offer = relationshipKindOffer(
+      graph,
+      { from: "api", to: "ui" },
+      VOCABULARY,
+      "composition",
+    );
+    expect(offer.narrowed).toBe(true);
+    expect(offer.options.map((option) => option.label)).toContain("composition");
+  });
+
+  it("judges nothing when an endpoint sits outside the core vocabulary", () => {
+    const extended: CanvasGraph = {
+      nodes: [node({ coreKindLabel: "notAKind" }), reviewer],
+      edges: [edge()],
+    };
+    const offer = relationshipKindOffer(
+      extended,
+      { from: "api", to: "ui" },
+      VOCABULARY,
+      "serving",
+    );
+    expect(offer.narrowed).toBe(false);
+    expect(offer.options).toEqual(VOCABULARY);
+  });
+
+  it("judges an extension kind by what it descends from", () => {
+    // `implements` extending `realization` is refused between an application
+    // component and a business actor exactly as `realization` is. Before
+    // `coreLabel` existed the browser could not see this, so every extension
+    // kind was offered unchecked and the menu could produce a YM404 after all.
+    const observes = kind("observes", "association");
+    const implementsKind = kind("implements", "realization");
+    const offer = relationshipKindOffer(
+      graph,
+      { from: "api", to: "ui" },
+      [...VOCABULARY, observes, implementsKind],
+      "serving",
+    );
+    expect(offer.narrowed).toBe(true);
+    const offered = offer.options.map((option) => option.label);
+    expect(offered).toContain("observes");
+    expect(offered).not.toContain("implements");
+  });
+
+  it("offers a kind whose lineage never reaches the table at all", () => {
+    // No row exists to judge it against, so refusing it would be a guess.
+    const offer = relationshipKindOffer(
+      graph,
+      { from: "api", to: "ui" },
+      [...VOCABULARY, kind("annotates", "annotates")],
+      "serving",
+    );
+    expect(offer.options.map((option) => option.label)).toContain("annotates");
+  });
+
+  it("follows the endpoints it is given, not the ones the edge was authored with", () => {
+    const both = relationshipKindOffer(
+      graph,
+      { from: "api", to: "api" },
+      VOCABULARY,
+      "serving",
+    );
+    // Same subject on both ends is a different row of the table; the point is
+    // that the answer is computed from the endpoints passed in.
+    expect(both.narrowed).toBe(true);
+  });
+});
+
+describe("placeMenu", () => {
+  const size = { width: 200, height: 300 };
+  const viewport = { width: 1000, height: 800 };
+
+  it("sits at the pointer when there is room", () => {
+    expect(placeMenu({ x: 100, y: 100 }, size, viewport)).toEqual({
+      left: 100,
+      top: 100,
+    });
+  });
+
+  it("flips to the other side of the pointer at the right edge", () => {
+    expect(placeMenu({ x: 950, y: 100 }, size, viewport).left).toBe(750);
+  });
+
+  it("flips above the pointer at the bottom edge", () => {
+    expect(placeMenu({ x: 100, y: 780 }, size, viewport).top).toBe(480);
+  });
+
+  it("clamps to the viewport rather than going negative", () => {
+    // A menu taller than the window: the top is the last thing to give up.
+    expect(placeMenu({ x: 10, y: 10 }, { width: 200, height: 900 }, viewport))
+      .toEqual({ left: 10, top: 0 });
+  });
+});
+
+/**
+ * Asserted on the markup rather than on the groups, because the rule is only
+ * a rule once it is drawn: a model returning `destructive: true` over a
+ * component that renders every group identically would still pass every
+ * assertion above while the menu put Delete next to Properties.
+ */
+describe("what the menu draws", () => {
+  const render = (target: Parameters<typeof contextMenuFor>[0]) =>
+    renderToStaticMarkup(
+      createElement(ContextMenu, {
+        groups: contextMenuFor(target, context({ filtered: true })),
+        x: 0,
+        y: 0,
+        onChoose: () => {},
+        onDismiss: () => {},
+      }),
+    );
+
+  it("draws Delete behind the rule, and nothing else with it", () => {
+    const markup = render({ kind: "subject", id: "api" });
+    // Everything after the destructive class opens is that group and no other,
+    // because it is the last group in the menu.
+    const behindTheRule = markup.slice(
+      markup.indexOf("context-menu-destructive"),
+    );
+    expect(behindTheRule).toContain("Delete from model…");
+    expect(behindTheRule).not.toContain("Properties");
+    expect(behindTheRule).not.toContain("Connect from here…");
+    // And Delete is not also drawn anywhere in front of it.
+    expect(
+      markup.slice(0, markup.indexOf("context-menu-destructive")),
+    ).not.toContain("Delete");
+  });
+
+  it("names each scope, so the split is read rather than inferred", () => {
+    const markup = render({ kind: "canvas" });
+    expect(markup).toContain("context-menu-view");
+    expect(markup).toContain("context-menu-model");
+    expect(markup).toContain(">View<");
+    expect(markup).toContain(">Model<");
+  });
+
+  it("draws no destructive group where there is nothing to destroy", () => {
+    expect(render({ kind: "view-row", id: "current" })).not.toContain(
+      "context-menu-destructive",
+    );
+    expect(render({ kind: "canvas" })).not.toContain(
+      "context-menu-destructive",
+    );
+  });
+
+  it("draws nothing at all for a target that has gone", () => {
+    expect(render({ kind: "subject", id: "gone" })).toBe("");
+  });
+});

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -1409,6 +1409,17 @@ relationships: []
       conceptKinds.map((kind) => kind.id).sort(),
     )
 
+    // Every option also says what it descends from, which is what lets the
+    // browser judge a kind against the ArchiMate table (#247). This workspace
+    // declares no profile of its own, so every kind IS a core kind and stands
+    // for itself - the resolution is the same one either way.
+    for (const option of [
+      ...model.vocabulary.conceptKinds,
+      ...model.vocabulary.relationshipKinds,
+    ]) {
+      expect(option.coreLabel).toBe(option.label)
+    }
+
     // One subject per kind the palette offers, in one batch: a vocabulary the
     // canvas can offer but not land is a palette of dead options, and only a
     // commit can tell the difference.

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -690,3 +690,60 @@ describe("the left rail's own state", () => {
     ).toBe(typed);
   });
 });
+
+describe("visualWorkspaceReducer context menu", () => {
+  const workspaceState = createVisualWorkspaceState(1280);
+  const opened = visualWorkspaceReducer(workspaceState, {
+    type: "menu.opened",
+    target: { kind: "subject", id: "system.api" },
+    x: 120,
+    y: 240,
+  });
+
+  it("holds what was right-clicked and where, and nothing about the items", () => {
+    // The contents are derived on every render, so a commit landing under an
+    // open menu cannot leave it pointing at a subject that has gone.
+    expect(opened.contextMenu).toEqual({
+      target: { kind: "subject", id: "system.api" },
+      x: 120,
+      y: 240,
+    });
+  });
+
+  it("is dismissed by everything a menu item can lead to", () => {
+    for (const action of [
+      { type: "menu.dismissed" },
+      { type: "connection.started", from: "system.api" },
+      { type: "subject.draft.opened" },
+      { type: "deletion.asked", id: "system.api" },
+      {
+        type: "subject.selected",
+        subject: normalizeSelectedElement(canvasNode()),
+      },
+    ] as const) {
+      expect(
+        visualWorkspaceReducer(opened, action).contextMenu,
+        `${action.type} closes the menu`,
+      ).toBeNull();
+    }
+  });
+
+  it("is dismissed by the commit that can take its target away", () => {
+    expect(
+      visualWorkspaceReducer(opened, { type: "model.replaced", graph: null })
+        .contextMenu,
+    ).toBeNull();
+  });
+
+  it("survives an agent's reply, which is not something the reviewer did", () => {
+    expect(
+      visualWorkspaceReducer(opened, { type: "attention.received" }).contextMenu,
+    ).toEqual(opened.contextMenu);
+  });
+
+  it("dismissing when nothing is open changes nothing", () => {
+    expect(
+      visualWorkspaceReducer(workspaceState, { type: "menu.dismissed" }),
+    ).toBe(workspaceState);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "src/visual-app",
     "test/visual-workspace-state.test.ts",
     "test/visual-app-render.test.ts",
+    "test/visual-context-menu.test.ts",
     "test/graph-canvas.test.ts",
     "test/filter-panel.test.ts",
     "test/save-view.test.ts",

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -24,6 +24,7 @@
     "test/kind-icons.test.ts",
     "test/visual-workspace-state.test.ts",
     "test/visual-app-render.test.ts",
+    "test/visual-context-menu.test.ts",
     "test/graph-canvas.test.ts",
     "test/filter-panel.test.ts",
     "test/save-view.test.ts",


### PR DESCRIPTION
## Summary

Four right-click menus — on a subject, a relationship, the empty canvas, and a
row in the rail — and one rule running through all four: **operations that edit
the view are separated from operations that edit the model.** Named headings,
view before model, and anything model-destructive last, behind a firm rule, in
`--failure`.

The rule is not decoration. Remove-from-view rewrites one projection and leaves
every other view alone; delete-from-model takes every relationship naming the
subject and changes every view that drew it. As neighbours in a flat list the
second is one slip away from someone who meant the first. Deleting still asks
through the confirmation the side panel already used, so a menu adds a way to
ask and no way to skip being asked.

What a menu contains is `contextMenuFor`, a pure function of the model
returning **intents rather than callbacks** — a closure cannot be compared, so a
menu built from closures is a menu no test can read. It is rebuilt on every
render rather than captured when it opened, so a commit landing underneath an
open menu redraws it instead of leaving items over a subject that has gone.

### The change-kind guarantee, and the hole under it

`Change kind` was supposed to offer only what the endpoint pairing permits. On
the way there I found the properties form had never done this: it offered the
profile's whole relationship vocabulary, so re-typing `applicationComponent
--serving--> businessActor` into a `composition` was one click away and the
`YM404` only arrived at commit — while `connectableKinds` sat two files over
giving the connection tool exactly that guarantee for a *new* edge. Both
surfaces now narrow through the table.

Narrowing alone could not close it. `VisualKindOption` carried an id and a
label, so an extension kind had no core ancestor the browser could read, and
every one had to be offered unchecked. **This repo's own `implements` was
offered on every edge**, including the pairings where the `realization` it
descends from is refused. The option now carries `coreLabel`, resolved
server-side through the profile's declared lineage exactly as a canvas subject
gets its own `coreKindLabel`.

Live, against this repo's own model:

| edge | Change kind offers |
| --- | --- |
| `check-command --serving--> check-core-contract` | association, flow, **serving**, triggering |
| `core-contract-release --realization--> manifest` | association, **realization**, `implements` |

`implements` where its ancestor is permitted, and nowhere else.

### Deliberately not here

**Remove-from-view.** It needs the staged view operation #255 is filed for, and
faking it against `view.save` (which lands immediately) would contradict that
design. The section it belongs in is already the shape it will land in. #246
fills in rename and delete on a view row.

**A submenu for change-kind.** It is a flat labelled group instead, for the same
reason the rail is buttons rather than an ARIA `tree`: a submenu owes the
reviewer hover intent and keyboard traversal, and there is no DOM test
environment here to hold that honest.

## Validation

`pnpm verify` exits 0 — 85 files, 1387 tests (up from 84/1356).
`node scripts/check-changelog.mjs` exits 0.

**Opened in a browser against this repo's own model**, because a green suite
says almost nothing about this app. Verified there: all four menus render with
the right groups and headings; the destructive group draws behind its rule in
`--failure`; the browser's own menu is suppressed on the canvas
(`defaultPrevented`); the menu lands at the pointer's client position and flips
at a viewport edge; Escape, a click outside, and a second right-click all
dismiss it, and a click inside does not; choosing `implements` staged
`update-relationship · … · kind` and closed the menu; `Delete from model…`
opened the existing confirmation naming the subject and its one relationship,
and cancelling left the tray empty.

**One gap, stated rather than glossed:** cytoscape ignores synthetic canvas
events, and no OS-level right-click tool is available in this environment, so
every canvas check above went through `cy.emit('cxttap', …)` rather than a real
right-click. Everything downstream of `cxttap` is verified on live data and all
three listeners (node, edge, background) are registered on the live instance;
the one unverified link is cytoscape's own native-event → `cxttap` step. Worth
one human right-click before merge.

## Related issue

Closes #247. Part of #244.

## Contract impact

`VisualKindOption` gains a required `coreLabel`. It is a wire type in
`protocol-contract.ts` and appears in no JSON schema, so no schema or protocol
version changes; the session server populates it for both concept and
relationship kinds. Three test fixtures updated.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
