### PR TITLE
A view is a staged change, and a write can remove (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## 1.0.0
 
+- **Breaking.** Saving a view is a staged change, not a write. `view.save` is
+  gone, and a commit carries `viewOperations` beside its model operations
+  (`yarramate/visual-protocol/v5`, ADR 0103). Saving used to compose a
+  projection and `writeFileSync` it the moment the reviewer pressed Save:
+  outside the changeset, so it could not be undone; outside ADR 0093's
+  staleness pin, so it overwrote a projection someone else had edited without
+  noticing; and outside the batch, so a view and the subjects it shows could
+  not land together. All three are closed by one mechanism, and the
+  confirm-before-overwrite dialog goes with them — a staged overwrite is a row
+  the reviewer can read and discard before it lands, which is a better answer
+  than a dialog. **Delete a view** from the rail's context menu, behind the
+  same rule every model-destructive item sits behind.
+
+- **Breaking.** A `PendingWrite` with a `null` source removes the document
+  (ADR 0103). `SourceStore` could create and replace but not remove, so nothing
+  in the engine could take a document away and a view rename — a write plus a
+  removal — could not be expressed at all. A removal lands in the same
+  all-or-none batch under the same compare-and-swap, and must name the revision
+  it was staged against: `expected: null` on a removal asks to remove a
+  document on condition it is not there, and is refused rather than treated as
+  a success.
+
+- **Added.** A commit lands the model and the views as **one** `store.writeAll`.
+  `landOperations` splits into `planOperations`, which returns the writes a
+  batch would make, and the visual runtime merges its projection writes into
+  that batch — so a view and the subjects it shows arrive together or not at
+  all, without making a presentation artifact into a semantic operation.
+  `yarramate/operations/v1` is unchanged, and Core keeps its invariant that a
+  projection is never an operation's own target.
+
+- **Added.** A view saved where the manifest's patterns cover no projection is
+  refused rather than written. This repository's own manifest uses
+  `projections/*.yaml`, which reaches no subdirectory, so the first view saved
+  into a folder would otherwise be a file the workspace silently never loads
+  (ADR 0043 names the same trap for `new projection`).
+
+- **Fix.** Pressing Commit on a changeset holding only a staged view did
+  nothing, and said nothing about why: the button's guard asked whether the
+  model's operation list was empty rather than whether the changeset was. Found
+  by staging a view in a browser and pressing the button, not by any test.
+
 - **Added.** Right-click menus on a subject, a relationship, the empty canvas
   and a row in the rail. Every one of them obeys one rule: **operations that
   edit the view are separated from operations that edit the model**, under

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -32,6 +32,26 @@ writes nothing and the browser is shown exactly the diagnostics that refused
 it, pointed at the changeset row that produced them
 ([ADR 0062](adr/0062-an-apply-diff-is-exactly-the-answer-it-landed.md)).
 
+**A saved view is a staged change too**
+([ADR 0103](adr/0103-a-write-can-remove-and-a-view-lands-in-the-same-batch-as-the-model.md)).
+Saving, overwriting and deleting a view all put a row in the same changeset,
+marked `view` where a subject's row is marked `model`, and land in the same
+batch: the runtime plans the model's writes, composes the projections', and
+hands the store **one** `writeAll`, so a view and the subjects it shows arrive
+together or not at all. The rows have different blast radius and the tray says
+which is which — a view row rewrites one projection, a model row changes every
+view that drew the subject.
+
+Core is untouched by this: `yarramate/operations/v1` has no projection
+operation, and a projection is still never an operation's own target. What made
+it possible is `SourceStore` learning to remove a document — a `PendingWrite`
+with a `null` source — which is also what makes a view rename expressible at
+all, since renaming writes one document and removes another.
+
+A view saved where the manifest's patterns cover no projection is refused
+rather than written: a projection nothing loads is worse than a refusal, and
+nothing later would say so.
+
 Before a commit, the tray walks its own staged set: **Undo** and **Redo** step
 through whole snapshots of the staged operations, so staging, discarding one
 row, and discarding all are reversible by the same control, and undoing a

--- a/docs/adr/0103-a-write-can-remove-and-a-view-lands-in-the-same-batch-as-the-model.md
+++ b/docs/adr/0103-a-write-can-remove-and-a-view-lands-in-the-same-batch-as-the-model.md
@@ -1,0 +1,158 @@
+# A write can remove, and a view lands in the same batch as the model
+
+Status: accepted
+
+[ADR 0100](0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md)
+gave a workspace a `SourceStore` whose `writeAll` lands a batch by
+compare-and-swap. It can create a document and it can replace one. It cannot
+remove one, and nothing else in the engine can either.
+
+That was not noticed because nothing needed it. The visual editor now does:
+[#246](https://github.com/yarrasys/yarramate/issues/246) asks for delete on a
+view, and states the constraint that makes it more than a menu item — creating
+and deleting a view writes and removes a projection document, so **both are
+staged and committed like any other change rather than landing immediately.**
+
+## Why
+
+**A projection is written outside every guarantee the engine has.** The visual
+runtime's `view.save` composes a projection, validates it, and writes it with
+`writeFileSync` the moment the reviewer presses Save. It is outside the
+changeset, so it cannot be undone. It is outside ADR 0093's staleness pin, so
+it overwrites a projection someone else edited without noticing. And it is
+outside the batch, so a view and the subjects it shows cannot land together.
+
+**Three separate features are blocked on the same missing thing.** #246 needs
+create and delete staged. [#248](https://github.com/yarrasys/yarramate/issues/248)
+needs a query edit staged. [#255](https://github.com/yarrasys/yarramate/issues/255)
+needs view membership staged. Each was filed as a UI change; each is the same
+absent mechanism wearing a different costume.
+
+**A rename is a create and a remove, and half of it is impossible.** A
+projection's id decides its path, so renaming a view writes one document and
+must remove another. With no removal, rename cannot be expressed at all — not
+staged, and not even immediately.
+
+## Decided
+
+### A pending write with no bytes removes the document
+
+```ts
+interface PendingWrite {
+  readonly path: string
+  // The bytes to leave behind, or null to remove the document.
+  readonly source: string | null
+  // The revision this edit was made against, or null for "must not exist yet".
+  readonly expected: string | null
+}
+```
+
+Removal is a write like any other. It lands in the same all-or-none batch,
+under the same compare-and-swap, so a view deleted beside a subject edit takes
+both or neither.
+
+**A removal must name a revision.** `expected: null` on a removal asks to
+remove a document on condition it is not there, which is not a thing to want.
+It is refused as `exists` rather than treated as a no-op, because a caller told
+its accidental delete worked is worse served than one told it made no sense.
+
+**An emptied directory is left behind.** A workspace cannot tell a directory it
+emptied from one it never had, and removing it would be the store inventing an
+intention the caller never stated.
+
+### A view operation is the adapter's, not Core's
+
+Core keeps its invariant. `applyOperations` says, and continues to say, that
+*projections and adapter mappings are never an operation's own target — they
+are only ever carried along by a rename.* `yarramate/operations/v1` is
+unchanged, and the Core contract with it.
+
+A projection change instead rides beside the model's operations on the visual
+adapter's own commit:
+
+```ts
+type VisualViewOperation =
+  | { op: 'write-view';  path: string; projection: ProjectionDefinition }
+  | { op: 'delete-view'; path: string }
+
+interface VisualChangesetCommitPayload {
+  operations:     readonly YarramateOperation[]    // the model
+  viewOperations: readonly VisualViewOperation[]   // the views
+  sourceDigests:  Readonly<Record<string, string>> // what both expected on disk
+}
+```
+
+**Atomicity comes from one `writeAll`, not from one list.** The adapter plans
+the model's writes, composes the views' writes, and hands the store a single
+batch. A view and the subjects it shows land together or not at all, which is
+the property that actually matters — and it is bought without making a
+presentation artifact into a semantic operation.
+
+To make that possible, `landOperations` splits: `planOperations` returns the
+writes a batch would make, and `landOperations` stays `planOperations` followed
+by `writeAll`. The CLI is untouched.
+
+### A projection written where nothing loads it is refused
+
+A manifest's patterns decide which files are the workspace.
+[ADR 0043](0043-projections-are-scaffolded-through-validated-writes.md) already
+names this trap for `new projection`, which reminds an author to include a file
+no glob covers. The editor cannot rely on a reminder — nobody is reading
+stdout — so a `write-view` whose path no pattern matches is refused before
+anything is written. This repository's own manifest uses `projections/*.yaml`,
+which reaches no subdirectory, so the first view saved into a folder would
+otherwise be a file the workspace silently never loads.
+
+## Consequences
+
+**`view.save` is retired.** The event, its result frame, and the browser state
+that tracked it all go. Saving a view becomes a row in the tray that can be
+read, discarded and undone, and the confirm-before-overwrite dialog becomes
+unnecessary because the overwrite is visible before it lands.
+
+**The visual protocol goes to `v5`.** The commit payload gains a required list
+and the model frame gains the projection digests a view operation pins against.
+Both are breaking, and both are free while the 1.0.0 tag is still unmade.
+
+**Projection digests are published separately from source digests.**
+`VisualRenderedModel.sourceDigests` means *what this graph was compiled from*,
+which `YMVS112` checks and a projection is not part of. A second map says what
+the views are. On the commit payload one map still covers both, because there
+the meaning is uniform: what the browser expected to find on disk.
+
+**Every store must now say what removal means for it.** The filesystem store
+unlinks. A D1 store deletes a row inside the same transaction and gets a
+stronger guarantee than the filesystem one; an S3 store deletes an object and
+gets a weaker one. That spread is the same one ADR 0100 already tabulated for
+writes, and this ADR does not narrow it.
+
+**A batch can now shrink a workspace.** `yarramate apply` cannot yet ask for
+that — no Core operation removes a document — so the reach is limited to the
+visual adapter today. If a Core-level document removal is ever wanted, this
+store surface is already what it would land on.
+
+## Rejected
+
+**Extending `YarramateOperation` with projection operations.** One mechanism
+instead of two, and it would give `yarramate apply` view editing for free.
+Rejected because it reverses a stated Core invariant in order to make a
+presentation artifact a semantic target, changes a contract registered in the
+Core contract, and buys an atomicity that a single `writeAll` already provides.
+If view editing from a terminal is ever wanted, this is the decision to
+revisit — and the store surface it needs is the one this ADR adds.
+
+**A separate `deleteAll` on the store.** Honest about the two operations being
+different, and fatal to the only property worth having: two calls are two
+batches, so a view removed in one and a subject edited in the other can half
+land. Rejected for the same reason ADR 0057 gives for staging a batch whole.
+
+**Keeping immediate writes and adding an undo stack for views.** Smaller, and
+it keeps `view.save`. Rejected because undo over a write that already happened
+is a second write, which is exactly the unconditional overwrite ADR 0093 exists
+to refuse — and because it leaves a view and the model landing at different
+times, which is the thing #246 asked not to have.
+
+**Letting a `write-view` create the manifest pattern it needs.** It would make
+folders work with no refusal. Rejected on ADR 0043's reasoning: the workspace
+manifest is the author's statement of what the workspace is, and a tool that
+edits it to make its own write valid has removed the author from the decision.

--- a/schema/yarramate-visual-event.schema.json
+++ b/schema/yarramate-visual-event.schema.json
@@ -33,7 +33,6 @@
         "choice.selected",
         "view.navigate",
         "filter.query",
-        "view.save",
         "changeset.commit",
         "layout.save",
         "session.end",
@@ -79,14 +78,6 @@
       "properties": {
         "type": { "const": "filter.query" },
         "payload": { "$ref": "#/$defs/filterQueryPayload" }
-      }
-    },
-    {
-      "type": "object",
-      "required": ["type", "payload"],
-      "properties": {
-        "type": { "const": "view.save" },
-        "payload": { "$ref": "#/$defs/viewSavePayload" }
       }
     },
     {
@@ -194,39 +185,59 @@
         }
       }
     },
-    "viewSavePayload": {
+    "viewOperation": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["title", "description", "query", "presentation"],
-      "properties": {
-        "id": {
-          "$ref": "https://yarramate.org/schema/projection/v1#/$defs/id"
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["op", "path", "projection"],
+          "properties": {
+            "op": { "const": "write-view" },
+            "path": {
+              "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/relativePath"
+            },
+            "projection": {
+              "$ref": "https://yarramate.org/schema/projection/v1"
+            }
+          }
         },
-        "title": {
-          "$ref": "https://yarramate.org/schema/projection/v1#/$defs/nonEmptyText"
-        },
-        "description": {
-          "$ref": "https://yarramate.org/schema/projection/v1#/$defs/nonEmptyText"
-        },
-        "query": {
-          "$ref": "https://yarramate.org/schema/projection/v1#/$defs/query"
-        },
-        "presentation": {
-          "$ref": "https://yarramate.org/schema/projection/v1#/$defs/presentation"
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["op", "path"],
+          "properties": {
+            "op": { "const": "delete-view" },
+            "path": {
+              "$ref": "https://yarramate.org/schema/visual-model/v1#/$defs/relativePath"
+            }
+          }
         }
-      }
+      ]
     },
     "changesetCommitPayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["operations", "sourceDigests"],
+      "required": ["operations", "viewOperations", "sourceDigests"],
+      "anyOf": [
+        {
+          "properties": { "operations": { "type": "array", "minItems": 1 } }
+        },
+        {
+          "properties": { "viewOperations": { "type": "array", "minItems": 1 } }
+        }
+      ],
       "properties": {
         "operations": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "https://yarrasys.dev/schema/yarramate-operations.schema.json#/$defs/operation"
           }
+        },
+        "viewOperations": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": { "$ref": "#/$defs/viewOperation" }
         },
         "sourceDigests": {
           "type": "object",
@@ -352,18 +363,6 @@
               "$ref": "#/$defs/acknowledgedSequence"
             },
             "payload": { "$ref": "#/$defs/filterQueryPayload" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["type", "lastAcknowledgedSequence", "payload"],
-          "properties": {
-            "type": { "const": "view.save" },
-            "lastAcknowledgedSequence": {
-              "$ref": "#/$defs/acknowledgedSequence"
-            },
-            "payload": { "$ref": "#/$defs/viewSavePayload" }
           }
         },
         {

--- a/schema/yarramate-visual-session-descriptor.schema.json
+++ b/schema/yarramate-visual-session-descriptor.schema.json
@@ -20,7 +20,7 @@
       "const": "yarramate/visual-session-descriptor/v2"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v4"
+      "const": "yarramate/visual-protocol/v5"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"

--- a/schema/yarramate-visual-session-started.schema.json
+++ b/schema/yarramate-visual-session-started.schema.json
@@ -25,7 +25,7 @@
       "const": "yarramate/visual-session-started/v2"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v4"
+      "const": "yarramate/visual-protocol/v5"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"

--- a/schema/yarramate-visual-status.schema.json
+++ b/schema/yarramate-visual-status.schema.json
@@ -24,7 +24,7 @@
       "const": "yarramate/visual-status/v1"
     },
     "protocolVersion": {
-      "const": "yarramate/visual-protocol/v4"
+      "const": "yarramate/visual-protocol/v5"
     },
     "sessionId": {
       "$ref": "https://yarramate.org/schema/visual-event/v1#/$defs/identifier"

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -19,13 +19,17 @@ import type {
 } from "../../projection.js";
 
 /**
- * The wire this adapter speaks. v4 retypes every path-carrying field from a
- * bare native string to a canonical local `file:` URI (ADR 0096), which is a
- * field-shape change rather than an additive one, so it mints a new protocol
- * version and new `format` versions on the three documents that carry a path.
- * A v3 peer and a v4 peer refuse each other at the first document exchanged.
+ * The wire this adapter speaks. v5 makes a view a staged change rather than an
+ * immediate write (ADR 0103): a commit carries `viewOperations` beside its
+ * model operations, a model frame carries the projection digests those
+ * operations pin against, and the `view.save` event that wrote a projection
+ * the moment it was composed is gone. A v4 peer and a v5 peer refuse each
+ * other at the first document exchanged.
+ *
+ * v4 retyped every path-carrying field from a bare native string to a
+ * canonical local `file:` URI (ADR 0096).
  */
-export const VISUAL_PROTOCOL_VERSION = "yarramate/visual-protocol/v4" as const;
+export const VISUAL_PROTOCOL_VERSION = "yarramate/visual-protocol/v5" as const;
 
 export const VISUAL_LIMITS = {
   messageBytes: 64 * 1024,
@@ -200,8 +204,37 @@ export interface VisualLayoutPositions {
   readonly [subjectId: string]: { readonly x: number; readonly y: number };
 }
 
+/**
+ * A change to a projection document, staged rather than written (ADR 0103).
+ *
+ * These ride beside the model's operations rather than inside them: Core holds
+ * that a projection is never an operation's own target, and a view is
+ * presentation rather than semantics. Atomicity does not come from sharing a
+ * list - it comes from the runtime planning both and issuing one
+ * `SourceStore.writeAll`, so a view and the subjects it shows land together or
+ * not at all.
+ *
+ * `path` is manifest-relative, the way `VisualViewSummary.path` names it. A
+ * `write-view` at a path the manifest's patterns do not cover is refused
+ * rather than written, because a projection nothing loads is worse than a
+ * refusal (ADR 0043).
+ */
+export type VisualViewOperation =
+  | {
+      readonly op: "write-view";
+      readonly path: string;
+      readonly projection: ProjectionDefinition;
+    }
+  | { readonly op: "delete-view"; readonly path: string };
+
 export interface VisualChangesetCommitPayload {
   readonly operations: readonly YarramateOperation[];
+  /**
+   * Projection writes and removals landing in the same batch as `operations`.
+   * Required, not optional, for the same reason `sourceDigests` is: a browser
+   * that may omit it is one whose commits mean two different things.
+   */
+  readonly viewOperations: readonly VisualViewOperation[];
   /**
    * What the browser believed each targeted document held when the rows were
    * staged — sha256 keyed by manifest-relative path, pinned at staging time and
@@ -212,6 +245,11 @@ export interface VisualChangesetCommitPayload {
    * Required, not optional: a browser that omits it is exactly the browser that
    * cannot detect the conflict, which is why this field is what makes the
    * protocol `v3`.
+   *
+   * One map covers both lists. On the model frame the two are kept apart,
+   * because there they mean different things — what the graph was compiled
+   * from, and what the views are — but a pin means the same thing for either:
+   * what the browser expected to find on disk.
    */
   readonly sourceDigests: Readonly<Record<string, string>>;
 }
@@ -277,11 +315,6 @@ export type VisualBrowserInput =
       readonly payload: VisualFilterQueryPayload;
     }
   | {
-      readonly type: "view.save";
-      readonly lastAcknowledgedSequence: number;
-      readonly payload: VisualViewSavePayload;
-    }
-  | {
       readonly type: "changeset.commit";
       readonly lastAcknowledgedSequence: number;
       readonly payload: VisualChangesetCommitPayload;
@@ -318,7 +351,6 @@ export type VisualEvent =
       VisualBrowserDisconnectedPayload
     >
   | VisualEventEnvelope<"filter.query", VisualFilterQueryPayload>
-  | VisualEventEnvelope<"view.save", VisualViewSavePayload>
   | VisualEventEnvelope<"changeset.commit", VisualChangesetCommitPayload>
   | VisualEventEnvelope<"layout.save", VisualLayoutSavePayload>;
 

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -73,9 +73,15 @@ import {
   type SemanticGraph,
 } from "../../compiler.js";
 import {
-  landOperations,
+  planOperations,
   posixDirectoryOf,
+  writeConflictDiagnostics,
+  type ApplyOutcome,
+  type PlannedOperations,
 } from "../../apply-command.js";
+import type { PendingWrite, SourceStore } from "../../source-store.js";
+import type { YarramateApplyResult } from "../../operations.js";
+import { DEFAULT_PROJECTION_DIRECTORY } from "./view-identity.js";
 import { createFileSystemStore } from "../../source-store.js";
 import { projectGraphForCanvas } from "../../graph-projection.js";
 import { kindLabelOf } from "../../kind-label.js";
@@ -83,7 +89,10 @@ import {
   loadWorkspaceManifest,
   type ResolvedWorkspace,
 } from "../../workspace.js";
-import type { VisualKindOption } from "./protocol-contract.js";
+import type {
+  VisualKindOption,
+  VisualViewOperation,
+} from "./protocol-contract.js";
 import type {
   VisualRenderedModel,
   VisualServerFrame,
@@ -490,8 +499,6 @@ const eventFrom = (
       return { ...envelope, type: input.type, payload: input.payload };
     case "filter.query":
       return { ...envelope, type: input.type, payload: input.payload };
-    case "view.save":
-      return { ...envelope, type: input.type, payload: input.payload };
     case "changeset.commit":
       return { ...envelope, type: input.type, payload: input.payload };
     case "layout.save":
@@ -500,25 +507,169 @@ const eventFrom = (
 };
 
 /**
- * Turns a view title into a schema-valid projection id: lowercase,
- * hyphen-separated, letter-led. A title with no letters or digits degrades
- * to "view" rather than producing an id the schema would reject.
+ * Whether the workspace would load a projection written at this path.
+ *
+ * This is a DIRECTORY check, not a pattern match, and deliberately so: ADR
+ * 0100 recorded that the manifest's pattern dialect has never been named - it
+ * is whatever `globSync` happens to support, undocumented and untested past
+ * one wildcard - so a matcher written here would be inventing the dialect
+ * rather than honouring it. A directory that already holds a projection the
+ * manifest resolved is a directory the manifest demonstrably reaches.
+ *
+ * A workspace with no projections at all has nothing to demonstrate, so the
+ * default directory is allowed: refusing there would make the first view in a
+ * fresh workspace impossible to create.
  */
-const slugify = (title: string): string => {
-  const cleaned = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  if (cleaned.length === 0) return "view";
-  return /^[a-z]/.test(cleaned) ? cleaned : `view-${cleaned}`;
+const projectionDirectoryIsCovered = (
+  path: string,
+  workspace: ResolvedWorkspace,
+): boolean => {
+  if (workspace.projections.length === 0) {
+    return posixDirectoryOf(path) === DEFAULT_PROJECTION_DIRECTORY;
+  }
+  const covered = new Set(workspace.projections.map(posixDirectoryOf));
+  return covered.has(posixDirectoryOf(path));
 };
 
-/** Appends a numeric suffix only when the base id collides with a known view. */
-const uniqueViewId = (base: string, taken: ReadonlySet<string>): string => {
-  if (!taken.has(base)) return base;
-  let suffix = 2;
-  while (taken.has(`${base}-${suffix}`)) suffix += 1;
-  return `${base}-${suffix}`;
+/**
+ * Turns staged view operations into pending writes, refusing before anything
+ * is written (ADR 0103).
+ *
+ * A `write-view` is validated through the same `loadProjection` the CLI's own
+ * projection writes go through, so a document the schema would reject never
+ * reaches the store. A `delete-view` names a revision, which is what makes a
+ * removal refusable rather than a silent success on a file someone else
+ * already changed.
+ */
+const planViewWrites = (
+  operations: readonly VisualViewOperation[],
+  workspace: ResolvedWorkspace,
+  store: SourceStore,
+):
+  | { readonly ok: true; readonly writes: readonly PendingWrite[] }
+  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] } => {
+  const writes: PendingWrite[] = [];
+  const diagnostics: VisualDiagnostic[] = [];
+  for (const operation of operations) {
+    const held = store.read(operation.path);
+    if (operation.op === "delete-view") {
+      if (held === undefined) {
+        diagnostics.push(
+          serverDiagnostic(
+            "YMVS314",
+            `View "${operation.path}" is already gone`,
+          ),
+        );
+        continue;
+      }
+      writes.push({
+        path: operation.path,
+        source: null,
+        expected: held.revision,
+      });
+      continue;
+    }
+    if (
+      held === undefined &&
+      !projectionDirectoryIsCovered(operation.path, workspace)
+    ) {
+      // A projection no pattern reaches is a file the workspace never loads,
+      // which is worse than a refusal because nothing later says so (ADR 0043).
+      diagnostics.push(
+        serverDiagnostic(
+          "YMVS315",
+          `The workspace manifest covers no projection in "${posixDirectoryOf(
+            operation.path,
+          )}", so a view saved there would never load`,
+        ),
+      );
+      continue;
+    }
+    const source = stringify(operation.projection);
+    const loaded = loadProjection({ path: operation.path, source });
+    if (!loaded.ok) {
+      // The composed document is the only source these are about, so they are
+      // published against it rather than against the workspace.
+      diagnostics.push(
+        ...published(loaded.diagnostics, [{ path: operation.path, source }]),
+      );
+      continue;
+    }
+    writes.push({
+      path: operation.path,
+      source,
+      expected: held?.revision ?? null,
+    });
+  }
+  return diagnostics.length > 0
+    ? { ok: false, diagnostics }
+    : { ok: true, writes };
+};
+
+/**
+ * What a batch that changes no subject reports.
+ *
+ * A commit carrying only view operations never reaches Core: an operations
+ * document with an empty list is refused by the operations schema (`YM201`),
+ * and rightly - "apply nothing" is not a batch. The receipt still has to name
+ * the documents that changed, which here are the projections.
+ */
+const noModelChange = (
+  workspace: string,
+  documents: readonly string[],
+): YarramateApplyResult => ({
+  format: "yarramate/apply-result/v1",
+  workspace,
+  applied: {
+    addedConcepts: 0,
+    addedRelationships: 0,
+    updatedConcepts: 0,
+    updatedRelationships: 0,
+    deletedConcepts: 0,
+    deletedRelationships: 0,
+    renamedConcepts: 0,
+    renamedRelationships: 0,
+    addedObservations: 0,
+    updatedObservations: 0,
+    deletedObservations: 0,
+  },
+  documents,
+});
+
+/**
+ * Lands a planned batch plus the view writes beside it, as one `writeAll`.
+ *
+ * `landOperations` would write the model's half on its own, which is the one
+ * thing this must not do: two calls are two batches, and a view removed in one
+ * and a subject edited in the other can half land.
+ */
+const landPlanned = (
+  store: SourceStore,
+  planned: PlannedOperations | null,
+  viewWrites: readonly PendingWrite[],
+  operationsPath: string,
+  workspaceId: string,
+): ApplyOutcome => {
+  if (planned !== null && !planned.ok) return planned.outcome;
+  const writes = [...(planned?.writes ?? []), ...viewWrites];
+  const outcome: ApplyOutcome =
+    planned === null
+      ? {
+          ok: true,
+          sources: [],
+          result: noModelChange(
+            workspaceId,
+            viewWrites.map((write) => write.path),
+          ),
+        }
+      : planned.outcome;
+  if (writes.length === 0) return outcome;
+  const written = store.writeAll(writes);
+  if (written.ok) return outcome;
+  return {
+    ok: false,
+    diagnostics: writeConflictDiagnostics(written.conflicts, operationsPath),
+  };
 };
 
 /**
@@ -604,39 +755,50 @@ export const startVisualServer = async (
     );
   })();
 
-  // Saved views join this list as they are written (see `view.save`), because
-  // a reconnecting browser is handed it in its snapshot and `layout.save`
-  // checks projection ids against it.
+  /**
+   * One view, read off disk. `undefined` for a projection that is unreadable
+   * or that the schema refuses — a broken saved view skips rather than failing
+   * the session, the same way a broken layout sidecar does.
+   *
+   * `subjectCount` is left at zero here and filled in by `recountViews`:
+   * counting needs the compiled graph, which does not exist yet when the
+   * session builds its first list.
+   */
+  const readViewSummary = (
+    projectionPath: string,
+  ): VisualViewSummary | undefined => {
+    try {
+      const projectionSource = readFileSync(
+        resolve(options.cwd, projectionPath),
+        "utf8",
+      );
+      const loaded = loadProjection({
+        path: projectionPath,
+        source: projectionSource,
+      });
+      if (!loaded.ok) return undefined;
+      const { projection } = loaded;
+      return {
+        id: projection.id,
+        title: projection.presentation?.title ?? projection.id,
+        description: projection.presentation?.description ?? "",
+        query: projection.query,
+        presentation: projection.presentation,
+        path: projectionPath,
+        subjectCount: 0,
+      };
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Saved views join this list as a commit lands them (see `adoptLandedViews`),
+  // because a reconnecting browser is handed it in its snapshot and
+  // `layout.save` checks projection ids against it.
   const views: VisualViewSummary[] = resolvedWorkspace.projections.flatMap(
     (projectionPath) => {
-      try {
-        const projectionSource = readFileSync(
-          resolve(options.cwd, projectionPath),
-          "utf8",
-        );
-        const loaded = loadProjection({
-          path: projectionPath,
-          source: projectionSource,
-        });
-        if (!loaded.ok) return [];
-        const { projection } = loaded;
-        return [
-          {
-            id: projection.id,
-            title: projection.presentation?.title ?? projection.id,
-            description: projection.presentation?.description ?? "",
-            query: projection.query,
-            presentation: projection.presentation,
-            path: projectionPath,
-            // Filled in by `recountViews`: counting needs the compiled graph,
-            // which is not built until after this list is.
-            subjectCount: 0,
-          },
-        ];
-      } catch {
-        // Skipped projection: session continues with remaining views.
-        return [];
-      }
+      const summary = readViewSummary(projectionPath);
+      return summary === undefined ? [] : [summary];
     },
   );
 
@@ -684,6 +846,10 @@ export const startVisualServer = async (
     vocabulary: { conceptKinds: [], relationshipKinds: [] },
     layouts,
     sourceDigests: request.initialModel.sourceDigests,
+    // The request's model has no projections in it - `visual-model/v1` carries
+    // a graph, not a workspace - so the fallback states nothing rather than
+    // guessing. `recompileWorkspace` below fills it from disk immediately.
+    projectionDigests: {},
   };
 
   const capabilities: VisualCapabilities = {
@@ -736,6 +902,31 @@ export const startVisualServer = async (
     }
   };
 
+  /**
+   * The digest of every projection the session knows about, read now.
+   *
+   * Read from `views` rather than from `resolvedWorkspace.projections`,
+   * because a view created mid-session joins the former and never the latter:
+   * the manifest is resolved once at startup and never again. One that has
+   * been removed is simply absent, which is the same thing the map says about
+   * one that never existed — and the browser reads both as "no pin", which is
+   * correct for a create and refused by the store for a delete.
+   */
+  const projectionDigestsNow = (): Readonly<Record<string, string>> => {
+    const digests: Record<string, string> = {};
+    for (const view of views) {
+      try {
+        digests[view.path] = digestOf(
+          readFileSync(resolve(options.cwd, view.path), "utf8"),
+        );
+      } catch {
+        // Gone from disk: nothing to pin against, and the commit's own
+        // conflict check is what reports it rather than a guess made here.
+      }
+    }
+    return digests;
+  };
+
   const recompileWorkspace = (): boolean => {
     try {
       const sources = workspaceSources();
@@ -777,6 +968,11 @@ export const startVisualServer = async (
         sourceDigests: Object.fromEntries(
           sources.map(({ path, source }) => [path, digestOf(source)]),
         ),
+        // Kept apart from `sourceDigests`, which means what this graph was
+        // compiled from and is what `YMVS112` checks — a projection is not
+        // that. A staged view operation pins against these (ADR 0103), and a
+        // projection missing from the map is one the commit will create.
+        projectionDigests: projectionDigestsNow(),
       };
       return true;
     } catch {
@@ -814,6 +1010,31 @@ export const startVisualServer = async (
       compiledWorkspace.profileContext,
     );
     return result.subjects.filter(({ type }) => type === "concept").length;
+  };
+
+  /**
+   * Brings `views` into line with the view operations a commit just landed.
+   *
+   * Nothing else does this. `resolvedWorkspace` is resolved once at startup, so
+   * a recompile learns nothing about a projection that has just appeared or
+   * gone; `recountViews` recounts what this list already holds rather than
+   * discovering what it should. A view is read back off disk rather than
+   * reconstructed from the operation, so what the rail shows is what landed.
+   */
+  const adoptLandedViews = (
+    operations: readonly VisualViewOperation[],
+  ): void => {
+    for (const operation of operations) {
+      const at = views.findIndex((view) => view.path === operation.path);
+      if (operation.op === "delete-view") {
+        if (at !== -1) views.splice(at, 1);
+        continue;
+      }
+      const summary = readViewSummary(operation.path);
+      if (summary === undefined) continue;
+      if (at === -1) views.push(summary);
+      else views[at] = summary;
+    }
   };
 
   /**
@@ -1405,61 +1626,6 @@ export const startVisualServer = async (
         });
         return;
       }
-      if (event.type === "view.save") {
-        // Saving a view is a pure filesystem write plus schema validation: it
-        // never asks the agent anything, so it is answered here directly
-        // rather than through the pending queue a poll would drain.
-        const existingIds = new Set(views.map((view) => view.id));
-        const id =
-          event.payload.id ??
-          uniqueViewId(slugify(event.payload.title), existingIds);
-        const presentation: ProjectionDefinition["presentation"] = {
-          ...(event.payload.presentation ?? {}),
-          title: event.payload.title,
-          description: event.payload.description,
-        };
-        const candidate: ProjectionDefinition = {
-          format: "yarramate/projection/v1",
-          id,
-          version: "1.0",
-          query: event.payload.query,
-          presentation,
-        };
-        const path = `.yarramate/projections/${id}.yaml`;
-        const source = stringify(candidate);
-        const loaded = loadProjection({ path, source });
-        if (!loaded.ok) {
-          sendFrame(socket, {
-            kind: "view-save-result",
-            result: { ok: false, diagnostics: loaded.diagnostics },
-          });
-          return;
-        }
-        mkdirSync(resolve(options.cwd, ".yarramate/projections"), {
-          recursive: true,
-        });
-        writeFileSync(resolve(options.cwd, path), source, "utf8");
-        // On disk is not enough: the list handed to a reconnecting browser and
-        // checked by `layout.save` lives here, so an overwrite replaces its
-        // summary in place and a new view joins the end.
-        const summary: VisualViewSummary = {
-          id,
-          title: event.payload.title,
-          description: event.payload.description,
-          query: event.payload.query,
-          presentation,
-          path,
-          subjectCount: conceptCount(event.payload.query),
-        };
-        const saved = views.findIndex((view) => view.id === id);
-        if (saved === -1) views.push(summary);
-        else views[saved] = summary;
-        sendFrame(socket, {
-          kind: "view-save-result",
-          result: { ok: true, id, path, subjectCount: summary.subjectCount },
-        });
-        return;
-      }
       if (event.type === "changeset.commit") {
         // Landing a batch is mechanical: Core's `applyOperations` never asks
         // the agent anything, so it is answered here directly rather than
@@ -1479,9 +1645,14 @@ export const startVisualServer = async (
         // state is decoration.
         const pins = event.payload.sourceDigests;
         const refused: VisualDiagnostic[] = [];
-        for (const path of new Set(
-          event.payload.operations.map((operation) => operation.document),
-        )) {
+        for (const path of new Set([
+          ...event.payload.operations.map((operation) => operation.document),
+          // A staged view is a document this batch touches like any other, so
+          // it answers to the same precondition (ADR 0103). Without this a
+          // projection someone edited on disk would be overwritten by a
+          // reviewer who never saw the edit.
+          ...event.payload.viewOperations.map((operation) => operation.path),
+        ])) {
           let held: string | undefined;
           try {
             held = digestOf(readFileSync(resolve(options.cwd, path), "utf8"));
@@ -1559,18 +1730,45 @@ export const startVisualServer = async (
           });
           return;
         }
-        const outcome = landOperations(
-          createFileSystemStore(options.cwd),
-          {
-            workspace: loadedWorkspace.workspace,
-            operations: {
-              path: "changeset.yaml",
-              source: operationsSource,
-            },
-            manifestDirectory: posixDirectoryOf(
-              relative(options.cwd, manifestPath),
-            ),
-          },
+        const store = createFileSystemStore(options.cwd);
+        // Core is asked nothing when nothing about the model changed: an
+        // operations document with an empty list is refused by the operations
+        // schema, and a batch of views only is a legitimate thing to commit.
+        const planned =
+          event.payload.operations.length === 0
+            ? null
+            : planOperations(store, {
+                workspace: loadedWorkspace.workspace,
+                operations: {
+                  path: "changeset.yaml",
+                  source: operationsSource,
+                },
+                manifestDirectory: posixDirectoryOf(
+                  relative(options.cwd, manifestPath),
+                ),
+              });
+        // The views' own writes, composed and validated the same way
+        // `view.save` used to compose one, but not yet written: both halves go
+        // to the store in a single batch so a view and the subjects it shows
+        // land together or not at all (ADR 0103).
+        const viewWrites = planViewWrites(
+          event.payload.viewOperations,
+          loadedWorkspace.workspace,
+          store,
+        );
+        if (!viewWrites.ok) {
+          sendFrame(socket, {
+            kind: "apply-result",
+            result: { ok: false, diagnostics: viewWrites.diagnostics },
+          });
+          return;
+        }
+        const outcome = landPlanned(
+          store,
+          planned,
+          viewWrites.writes,
+          "changeset.yaml",
+          loadedWorkspace.workspace.id,
         );
         if (!outcome.ok) {
           // Nothing landed: forward Core's diagnostics verbatim (ADR 0062)
@@ -1584,6 +1782,14 @@ export const startVisualServer = async (
           });
           return;
         }
+        // The views list is maintained by hand, because nothing else will:
+        // `resolvedWorkspace` was resolved once at startup and never again, so
+        // a recompile re-reads the documents it already knew about and learns
+        // nothing about a projection this batch just created or removed. The
+        // rail, `layout.save`'s id check, and a reconnecting browser all read
+        // this list, so leaving it stale is how they come to disagree with the
+        // disk.
+        adoptLandedViews(event.payload.viewOperations);
         sendFrame(socket, {
           kind: "apply-result",
           result: { ok: true, result: outcome.result },

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -1,0 +1,87 @@
+import type { ProjectionDefinition, ProjectionQuery } from "../../projection.js";
+
+/**
+ * How a saved view gets its id, its path, and its document.
+ *
+ * The browser composes a `write-view` operation now rather than asking the
+ * server to compose one at commit time (ADR 0103): a staged row has to name
+ * the document it will write before it is committed, because that is what the
+ * reviewer reads in the tray and what the digest pins against.
+ *
+ * So this lives where both sides can reach it. No React, no cytoscape, and
+ * nothing from `node:` — the browser bundle imports it for its value, and
+ * `visual-app-browser-safety.test.ts` is what holds that honest. Validation
+ * stays on the server, where the schema and its loader are: composing a
+ * projection is arithmetic, deciding it is acceptable is not.
+ */
+
+/** Where projections live when nothing says otherwise. */
+export const DEFAULT_PROJECTION_DIRECTORY = ".yarramate/projections";
+
+/**
+ * Turns a view title into a schema-valid projection id: lowercase,
+ * hyphen-separated, letter-led. A title with no letters or digits degrades
+ * to "view" rather than producing an id the schema would reject.
+ */
+export const slugify = (title: string): string => {
+  const cleaned = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (cleaned.length === 0) return "view";
+  return /^[a-z]/.test(cleaned) ? cleaned : `view-${cleaned}`;
+};
+
+/** Appends a numeric suffix only when the base id collides with a known view. */
+export const uniqueViewId = (
+  base: string,
+  taken: ReadonlySet<string>,
+): string => {
+  if (!taken.has(base)) return base;
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) suffix += 1;
+  return `${base}-${suffix}`;
+};
+
+/** The id a title should take, given the ids already in use. */
+export const viewIdFrom = (
+  title: string,
+  taken: ReadonlySet<string>,
+): string => uniqueViewId(slugify(title), taken);
+
+/**
+ * Where a view's document goes. `directory` is manifest-relative and comes
+ * from the folder the reviewer saved into — folders are read back off these
+ * paths rather than declared in the format (#245), so the path is the only
+ * place a folder is ever stated.
+ */
+export const projectionPathFor = (
+  id: string,
+  directory: string = DEFAULT_PROJECTION_DIRECTORY,
+): string => `${directory.replace(/\/+$/, "")}/${id}.yaml`;
+
+/**
+ * The projection document a saved view is, composed from what the form holds.
+ *
+ * `title` and `description` are presentation fields rather than top-level
+ * ones, which is where `ProjectionDefinition` puts them, and every other
+ * presentation field the active view declared is carried through — dropping
+ * one here is how overwriting a view silently loses its nesting or direction.
+ */
+export const composeProjection = (input: {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly query: ProjectionQuery;
+  readonly presentation: ProjectionDefinition["presentation"];
+}): ProjectionDefinition => ({
+  format: "yarramate/projection/v1",
+  id: input.id,
+  version: "1.0",
+  query: input.query,
+  presentation: {
+    ...(input.presentation ?? {}),
+    title: input.title,
+    description: input.description,
+  },
+});

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -14,7 +14,6 @@ import type {
   VisualLayoutSaveResultPayload,
   VisualResponse,
   VisualTerminationReason,
-  VisualViewSaveResultPayload,
   VisualViewSummary,
 } from './protocol-contract.js'
 
@@ -49,6 +48,17 @@ export interface VisualRenderedModel {
    * can state what it rendered when it asks for a commit.
    */
   readonly sourceDigests: Readonly<Record<string, string>>
+  /**
+   * The sha256 of every projection this session knows about, keyed by
+   * manifest-relative path.
+   *
+   * Kept apart from `sourceDigests` rather than folded into it: that map means
+   * what the GRAPH was compiled from, which `YMVS112` requires a canonical
+   * model to state, and a projection is not part of it. A staged view
+   * operation pins against this one instead (ADR 0103), and a path absent from
+   * it is a projection the commit will create.
+   */
+  readonly projectionDigests: Readonly<Record<string, string>>
 }
 
 /**
@@ -136,7 +146,6 @@ export type VisualServerFrame =
       readonly views: readonly VisualViewSummary[]
     }
   | { readonly kind: 'filter-result'; readonly result: VisualFilterResultPayload }
-  | { readonly kind: 'view-save-result'; readonly result: VisualViewSaveResultPayload }
   | { readonly kind: 'apply-result'; readonly result: VisualApplyResultPayload }
   | {
       readonly kind: 'layout-save-result'

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -42,7 +42,9 @@ import {
 } from './workspace.js'
 import {
   createFileSystemStore,
+  type PendingWrite,
   type SourceStore,
+  type WriteConflict,
 } from './source-store.js'
 
 /**
@@ -1170,24 +1172,33 @@ export const applyOperations = (
 }
 
 
+export type PlannedOperations =
+  | {
+      readonly ok: true
+      readonly outcome: ApplyOutcome & { readonly ok: true }
+      /** What this batch would write, unwritten. Empty when it changes nothing. */
+      readonly writes: readonly PendingWrite[]
+    }
+  | { readonly ok: false; readonly outcome: ApplyOutcome & { readonly ok: false } }
+
 /**
- * Reads a workspace through a store, applies a batch, and writes what changed
- * back only if every document still holds what was read (ADR 0100).
+ * Reads a workspace through a store and applies a batch, stopping short of
+ * writing (ADR 0100).
  *
- * This is the composition Core deliberately does not perform: `applyOperations`
- * is a pure function, and the comparison that decides whether a batch lands
- * belongs to the store. Both callers - the CLI and the visual session server -
- * go through here so the precondition exists in one place rather than being
- * remembered twice.
+ * Separated from {@link landOperations} because a caller may have writes of
+ * its own to land in the same batch: the visual runtime commits a projection
+ * beside the model it belongs to, and one `writeAll` is what makes the two
+ * arrive together or not at all (ADR 0103). A caller with nothing to add wants
+ * `landOperations` and should not see this.
  */
-export const landOperations = (
+export const planOperations = (
   store: SourceStore,
   input: {
     readonly workspace: ResolvedWorkspace
     readonly operations: WorkspaceSource
     readonly manifestDirectory: string
   },
-): ApplyOutcome => {
+): PlannedOperations => {
   const revisions = new Map<string, string>()
   const sources: WorkspaceSource[] = []
   for (const path of [
@@ -1208,39 +1219,77 @@ export const landOperations = (
     operations: input.operations,
     manifestDirectory: input.manifestDirectory,
   })
-  if (!outcome.ok) return outcome
-  if (outcome.sources.length === 0) return outcome
+  if (!outcome.ok) return { ok: false, outcome }
 
   // A document Core rewrote must still hold what Core was shown. One it
   // created must still not be there. There is no third case: a batch that
   // vouches for nothing would buy back the unconditional write by omission.
-  const written = store.writeAll(
-    outcome.sources.map((source) => ({
+  return {
+    ok: true,
+    outcome,
+    writes: outcome.sources.map((source) => ({
       path: source.path,
       source: source.source,
       expected: revisions.get(source.path) ?? null,
     })),
-  )
-  if (written.ok) return outcome
+  }
+}
+
+/**
+ * The diagnostics a refused `writeAll` becomes, in the workspace range
+ * (ADR 0100). Shared so a caller that merges writes of its own into the batch
+ * reports a conflict the same way the CLI does.
+ */
+export const writeConflictDiagnostics = (
+  conflicts: readonly WriteConflict[],
+  operationsPath: string,
+): readonly Diagnostic[] =>
+  conflicts.map((conflict) => ({
+    severity: 'error' as const,
+    code: conflict.reason === 'exists' ? 'YM705' : 'YM704',
+    message:
+      conflict.reason === 'exists'
+        ? `Document "${conflict.path}" already exists; this batch expected to create it`
+        : conflict.reason === 'missing'
+          ? `Document "${conflict.path}" no longer exists; this batch was staged against it`
+          : `Document "${conflict.path}" changed after this batch was staged`,
+    path: operationsPath,
+    // The conflict is about the batch rather than about any one line of it:
+    // the operation that named the document is not what went wrong.
+    pointer: '/',
+    line: 1,
+    column: 1,
+  }))
+
+/**
+ * Reads a workspace through a store, applies a batch, and writes what changed
+ * back only if every document still holds what was read (ADR 0100).
+ *
+ * This is the composition Core deliberately does not perform: `applyOperations`
+ * is a pure function, and the comparison that decides whether a batch lands
+ * belongs to the store.
+ */
+export const landOperations = (
+  store: SourceStore,
+  input: {
+    readonly workspace: ResolvedWorkspace
+    readonly operations: WorkspaceSource
+    readonly manifestDirectory: string
+  },
+): ApplyOutcome => {
+  const planned = planOperations(store, input)
+  if (!planned.ok) return planned.outcome
+  if (planned.writes.length === 0) return planned.outcome
+
+  const written = store.writeAll(planned.writes)
+  if (written.ok) return planned.outcome
 
   return {
     ok: false,
-    diagnostics: written.conflicts.map((conflict) => ({
-      severity: 'error' as const,
-      code: conflict.reason === 'exists' ? 'YM705' : 'YM704',
-      message:
-        conflict.reason === 'exists'
-          ? `Document "${conflict.path}" already exists; this batch expected to create it`
-          : conflict.reason === 'missing'
-            ? `Document "${conflict.path}" no longer exists; this batch was staged against it`
-            : `Document "${conflict.path}" changed after this batch was staged`,
-      path: input.operations.path,
-      // The conflict is about the batch rather than about any one line of it:
-      // the operation that named the document is not what went wrong.
-      pointer: '/',
-      line: 1,
-      column: 1,
-    })),
+    diagnostics: writeConflictDiagnostics(
+      written.conflicts,
+      input.operations.path,
+    ),
   }
 }
 

--- a/src/source-store.ts
+++ b/src/source-store.ts
@@ -30,7 +30,11 @@ export interface SourceStore {
   list(): readonly string[]
   /** The bytes, and an opaque statement of which bytes they are. */
   read(path: string): StoredSource | undefined
-  /** All of them or none, each only if it still holds what was read. */
+  /**
+   * All of them or none, each only if it still holds what was read. A write
+   * with a `null` source removes the document instead of replacing it
+   * (ADR 0103), under the same condition and in the same batch.
+   */
   writeAll(writes: readonly PendingWrite[]): WriteOutcome
 }
 
@@ -47,11 +51,24 @@ export interface StoredSource {
 
 export interface PendingWrite {
   readonly path: string
-  readonly source: string
+  /**
+   * The bytes to leave behind, or `null` to remove the document (ADR 0103).
+   *
+   * Removal is a write like any other: it lands in the same all-or-none batch,
+   * under the same compare-and-swap, so a view deleted beside a subject edit
+   * either takes both or neither. A store with nothing to remove things from
+   * is a store that cannot express a workspace shrinking, and the alternative -
+   * a second call outside the batch - is exactly the unconditional write the
+   * `expected` field exists to refuse.
+   */
+  readonly source: string | null
   /**
    * The revision this edit was made against, or `null` to require that the
    * document does not exist yet. There is no way to write unconditionally:
    * a caller with nothing to state is a caller that cannot detect a conflict.
+   *
+   * A removal must name a revision. `null` here would ask to remove something
+   * on condition it is not there, which is not a thing to want.
    */
   readonly expected: string | null
 }
@@ -59,7 +76,11 @@ export interface PendingWrite {
 export type WriteConflict =
   /** Someone else wrote it after this edit was made. */
   | { readonly path: string; readonly reason: 'changed' }
-  /** Expected to be new, but something is already there. */
+  /**
+   * Expected to be new, but something is already there - or a removal that
+   * named no revision, which asks to remove a document on condition it does
+   * not exist. Both are a caller stating something the store cannot satisfy.
+   */
   | { readonly path: string; readonly reason: 'exists' }
   /** Expected to be there, and is not. */
   | { readonly path: string; readonly reason: 'missing' }
@@ -185,7 +206,10 @@ export const createFileSystemStore = (root: string): SourceStore => {
         resolved.set(write.path, absolute)
         const held = revisionOf(absolute)
         if (write.expected === null) {
-          if (held !== undefined) {
+          // A removal on condition the document is not there is not a thing to
+          // want, and treating it as a no-op would let a caller delete by
+          // accident and be told it worked.
+          if (write.source === null || held !== undefined) {
             conflicts.push({ path: write.path, reason: 'exists' })
           }
           continue
@@ -205,6 +229,13 @@ export const createFileSystemStore = (root: string): SourceStore => {
       const revisions = new Map<string, string>()
       for (const write of writes) {
         const absolute = resolved.get(write.path)!
+        if (write.source === null) {
+          // Nothing is staged and renamed: there are no bytes to land whole,
+          // and the directory is left behind because an empty one is not
+          // something a workspace can tell from a directory it never had.
+          rmSync(absolute, { force: true })
+          continue
+        }
         mkdirSync(dirname(absolute), { recursive: true })
         // Each file lands whole: a reader sees the old bytes or the new ones,
         // never a half-written document. The batch as a whole is not atomic on

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -26,7 +26,7 @@ import type {
   VisualChoicePresentPayload,
   VisualDiagnostic,
   VisualLayoutSavePayload,
-  VisualViewSavePayload,
+  VisualViewOperation,
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
 import { useVisualSession } from "./session-client.js";
@@ -123,8 +123,7 @@ const CommandStrip = ({
   onQuickFilterChange,
   saveViewOpen,
   onToggleSaveView,
-  onSaveView,
-  onDismissSavedNotice,
+  onStageView,
   onEnd,
 }: {
   readonly state: VisualAppState;
@@ -149,8 +148,7 @@ const CommandStrip = ({
   readonly onQuickFilterChange: (text: string) => void;
   readonly saveViewOpen: boolean;
   readonly onToggleSaveView: () => void;
-  readonly onSaveView: (payload: VisualViewSavePayload) => void;
-  readonly onDismissSavedNotice: () => void;
+  readonly onStageView: (operation: VisualViewOperation) => void;
   readonly onEnd: () => void;
 }) => (
   <header className="command-strip">
@@ -188,12 +186,9 @@ const CommandStrip = ({
         showLifecycle={showLifecycle}
         showEvidence={showEvidence}
         showOwnership={showOwnership}
-        pendingSave={state.pendingViewSave !== null}
-        notice={state.viewSaveNotice}
         open={saveViewOpen}
         onToggle={onToggleSaveView}
-        onSave={onSaveView}
-        onDismissNotice={onDismissSavedNotice}
+        onStage={onStageView}
       />
       <button
         type="button"
@@ -884,9 +879,8 @@ export const App = () => {
     filter,
     clearFilter,
     setQuickFilterText,
-    saveView,
+    stageViewChange,
     saveLayout,
-    dismissSavedNotice,
     discardChange,
     stageChange,
     clearChangeset,
@@ -1112,8 +1106,21 @@ export const App = () => {
         setSaveViewOpen(true);
         dispatchWorkspace({ type: "menu.dismissed" });
         return;
+      case "view.delete":
+        // Asked, not done: removing a projection is the one view operation
+        // that destroys authored text, so it goes through the same
+        // confirm-then-stage shape a subject deletion does.
+        dispatchWorkspace({ type: "viewDeletion.asked", id: intent.id });
+        return;
     }
   };
+
+  const pendingViewDelete =
+    workspace.pendingViewDeletion === null
+      ? null
+      : (state.views.find(
+          (view) => view.id === workspace.pendingViewDeletion,
+        ) ?? null);
 
   return (
     <main className="visual-shell" style={shellStyle}>
@@ -1143,8 +1150,7 @@ export const App = () => {
         onQuickFilterChange={setQuickFilterText}
         saveViewOpen={saveViewOpen}
         onToggleSaveView={() => setSaveViewOpen((open) => !open)}
-        onSaveView={saveView}
-        onDismissSavedNotice={dismissSavedNotice}
+        onStageView={stageViewChange}
         onEnd={end}
       />
       <div
@@ -1286,6 +1292,22 @@ export const App = () => {
           y={workspace.contextMenu.y}
           onChoose={runIntent}
           onDismiss={() => dispatchWorkspace({ type: "menu.dismissed" })}
+        />
+      )}
+      {pendingViewDelete === null ? null : (
+        <ConfirmDialog
+          title="Delete view"
+          message={`Stage the removal of "${pendingViewDelete.title}"? The projection document goes when the changeset is committed; no subject is touched.`}
+          confirmLabel="Delete"
+          cancelLabel="Keep"
+          onConfirm={() => {
+            stageViewChange({
+              op: "delete-view",
+              path: pendingViewDelete.path,
+            });
+            dispatchWorkspace({ type: "viewDeletion.dismissed" });
+          }}
+          onCancel={() => dispatchWorkspace({ type: "viewDeletion.dismissed" })}
         />
       )}
     </main>

--- a/src/visual-app/changeset-tray.tsx
+++ b/src/visual-app/changeset-tray.tsx
@@ -1,4 +1,8 @@
-import type { VisualDiagnostic } from '../adapters/visual/protocol-contract.js'
+import type {
+  VisualChangesetCommitPayload,
+  VisualDiagnostic,
+  VisualViewOperation,
+} from '../adapters/visual/protocol-contract.js'
 import { summarise } from './faults.js'
 import type { CanvasGraph } from '../graph-projection.js'
 import type { YarramateOperation } from '../operations.js'
@@ -37,11 +41,53 @@ export const resolveSubjectName = (
 
 /** One staged operation, reduced to what a row needs to say. */
 export interface ChangesetRowDescription {
-  readonly verb: YarramateOperation['op']
+  readonly verb: YarramateOperation['op'] | VisualViewOperation['op']
   readonly subjectName: string
   readonly fields: readonly string[]
   readonly removedFields: readonly string[]
+  /**
+   * Which half of the split this row edits. The tray states it because the two
+   * have different blast radius: a view row rewrites one projection, a model
+   * row changes every view that drew the subject. A reviewer reading a mixed
+   * changeset has to be able to tell them apart at a glance.
+   */
+  readonly scope: 'model' | 'view'
 }
+
+/**
+ * Every staged row, model rows first, as one list.
+ *
+ * One list because the reviewer sees one tray and discards by one index; the
+ * order is defined here and `changeset.discarded` maps it back, so the two
+ * cannot disagree about which row a click meant.
+ */
+export const changesetRows = (
+  changeset: VisualChangesetCommitPayload,
+  graph: CanvasGraph | null,
+): readonly ChangesetRowDescription[] => [
+  ...changeset.operations.map((operation) =>
+    describeChangesetRow(operation, graph),
+  ),
+  ...changeset.viewOperations.map(describeViewRow),
+]
+
+/**
+ * A staged view, reduced the same way. The document's path is the subject:
+ * a view has no id on the canvas to resolve a name from, and the path is what
+ * the reviewer picked the folder of.
+ */
+export const describeViewRow = (
+  operation: VisualViewOperation,
+): ChangesetRowDescription => ({
+  verb: operation.op,
+  subjectName:
+    operation.op === 'write-view'
+      ? (operation.projection.presentation?.title ?? operation.projection.id)
+      : operation.path,
+  fields: operation.op === 'write-view' ? [operation.path] : [],
+  removedFields: [],
+  scope: 'view',
+})
 
 export const describeChangesetRow = (
   operation: YarramateOperation,
@@ -65,6 +111,7 @@ export const describeChangesetRow = (
       subjectName: key === undefined ? name : `${name} (${key})`,
       fields: Object.keys(fields),
       removedFields,
+      scope: 'model',
     }
   }
   // Every other union member's payload carries `id`; scalars/lists it sets
@@ -75,6 +122,7 @@ export const describeChangesetRow = (
     subjectName: resolveSubjectName(operation.document, payload.id, graph),
     fields: Object.keys(payload).filter((key) => key !== 'id'),
     removedFields,
+    scope: 'model',
   }
 }
 
@@ -135,11 +183,25 @@ export const stagedRowConflict = (
   operation: YarramateOperation,
   pins: Readonly<Record<string, string>>,
   model: VisualRenderedModel | null,
+): string | null => rowConflict(operation.document, pins, model)
+
+/**
+ * The same question asked of any staged document, model or view.
+ *
+ * A view is compared against `projectionDigests` rather than `sourceDigests`,
+ * because that is where a projection's digest is published (ADR 0103); a
+ * document in neither map is one the commit will create and has no prior value
+ * to be stale against.
+ */
+export const rowConflict = (
+  path: string,
+  pins: Readonly<Record<string, string>>,
+  model: VisualRenderedModel | null,
 ): string | null => {
-  const pinned = pins[operation.document]
+  const pinned = pins[path]
   if (pinned === undefined) return null
-  const current = model?.sourceDigests[operation.document]
-  return current === undefined || current === pinned ? null : operation.document
+  const current = model?.sourceDigests[path] ?? model?.projectionDigests[path]
+  return current === undefined || current === pinned ? null : path
 }
 
 const DiagnosticLine = ({
@@ -173,6 +235,12 @@ const ChangesetRow = ({
   <li className={conflict === null ? 'changeset-row' : 'changeset-row conflicted'}>
     <div className="changeset-row-line">
       <span className="changeset-row-label">{changesetRowLabel(row)}</span>
+      {/* Which half of the split this row edits, stated rather than inferred
+          from the verb: the two have different blast radius, and a reviewer
+          reading a mixed changeset has to tell them apart at a glance. */}
+      <span className={`changeset-row-scope changeset-scope-${row.scope}`}>
+        {row.scope}
+      </span>
       <button type="button" className="changeset-row-discard" onClick={onDiscard}>
         Discard
       </button>
@@ -216,12 +284,16 @@ export const ChangesetTray = ({
   readonly onRedoChangeset: () => void
   readonly onCommitChangeset: () => void
 }) => {
-  const operations = state.pendingChangeset.operations
+  const graph = state.model?.graph ?? null
+  // Both lists, as one: a changeset holding only a staged view is not an empty
+  // one, and a tray that hid it would let the reviewer commit a write they
+  // could not see.
+  const rows = changesetRows(state.pendingChangeset, graph)
   // History keeps the tray mounted even with nothing staged: undoing the last
   // row back to an empty set must leave Redo reachable, and discarding all of
   // them must leave Undo reachable.
   if (
-    operations.length === 0 &&
+    rows.length === 0 &&
     state.commitNotice === null &&
     state.commitDiagnostics === null &&
     state.undoStack.length === 0 &&
@@ -230,7 +302,6 @@ export const ChangesetTray = ({
     return null
   }
 
-  const graph = state.model?.graph ?? null
   const { byRow, batch } = partitionDiagnostics(state.commitDiagnostics ?? [])
   const committing = state.commitStatus === 'committing'
 
@@ -255,7 +326,7 @@ export const ChangesetTray = ({
           >
             Redo
           </button>
-          {operations.length === 0 ? null : (
+          {rows.length === 0 ? null : (
             <button
               type="button"
               className="changeset-discard-all"
@@ -294,16 +365,24 @@ export const ChangesetTray = ({
         </ul>
       )}
 
-      {operations.length === 0 ? null : (
+      {rows.length === 0 ? null : (
         <ol className="changeset-rows">
-          {operations.map((operation, index) => (
+          {rows.map((row, index) => (
             <ChangesetRow
               key={index}
               index={index}
-              row={describeChangesetRow(operation, graph)}
+              row={row}
+              // Diagnostics point into `/operations/N`, which is the model
+              // list. A view row's index is past the end of it and never
+              // matches, which is right: a refused projection is reported
+              // against its document rather than against a row.
               diagnostics={byRow.get(index) ?? []}
-              conflict={stagedRowConflict(
-                operation,
+              conflict={rowConflict(
+                index < state.pendingChangeset.operations.length
+                  ? state.pendingChangeset.operations[index]!.document
+                  : state.pendingChangeset.viewOperations[
+                      index - state.pendingChangeset.operations.length
+                    ]!.path,
                 state.pendingChangeset.sourceDigests,
                 state.model,
               )}
@@ -317,7 +396,7 @@ export const ChangesetTray = ({
         <button
           type="button"
           className="changeset-commit"
-          disabled={operations.length === 0 || committing}
+          disabled={rows.length === 0 || committing}
           aria-busy={committing}
           onClick={onCommitChangeset}
         >

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -50,7 +50,8 @@ export type ContextMenuIntent =
   | { readonly type: "canvas.draft-subject" }
   | { readonly type: "view.open"; readonly id: string }
   | { readonly type: "view.clear" }
-  | { readonly type: "view.new" };
+  | { readonly type: "view.new" }
+  | { readonly type: "view.delete"; readonly id: string };
 
 /** Which half of the split an operation belongs to. */
 export type ContextMenuScope = "view" | "model";
@@ -229,25 +230,48 @@ const canvasMenu = (
 const viewRowMenu = (
   id: string,
   context: ContextMenuContext,
-): readonly ContextMenuGroup[] => [
-  {
-    key: "view",
-    scope: "view",
-    label: "View",
-    destructive: false,
-    items: [
-      id === ALL_SUBJECTS_VIEW
-        ? SHOW_ALL
-        : {
-            key: "view.open",
-            label: "Open view",
-            intent: { type: "view.open", id },
-            ...(id === context.activeViewId ? { current: true as const } : {}),
-          },
-      NEW_VIEW,
-    ],
-  },
-];
+): readonly ContextMenuGroup[] => {
+  const groups: ContextMenuGroup[] = [
+    {
+      key: "view",
+      scope: "view",
+      label: "View",
+      destructive: false,
+      items: [
+        id === ALL_SUBJECTS_VIEW
+          ? SHOW_ALL
+          : {
+              key: "view.open",
+              label: "Open view",
+              intent: { type: "view.open", id },
+              ...(id === context.activeViewId ? { current: true as const } : {}),
+            },
+        NEW_VIEW,
+      ],
+    },
+  ];
+  // "All subjects" is the absence of a view, not a document, so there is
+  // nothing to delete and no rule to draw.
+  if (id !== ALL_SUBJECTS_VIEW) {
+    // Behind the rule and in `--failure` like every other destructive item,
+    // even though its blast radius is one projection: the reviewer learns one
+    // rule about where the dangerous items sit, not two.
+    groups.push({
+      key: "delete",
+      scope: "view",
+      label: null,
+      destructive: true,
+      items: [
+        {
+          key: "delete",
+          label: "Delete view…",
+          intent: { type: "view.delete", id },
+        },
+      ],
+    });
+  }
+  return groups;
+};
 
 const modelRowMenu = (
   id: string,

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -1,10 +1,14 @@
 import { useState } from "react";
 import type { ProjectionQuery } from "../projection.js";
 import type {
-  VisualViewSavePayload,
+  VisualViewOperation,
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
-import { ConfirmDialog } from "./confirm-dialog.js";
+import {
+  composeProjection,
+  projectionPathFor,
+  viewIdFrom,
+} from "../adapters/visual/view-identity.js";
 
 export interface SaveViewControlProps {
   readonly views: readonly VisualViewSummary[];
@@ -14,8 +18,6 @@ export interface SaveViewControlProps {
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
-  readonly pendingSave: boolean;
-  readonly notice: boolean;
   /**
    * Openness is the caller's, not the panel's: the tree's new-view button
    * opens this form from the other side of the shell, and two components
@@ -23,12 +25,21 @@ export interface SaveViewControlProps {
    */
   readonly open: boolean;
   readonly onToggle: () => void;
-  readonly onSave: (payload: VisualViewSavePayload) => void;
-  readonly onDismissNotice: () => void;
+  /** Stages the write. Nothing is on disk until the changeset is committed. */
+  readonly onStage: (operation: VisualViewOperation) => void;
 }
 
 export interface BuildPayloadParams {
+  /** The view being overwritten, or undefined to mint a new one. */
   readonly id: string | undefined;
+  /**
+   * Every view id already in use, so a new one takes a free slug. The server
+   * used to mint this; a staged row has to name the document it will write
+   * before it is committed, so the browser mints it now (ADR 0103).
+   */
+  readonly taken: ReadonlySet<string>;
+  /** Where the overwritten view's document already lives, if there is one. */
+  readonly path: string | undefined;
   readonly title: string;
   readonly description: string;
   readonly query: ProjectionQuery | null;
@@ -46,12 +57,21 @@ export interface BuildPayloadParams {
   readonly carriedDirection: "top-down" | "left-right" | undefined;
 }
 
-/** Pure translation from the form's local state to the wire payload — no
+/**
+ * Pure translation from the form's local state to the staged operation — no
  * active filter names an unfiltered view, since every field of a
- * `ProjectionQuery` is optional and `{}` is itself a valid, if
- * unconstrained, query. */
+ * `ProjectionQuery` is optional and `{}` is itself a valid, if unconstrained,
+ * query.
+ *
+ * A saved view is a row in the changeset rather than a write (ADR 0103), so
+ * this composes the whole projection document and the path it will occupy.
+ * Overwriting keeps the path the view already has; a new view takes a fresh
+ * slug in the default directory.
+ */
 export const buildPayload = ({
   id,
+  taken,
+  path,
   title,
   description,
   query,
@@ -60,25 +80,31 @@ export const buildPayload = ({
   showEvidence,
   showOwnership,
   carriedDirection,
-}: BuildPayloadParams): VisualViewSavePayload => ({
-  ...(id === undefined ? {} : { id }),
-  title,
-  description,
-  query: query ?? {},
-  presentation: {
-    layout,
-    ...(carriedDirection === undefined ? {} : { direction: carriedDirection }),
-    showLifecycle,
-    showEvidence,
-    showOwnership,
-  },
-});
+}: BuildPayloadParams): VisualViewOperation => {
+  const viewId = id ?? viewIdFrom(title, taken);
+  return {
+    op: "write-view",
+    path: path ?? projectionPathFor(viewId),
+    projection: composeProjection({
+      id: viewId,
+      title,
+      description,
+      query: query ?? {},
+      presentation: {
+        layout,
+        ...(carriedDirection === undefined
+          ? {}
+          : { direction: carriedDirection }),
+        showLifecycle,
+        showEvidence,
+        showOwnership,
+      },
+    }),
+  };
+};
 
 interface SaveViewFormProps {
   readonly activeView: VisualViewSummary | null;
-  readonly pendingSave: boolean;
-  readonly notice: boolean;
-  readonly onDismissNotice: () => void;
   readonly onSubmit: (
     id: string | undefined,
     title: string,
@@ -95,13 +121,7 @@ interface SaveViewFormProps {
  * an overwrite of the active view with nothing retyped, and closing it
  * discard a half-typed name that was never workspace state.
  */
-function SaveViewForm({
-  activeView,
-  pendingSave,
-  notice,
-  onDismissNotice,
-  onSubmit,
-}: SaveViewFormProps) {
+function SaveViewForm({ activeView, onSubmit }: SaveViewFormProps) {
   const [title, setTitle] = useState(activeView?.title ?? "");
   const [description, setDescription] = useState(activeView?.description ?? "");
 
@@ -113,14 +133,6 @@ function SaveViewForm({
   return (
     <div className="save-view-panel">
       <div id="save-view-panel-body" className="save-view-panel-body">
-        {notice ? (
-          <p className="save-view-notice" role="status">
-            View saved
-            <button type="button" onClick={onDismissNotice}>
-              Dismiss
-            </button>
-          </p>
-        ) : null}
         <form
           className="save-view-form"
           onSubmit={(event) => {
@@ -136,7 +148,6 @@ function SaveViewForm({
               type="text"
               value={title}
               onChange={(event) => setTitle(event.currentTarget.value)}
-              disabled={pendingSave}
               required
             />
           </div>
@@ -146,20 +157,19 @@ function SaveViewForm({
               id="save-view-description"
               value={description}
               onChange={(event) => setDescription(event.currentTarget.value)}
-              disabled={pendingSave}
               required
             />
           </div>
           <div className="save-view-actions">
             <button
               type="submit"
-              disabled={pendingSave || activeView === null || incomplete}
+              disabled={activeView === null || incomplete}
             >
               Save
             </button>
             <button
               type="button"
-              disabled={pendingSave || incomplete}
+              disabled={incomplete}
               onClick={() => {
                 if (incomplete) return;
                 onSubmit(undefined, title, description);
@@ -174,12 +184,17 @@ function SaveViewForm({
   );
 }
 
+
 /**
- * Saves the reviewer's current filter and presentation as a named
- * projection document. "Save" overwrites whatever view is active — behind a
- * confirm dialog, since that is destructive — and "Save As New" always
- * creates a fresh one, which the server can never collide with a
- * client-chosen id, so it needs no confirmation.
+ * Stages the reviewer's current filter and presentation as a named projection
+ * document. "Save" overwrites whatever view is active and "Save As New" mints
+ * a fresh id.
+ *
+ * Neither writes anything: both stage a row in the changeset (ADR 0103), which
+ * is why the overwrite no longer asks first. The confirmation existed because
+ * an overwrite was immediate and unundoable; a staged overwrite is a row the
+ * reviewer can read, discard and undo before it lands, which is a better
+ * answer than a dialog.
  */
 export function SaveViewControl({
   views,
@@ -189,19 +204,10 @@ export function SaveViewControl({
   showLifecycle,
   showEvidence,
   showOwnership,
-  pendingSave,
-  notice,
   open,
   onToggle,
-  onSave,
-  onDismissNotice,
+  onStage,
 }: SaveViewControlProps) {
-  // What an overwrite would send, held while the reviewer is asked to confirm
-  // it — the payload rather than the id, because the fields it was built from
-  // belong to the form and the dialog has to outlive them.
-  const [confirming, setConfirming] = useState<VisualViewSavePayload | null>(
-    null,
-  );
   const activeView = views.find((view) => view.id === activeViewId) ?? null;
 
   const submit = (
@@ -209,25 +215,27 @@ export function SaveViewControl({
     title: string,
     description: string,
   ) => {
-    const payload = buildPayload({
-      id,
-      title,
-      description,
-      query,
-      layout,
-      showLifecycle,
-      showEvidence,
-      showOwnership,
-      // Overwriting carries the view's own direction; a brand new view has
-      // none to carry, and the export's own default applies.
-      carriedDirection:
-        id === undefined ? undefined : activeView?.presentation?.direction,
-    });
-    if (id === undefined) {
-      onSave(payload);
-      return;
-    }
-    setConfirming(payload);
+    onStage(
+      buildPayload({
+        id,
+        taken: new Set(views.map((view) => view.id)),
+        // Overwriting writes the document the view already occupies, which is
+        // not always the one its id would derive: a view saved into a folder
+        // keeps its folder rather than being moved by a later save.
+        path: id === undefined ? undefined : activeView?.path,
+        title,
+        description,
+        query,
+        layout,
+        showLifecycle,
+        showEvidence,
+        showOwnership,
+        // Overwriting carries the view's own direction; a brand new view has
+        // none to carry, and the export's own default applies.
+        carriedDirection:
+          id === undefined ? undefined : activeView?.presentation?.direction,
+      }),
+    );
   };
 
   return (
@@ -238,7 +246,6 @@ export function SaveViewControl({
         aria-expanded={open}
         aria-controls="save-view-panel-body"
         onClick={onToggle}
-        disabled={pendingSave}
       >
         Save view
       </button>
@@ -248,25 +255,9 @@ export function SaveViewControl({
           // the fields describe the view the Save button would overwrite.
           key={activeViewId}
           activeView={activeView}
-          pendingSave={pendingSave}
-          notice={notice}
-          onDismissNotice={onDismissNotice}
           onSubmit={submit}
         />
       ) : null}
-      {confirming === null ? null : (
-        <ConfirmDialog
-          title="Overwrite this view?"
-          message={`Saving will replace "${activeView?.title ?? confirming.id ?? ""}" with the current filter and layout.`}
-          confirmLabel="Overwrite"
-          cancelLabel="Cancel"
-          onConfirm={() => {
-            onSave(confirming);
-            setConfirming(null);
-          }}
-          onCancel={() => setConfirming(null)}
-        />
-      )}
     </div>
   );
 }

--- a/src/visual-app/session-client.tsx
+++ b/src/visual-app/session-client.tsx
@@ -6,11 +6,12 @@ import type {
 import type { ProjectionQuery } from '../projection.js'
 import type {
   VisualLayoutSavePayload,
-  VisualViewSavePayload,
+  VisualViewOperation,
 } from '../adapters/visual/protocol-contract.js'
 import type { YarramateOperation } from '../operations.js'
 import {
   canReconnect,
+  changesetIsEmpty,
   initialVisualAppState,
   filterToReresolve,
   visualAppActionsForFrame,
@@ -45,7 +46,7 @@ export interface VisualSession {
   readonly filter: (query: ProjectionQuery, origin?: 'view' | 'panel' | 'chat') => void
   readonly clearFilter: () => void
   readonly setQuickFilterText: (text: string) => void
-  readonly saveView: (payload: VisualViewSavePayload) => void
+  readonly stageViewChange: (operation: VisualViewOperation) => void
   readonly stageChange: (operation: YarramateOperation) => void
   readonly discardChange: (index: number) => void
   readonly clearChangeset: () => void
@@ -53,7 +54,6 @@ export interface VisualSession {
   readonly redoChangeset: () => void
   readonly commitChangeset: () => void
   readonly saveLayout: (payload: VisualLayoutSavePayload) => void
-  readonly dismissSavedNotice: () => void
   readonly end: () => void
 }
 
@@ -227,17 +227,15 @@ export const useVisualSession = (): VisualSession => {
     dispatch({ type: 'quickFilter.changed', text })
   }, [])
 
-  const saveView = useCallback(
-    (payload: VisualViewSavePayload) => {
-      dispatch({ type: 'view.save.sent', payload })
-      send({ kind: 'save-view', payload })
-    },
-    [send],
-  )
-
   // Staging is local: nothing leaves the browser until the reviewer commits.
+  // That is now true of views as well as subjects (ADR 0103), which is why
+  // there is no `saveView` here any more - a view is staged, not sent.
   const stageChange = useCallback((operation: YarramateOperation) => {
     dispatch({ type: 'changeset.staged', operation })
+  }, [])
+
+  const stageViewChange = useCallback((operation: VisualViewOperation) => {
+    dispatch({ type: 'changeset.viewStaged', operation })
   }, [])
 
   const discardChange = useCallback((index: number) => {
@@ -260,8 +258,10 @@ export const useVisualSession = (): VisualSession => {
 
   const commitChangeset = useCallback(() => {
     // An empty changeset has nothing to validate: the runtime would refuse it,
-    // so the button never spends a round trip proving that.
-    if (stateRef.current.pendingChangeset.operations.length === 0) return
+    // so the button never spends a round trip proving that. Empty means BOTH
+    // lists - guarding on the model's alone made a changeset holding only a
+    // staged view silently do nothing when the reviewer pressed Commit.
+    if (changesetIsEmpty(stateRef.current.pendingChangeset)) return
     dispatch({ type: 'changeset.commit.sent' })
     send({ kind: 'commit-changeset' })
   }, [send])
@@ -272,10 +272,6 @@ export const useVisualSession = (): VisualSession => {
     },
     [send],
   )
-
-  const dismissSavedNotice = useCallback(() => {
-    dispatch({ type: 'view.saveNotice.dismissed' })
-  }, [])
 
   const end = useCallback(() => {
     dispatch({ type: 'end.requested' })
@@ -291,7 +287,7 @@ export const useVisualSession = (): VisualSession => {
     filter,
     clearFilter,
     setQuickFilterText,
-    saveView,
+    stageViewChange,
     stageChange,
     discardChange,
     clearChangeset,
@@ -299,7 +295,6 @@ export const useVisualSession = (): VisualSession => {
     redoChangeset,
     commitChangeset,
     saveLayout,
-    dismissSavedNotice,
     end,
   }
 }

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -4,13 +4,12 @@ import {
   type VisualAuthority,
   type VisualBrowserInput,
   type VisualChangesetCommitPayload,
+  type VisualViewOperation,
   type VisualChoicePresentPayload,
   type VisualDiagnostic,
   type VisualHandoffSummary,
   type VisualLayoutSavePayload,
   type VisualLayoutSaveResultPayload,
-  type VisualViewSavePayload,
-  type VisualViewSaveResultPayload,
   type VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
 
@@ -102,12 +101,6 @@ export interface VisualAppState {
   /** Client-side substring narrowing layered on top of `activeFilter`. */
   readonly quickFilterText: string;
   readonly closedReason: string | null;
-  /** The save in flight, so the panel can disable itself and the result can
-   * be matched back to what it named — the result carries only an id. */
-  readonly pendingViewSave: VisualViewSavePayload | null;
-  /** Shown once a save lands ok, until the reviewer dismisses it or a fresh
-   * save starts. */
-  readonly viewSaveNotice: boolean;
   /**
    * Operations staged for commit; replaces on same-field re-edit. Typed as the
    * commit payload itself, so the tray holds exactly what the wire takes and
@@ -175,15 +168,13 @@ export type VisualAppAction =
     }
   | { readonly type: "filter.cleared" }
   | { readonly type: "quickFilter.changed"; readonly text: string }
-  | { readonly type: "view.save.sent"; readonly payload: VisualViewSavePayload }
-  | {
-      readonly type: "view.saved";
-      readonly result: VisualViewSaveResultPayload;
-    }
-  | { readonly type: "view.saveNotice.dismissed" }
   | {
       readonly type: "changeset.staged";
       readonly operation: YarramateOperation;
+    }
+  | {
+      readonly type: "changeset.viewStaged";
+      readonly operation: VisualViewOperation;
     }
   | { readonly type: "changeset.discarded"; readonly index: number }
   | { readonly type: "changeset.cleared" }
@@ -220,6 +211,26 @@ export type VisualAppAction =
   | { readonly type: "connection.lost" }
   | { readonly type: "session.closed"; readonly reason: string };
 
+/**
+ * A changeset with nothing in it. Named rather than repeated, because the day
+ * the payload grows a third list is the day three literals silently disagree.
+ */
+export const EMPTY_CHANGESET: VisualChangesetCommitPayload = {
+  operations: [],
+  viewOperations: [],
+  sourceDigests: {},
+};
+
+/**
+ * Whether a changeset would land anything. Both lists count: a changeset
+ * holding only a staged view is not an empty one, and every control that reads
+ * "is there anything to commit" has to agree about that.
+ */
+export const changesetIsEmpty = (
+  changeset: VisualChangesetCommitPayload,
+): boolean =>
+  changeset.operations.length === 0 && changeset.viewOperations.length === 0;
+
 export const initialVisualAppState: VisualAppState = {
   lifecycle: "connecting",
   authority: "canonical",
@@ -243,9 +254,7 @@ export const initialVisualAppState: VisualAppState = {
   activeFilter: null,
   quickFilterText: "",
   closedReason: null,
-  pendingViewSave: null,
-  viewSaveNotice: false,
-  pendingChangeset: { operations: [], sourceDigests: {} },
+  pendingChangeset: EMPTY_CHANGESET,
   undoStack: [],
   redoStack: [],
   commitStatus: "idle",
@@ -357,20 +366,59 @@ const changesetTargetKey = (op: YarramateOperation): string => {
  */
 const pinnedDigests = (
   operations: readonly YarramateOperation[],
+  viewOperations: readonly VisualViewOperation[],
   previous: Readonly<Record<string, string>>,
   model: VisualRenderedModel | null,
 ): Readonly<Record<string, string>> => {
   const pins: Record<string, string> = {};
-  for (const operation of operations) {
-    if (pins[operation.document] !== undefined) continue;
-    const pinned =
-      previous[operation.document] ?? model?.sourceDigests[operation.document];
-    // A document the model does not name is one `apply` will create: there is no
-    // prior value to be stale against, so it is left unpinned rather than
+  const pin = (path: string, held: string | undefined): void => {
+    if (pins[path] !== undefined) return;
+    const pinned = previous[path] ?? held;
+    // A document the model does not name is one the commit will create: there is
+    // no prior value to be stale against, so it is left unpinned rather than
     // pinned to a digest nobody minted.
-    if (pinned !== undefined) pins[operation.document] = pinned;
+    if (pinned !== undefined) pins[path] = pinned;
+  };
+  for (const operation of operations) {
+    pin(operation.document, model?.sourceDigests[operation.document]);
+  }
+  // A view pins against the projection digests, which are published as their
+  // own map: `sourceDigests` means what the graph was compiled from, and a
+  // projection is not part of that (ADR 0103).
+  for (const operation of viewOperations) {
+    pin(operation.path, model?.projectionDigests[operation.path]);
   }
   return pins;
+};
+
+/**
+ * A changeset with one of its lists replaced and its pins recomputed.
+ *
+ * Every path that stages, discards or clears goes through here, so `sourceDigests`
+ * cannot drift from the rows it vouches for - which is the invariant the whole
+ * pin mechanism rests on, and one that three separate object literals would
+ * lose the first time a fourth was added.
+ */
+const restage = (
+  changeset: VisualChangesetCommitPayload,
+  model: VisualRenderedModel | null,
+  next: {
+    readonly operations?: readonly YarramateOperation[];
+    readonly viewOperations?: readonly VisualViewOperation[];
+  },
+): VisualChangesetCommitPayload => {
+  const operations = next.operations ?? changeset.operations;
+  const viewOperations = next.viewOperations ?? changeset.viewOperations;
+  return {
+    operations,
+    viewOperations,
+    sourceDigests: pinnedDigests(
+      operations,
+      viewOperations,
+      changeset.sourceDigests,
+      model,
+    ),
+  };
 };
 
 const transition = (
@@ -402,10 +450,6 @@ const transition = (
           state.lastSequence,
           action.snapshot.lastSequence,
         ),
-        // A reconnect must not resurrect an in-flight save from before the
-        // socket dropped, nor replay a notice for one that already landed.
-        pendingViewSave: null,
-        viewSaveNotice: false,
       };
     case "model.received":
       // Mid-session model frames replace the compilation; preserve the
@@ -501,7 +545,6 @@ const transition = (
         ...state,
         diagnostics: action.diagnostics,
         frozen: state.frozen || action.frozen,
-        ...(died("view.save") ? { pendingViewSave: null } : {}),
         // The refusal is the commit's answer, and it points at the rows it
         // refused, so the tray shows it where the reviewer is already looking.
         ...(died("changeset.commit")
@@ -551,52 +594,6 @@ const transition = (
       return state.quickFilterText === action.text
         ? state
         : { ...state, quickFilterText: action.text };
-    case "view.save.sent":
-      return {
-        ...state,
-        pendingViewSave: action.payload,
-        viewSaveNotice: false,
-      };
-    case "view.saved": {
-      if (!action.result.ok) {
-        // The failed candidate names nothing new; what was saved before, if
-        // anything, is unchanged. Every reason it failed is shown, verbatim.
-        return {
-          ...state,
-          diagnostics: action.result.diagnostics,
-          pendingViewSave: null,
-        };
-      }
-      const pending = state.pendingViewSave;
-      // A result with nothing pending names a save this browser never sent —
-      // stale or duplicated, either way nothing here to build a summary from.
-      if (pending === null) return state;
-      const saved: VisualViewSummary = {
-        id: action.result.id,
-        title: pending.title,
-        description: pending.description,
-        query: pending.query,
-        presentation: pending.presentation,
-        path: action.result.path,
-        subjectCount: action.result.subjectCount,
-      };
-      const existingIndex = state.views.findIndex(
-        (view) => view.id === saved.id,
-      );
-      return {
-        ...state,
-        views:
-          existingIndex === -1
-            ? [...state.views, saved]
-            : state.views.map((view, index) =>
-                index === existingIndex ? saved : view,
-              ),
-        viewSaveNotice: true,
-        pendingViewSave: null,
-      };
-    }
-    case "view.saveNotice.dismissed":
-      return { ...state, viewSaveNotice: false };
     case "changeset.staged": {
       // Replacing: if an operation targets the same subject and field, remove the old one.
       const key = changesetTargetKey(action.operation);
@@ -606,14 +603,9 @@ const transition = (
       const operations = [...filtered, action.operation];
       return {
         ...state,
-        pendingChangeset: {
+        pendingChangeset: restage(state.pendingChangeset, state.model, {
           operations,
-          sourceDigests: pinnedDigests(
-            operations,
-            state.pendingChangeset.sourceDigests,
-            state.model,
-          ),
-        },
+        }),
         undoStack: [...state.undoStack, state.pendingChangeset],
         redoStack: [],
         commitDiagnostics: null,
@@ -621,44 +613,69 @@ const transition = (
         commitNotice: null,
       };
     }
-    case "changeset.discarded": {
-      const { index } = action;
-      if (index < 0 || index >= state.pendingChangeset.operations.length) {
-        return state;
-      }
-      const operations = state.pendingChangeset.operations.filter(
-        (_, i) => i !== index,
+    case "changeset.viewStaged": {
+      // One row per document, the same rule the model's rows follow: saving
+      // over a view already staged replaces that row rather than queueing a
+      // second write of the same file. A delete replaces a pending write too -
+      // the last thing said about a document is what the reviewer meant.
+      const filtered = state.pendingChangeset.viewOperations.filter(
+        (operation) => operation.path !== action.operation.path,
       );
       return {
         ...state,
-        pendingChangeset: {
-          operations,
-          sourceDigests: pinnedDigests(
-            operations,
-            state.pendingChangeset.sourceDigests,
-            state.model,
-          ),
-        },
+        pendingChangeset: restage(state.pendingChangeset, state.model, {
+          viewOperations: [...filtered, action.operation],
+        }),
+        undoStack: [...state.undoStack, state.pendingChangeset],
+        redoStack: [],
+        commitDiagnostics: null,
+        commitNotice: null,
+      };
+    }
+    case "changeset.discarded": {
+      // The tray shows one list, so the reviewer discards by one index. Which
+      // of the two underlying lists that row came from is arithmetic, done
+      // where the ordering is defined rather than guessed at by the caller.
+      const { index } = action;
+      const rows = state.pendingChangeset.operations.length;
+      const total = rows + state.pendingChangeset.viewOperations.length;
+      if (index < 0 || index >= total) return state;
+      const next =
+        index < rows
+          ? {
+              operations: state.pendingChangeset.operations.filter(
+                (_, i) => i !== index,
+              ),
+            }
+          : {
+              viewOperations: state.pendingChangeset.viewOperations.filter(
+                (_, i) => i !== index - rows,
+              ),
+            };
+      return {
+        ...state,
+        pendingChangeset: restage(state.pendingChangeset, state.model, next),
         undoStack: [...state.undoStack, state.pendingChangeset],
         redoStack: [],
         // Diagnostics point at rows by index, so a shorter list mis-attributes them.
         commitDiagnostics: null,
       };
     }
-    case "changeset.cleared":
+    case "changeset.cleared": {
       // Clearing an already-empty changeset must not stack an undo step that
-      // would restore the same empty list.
+      // would restore the same empty list - and "empty" means both lists, or
+      // clearing a changeset holding only a staged view would be unundoable.
+      const empty = changesetIsEmpty(state.pendingChangeset);
       return {
         ...state,
-        pendingChangeset: { operations: [], sourceDigests: {} },
-        undoStack:
-          state.pendingChangeset.operations.length === 0
-            ? state.undoStack
-            : [...state.undoStack, state.pendingChangeset],
-        redoStack:
-          state.pendingChangeset.operations.length === 0 ? state.redoStack : [],
+        pendingChangeset: EMPTY_CHANGESET,
+        undoStack: empty
+          ? state.undoStack
+          : [...state.undoStack, state.pendingChangeset],
+        redoStack: empty ? state.redoStack : [],
         commitDiagnostics: null,
       };
+    }
     case "changeset.undone": {
       const restored = state.undoStack.at(-1);
       if (restored === undefined) {
@@ -693,7 +710,7 @@ const transition = (
       // A landed batch is reverted with `git revert`, never resurrected here.
       return {
         ...state,
-        pendingChangeset: { operations: [], sourceDigests: {} },
+        pendingChangeset: EMPTY_CHANGESET,
         undoStack: [],
         redoStack: [],
         commitStatus: "idle",
@@ -749,7 +766,6 @@ export type VisualAppIntent =
   | { readonly kind: "navigate"; readonly viewId: string }
   | { readonly kind: "end" }
   | { readonly kind: "filter"; readonly query: ProjectionQuery }
-  | { readonly kind: "save-view"; readonly payload: VisualViewSavePayload }
   | { readonly kind: "commit-changeset" }
   | { readonly kind: "save-layout"; readonly payload: VisualLayoutSavePayload };
 
@@ -795,12 +811,6 @@ export const visualBrowserInputFor = (
         type: "filter.query",
         lastAcknowledgedSequence,
         payload: { query: intent.query },
-      };
-    case "save-view":
-      return {
-        type: "view.save",
-        lastAcknowledgedSequence,
-        payload: intent.payload,
       };
     case "commit-changeset":
       return {
@@ -907,8 +917,6 @@ export const visualAppActionsForFrame = (
           source: filterOrigin,
         },
       ];
-    case "view-save-result":
-      return [{ type: "view.saved", result: frame.result }];
     case "response":
       switch (frame.response.type) {
         case "chat.response": {

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1794,3 +1794,22 @@ body {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+/* Which half of the split a staged row edits (ADR 0103). A view row rewrites
+   one projection; a model row changes every view that drew the subject. */
+.changeset-row-scope {
+  flex: none;
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 calc(var(--step) * 0.5);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  color: var(--quiet);
+}
+
+.changeset-scope-view {
+  color: var(--cobalt);
+  border-color: color-mix(in oklab, var(--cobalt) 40%, transparent);
+}

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -132,6 +132,13 @@ export interface VisualWorkspaceState {
    * so it is the one that asks first.
    */
   readonly pendingDeletion: string | null;
+  /**
+   * The view a deletion has been asked for, held until the reviewer confirms.
+   * Separate from `pendingDeletion` because the two ask different questions: a
+   * subject's deletion is described against the graph and takes relationships
+   * with it, a view's removes one projection document and touches no subject.
+   */
+  readonly pendingViewDeletion: string | null;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   /**
@@ -145,11 +152,6 @@ export interface VisualWorkspaceState {
     readonly collapsed: readonly string[];
   };
   /**
-   * What draws as nesting in the active view, in precedence order (ADR 0101).
-   * A view that says nothing keeps `DEFAULT_NESTING`, which is composition
-   * alone - the behaviour that shipped before a view could say.
-   */
-  /**
    * The open context menu: what was right-clicked and where the pointer was,
    * or null. The menu's CONTENTS are not held here — `contextMenuFor` derives
    * them from the model on every render, so a commit that lands while a menu
@@ -161,6 +163,11 @@ export interface VisualWorkspaceState {
     readonly x: number;
     readonly y: number;
   } | null;
+  /**
+   * What draws as nesting in the active view, in precedence order (ADR 0101).
+   * A view that says nothing keeps `DEFAULT_NESTING`, which is composition
+   * alone - the behaviour that shipped before a view could say.
+   */
   readonly nesting: readonly NestingKind[];
   readonly layout: "layered";
   readonly showLifecycle: boolean;
@@ -186,6 +193,8 @@ export type VisualWorkspaceAction =
   | { readonly type: "subject.draft.closed" }
   | { readonly type: "deletion.asked"; readonly id: string }
   | { readonly type: "deletion.dismissed" }
+  | { readonly type: "viewDeletion.asked"; readonly id: string }
+  | { readonly type: "viewDeletion.dismissed" }
   | {
       readonly type: "subject.selected";
       readonly subject: SelectedDiagramSubject;
@@ -352,6 +361,7 @@ export const createVisualWorkspaceState = (
   connection: null,
   draftingSubject: false,
   pendingDeletion: null,
+  pendingViewDeletion: null,
   contextMenu: null,
   nesting: DEFAULT_NESTING,
   layout: "layered",
@@ -470,6 +480,12 @@ export const visualWorkspaceReducer = (
       return state.pendingDeletion === null
         ? state
         : { ...state, pendingDeletion: null };
+    case "viewDeletion.asked":
+      return { ...state, pendingViewDeletion: action.id, contextMenu: null };
+    case "viewDeletion.dismissed":
+      return state.pendingViewDeletion === null
+        ? state
+        : { ...state, pendingViewDeletion: null };
     case "subject.selected":
       return {
         ...state,

--- a/test/changeset-tray.test.ts
+++ b/test/changeset-tray.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type {
   VisualChangesetCommitPayload,
   VisualDiagnostic,
+  VisualViewOperation,
 } from '../src/adapters/visual/protocol-contract.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
 import type { YarramateOperation } from '../src/operations.js'
@@ -167,6 +168,7 @@ describe('describeChangesetRow / changesetRowLabel', () => {
       subjectName: 'Checkout Service',
       fields: ['name'],
       removedFields: [],
+      scope: 'model',
     })
     expect(changesetRowLabel(row)).toBe('update-concept · Checkout Service · name')
   })
@@ -200,6 +202,7 @@ describe('describeChangesetRow / changesetRowLabel', () => {
       subjectName: 'checkout (exists)',
       fields: ['value', 'result', 'evidence'],
       removedFields: [],
+      scope: 'model',
     })
     expect(changesetRowLabel(row)).toBe(
       'add-observation · checkout (exists) · value, result, evidence',
@@ -278,7 +281,8 @@ describe('partitionDiagnostics', () => {
 const staged = (
   operations: readonly YarramateOperation[],
   sourceDigests: Readonly<Record<string, string>> = {},
-): VisualChangesetCommitPayload => ({ operations, sourceDigests })
+  viewOperations: readonly VisualViewOperation[] = [],
+): VisualChangesetCommitPayload => ({ operations, viewOperations, sourceDigests })
 
 const baseState: VisualAppState = {
   lifecycle: 'active',
@@ -294,6 +298,7 @@ const baseState: VisualAppState = {
     vocabulary: { conceptKinds: [], relationshipKinds: [] },
     layouts: {},
     sourceDigests: {},
+    projectionDigests: {},
   },
   styleNonce: '',
   activeView: '',
@@ -311,9 +316,7 @@ const baseState: VisualAppState = {
   lastSequence: 0,
   frozen: false,
   closedReason: null,
-  pendingViewSave: null,
-  viewSaveNotice: false,
-  pendingChangeset: { operations: [], sourceDigests: {} },
+  pendingChangeset: { operations: [], viewOperations: [], sourceDigests: {} },
   undoStack: [],
   redoStack: [],
   commitStatus: 'idle',

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -4,189 +4,119 @@ import type { ProjectionQuery } from '../src/projection.js'
 
 const query: ProjectionQuery = { kinds: ['yarramate/core@0.1#businessActor'] }
 
+/**
+ * Saving a view stages a `write-view` (ADR 0103), so this composes the whole
+ * projection document and the path it will occupy rather than a payload the
+ * server would finish. The properties are the same ones as before; what moved
+ * is that they now sit inside `projection`, and that the id and the path are
+ * decided here rather than on the far side of a round trip.
+ */
+const build = (
+  overrides: Partial<Parameters<typeof buildPayload>[0]> = {},
+) =>
+  buildPayload({
+    id: 'existing-view',
+    taken: new Set<string>(),
+    path: '.yarramate/projections/existing-view.yaml',
+    title: 'My View',
+    description: 'desc',
+    query,
+    layout: 'layered',
+    carriedDirection: 'top-down',
+    showLifecycle: true,
+    showEvidence: true,
+    showOwnership: false,
+    ...overrides,
+  })
+
+/** Narrowed once so each test reads `projection` without re-checking the op. */
+const projectionOf = (operation: ReturnType<typeof buildPayload>) => {
+  if (operation.op !== 'write-view') throw new Error('expected a write-view')
+  return operation.projection
+}
+
 describe('buildPayload', () => {
-  it('carries the active view id when overwriting an existing view', () => {
-    const payload = buildPayload({
-      id: 'existing-view',
-      title: 'My View',
-      description: 'desc',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
-    })
+  it('writes the document the view already occupies when overwriting', () => {
+    const operation = build()
 
-    expect(payload).toEqual({
-      id: 'existing-view',
-      title: 'My View',
-      description: 'desc',
-      query,
-      presentation: {
-        layout: 'layered',
-        direction: 'top-down',
-        showLifecycle: true,
-        showEvidence: true,
-        showOwnership: false,
+    expect(operation).toEqual({
+      op: 'write-view',
+      path: '.yarramate/projections/existing-view.yaml',
+      projection: {
+        format: 'yarramate/projection/v1',
+        id: 'existing-view',
+        version: '1.0',
+        query,
+        presentation: {
+          title: 'My View',
+          description: 'desc',
+          layout: 'layered',
+          direction: 'top-down',
+          showLifecycle: true,
+          showEvidence: true,
+          showOwnership: false,
+        },
       },
     })
   })
 
-  it('round-trips the three presentation flags into the saved presentation object', () => {
-    const payload = buildPayload({
-      id: 'existing-view',
-      title: 'My View',
-      description: 'desc',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: false,
-      showEvidence: true,
-      showOwnership: true,
-    })
-
-    expect(payload.presentation?.showLifecycle).toBe(false)
-    expect(payload.presentation?.showEvidence).toBe(true)
-    expect(payload.presentation?.showOwnership).toBe(true)
+  it('keeps a view in the folder it was saved into', () => {
+    // Folders are read back off projection paths (#245), so a save that
+    // rebuilt the path from the id would quietly move the view.
+    expect(
+      build({ path: '.yarramate/projections/current/engine.yaml' }).path,
+    ).toBe('.yarramate/projections/current/engine.yaml')
   })
 
-  it('omits id entirely for an ad-hoc/new view', () => {
-    const payload = buildPayload({
-      id: undefined,
-      title: 'New View',
-      description: 'desc',
-      query,
-      layout: 'layered',
-      carriedDirection: 'left-right',
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
-    })
+  it('mints an id and a path for a new view, from its title', () => {
+    const operation = build({ id: undefined, path: undefined, title: 'My New View' })
 
-    expect(payload).not.toHaveProperty('id')
-    expect(payload).toEqual({
-      title: 'New View',
-      description: 'desc',
-      query,
-      presentation: {
-        layout: 'layered',
-        direction: 'left-right',
-        showLifecycle: true,
-        showEvidence: true,
-        showOwnership: false,
-      },
-    })
+    expect(operation.path).toBe('.yarramate/projections/my-new-view.yaml')
+    expect(projectionOf(operation).id).toBe('my-new-view')
   })
 
-  it('passes title, description, and direction through unchanged', () => {
-    const payload = buildPayload({
+  it('steps past an id already in use rather than overwriting it', () => {
+    const operation = build({
       id: undefined,
-      title: 'Exact Title',
-      description: 'Exact description',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
+      path: undefined,
+      title: 'My New View',
+      taken: new Set(['my-new-view']),
     })
 
-    expect(payload.title).toBe('Exact Title')
-    expect(payload.description).toBe('Exact description')
-    expect(payload.presentation?.direction).toBe('top-down')
-    expect(payload.presentation?.layout).toBe('layered')
+    expect(projectionOf(operation).id).toBe('my-new-view-2')
+    expect(operation.path).toBe('.yarramate/projections/my-new-view-2.yaml')
+  })
+
+  it('round-trips the three presentation flags', () => {
+    const presentation = projectionOf(
+      build({ showLifecycle: false, showEvidence: true, showOwnership: true }),
+    ).presentation
+
+    expect(presentation?.showLifecycle).toBe(false)
+    expect(presentation?.showEvidence).toBe(true)
+    expect(presentation?.showOwnership).toBe(true)
   })
 
   it('substitutes an empty query object when no filter is active', () => {
-    const payload = buildPayload({
-      id: undefined,
-      title: 'Unfiltered',
-      description: 'desc',
-      query: null,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: false,
-      showOwnership: false,
-    })
-
-    expect(payload.query).toEqual({})
+    // Every field of a `ProjectionQuery` is optional, so `{}` is a valid if
+    // unconstrained query - an unfiltered view is a view over everything.
+    expect(projectionOf(build({ query: null })).query).toEqual({})
   })
 
   it('carries the layout through to presentation', () => {
-    const payload = buildPayload({
-      id: 'view-id',
-      title: 'Layered View',
-      description: 'A layout round-trip test',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: false,
-      showOwnership: false,
-    })
-
-    expect(payload.presentation?.layout).toBe('layered')
-    expect(payload.id).toBe('view-id')
-    expect(payload.title).toBe('Layered View')
-    expect(payload.description).toBe('A layout round-trip test')
-    expect(payload.query).toEqual(query)
-    expect(payload.presentation?.direction).toBe('top-down')
+    expect(projectionOf(build()).presentation?.layout).toBe('layered')
   })
 
-  // ArchiMate is the only notation, so a save writes no `notation` at all
-  // rather than stamping the same value onto every projection it touches. A
-  // view that declares one by hand keeps it; nothing here mints one.
   it('writes no notation, because there is only one', () => {
-    const payload = buildPayload({
-      id: 'view-id',
-      title: 'A View',
-      description: 'A test',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
-    })
-
-    expect(payload.presentation?.notation).toBeUndefined()
+    expect(projectionOf(build()).presentation?.notation).toBeUndefined()
   })
 
   // The canvas has no direction control, so a save must carry through what the
   // view already declared. Dropping it would discard a value the LikeC4 export
   // reads and the reviewer never saw.
   it('omits direction entirely when there is none to carry', () => {
-    const payload = buildPayload({
-      id: undefined,
-      title: 'A New View',
-      description: 'A test',
-      query,
-      layout: 'layered',
-      carriedDirection: undefined,
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
-    })
-
-    expect(payload.presentation).not.toHaveProperty('direction')
-  })
-
-  // The seed the canvas actually laid this view out with is what a save must
-  // write back - not the placeholder a view with no declared seed falls to.
-  it('carries the live canvas seed through to presentation', () => {
-    const payload = buildPayload({
-      id: 'view-id',
-      title: 'Seeded View',
-      description: 'A reviewer-chosen seed',
-      query,
-      layout: 'layered',
-      carriedDirection: 'top-down',
-      showLifecycle: true,
-      showEvidence: true,
-      showOwnership: false,
-    })
-
+    expect(
+      projectionOf(build({ carriedDirection: undefined })).presentation,
+    ).not.toHaveProperty('direction')
   })
 })

--- a/test/source-store.test.ts
+++ b/test/source-store.test.ts
@@ -241,4 +241,112 @@ describe('filesystem source store', () => {
       expect(readdirSync(root)).toEqual(['a.yaml'])
     })
   })
+
+  // A write with no bytes removes the document (ADR 0103), under the same
+  // compare-and-swap and in the same all-or-none batch as every other write.
+  describe('removal', () => {
+    it('removes a document that still holds what was read', () => {
+      write('a.yaml', 'one\n')
+      const store = createFileSystemStore(root)
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: null, expected: store.read('a.yaml')!.revision },
+      ])
+
+      expect(outcome.ok).toBe(true)
+      expect(store.read('a.yaml')).toBeUndefined()
+      expect(readdirSync(root)).toEqual([])
+    })
+
+    it('reports no revision for what it removed', () => {
+      write('a.yaml', 'one\n')
+      write('b.yaml', 'two\n')
+      const store = createFileSystemStore(root)
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: null, expected: store.read('a.yaml')!.revision },
+        { path: 'b.yaml', source: 'three\n', expected: store.read('b.yaml')!.revision },
+      ])
+
+      expect(outcome.ok).toBe(true)
+      if (!outcome.ok) return
+      expect([...outcome.revisions.keys()]).toEqual(['b.yaml'])
+    })
+
+    it('refuses to remove a document that changed after the edit was staged', () => {
+      write('a.yaml', 'one\n')
+      const store = createFileSystemStore(root)
+      const stale = store.read('a.yaml')!.revision
+      write('a.yaml', 'somebody else\n')
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: null, expected: stale },
+      ])
+
+      expect(outcome).toEqual({
+        ok: false,
+        conflicts: [{ path: 'a.yaml', reason: 'changed' }],
+      })
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('somebody else\n')
+    })
+
+    it('refuses to remove a document that is already gone', () => {
+      const store = createFileSystemStore(root)
+
+      expect(
+        store.writeAll([
+          { path: 'a.yaml', source: null, expected: 'a'.repeat(64) },
+        ]),
+      ).toEqual({ ok: false, conflicts: [{ path: 'a.yaml', reason: 'missing' }] })
+    })
+
+    it('refuses a removal that names no revision', () => {
+      // `expected: null` asks to remove a document on condition it is not
+      // there, which is not a thing to want - and a caller told its accidental
+      // delete worked is worse served than one told it made no sense.
+      write('a.yaml', 'one\n')
+      const store = createFileSystemStore(root)
+
+      expect(
+        store.writeAll([{ path: 'a.yaml', source: null, expected: null }]),
+      ).toEqual({ ok: false, conflicts: [{ path: 'a.yaml', reason: 'exists' }] })
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('one\n')
+    })
+
+    it('writes nothing at all when one removal in the batch is stale', () => {
+      // The property the visual runtime leans on: a view removed beside a
+      // subject edit takes both or neither.
+      write('a.yaml', 'one\n')
+      write('b.yaml', 'two\n')
+      const store = createFileSystemStore(root)
+      const staleForB = store.read('b.yaml')!.revision
+      write('b.yaml', 'somebody else\n')
+
+      const outcome = store.writeAll([
+        { path: 'a.yaml', source: 'edited\n', expected: store.read('a.yaml')!.revision },
+        { path: 'b.yaml', source: null, expected: staleForB },
+      ])
+
+      expect(outcome.ok).toBe(false)
+      expect(readFileSync(join(root, 'a.yaml'), 'utf8')).toBe('one\n')
+      expect(readFileSync(join(root, 'b.yaml'), 'utf8')).toBe('somebody else\n')
+    })
+
+    it('leaves the emptied directory behind', () => {
+      // A workspace cannot tell a directory it emptied from one it never had.
+      write('projections/one.yaml', 'a\n')
+      const store = createFileSystemStore(root)
+
+      store.writeAll([
+        {
+          path: 'projections/one.yaml',
+          source: null,
+          expected: store.read('projections/one.yaml')!.revision,
+        },
+      ])
+
+      expect(readdirSync(root)).toEqual(['projections'])
+      expect(readdirSync(join(root, 'projections'))).toEqual([])
+    })
+  })
 })

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -35,9 +35,7 @@ const session = vi.hoisted(() => {
     lastSequence: 1,
     frozen: false,
     closedReason: null,
-    pendingViewSave: null,
-    viewSaveNotice: false,
-    pendingChangeset: { operations: [], sourceDigests: {} },
+    pendingChangeset: { operations: [], viewOperations: [], sourceDigests: {} },
     undoStack: [],
     redoStack: [],
     commitStatus: 'idle',
@@ -134,6 +132,7 @@ const renderedModel: VisualRenderedModel = {
   vocabulary: { conceptKinds: [], relationshipKinds: [] },
   layouts: {},
   sourceDigests: {},
+  projectionDigests: {},
 }
 
 

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -11,7 +11,9 @@ import type {
 import {
   RECONNECT_WINDOW_MS,
   VISUAL_END_NOTICE,
+  EMPTY_CHANGESET,
   canReconnect,
+  changesetIsEmpty,
   filterToReresolve,
   initialVisualAppState,
   visualAppActionsForFrame,
@@ -22,15 +24,18 @@ import {
   type VisualAppState,
 } from "../src/visual-app/state.js";
 import type { ProjectionQuery } from "../src/projection.js";
+import type { VisualViewOperation } from "../src/adapters/visual/protocol-contract.js";
 
 /** A rendered model with an empty canvas graph — only initialView matters here. */
 const model = (
   initialView: string,
   sourceDigests: Readonly<Record<string, string>> = {},
+  projectionDigests: Readonly<Record<string, string>> = {},
 ): VisualRenderedModel => ({
   authority: "canonical",
   initialView,
   graph: { nodes: [], edges: [] },
+  projectionDigests,
   documents: [],
   vocabulary: {
     conceptKinds: [],
@@ -44,7 +49,7 @@ const model = (
 const digest = (seed: string): string => seed.repeat(64).slice(0, 64);
 
 const serverSnapshot: VisualSessionSnapshot = {
-  protocolVersion: "yarramate/visual-protocol/v4",
+  protocolVersion: "yarramate/visual-protocol/v5",
   sessionId: "0".repeat(32),
   authority: "canonical",
   title: "Choose a delivery design",
@@ -1046,30 +1051,6 @@ describe("visualAppReducer acknowledgement and refusal", () => {
     expect(next.composerEnabled).toBe(false);
   });
 
-  it("retires a save that was refused, so the control is usable again", () => {
-    const sent = visualAppReducer(activeState, {
-      type: "view.save.sent",
-      payload: {
-        title: "Refused view",
-        description: "",
-        query: {},
-        presentation: {
-          layout: "layered",
-          direction: "top-down",
-        },
-      },
-    });
-    expect(sent.pendingViewSave).not.toBeNull();
-    // No `view-save-result` ever follows a refusal, so nothing else would
-    // clear it and every later Save would stay disabled.
-    const refused = visualAppReducer(sent, {
-      type: "input.refused",
-      diagnostics: [compileDiagnostic],
-      frozen: false,
-    });
-    expect(refused.pendingViewSave).toBeNull();
-  });
-
   it("retires a commit the server refused, on the rows it refused", () => {
     const staged = visualAppReducer(activeState, {
       type: "changeset.staged",
@@ -1095,27 +1076,27 @@ describe("visualAppReducer acknowledgement and refusal", () => {
   });
 
   it("leaves controls the refusal did not name alone", () => {
-    const sent = visualAppReducer(activeState, {
-      type: "view.save.sent",
-      payload: {
-        title: "Still saving",
-        description: "",
-        query: {},
-        presentation: {
-          layout: "layered",
-          direction: "top-down",
-        },
-      },
+    const staged = visualAppReducer(activeState, {
+      type: "changeset.staged",
+      operation: {
+        op: "update-concept",
+        document: "model.yaml",
+        concept: { id: "Q1", name: "Renamed" },
+      } as const,
     });
+    const sent = visualAppReducer(staged, { type: "changeset.commit.sent" });
     const refused = visualAppReducer(sent, {
       type: "input.refused",
-      refused: "changeset.commit",
+      refused: "chat.message",
       diagnostics: [compileDiagnostic],
       frozen: false,
     });
-    // A refused commit says nothing about a save the server never answered.
-    expect(refused.pendingViewSave).not.toBeNull();
-    expect(refused.commitStatus).toBe("idle");
+
+    // A refused chat message says nothing about a commit the server has not
+    // answered yet: retiring it here would put the button back while the
+    // batch is still in flight.
+    expect(refused.commitStatus).toBe("committing");
+    expect(refused.commitDiagnostics).toBeNull();
   });
 });
 
@@ -1463,174 +1444,169 @@ describe("canReconnect", () => {
   });
 });
 
-describe("visualAppReducer view save", () => {
-  it("stores pending save on view.save.sent", () => {
-    const payload = {
-      title: "My view",
-      description: "A test view",
-      query: { subjects: ["Q1"] },
-      presentation: {
-        layout: "layered",
-        direction: "top-down",
-      } as const,
-    };
-    const sent = visualAppReducer(initialVisualAppState, {
-      type: "view.save.sent",
-      payload,
-    });
-    expect(sent.pendingViewSave).toEqual(payload);
-    expect(sent.viewSaveNotice).toBe(false);
+/**
+ * Saving a view is staged, not sent (ADR 0103). These replace the tests of the
+ * `view.save` round trip: there is no pending save to hold, no result to match
+ * back, and no notice to dismiss, because nothing has left the browser.
+ */
+describe("visualAppReducer view staging", () => {
+  const write = (path: string, id = "current-engine"): VisualViewOperation => ({
+    op: "write-view",
+    path,
+    projection: {
+      format: "yarramate/projection/v1",
+      id,
+      version: "1.0",
+      query: {},
+      presentation: { title: "Current engine", description: "A view" },
+    },
   });
 
-  it("saves view and shows notice on view.saved ok:true", () => {
-    const payload = {
-      title: "My view",
-      description: "A test view",
-      query: { subjects: ["Q1"] },
-      presentation: {
-        layout: "layered",
-        direction: "top-down",
-      } as const,
-    };
-    const sent = visualAppReducer(initialVisualAppState, {
-      type: "view.save.sent",
-      payload,
+  const staged = (
+    operation: VisualViewOperation,
+    from = initialVisualAppState,
+  ) => visualAppReducer(from, { type: "changeset.viewStaged", operation });
+
+  it("stages a view into the same changeset the model's rows go into", () => {
+    const state = staged(write(".yarramate/projections/current-engine.yaml"));
+
+    expect(state.pendingChangeset.viewOperations).toEqual([
+      write(".yarramate/projections/current-engine.yaml"),
+    ]);
+    expect(state.pendingChangeset.operations).toEqual([]);
+  });
+
+  it("pins a view against the projection digests, not the source digests", () => {
+    // `sourceDigests` means what the graph was compiled from, and a projection
+    // is not part of that - pinning from the wrong map would silently vouch
+    // for nothing at all.
+    const path = ".yarramate/projections/current-engine.yaml";
+    const loaded = visualAppReducer(initialVisualAppState, {
+      type: "model.received",
+      model: model("", { "main.yaml": "a".repeat(64) }, { [path]: "b".repeat(64) }),
+      views: [],
     });
-    const saved = visualAppReducer(sent, {
-      type: "view.saved",
-      result: {
-        ok: true,
-        id: "view-1",
-        path: "/views/view-1",
-        subjectCount: 3,
+
+    expect(staged(write(path), loaded).pendingChangeset.sourceDigests).toEqual({
+      [path]: "b".repeat(64),
+    });
+  });
+
+  it("leaves a view the model has never seen unpinned, because the commit creates it", () => {
+    const state = staged(write(".yarramate/projections/brand-new.yaml"));
+
+    expect(state.pendingChangeset.sourceDigests).toEqual({});
+  });
+
+  it("replaces a row targeting the same document rather than queueing a second", () => {
+    const path = ".yarramate/projections/current-engine.yaml";
+    const once = staged(write(path));
+    const twice = staged({ op: "delete-view", path }, once);
+
+    expect(twice.pendingChangeset.viewOperations).toEqual([
+      { op: "delete-view", path },
+    ]);
+  });
+
+  it("discards a view row by its index in the tray, past the model's rows", () => {
+    const path = ".yarramate/projections/current-engine.yaml";
+    const withModelRow = visualAppReducer(initialVisualAppState, {
+      type: "changeset.staged",
+      operation: {
+        op: "update-concept",
+        document: "main.yaml",
+        concept: { id: "api", name: "API" },
       },
     });
-    expect(saved.views).toHaveLength(1);
-    expect(saved.views[0]).toEqual({
-      id: "view-1",
-      title: "My view",
-      description: "A test view",
-      query: { subjects: ["Q1"] },
-      presentation: { layout: "layered", direction: "top-down" },
-      // Taken from the result, not from the payload: only the runtime can
-      // resolve what a query matches, so the row joins the tree with the
-      // count the server just measured rather than a placeholder.
-      path: "/views/view-1",
-      subjectCount: 3,
+    const both = staged(write(path), withModelRow);
+    expect(both.pendingChangeset.operations).toHaveLength(1);
+    expect(both.pendingChangeset.viewOperations).toHaveLength(1);
+
+    // Index 1 is the view row: model rows come first in the tray.
+    const discarded = visualAppReducer(both, {
+      type: "changeset.discarded",
+      index: 1,
     });
-    expect(saved.viewSaveNotice).toBe(true);
-    expect(saved.pendingViewSave).toBe(null);
+    expect(discarded.pendingChangeset.operations).toHaveLength(1);
+    expect(discarded.pendingChangeset.viewOperations).toEqual([]);
+
+    // Index 0 is the model row, and discarding it leaves the view alone.
+    const other = visualAppReducer(both, {
+      type: "changeset.discarded",
+      index: 0,
+    });
+    expect(other.pendingChangeset.operations).toEqual([]);
+    expect(other.pendingChangeset.viewOperations).toHaveLength(1);
   });
 
-  it("replaces existing view on overwrite", () => {
-    const view1 = {
-      id: "view-1",
-      title: "Old title",
-      description: "Old desc",
-      query: {} as ProjectionQuery,
-      presentation: {
-        layout: "layered",
-        direction: "top-down",
-      } as const,
-      path: "/views/view-1",
-      subjectCount: 3,
-    };
-    const state = { ...initialVisualAppState, views: [view1] };
-    const payload = {
-      id: "view-1",
-      title: "New title",
-      description: "New desc",
-      query: {},
-      presentation: {
-        layout: "layered",
-        direction: "left-right",
-      } as const,
-    };
-    const sent = visualAppReducer(state, {
-      type: "view.save.sent",
-      payload,
-    });
-    const saved = visualAppReducer(sent, {
-      type: "view.saved",
-      result: {
-        ok: true,
-        id: "view-1",
-        path: "/views/view-1",
-        subjectCount: 3,
+  it("undoes across a mixed changeset", () => {
+    const path = ".yarramate/projections/current-engine.yaml";
+    const withModelRow = visualAppReducer(initialVisualAppState, {
+      type: "changeset.staged",
+      operation: {
+        op: "update-concept",
+        document: "main.yaml",
+        concept: { id: "api", name: "API" },
       },
     });
-    expect(saved.views).toHaveLength(1);
-    expect(saved.views[0]?.title).toBe("New title");
+    const both = staged(write(path), withModelRow);
+    const undone = visualAppReducer(both, { type: "changeset.undone" });
+
+    expect(undone.pendingChangeset.viewOperations).toEqual([]);
+    expect(undone.pendingChangeset.operations).toHaveLength(1);
+    expect(
+      visualAppReducer(undone, { type: "changeset.redone" }).pendingChangeset
+        .viewOperations,
+    ).toHaveLength(1);
   });
 
-  it("sets diagnostics and clears pending on view.saved ok:false", () => {
-    const payload = {
-      title: "Bad view",
-      description: "Will fail",
-      query: {},
-      presentation: {
-        layout: "layered",
-        direction: "top-down",
-      } as const,
-    };
-    const sent = visualAppReducer(initialVisualAppState, {
-      type: "view.save.sent",
-      payload,
-    });
-    const diag = {
-      severity: "error" as const,
-      code: "E001",
-      message: "Invalid",
-      path: "test.yaml",
-      line: 1,
-      column: 1,
-      pointer: "/x",
-    };
-    const saved = visualAppReducer(sent, {
-      type: "view.saved",
-      result: { ok: false, diagnostics: [diag] },
-    });
-    expect(saved.diagnostics).toEqual([diag]);
-    expect(saved.pendingViewSave).toBe(null);
+  it("treats a changeset holding only a view as something to clear", () => {
+    // A clear that stacked no undo step here would make a staged view the one
+    // thing the reviewer could not get back.
+    const both = staged(write(".yarramate/projections/current-engine.yaml"));
+    const cleared = visualAppReducer(both, { type: "changeset.cleared" });
+
+    expect(cleared.pendingChangeset.viewOperations).toEqual([]);
+    expect(cleared.undoStack).toHaveLength(2);
+    expect(
+      visualAppReducer(cleared, { type: "changeset.undone" }).pendingChangeset
+        .viewOperations,
+    ).toHaveLength(1);
   });
 
-  it("clears notice on view.saveNotice.dismissed", () => {
-    const state = { ...initialVisualAppState, viewSaveNotice: true };
-    const dismissed = visualAppReducer(state, {
-      type: "view.saveNotice.dismissed",
-    });
-    expect(dismissed.viewSaveNotice).toBe(false);
+  it("sends both lists in one commit", () => {
+    const path = ".yarramate/projections/current-engine.yaml";
+    const both = staged(write(path));
+    const input = visualBrowserInputFor({ kind: "commit-changeset" }, both);
+
+    expect(input.type).toBe("changeset.commit");
+    expect(input.payload).toEqual(both.pendingChangeset);
   });
 
-  it("clears pending/notice on session.loaded reconnect", () => {
-    const payload = {
-      title: "Stale",
-      description: "Should go away",
-      query: {},
-      presentation: {
-        layout: "layered",
-        direction: "top-down",
-      } as const,
-    };
-    const state = {
-      ...initialVisualAppState,
-      pendingViewSave: payload,
-      viewSaveNotice: true,
-    };
-    const reloaded = visualAppReducer(state, {
-      type: "session.loaded",
-      snapshot: visualAppSnapshotFrom({
-        ...serverSnapshot,
-        authority: "canonical",
-        title: "Test",
-        description: "Test session",
-        views: [],
-        lastSequence: 0,
-        agentTurnOpen: false,
-      }),
-    });
-    expect(reloaded.pendingViewSave).toBe(null);
-    expect(reloaded.viewSaveNotice).toBe(false);
+  it("counts a changeset holding only a view as something to commit", () => {
+    // Found in a browser, not here: the commit button's own guard asked only
+    // whether `operations` was empty, so pressing Commit on a staged view did
+    // nothing at all and said nothing about why. Every control that asks "is
+    // there anything to commit" has to ask it of both lists.
+    expect(changesetIsEmpty(EMPTY_CHANGESET)).toBe(true);
+    expect(
+      changesetIsEmpty(
+        staged(write(".yarramate/projections/current-engine.yaml"))
+          .pendingChangeset,
+      ),
+    ).toBe(false);
+    expect(
+      changesetIsEmpty(
+        visualAppReducer(initialVisualAppState, {
+          type: "changeset.staged",
+          operation: {
+            op: "update-concept",
+            document: "main.yaml",
+            concept: { id: "api", name: "API" },
+          },
+        }).pendingChangeset,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -137,10 +137,15 @@ describe("the view/model split every menu has to teach", () => {
   });
 
   it("gives a view row nothing that edits the model", () => {
+    // Including its delete: removing a view rewrites one projection and leaves
+    // every subject alone, which is exactly the distinction the rule teaches.
     const groups = contextMenuFor({ kind: "view-row", id: "current" }, context());
     expect(groups.every((group) => group.scope === "view")).toBe(true);
-    expect(groups.some((group) => group.destructive)).toBe(false);
-    expect(labels(groups)).toEqual(["Open view", "New view…"]);
+    expect(labels(groups)).toEqual([
+      "Open view",
+      "New view…",
+      "Delete view…",
+    ]);
   });
 });
 
@@ -369,12 +374,27 @@ describe("what the menu draws", () => {
   });
 
   it("draws no destructive group where there is nothing to destroy", () => {
-    expect(render({ kind: "view-row", id: "current" })).not.toContain(
-      "context-menu-destructive",
-    );
+    // The empty canvas destroys nothing; "All subjects" is the absence of a
+    // view rather than a document, so it has no delete either.
     expect(render({ kind: "canvas" })).not.toContain(
       "context-menu-destructive",
     );
+    expect(render({ kind: "view-row", id: "" })).not.toContain(
+      "context-menu-destructive",
+    );
+  });
+
+  it("puts a view's own delete behind the same rule, in the same red", () => {
+    const markup = render({ kind: "view-row", id: "current" });
+    const behindTheRule = markup.slice(
+      markup.indexOf("context-menu-destructive"),
+    );
+
+    expect(behindTheRule).toContain("Delete view…");
+    expect(behindTheRule).not.toContain("Open view");
+    // Still a view-scope group: what it destroys is a projection, not a
+    // subject, and the reviewer learns one rule about where danger sits.
+    expect(markup).toContain("context-menu-view context-menu-destructive");
   });
 
   it("draws nothing at all for a target that has gone", () => {

--- a/test/visual-journey.test.ts
+++ b/test/visual-journey.test.ts
@@ -1122,6 +1122,7 @@ relationships: []
       operations: [
         { op: 'update-concept', document, concept: { id: 'checkout', name } },
       ],
+      viewOperations: [],
       sourceDigests,
     },
   })

--- a/test/visual-protocol.test.ts
+++ b/test/visual-protocol.test.ts
@@ -127,12 +127,6 @@ const eventPayloads: Readonly<Record<string, unknown>> = {
   'choice.selected': { choiceId: 'delivery', optionId: 'option-b' },
   'view.navigate': { viewId: 'option-b', requiresAttention: false },
   'filter.query': { query: { kinds: ['yarramate/core@0.1#applicationComponent'] } },
-  'view.save': {
-    title: 'My View',
-    description: 'desc',
-    query: { kinds: ['yarramate/core@0.1#applicationComponent'] },
-    presentation: { layout: 'layered' },
-  },
   'session.end': { reason: 'user-ended' },
   'browser.connected': { connectionId: 'c1' },
   'browser.disconnected': { connectionId: 'c1', code: 1001 },
@@ -216,8 +210,6 @@ describe('visual protocol', () => {
       }),
     ).toMatchObject({ ok: true })
   })
-
-
 
   it('rejects messages over the exact limit', () => {
     expect(VISUAL_LIMITS.messageBytes).toBe(64 * 1024)
@@ -337,7 +329,7 @@ describe('visual protocol', () => {
     ).toMatchObject({ ok: true })
   })
 
-  it.each(['filter.query', 'view.save'] as const)(
+  it.each(['filter.query'] as const)(
     'accepts the %s browser input',
     (type) => {
       expect(
@@ -487,7 +479,11 @@ describe('visual protocol', () => {
       parseVisualBrowserInput({
         type: 'changeset.commit',
         lastAcknowledgedSequence: 0,
-        payload: { operations: [operation], sourceDigests: {} },
+        payload: {
+          operations: [operation],
+          viewOperations: [],
+          sourceDigests: {},
+        },
       })
 
     it('reports a blank field once, on the field', () => {
@@ -556,6 +552,7 @@ describe('visual protocol', () => {
               concept: { id: 'check', name: 'Check' },
             },
           ],
+          viewOperations: [],
         },
       })
       expect(result.ok).toBe(false)
@@ -581,6 +578,7 @@ describe('visual protocol', () => {
               concept: { id: 'check', name: 'Check' },
             },
           ],
+          viewOperations: [],
           sourceDigests: { 'architecture/engine.yaml': digest },
         },
       })

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { once } from "node:events";
 import { watch as watchEagerly } from "node:fs";
 import {
@@ -1736,7 +1736,7 @@ describe("startVisualServer lifecycle", () => {
     );
     expect(descriptor).toMatchObject({
       format: "yarramate/visual-session-descriptor/v2",
-      protocolVersion: "yarramate/visual-protocol/v4",
+      protocolVersion: "yarramate/visual-protocol/v5",
       sessionId: server.started.sessionId,
       origin: server.started.origin,
       sessionRoot: server.started.sessionRoot,
@@ -2709,7 +2709,14 @@ evidence: []
   });
 });
 
-describe("startVisualServer view.save", () => {
+/**
+ * Saving a view is a row in a changeset, not a write of its own (ADR 0103).
+ * These replace the `view.save` round-trip tests: the event is gone, and what
+ * matters now is that a view and the model land in ONE batch, that a view
+ * answers to the same staleness pin every other document does, and that a
+ * removal is refused rather than half-applied.
+ */
+describe("startVisualServer staged view operations", () => {
   const document = `format: yarramate/v1
 id: main
 profile: yarramate/core@0.1
@@ -2724,16 +2731,33 @@ id: save-fixture
 documents:
   - architecture/main.yaml
 profiles: []
-projections: []
+projections:
+  - projections/*.yaml
 adapterMappings: []
 evidence: []
+`;
+  const seeded = `format: yarramate/projection/v1
+id: seeded
+version: '1.0'
+query:
+  kinds:
+    - yarramate/core@0.1#businessActor
+presentation:
+  title: Seeded
+  description: A view that already exists
 `;
 
   const withWorkspace = async () => {
     await mkdir(join(baseDir, ".yarramate/architecture"), { recursive: true });
+    await mkdir(join(baseDir, ".yarramate/projections"), { recursive: true });
     await writeFile(
       join(baseDir, ".yarramate/architecture/main.yaml"),
       document,
+      "utf8",
+    );
+    await writeFile(
+      join(baseDir, ".yarramate/projections/seeded.yaml"),
+      seeded,
       "utf8",
     );
     await writeFile(
@@ -2743,180 +2767,237 @@ evidence: []
     );
   };
 
-  const sendViewSave = (
+  const projection = (id: string, title: string) => ({
+    format: "yarramate/projection/v1" as const,
+    id,
+    version: "1.0",
+    query: { kinds: ["yarramate/core@0.1#businessActor"] },
+    presentation: { title, description: "staged" },
+  });
+
+  /** A commit carrying whatever mix of the two lists a test needs. */
+  const sendCommit = (
     socket: WebSocket,
     payload: {
-      readonly id?: string;
-      readonly title: string;
-      readonly description: string;
-      readonly query: Record<string, unknown>;
-      readonly presentation?: Record<string, unknown>;
+      readonly operations?: readonly unknown[];
+      readonly viewOperations?: readonly unknown[];
+      readonly sourceDigests?: Readonly<Record<string, string>>;
     },
   ) => {
-    const result = nextFrame(socket, "view-save-result");
+    const result = nextFrame(socket, "apply-result");
     socket.send(
       JSON.stringify({
-        type: "view.save",
+        type: "changeset.commit",
         lastAcknowledgedSequence: 0,
-        payload,
+        payload: {
+          operations: payload.operations ?? [],
+          viewOperations: payload.viewOperations ?? [],
+          sourceDigests: payload.sourceDigests ?? {},
+        },
       }),
     );
     return result;
   };
 
-  it("saves a new view with no id in the payload", async () => {
+  const digestOfFile = async (path: string): Promise<string> =>
+    createHash("sha256")
+      .update(await readFile(join(baseDir, path), "utf8"), "utf8")
+      .digest("hex");
+
+  const sessionViews = async (
+    server: Awaited<ReturnType<typeof start>>,
+    cookie: string,
+  ) => {
+    const body = (await (
+      await fetch(`${server.started.origin}/api/session`, {
+        headers: { Cookie: cookie },
+      })
+    ).json()) as { readonly views: readonly VisualViewSummary[] };
+    return body.views;
+  };
+
+  it("writes a projection a commit staged", async () => {
+    await withWorkspace();
     const server = await start();
     const { cookie } = await bootstrap(server);
     const socket = await openBrowserSocket(server, cookie);
 
-    const frame = await sendViewSave(socket, {
-      title: "My View",
-      description: "desc",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
-    });
-
-    expect(frame.result).toEqual({
-      ok: true,
-      id: "my-view",
-      path: ".yarramate/projections/my-view.yaml",
-      // This fixture's manifest declares no documents, so the query it just
-      // saved matches nothing — the count is measured, not assumed.
-      subjectCount: 0,
-    });
-
-    const fileContent = await readFile(
-      join(baseDir, ".yarramate/projections/my-view.yaml"),
-      "utf8",
-    );
-    const parsed = parse(fileContent);
-    expect(parsed).toMatchObject({
-      id: "my-view",
-      version: "1.0",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: {
-        title: "My View",
-        description: "desc",
-        layout: "layered",
-      },
-    });
-    socket.close();
-  });
-
-  it("hands a saved view to a browser that reloads, replacing it on overwrite", async () => {
-    const server = await start();
-    const { cookie } = await bootstrap(server);
-    const socket = await openBrowserSocket(server, cookie);
-    // The reload path: a returning browser reads its whole starting state
-    // from this snapshot, so a view saved mid-session has to be in it.
-    const reloadedViews = async () => {
-      const body = (await (
-        await fetch(`${server.started.origin}/api/session`, {
-          headers: { Cookie: cookie },
-        })
-      ).json()) as { readonly views: readonly VisualViewSummary[] };
-      return body.views;
-    };
-
-    await sendViewSave(socket, {
-      id: "reload-view",
-      title: "Reload View",
-      description: "first",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
-    });
-
-    expect(await reloadedViews()).toEqual([
-      {
-        id: "reload-view",
-        title: "Reload View",
-        description: "first",
-        query: { kinds: ["yarramate/core@0.1#businessActor"] },
-        presentation: {
-          layout: "layered",
-          title: "Reload View",
-          description: "first",
+    const frame = await sendCommit(socket, {
+      viewOperations: [
+        {
+          op: "write-view",
+          path: ".yarramate/projections/my-view.yaml",
+          projection: projection("my-view", "My View"),
         },
-        path: ".yarramate/projections/reload-view.yaml",
-        subjectCount: 0,
-      },
-    ]);
-
-    // An overwrite must replace the summary the next reload reads, never
-    // stack a second entry under the same id.
-    await sendViewSave(socket, {
-      id: "reload-view",
-      title: "Reload View",
-      description: "second",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
+      ],
     });
 
-    const after = await reloadedViews();
-    expect(after).toHaveLength(1);
-    expect(after[0]).toMatchObject({
-      id: "reload-view",
-      description: "second",
-      presentation: { layout: "layered" },
+    expect(frame.result).toMatchObject({ ok: true });
+    expect(
+      parse(
+        await readFile(
+          join(baseDir, ".yarramate/projections/my-view.yaml"),
+          "utf8",
+        ),
+      ),
+    ).toMatchObject({
+      id: "my-view",
+      presentation: { title: "My View", description: "staged" },
     });
     socket.close();
   });
 
-  it("overwrites an existing view when the payload carries its id", async () => {
+  it("joins the view list a reloading browser is handed", async () => {
+    // `resolvedWorkspace` is resolved once at startup and never again, so a
+    // projection created mid-session reaches this list only because the commit
+    // handler puts it there. The rail and `layout.save` both read it.
+    await withWorkspace();
     const server = await start();
     const { cookie } = await bootstrap(server);
     const socket = await openBrowserSocket(server, cookie);
 
-    const created = await sendViewSave(socket, {
-      id: "shared-view",
-      title: "Original Title",
-      description: "original desc",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
-    });
-    expect(created.result).toEqual({
-      ok: true,
-      id: "shared-view",
-      path: ".yarramate/projections/shared-view.yaml",
-      subjectCount: 0,
+    await sendCommit(socket, {
+      viewOperations: [
+        {
+          op: "write-view",
+          path: ".yarramate/projections/joined.yaml",
+          projection: projection("joined", "Joined"),
+        },
+      ],
     });
 
-    const overwritten = await sendViewSave(socket, {
-      id: "shared-view",
-      title: "Updated Title",
-      description: "updated desc",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
-    });
-    expect(overwritten.result).toEqual({
-      ok: true,
-      id: "shared-view",
-      path: ".yarramate/projections/shared-view.yaml",
-      subjectCount: 0,
-    });
-
-    const fileContent = await readFile(
-      join(baseDir, ".yarramate/projections/shared-view.yaml"),
-      "utf8",
-    );
-    expect(parse(fileContent)).toMatchObject({
-      id: "shared-view",
-      presentation: {
-        title: "Updated Title",
-        description: "updated desc",
-        layout: "layered",
-      },
-    });
+    expect((await sessionViews(server, cookie)).map((view) => view.id)).toEqual([
+      "seeded",
+      "joined",
+    ]);
     socket.close();
   });
 
-  it("rejects a view whose query violates the protocol schema", async () => {
-    // query/presentation reuse the exact same $defs as ProjectionDefinition's
-    // (see schema/yarramate-visual-event.schema.json), so any query that
-    // would fail loadProjection's schema check fails the browser-input
-    // schema first. The browser sees a protocol-level 'rejected' frame, not
-    // a 'view-save-result' - loadProjection's own !ok branch in
-    // session-server.ts is unreachable defense-in-depth from a live socket.
+  it("removes a projection a commit staged, and drops it from the view list", async () => {
+    await withWorkspace();
+    const server = await start();
+    const { cookie } = await bootstrap(server);
+    const socket = await openBrowserSocket(server, cookie);
+
+    const frame = await sendCommit(socket, {
+      viewOperations: [
+        { op: "delete-view", path: ".yarramate/projections/seeded.yaml" },
+      ],
+      sourceDigests: {
+        ".yarramate/projections/seeded.yaml": await digestOfFile(
+          ".yarramate/projections/seeded.yaml",
+        ),
+      },
+    });
+
+    expect(frame.result).toMatchObject({ ok: true });
+    await expect(
+      readFile(join(baseDir, ".yarramate/projections/seeded.yaml"), "utf8"),
+    ).rejects.toThrow();
+    expect(await sessionViews(server, cookie)).toEqual([]);
+    socket.close();
+  });
+
+  it("lands a view and a subject as one batch, or neither", async () => {
+    // The property the whole adapter-level shape exists for: one `writeAll`,
+    // so a view and the subjects it shows cannot half arrive.
+    await withWorkspace();
+    const server = await start();
+    const { cookie } = await bootstrap(server);
+    const socket = await openBrowserSocket(server, cookie);
+
+    const frame = await sendCommit(socket, {
+      operations: [
+        {
+          op: "update-concept",
+          document: ".yarramate/architecture/main.yaml",
+          concept: { id: "user", name: "Renamed User" },
+        },
+      ],
+      viewOperations: [
+        {
+          op: "write-view",
+          path: ".yarramate/projections/together.yaml",
+          projection: projection("together", "Together"),
+        },
+      ],
+      sourceDigests: {
+        ".yarramate/architecture/main.yaml": await digestOfFile(
+          ".yarramate/architecture/main.yaml",
+        ),
+      },
+    });
+
+    expect(frame.result).toMatchObject({ ok: true });
+    expect(
+      await readFile(join(baseDir, ".yarramate/architecture/main.yaml"), "utf8"),
+    ).toContain("Renamed User");
+    expect(
+      await readFile(
+        join(baseDir, ".yarramate/projections/together.yaml"),
+        "utf8",
+      ),
+    ).toContain("together");
+    socket.close();
+  });
+
+  it("refuses the whole batch when a staged view changed on disk, writing nothing", async () => {
+    await withWorkspace();
+    const server = await start();
+    const { cookie } = await bootstrap(server);
+    const socket = await openBrowserSocket(server, cookie);
+
+    const stale = await digestOfFile(".yarramate/projections/seeded.yaml");
+    // Somebody else edits it after the row was staged.
+    await writeFile(
+      join(baseDir, ".yarramate/projections/seeded.yaml"),
+      seeded.replace("A view that already exists", "Edited elsewhere"),
+      "utf8",
+    );
+
+    const frame = await sendCommit(socket, {
+      operations: [
+        {
+          op: "update-concept",
+          document: ".yarramate/architecture/main.yaml",
+          concept: { id: "user", name: "Should Not Land" },
+        },
+      ],
+      viewOperations: [
+        {
+          op: "write-view",
+          path: ".yarramate/projections/seeded.yaml",
+          projection: projection("seeded", "Overwritten"),
+        },
+      ],
+      sourceDigests: {
+        ".yarramate/architecture/main.yaml": await digestOfFile(
+          ".yarramate/architecture/main.yaml",
+        ),
+        ".yarramate/projections/seeded.yaml": stale,
+      },
+    });
+
+    expect(frame.result).toMatchObject({ ok: false });
+    // Neither half landed: the model document is untouched and the projection
+    // still holds what the other writer put there.
+    expect(
+      await readFile(join(baseDir, ".yarramate/architecture/main.yaml"), "utf8"),
+    ).not.toContain("Should Not Land");
+    expect(
+      await readFile(
+        join(baseDir, ".yarramate/projections/seeded.yaml"),
+        "utf8",
+      ),
+    ).toContain("Edited elsewhere");
+    socket.close();
+  });
+
+  it("refuses a malformed projection at the gate, before the handler sees it", async () => {
+    // `viewOperation` in the event schema refs the projection schema, so a
+    // document the schema would refuse never reaches the commit path at all -
+    // the refusal is a `rejected` frame rather than an `apply-result`.
+    await withWorkspace();
     const server = await start();
     const { cookie } = await bootstrap(server);
     const socket = await openBrowserSocket(server, cookie);
@@ -2924,55 +3005,79 @@ evidence: []
     const rejected = nextFrame(socket, "rejected");
     socket.send(
       JSON.stringify({
-        type: "view.save",
+        type: "changeset.commit",
         lastAcknowledgedSequence: 0,
         payload: {
-          title: "Bad Query",
-          description: "empty subjects",
-          query: { subjects: [] },
-          presentation: {},
+          operations: [],
+          viewOperations: [
+            {
+              op: "write-view",
+              path: ".yarramate/projections/bad.yaml",
+              projection: {
+                ...projection("bad", "Bad"),
+                query: { kinds: "not-a-list" },
+              },
+            },
+          ],
+          sourceDigests: {},
         },
       }),
     );
-    expect((await rejected).diagnostics.length).toBeGreaterThan(0);
 
+    expect((await rejected).refused).toBe("changeset.commit");
     await expect(
-      readFile(join(baseDir, ".yarramate/projections/bad-query.yaml"), "utf8"),
+      readFile(join(baseDir, ".yarramate/projections/bad.yaml"), "utf8"),
     ).rejects.toThrow();
     socket.close();
   });
 
-  it("journals the save for audit without waking the agent poll loop", async () => {
-    const server = await start({ agentPollMs: 60 });
-    const capability = await capabilityOf(server);
+  it("refuses a view saved where the manifest covers no projection", async () => {
+    // This repo's own manifest uses `projections/*.yaml`, which reaches no
+    // subdirectory - a view written there is a file the workspace never loads,
+    // and nothing later would say so (ADR 0043).
+    await withWorkspace();
+    const server = await start();
     const { cookie } = await bootstrap(server);
     const socket = await openBrowserSocket(server, cookie);
 
-    await sendViewSave(socket, {
-      title: "Audit Test",
-      description: "test",
-      query: { kinds: ["yarramate/core@0.1#businessActor"] },
-      presentation: { layout: "layered" },
+    const frame = await sendCommit(socket, {
+      viewOperations: [
+        {
+          op: "write-view",
+          path: ".yarramate/projections/current/nested.yaml",
+          projection: projection("nested", "Nested"),
+        },
+      ],
     });
 
-    const journal = await journalOf(server);
-    expect(journal.at(-1)).toMatchObject({
-      type: "view.save",
-      payload: {
-        title: "Audit Test",
-        description: "test",
-      },
-    });
-    // Non-actionable: the poll loop never saw it, so a poll from before the
-    // journal's start is still waiting rather than replaying it.
-    await expect(
-      (
-        await agentFetch(server, capability, "/api/agent/events?after=0")
-      ).json(),
-    ).resolves.toMatchObject({ waiting: true, lastSequence: 2 });
+    expect(frame.result).toMatchObject({ ok: false });
+    expect(
+      JSON.stringify((frame.result as { readonly diagnostics: unknown })
+        .diagnostics),
+    ).toContain("YMVS315");
+    socket.close();
+  });
+
+  it("publishes the projection digests a staged view pins against", async () => {
+    await withWorkspace();
+    const server = await start();
+    const { cookie } = await bootstrap(server);
+    const socket = await openBrowserSocket(server, cookie);
+    const ready = await nextFrame(socket, "ready");
+
+    const digests = ready.snapshot.model.projectionDigests;
+    expect(digests[".yarramate/projections/seeded.yaml"]).toBe(
+      await digestOfFile(".yarramate/projections/seeded.yaml"),
+    );
+    // Kept out of `sourceDigests`, which states what the GRAPH was compiled
+    // from and is what `YMVS112` checks.
+    expect(
+      ready.snapshot.model.sourceDigests[".yarramate/projections/seeded.yaml"],
+    ).toBeUndefined();
     socket.close();
   });
 });
+
 
 it("keeps the fixture asset root free of anything the server must not serve", async () => {
   expect(dirname(assetRoot)).toBe(fixtures.replace(/\/$/, ""));

--- a/test/visual-session-store.test.ts
+++ b/test/visual-session-store.test.ts
@@ -284,7 +284,7 @@ describe("visual session store", () => {
       overrides: Partial<VisualSessionDescriptor> = {},
     ): VisualSessionDescriptor => ({
       format: "yarramate/visual-session-descriptor/v2",
-      protocolVersion: "yarramate/visual-protocol/v4",
+      protocolVersion: "yarramate/visual-protocol/v5",
       sessionId,
       origin: "http://127.0.0.1:49152",
       agentCapability: "5c".repeat(32),


### PR DESCRIPTION
> **Stacked on #257** (`worktree-context-menus-247`), because the delete item lives in the menus that PR adds. Retarget to `main` once #257 merges.

## Summary

#246 asks for delete on a view and states the constraint that makes it more
than a menu item:

> Creating and deleting a view writes and removes a projection document, so
> **both are staged and committed like any other change** rather than landing
> immediately.

Nothing could do that, and finding out why turned a UI task into a contract
one. This is **the machinery**; the rest of #246's menu items (rename,
duplicate, new-in-folder, copy path, export PNG) follow on top of it.

### What was actually missing

- `view.save` composed a projection and `writeFileSync`'d it the moment Save
  was pressed — outside the changeset (no undo), outside ADR 0093's staleness
  pin (silently overwrote someone else's edit), outside the batch (a view and
  the subjects it shows could not land together).
- `SourceStore` could create and replace but **never remove**, so a view
  rename — a write plus a removal — could not be expressed at all.
- Three issues were blocked on the same absent mechanism: **#246** (create and
  delete staged), **#248** (a query edit staged — you settled this today),
  **#255** (view membership staged). Each was filed as a UI change; each is the
  same missing thing in a different costume.

### The decision — ADR 0103

- **A `PendingWrite` with a `null` source removes the document**, in the same
  all-or-none batch under the same compare-and-swap. A removal must name the
  revision it was staged against: `expected: null` asks to remove a document on
  condition it is not there, which is refused rather than called a success.
- **A view operation is the adapter's, not Core's.**
  `yarramate/operations/v1` is unchanged and Core keeps its stated invariant
  that a projection is never an operation's own target.
- **Atomicity comes from one `writeAll`, not one list.** `landOperations`
  splits into `planOperations` (returns the writes) and the runtime merges both
  write sets before anything lands. A view and the subjects it shows arrive
  together or not at all — bought without making a presentation artifact into a
  semantic operation.
- **A view saved where the manifest covers no projection is refused.** This
  repo's own `projections/*.yaml` reaches no subdirectory, so the first view
  saved into a folder would otherwise be a file the workspace never loads
  (ADR 0043 names the same trap for `new projection`).

`view.save` is retired with its result frame and browser state. The
confirm-before-overwrite dialog goes too: a staged overwrite is a row you can
read and discard *before* it lands, which is a better answer than a dialog.

## Validation

`pnpm verify` exits 0 — 85 files, 1398 tests (up from 85/1397).
`node scripts/check-changelog.mjs` exits 0.

**Opened in a browser against this repo's own model**, and it found a defect
the green suite did not: **pressing Commit on a changeset holding only a staged
view did nothing, and said nothing about why** — the button's guard asked
whether the *model's* operation list was empty rather than whether the
changeset was. Fixed, with `changesetIsEmpty` as the one place that question is
answered, and a test.

Also verified live: staging writes nothing to disk; `Delete view…` from the
rail stages a `delete-view` row marked `view`; committing removes the
projection and drops its row from the rail; and a view the browser composed
lands with the id and path the browser minted. (The repo's own
`current-engine.yaml` was deleted and restored with `git checkout` in the
course of this; the tree is clean.)

New server-side coverage walks the same path end to end against a fixture
workspace, including the one that matters most: **a batch with a stale view pin
writes neither half**.

## Related issue

Part of #244 and #246. Unblocks the staging half of #248 and #255.

## Contract impact

Substantial, and all pre-1.0:

- **`yarramate/visual-protocol/v5`.** The commit payload gains a required
  `viewOperations`; `view.save` and its result frame are gone; the model frame
  gains `projectionDigests` (kept apart from `sourceDigests`, which means what
  the *graph* was compiled from and is what `YMVS112` checks).
- **`SourceStore.PendingWrite.source` is now `string | null`.** Every store
  must say what removal means for it; the filesystem store unlinks.
- **`landOperations` gains a sibling**, `planOperations`. `landOperations`
  itself is unchanged for the CLI.
- Two new diagnostics: `YMVS314` (a view already gone), `YMVS315` (a view saved
  where the manifest covers nothing).
- Schemas updated: the event schema's commit payload, and the three carrying
  the protocol version constant.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
