### PR TITLE
Rename, duplicate and export a view from the rail (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 1.0.0
 
+- **Added.** View CRUD from the rail's context menu (#246): **Rename**,
+  **Duplicate**, **New view in this folder**, **Copy projection path**, and
+  **Export PNG** on the canvas. Rename and duplicate stage a row like every
+  other change, so both are visible before they land and undoable after.
+  **A rename changes what a view is called and moves nothing**: a projection's
+  id decides its filename *and* keys its layout sidecar
+  (`.yarramate/visual-layout/<id>.yaml`), so a rename that carried the id along
+  would silently orphan the positions the reviewer dragged. Duplicating keeps
+  the source's folder and takes a free id; it does not inherit the layout,
+  because that is keyed by id and a copy is a different view.
+  A view saved *in this folder* names its folder by pointing at a view already
+  in it, which is also what makes the folder one the manifest demonstrably
+  reaches.
+
 - **Breaking.** Saving a view is a staged change, not a write. `view.save` is
   gone, and a commit carries `viewOperations` beside its model operations
   (`yarramate/visual-protocol/v5`, ADR 0103). Saving used to compose a

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -208,6 +208,22 @@ ArchiMate table has no row to judge it against and is offered rather than
 refused on a guess. The kind an edge already carries is always offered, because
 a model authored outside this editor is not the editor's to silently rewrite.
 
+A view row carries its own CRUD: **Open**, **Rename…**, **Duplicate**, **New
+view in this folder…**, **Copy projection path**, and **Delete view…** behind
+the rule. Rename and duplicate stage rows like anything else.
+
+**A rename changes what a view is called and moves nothing.** A projection's id
+decides its filename and also keys its layout sidecar
+(`.yarramate/visual-layout/<id>.yaml`), so a rename that carried the id along
+would silently orphan the positions the reviewer dragged. Duplicating keeps the
+source's folder and takes a free id, and does not inherit the layout — that is
+keyed by id, and a copy is a different view that lays itself out.
+
+Folders are read off projection paths (#245), so the only way to name one is to
+point at a view already in it — which is also what makes it a folder the
+manifest demonstrably reaches. **Export PNG** on the canvas menu photographs
+what is drawn, at 2× on white.
+
 What a menu contains is a pure function of the model (`contextMenuFor`), and
 its items name intents rather than carrying callbacks, so what a right-click
 puts on screen is something a test can read. It is rebuilt on every render

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -68,6 +68,73 @@ export const projectionPathFor = (
  * presentation field the active view declared is carried through — dropping
  * one here is how overwriting a view silently loses its nesting or direction.
  */
+/** The folder a projection sits in, which is the only place a folder is stated. */
+export const directoryOf = (path: string): string =>
+  path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
+
+/**
+ * Retitling a view, as a staged write.
+ *
+ * The path and the id do NOT move. A projection's id decides its filename and
+ * also keys its layout sidecar (`.yarramate/visual-layout/<id>.yaml`), so a
+ * rename that carried the id along would silently orphan the positions the
+ * reviewer dragged. Renaming is a change to what the view is called; moving it
+ * is a different motion, and not one #246 asked for.
+ *
+ * Every other presentation field the view declared is carried through by
+ * `composeProjection`, so a rename cannot quietly drop a nesting vocabulary or
+ * a direction the canvas never showed.
+ */
+export const renameView = (
+  view: SavedView,
+  title: string,
+): { readonly path: string; readonly projection: ProjectionDefinition } => ({
+  path: view.path,
+  projection: composeProjection({
+    id: view.id,
+    title,
+    description: view.description,
+    query: view.query,
+    presentation: view.presentation,
+  }),
+});
+
+/**
+ * Copying a view into a new document beside it.
+ *
+ * The copy keeps the original's folder, because a duplicate the reviewer then
+ * has to move is a duplicate in the wrong place, and the folder is one the
+ * manifest demonstrably reaches. It does NOT inherit the layout sidecar: that
+ * is keyed by id, and a copy is a different view that lays itself out.
+ */
+export const duplicateView = (
+  view: SavedView,
+  taken: ReadonlySet<string>,
+): { readonly path: string; readonly projection: ProjectionDefinition } => {
+  const title = `${view.title} copy`;
+  const id = viewIdFrom(title, taken);
+  return {
+    path: projectionPathFor(id, directoryOf(view.path)),
+    projection: composeProjection({
+      id,
+      title,
+      description: view.description,
+      query: view.query,
+      presentation: view.presentation,
+    }),
+  };
+};
+
+/** What these need of a saved view, and nothing about how it is drawn. */
+export interface SavedView {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly query: ProjectionQuery;
+  readonly presentation: ProjectionDefinition["presentation"];
+  readonly path: string;
+}
+
 export const composeProjection = (input: {
   readonly id: string;
   readonly title: string;

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -47,6 +47,12 @@ import { ConnectionPanel } from "./connection-panel.js";
 import { faultedSubjects } from "./faults.js";
 import { SubjectDraftPanel } from "./subject-draft-panel.js";
 import { ConfirmDialog } from "./confirm-dialog.js";
+import { PromptDialog } from "./prompt-dialog.js";
+import {
+  directoryOf,
+  duplicateView,
+  renameView,
+} from "../adapters/visual/view-identity.js";
 import { ContextMenu } from "./context-menu.js";
 import {
   contextMenuFor,
@@ -122,6 +128,7 @@ const CommandStrip = ({
   quickFilterText,
   onQuickFilterChange,
   saveViewOpen,
+  saveViewDirectory,
   onToggleSaveView,
   onStageView,
   onEnd,
@@ -147,6 +154,7 @@ const CommandStrip = ({
   readonly quickFilterText: string;
   readonly onQuickFilterChange: (text: string) => void;
   readonly saveViewOpen: boolean;
+  readonly saveViewDirectory: string | undefined;
   readonly onToggleSaveView: () => void;
   readonly onStageView: (operation: VisualViewOperation) => void;
   readonly onEnd: () => void;
@@ -187,6 +195,7 @@ const CommandStrip = ({
         showEvidence={showEvidence}
         showOwnership={showOwnership}
         open={saveViewOpen}
+        directory={saveViewDirectory}
         onToggle={onToggleSaveView}
         onStage={onStageView}
       />
@@ -315,6 +324,7 @@ const DiagramWorkspace = ({
   onCanvasMenu,
   onClearFilter,
   onSaveLayout,
+  onCanvasReady,
 }: {
   readonly state: VisualAppState;
   readonly selectedId: string | null;
@@ -343,6 +353,7 @@ const DiagramWorkspace = ({
   ) => void;
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
+  readonly onCanvasReady: (png: (() => string) | null) => void;
 }) => {
   // An edge names its endpoints by node id; the reviewer reads titles. The
   // rendering model the renderer itself draws answers that, so nothing here
@@ -471,6 +482,7 @@ const DiagramWorkspace = ({
             activeViewId={state.activeView}
             savedPositions={state.model.layouts[state.activeView]}
             onSaveLayout={onSaveLayout}
+            onCanvasReady={onCanvasReady}
           />
         )}
         {state.layoutNotice === null ? null : (
@@ -900,6 +912,16 @@ export const App = () => {
   // The save-view form has two openers now — its own toggle in the strip and
   // the tree's new-view button — so the shell owns whether it is open.
   const [saveViewOpen, setSaveViewOpen] = useState(false);
+  // Which folder a new view is saved into. Set by "New view in this folder…"
+  // and cleared by every other opener, so the default directory is what a
+  // plain "New view…" gets.
+  const [saveViewDirectory, setSaveViewDirectory] = useState<
+    string | undefined
+  >(undefined);
+  // A way to photograph the canvas, handed up by `GraphCanvas` while one
+  // exists. A ref rather than state: nothing renders differently because of
+  // it, and a menu item reads it at the moment it is chosen.
+  const canvasPngRef = useRef<(() => string) | null>(null);
 
   useEffect(() => {
     const resized = () =>
@@ -1103,6 +1125,7 @@ export const App = () => {
         // starts from the whole model, and the form seeds itself from what is
         // active, so clearing first is what makes its fields blank.
         clearFilter();
+        setSaveViewDirectory(undefined);
         setSaveViewOpen(true);
         dispatchWorkspace({ type: "menu.dismissed" });
         return;
@@ -1112,6 +1135,51 @@ export const App = () => {
         // confirm-then-stage shape a subject deletion does.
         dispatchWorkspace({ type: "viewDeletion.asked", id: intent.id });
         return;
+      case "view.rename":
+        dispatchWorkspace({ type: "viewRename.asked", id: intent.id });
+        return;
+      case "view.duplicate": {
+        const view = state.views.find((candidate) => candidate.id === intent.id);
+        if (view === undefined) return;
+        const copy = duplicateView(
+          view,
+          new Set(state.views.map((candidate) => candidate.id)),
+        );
+        stageViewChange({ op: "write-view", ...copy });
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
+      case "view.new-in-folder": {
+        const view = state.views.find((candidate) => candidate.id === intent.id);
+        if (view === undefined) return;
+        // The form writes into this folder rather than the default one. A
+        // folder that already holds a projection is one the manifest reaches,
+        // which is why the only way to name a folder is to point at a view in
+        // it.
+        setSaveViewDirectory(directoryOf(view.path));
+        clearFilter();
+        setSaveViewOpen(true);
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
+      case "view.copy-path": {
+        const view = state.views.find((candidate) => candidate.id === intent.id);
+        if (view === undefined) return;
+        void navigator.clipboard?.writeText(view.path);
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
+      case "canvas.export-png": {
+        const png = canvasPngRef.current;
+        if (png === null) return;
+        // A local page, so an anchor with a data: href is the whole download.
+        const link = document.createElement("a");
+        link.href = png();
+        link.download = `${state.activeView === "" ? "all-subjects" : state.activeView}.png`;
+        link.click();
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
     }
   };
 
@@ -1121,6 +1189,12 @@ export const App = () => {
       : (state.views.find(
           (view) => view.id === workspace.pendingViewDeletion,
         ) ?? null);
+
+  const pendingViewRename =
+    workspace.pendingViewRename === null
+      ? null
+      : (state.views.find((view) => view.id === workspace.pendingViewRename) ??
+        null);
 
   return (
     <main className="visual-shell" style={shellStyle}>
@@ -1149,6 +1223,7 @@ export const App = () => {
         quickFilterText={state.quickFilterText}
         onQuickFilterChange={setQuickFilterText}
         saveViewOpen={saveViewOpen}
+        saveViewDirectory={saveViewDirectory}
         onToggleSaveView={() => setSaveViewOpen((open) => !open)}
         onStageView={stageViewChange}
         onEnd={end}
@@ -1183,6 +1258,7 @@ export const App = () => {
             // the last one narrowed to, and the form seeds itself from the
             // active view — so clearing first is what makes its fields blank.
             clearFilter();
+            setSaveViewDirectory(undefined);
             setSaveViewOpen(true);
           }}
           onSelectSubject={(id) => {
@@ -1247,6 +1323,9 @@ export const App = () => {
           }
           onClearFilter={clearFilter}
           onSaveLayout={saveLayout}
+          onCanvasReady={(png) => {
+            canvasPngRef.current = png;
+          }}
         />
         {conversationOpen ? (
           <ConversationSeparator
@@ -1292,6 +1371,23 @@ export const App = () => {
           y={workspace.contextMenu.y}
           onChoose={runIntent}
           onDismiss={() => dispatchWorkspace({ type: "menu.dismissed" })}
+        />
+      )}
+      {pendingViewRename === null ? null : (
+        <PromptDialog
+          title="Rename view"
+          label="Title"
+          initialValue={pendingViewRename.title}
+          confirmLabel="Rename"
+          cancelLabel="Cancel"
+          onConfirm={(title) => {
+            stageViewChange({
+              op: "write-view",
+              ...renameView(pendingViewRename, title),
+            });
+            dispatchWorkspace({ type: "viewRename.dismissed" });
+          }}
+          onCancel={() => dispatchWorkspace({ type: "viewRename.dismissed" })}
         />
       )}
       {pendingViewDelete === null ? null : (

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -51,6 +51,17 @@ export type ContextMenuIntent =
   | { readonly type: "view.open"; readonly id: string }
   | { readonly type: "view.clear" }
   | { readonly type: "view.new" }
+  /**
+   * A new view in the folder this one occupies. Folders come from projection
+   * paths (#245), so the only way to name one is to point at a view already in
+   * it — which also means the folder is one the manifest demonstrably reaches.
+   */
+  | { readonly type: "view.new-in-folder"; readonly id: string }
+  /** Retitles the view. The id and the path do not move — see `viewRowMenu`. */
+  | { readonly type: "view.rename"; readonly id: string }
+  | { readonly type: "view.duplicate"; readonly id: string }
+  | { readonly type: "view.copy-path"; readonly id: string }
+  | { readonly type: "canvas.export-png" }
   | { readonly type: "view.delete"; readonly id: string };
 
 /** Which half of the split an operation belongs to. */
@@ -209,7 +220,17 @@ const canvasMenu = (
       scope: "view",
       label: "View",
       destructive: false,
-      items: context.filtered ? [NEW_VIEW, SHOW_ALL] : [NEW_VIEW],
+      items: [
+        NEW_VIEW,
+        ...(context.filtered ? [SHOW_ALL] : []),
+        // What is on screen, as a picture. A view-scope read rather than a
+        // model one: it takes a copy of the canvas and changes nothing.
+        {
+          key: "canvas.export-png",
+          label: "Export PNG",
+          intent: { type: "canvas.export-png" },
+        },
+      ],
     },
     {
       key: "model",
@@ -237,17 +258,44 @@ const viewRowMenu = (
       scope: "view",
       label: "View",
       destructive: false,
-      items: [
+      items:
         id === ALL_SUBJECTS_VIEW
-          ? SHOW_ALL
-          : {
-              key: "view.open",
-              label: "Open view",
-              intent: { type: "view.open", id },
-              ...(id === context.activeViewId ? { current: true as const } : {}),
-            },
-        NEW_VIEW,
-      ],
+          ? [SHOW_ALL, NEW_VIEW]
+          : [
+              {
+                key: "view.open",
+                label: "Open view",
+                intent: { type: "view.open", id },
+                ...(id === context.activeViewId
+                  ? { current: true as const }
+                  : {}),
+              },
+              // Retitling only. The id decides the path AND keys the layout
+              // sidecar (`.yarramate/visual-layout/<id>.yaml`), so a rename
+              // that moved the id would silently orphan the positions the
+              // reviewer dragged. Moving a view is a different motion.
+              {
+                key: "view.rename",
+                label: "Rename…",
+                intent: { type: "view.rename", id },
+              },
+              {
+                key: "view.duplicate",
+                label: "Duplicate",
+                intent: { type: "view.duplicate", id },
+              },
+              {
+                key: "view.new-in-folder",
+                label: "New view in this folder…",
+                intent: { type: "view.new-in-folder", id },
+              },
+              NEW_VIEW,
+              {
+                key: "view.copy-path",
+                label: "Copy projection path",
+                intent: { type: "view.copy-path", id },
+              },
+            ],
     },
   ];
   // "All subjects" is the absence of a view, not a document, so there is

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -889,6 +889,13 @@ interface GraphCanvasProps {
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
+  /**
+   * A way to take a picture of what is drawn, handed up once the instance
+   * exists and withdrawn when it goes. The shell holds it so a menu item can
+   * export a PNG without reaching into cytoscape itself; `null` means there is
+   * no canvas to photograph, which is what the menu reads to stay honest.
+   */
+  readonly onCanvasReady?: (png: (() => string) | null) => void
 }
 
 /**
@@ -912,6 +919,7 @@ export function GraphCanvas({
   activeViewId,
   savedPositions,
   onSaveLayout,
+  onCanvasReady,
   showLifecycle,
   showEvidence,
   showOwnership,
@@ -919,6 +927,8 @@ export function GraphCanvas({
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<Core | null>(null)
   const onSelectRef = useRef(onSelect)
+  const onCanvasReadyRef = useRef(onCanvasReady)
+  onCanvasReadyRef.current = onCanvasReady
   const onContextMenuRef = useRef(onContextMenu)
   const isInitialSyncRef = useRef(true)
   const isInitialPresentationSyncRef = useRef(true)
@@ -981,6 +991,15 @@ export function GraphCanvas({
     })
 
     cyRef.current = cy
+
+    // Hand the shell a way to photograph what is drawn. Cytoscape renders to a
+    // canvas, so the only thing that can produce the image is the instance
+    // itself; a white background rather than transparent, because a diagram
+    // pasted onto a dark surface with transparent gaps is not a picture of
+    // what was on screen.
+    onCanvasReadyRef.current?.(() =>
+      cy.png({ full: true, scale: 2, bg: '#ffffff' }),
+    )
 
     // Tap handler for nodes
     cy.on('tap', 'node', (evt) => {
@@ -1090,6 +1109,9 @@ export function GraphCanvas({
       cancelAnimationFrame(pendingFrame)
       observer.disconnect()
       dragSaveHandleRef.current?.dispose()
+      // Withdrawn before the instance goes, so nothing can photograph a
+      // destroyed canvas.
+      onCanvasReadyRef.current?.(null)
       cy.destroy()
       cyRef.current = null
     }

--- a/src/visual-app/prompt-dialog.tsx
+++ b/src/visual-app/prompt-dialog.tsx
@@ -1,0 +1,83 @@
+import { useState, type FormEvent } from "react";
+
+export interface PromptDialogProps {
+  readonly title: string;
+  readonly label: string;
+  readonly initialValue: string;
+  readonly confirmLabel: string;
+  readonly cancelLabel: string;
+  readonly onConfirm: (value: string) => void;
+  readonly onCancel: () => void;
+}
+
+/**
+ * One line of text, asked for. The sibling of `ConfirmDialog`: that one asks a
+ * yes-or-no before something destructive, this one asks for a value before
+ * something the reviewer has to name.
+ *
+ * A blank answer is refused by disabling the button rather than by staging a
+ * row that the projection schema would then reject — `presentation.title` is
+ * required non-empty text, so an empty rename can only ever come back as a
+ * fault.
+ *
+ * The value lives here rather than in the caller because it belongs to the
+ * dialog while it is on screen: a half-typed name is not workspace state, and
+ * closing the dialog is what discards it.
+ */
+export function PromptDialog({
+  title,
+  label,
+  initialValue,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: PromptDialogProps) {
+  const [value, setValue] = useState(initialValue);
+  const blank = value.trim() === "";
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (blank) return;
+    onConfirm(value.trim());
+  };
+
+  return (
+    <div
+      className="confirm-dialog-backdrop"
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        className="confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="prompt-dialog-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="prompt-dialog-title">{title}</h2>
+        <form className="prompt-dialog-form" onSubmit={submit}>
+          <label htmlFor="prompt-dialog-value">{label}</label>
+          <input
+            id="prompt-dialog-value"
+            type="text"
+            value={value}
+            autoFocus
+            onChange={(event) => setValue(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") onCancel();
+            }}
+          />
+          <div className="confirm-dialog-actions">
+            <button type="button" onClick={onCancel}>
+              {cancelLabel}
+            </button>
+            <button type="submit" disabled={blank}>
+              {confirmLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -24,6 +24,12 @@ export interface SaveViewControlProps {
    * cannot both own one boolean.
    */
   readonly open: boolean;
+  /**
+   * Where a NEW view is written. Comes from "New view in this folder…", which
+   * names a folder by pointing at a view already in it - so the folder is one
+   * the manifest demonstrably reaches. Undefined is the default directory.
+   */
+  readonly directory: string | undefined;
   readonly onToggle: () => void;
   /** Stages the write. Nothing is on disk until the changeset is committed. */
   readonly onStage: (operation: VisualViewOperation) => void;
@@ -40,6 +46,8 @@ export interface BuildPayloadParams {
   readonly taken: ReadonlySet<string>;
   /** Where the overwritten view's document already lives, if there is one. */
   readonly path: string | undefined;
+  /** Which folder a NEW view goes in. Undefined is the default directory. */
+  readonly directory: string | undefined;
   readonly title: string;
   readonly description: string;
   readonly query: ProjectionQuery | null;
@@ -72,6 +80,7 @@ export const buildPayload = ({
   id,
   taken,
   path,
+  directory,
   title,
   description,
   query,
@@ -84,7 +93,7 @@ export const buildPayload = ({
   const viewId = id ?? viewIdFrom(title, taken);
   return {
     op: "write-view",
-    path: path ?? projectionPathFor(viewId),
+    path: path ?? projectionPathFor(viewId, directory),
     projection: composeProjection({
       id: viewId,
       title,
@@ -205,6 +214,7 @@ export function SaveViewControl({
   showEvidence,
   showOwnership,
   open,
+  directory,
   onToggle,
   onStage,
 }: SaveViewControlProps) {
@@ -222,7 +232,11 @@ export function SaveViewControl({
         // Overwriting writes the document the view already occupies, which is
         // not always the one its id would derive: a view saved into a folder
         // keeps its folder rather than being moved by a later save.
-        path: id === undefined ? undefined : activeView?.path,
+        path:
+          id === undefined
+            ? undefined
+            : activeView?.path,
+        directory,
         title,
         description,
         query,

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1813,3 +1813,38 @@ body {
   color: var(--cobalt);
   border-color: color-mix(in oklab, var(--cobalt) 40%, transparent);
 }
+
+/* The rename prompt: `ConfirmDialog`'s sibling, so it borrows that dialog's
+   box and only adds the field. */
+.prompt-dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--step) * 0.75);
+  text-align: left;
+}
+
+.prompt-dialog-form label {
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+.prompt-dialog-form input {
+  padding: calc(var(--step) * 0.75);
+  font: inherit;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-firm);
+  border-radius: 2px;
+}
+
+.prompt-dialog-form input:focus {
+  border-color: var(--cobalt);
+}
+
+.prompt-dialog-form .confirm-dialog-actions {
+  margin-top: calc(var(--step) * 0.5);
+}

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -139,6 +139,11 @@ export interface VisualWorkspaceState {
    * with it, a view's removes one projection document and touches no subject.
    */
   readonly pendingViewDeletion: string | null;
+  /**
+   * The view being retitled, held while the reviewer types. Only the id: the
+   * half-typed name belongs to the dialog while it is on screen.
+   */
+  readonly pendingViewRename: string | null;
   readonly descriptionExpanded: boolean;
   readonly detailsOpen: boolean;
   /**
@@ -195,6 +200,8 @@ export type VisualWorkspaceAction =
   | { readonly type: "deletion.dismissed" }
   | { readonly type: "viewDeletion.asked"; readonly id: string }
   | { readonly type: "viewDeletion.dismissed" }
+  | { readonly type: "viewRename.asked"; readonly id: string }
+  | { readonly type: "viewRename.dismissed" }
   | {
       readonly type: "subject.selected";
       readonly subject: SelectedDiagramSubject;
@@ -362,6 +369,7 @@ export const createVisualWorkspaceState = (
   draftingSubject: false,
   pendingDeletion: null,
   pendingViewDeletion: null,
+  pendingViewRename: null,
   contextMenu: null,
   nesting: DEFAULT_NESTING,
   layout: "layered",
@@ -486,6 +494,12 @@ export const visualWorkspaceReducer = (
       return state.pendingViewDeletion === null
         ? state
         : { ...state, pendingViewDeletion: null };
+    case "viewRename.asked":
+      return { ...state, pendingViewRename: action.id, contextMenu: null };
+    case "viewRename.dismissed":
+      return state.pendingViewRename === null
+        ? state
+        : { ...state, pendingViewRename: null };
     case "subject.selected":
       return {
         ...state,

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { buildPayload } from '../src/visual-app/save-view.js'
 import type { ProjectionQuery } from '../src/projection.js'
+import {
+  directoryOf,
+  duplicateView,
+  renameView,
+} from '../src/adapters/visual/view-identity.js'
 
 const query: ProjectionQuery = { kinds: ['yarramate/core@0.1#businessActor'] }
 
@@ -18,6 +23,7 @@ const build = (
     id: 'existing-view',
     taken: new Set<string>(),
     path: '.yarramate/projections/existing-view.yaml',
+    directory: undefined,
     title: 'My View',
     description: 'desc',
     query,
@@ -118,5 +124,80 @@ describe('buildPayload', () => {
     expect(
       projectionOf(build({ carriedDirection: undefined })).presentation,
     ).not.toHaveProperty('direction')
+  })
+
+  it('writes a new view into the folder it was asked for', () => {
+    const operation = build({
+      id: undefined,
+      path: undefined,
+      directory: '.yarramate/projections/current',
+      title: 'In A Folder',
+    })
+
+    expect(operation.path).toBe('.yarramate/projections/current/in-a-folder.yaml')
+  })
+})
+
+describe('renaming and duplicating a view', () => {
+  const view = {
+    id: 'current-engine',
+    title: 'Current engine',
+    description: 'What is built today',
+    query,
+    presentation: {
+      title: 'Current engine',
+      description: 'What is built today',
+      layout: 'layered',
+      direction: 'top-down',
+      nesting: ['composition'],
+    },
+    path: '.yarramate/projections/current/current-engine.yaml',
+  } as const
+
+  it('renames without moving the document or the id', () => {
+    // The id keys the layout sidecar (`.yarramate/visual-layout/<id>.yaml`), so
+    // a rename that carried it along would orphan the positions the reviewer
+    // dragged. Renaming is what a view is CALLED.
+    const renamed = renameView(view, 'Engine today')
+
+    expect(renamed.path).toBe(view.path)
+    expect(renamed.projection.id).toBe('current-engine')
+    expect(renamed.projection.presentation?.title).toBe('Engine today')
+  })
+
+  it('carries every other presentation field through a rename', () => {
+    const renamed = renameView(view, 'Engine today')
+
+    expect(renamed.projection.presentation?.direction).toBe('top-down')
+    expect(renamed.projection.presentation?.nesting).toEqual(['composition'])
+    expect(renamed.projection.query).toEqual(query)
+  })
+
+  it('duplicates into the same folder, with a free id', () => {
+    // A duplicate the reviewer then has to move is a duplicate in the wrong
+    // place - and the source's folder is one the manifest demonstrably reaches.
+    const copy = duplicateView(view, new Set(['current-engine']))
+
+    expect(copy.path).toBe(
+      '.yarramate/projections/current/current-engine-copy.yaml',
+    )
+    expect(copy.projection.id).toBe('current-engine-copy')
+    expect(copy.projection.presentation?.title).toBe('Current engine copy')
+  })
+
+  it('steps past a duplicate id already taken', () => {
+    const copy = duplicateView(
+      view,
+      new Set(['current-engine', 'current-engine-copy']),
+    )
+
+    expect(copy.projection.id).toBe('current-engine-copy-2')
+  })
+
+  it('reads a folder off a path, and calls the default directory no folder', () => {
+    expect(directoryOf('.yarramate/projections/current/a.yaml')).toBe(
+      '.yarramate/projections/current',
+    )
+    expect(directoryOf('a.yaml')).toBe('')
   })
 })

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -143,7 +143,11 @@ describe("the view/model split every menu has to teach", () => {
     expect(groups.every((group) => group.scope === "view")).toBe(true);
     expect(labels(groups)).toEqual([
       "Open view",
+      "Rename…",
+      "Duplicate",
+      "New view in this folder…",
       "New view…",
+      "Copy projection path",
       "Delete view…",
     ]);
   });
@@ -153,7 +157,19 @@ describe("what each menu offers", () => {
   it("offers the canvas a view group and a model group", () => {
     const groups = contextMenuFor({ kind: "canvas" }, context());
     expect(groups.map((group) => group.label)).toEqual(["View", "Model"]);
-    expect(labels(groups)).toEqual(["New view…", "Add subject…"]);
+    expect(labels(groups)).toEqual([
+      "New view…",
+      "Export PNG",
+      "Add subject…",
+    ]);
+  });
+
+  it("gives the all-subjects row no rename, duplicate or path to copy", () => {
+    // It is the absence of a view, not a document: there is nothing to
+    // retitle, nothing to copy, and no folder to add a sibling to.
+    expect(labels(contextMenuFor({ kind: "view-row", id: "" }, context()))).toEqual(
+      ["Show all subjects", "New view…"],
+    );
   });
 
   it("offers to show all only while something is narrowing the canvas", () => {


### PR DESCRIPTION
## Summary

The rest of **#246**, on the staged-view machinery ADR 0103 landed in #259. A
view row now carries **Open**, **Rename…**, **Duplicate**, **New view in this
folder…**, **Copy projection path**, and **Delete view…** behind the rule; the
canvas menu gains **Export PNG**.

### A rename changes what a view is *called* and moves nothing

A projection's id decides its filename **and keys its layout sidecar**
(`.yarramate/visual-layout/<id>.yaml`). A rename that carried the id along
would silently orphan the positions the reviewer dragged, so renaming and
moving are different motions and #246 asked for the first. Every other
presentation field the view declared is carried through, so a rename cannot
quietly drop a nesting vocabulary or a direction the canvas never showed.

**Duplicating** keeps the source's folder — a duplicate the reviewer then has
to move is a duplicate in the wrong place, and the source's folder is one the
manifest demonstrably reaches — and takes a free id. It does **not** inherit
the layout sidecar: that is keyed by id, and a copy is a different view that
lays itself out.

Rename and duplicate stage rows like everything else, so both are visible
before they land and undoable after. Copy path and Export PNG stage nothing.

### Why there is no "New folder"

Folders are read off projection paths (#245), so the only way to name one is to
point at a view already in it — which is exactly what "New view in this
folder…" does, and which also guarantees the folder is one the manifest
reaches. A folder the manifest does **not** cover produces #259's `YMVS315`
refusal rather than a view.

**This is the open question I flagged and it is still yours:** should the
editor refuse, or offer to widen the manifest pattern? ADR 0043 says a tool
that edits the author's manifest to make its own write valid has removed the
author from the decision, which is why I have not done it. Say the word and
"New folder" becomes a two-line follow-up.

## Validation

`pnpm verify` exits 0 — 85 files, 1405 tests (up from 85/1398).
`node scripts/check-changelog.mjs` exits 0.

**Browser-verified end to end**, item by item:

| Item | Verified |
| --- | --- |
| Menu | all seven items, in order, delete behind the rule |
| Rename… | opens seeded with the current title; stages `write-view` at the **same** path |
| Duplicate | stages `current-engine-copy` beside its source |
| Copy projection path | writes `.yarramate/projections/current-engine.yaml`, stages nothing |
| Export PNG | hands over a 663KB `data:image/png` named after the active view |
| New view in this folder… | writes into the row's folder |

A rename was then **committed for real**: the document came back with `id:
current-engine` unchanged and `title: Engine today`, proving the filename and
the layout sidecar both survive. Reverted with `git checkout`; the tree is
clean.

## Related issue

Closes #246. Part of #244.

## Contract impact

**None.** No protocol change, no schema change, no new diagnostics — every item
composes operations the `viewOperations` list already carries. `GraphCanvas`
gains an optional `onCanvasReady` prop so the shell can photograph the canvas
without reaching into cytoscape itself.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
