### PR TITLE
A subject you create joins the view that created it (#255), and a commit against a profiled workspace stops dying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@
   exactly why a green suite never saw it; this repository's own workspace
   declares one, so the visual editor could not commit anything to it at all.
 
+- **Added.** Creating a subject puts it in the view that created it (#255). A
+  view that enumerates `subjects:` cannot match a subject that did not exist
+  when the list was written, so creating one now stages two rows — the model's
+  `add-concept` and the view's membership — and the tray tells them apart:
+  `write-view · Payment flow · +fraud-screening`, badged `view`. **Remove from
+  view** and **Add to this view** stage the same amendment from the subject and
+  Model-tree menus, in the view group, above the model's and well away from
+  **Delete from model…**. Neither appears for a view that describes its
+  subjects with facets, because there is no list to edit.
+
+- **Fixed.** A commit that landed a change to the active view's own query
+  re-asked the query the browser was holding, which is that query as it was.
+  The commit reported success, the projection on disk named the new subject,
+  and the canvas did not change. The view's query is now re-read off the model
+  frame that replaced it.
+
+- **Fixed.** A commit that wrote both model documents and projections reported
+  only the model's half: "Committed · 1 file" where two landed. Core names the
+  documents it rewrote, and the projections went out in the same `writeAll`.
+
 - **Added.** View CRUD from the rail's context menu (#246): **Rename**,
   **Duplicate**, **New view in this folder**, **Copy projection path**, and
   **Export PNG** on the canvas. Rename and duplicate stage a row like every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 1.0.0
 
+- **Fixed.** A commit from the visual editor died on any workspace that
+  declares a profile. `planOperations` gathered documents, projections,
+  evidence and adapter mappings and left the PROFILES out, and
+  `applyOperations` reads nothing it is not handed (ADR 0100) — so the compile
+  inside it was shown an empty string where a profile should be, which parses
+  to `null`, and the compiler asked that `null` for its `profile`. The browser
+  reported `YMVS307 Cannot read properties of null` and nothing landed. Every
+  fixture in `apply-operations.test.ts` declared `profiles: []`, which is
+  exactly why a green suite never saw it; this repository's own workspace
+  declares one, so the visual editor could not commit anything to it at all.
+
 - **Added.** View CRUD from the rail's context menu (#246): **Rename**,
   **Duplicate**, **New view in this folder**, **Copy projection path**, and
   **Export PNG** on the canvas. Rename and duplicate stage a row like every

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -230,6 +230,39 @@ puts on screen is something a test can read. It is rebuilt on every render
 rather than captured when it opened: a commit landing underneath an open menu
 redraws it instead of leaving items pointing at a subject that has gone.
 
+### View membership
+
+A view that ENUMERATES `subjects:` is the only kind that can be told which
+subjects it holds. A view that describes them with facets — a layer, a kind, a
+state — already includes anything matching them, so there is nothing a
+membership edit could say to it: the subject is in or out by what it *is*, and
+changing that means editing the query.
+
+Three motions stage the same thing, a `write-view` amending that list:
+
+- **creating a subject** stages two rows, the model's `add-concept` and the
+  view's membership, so a subject the reviewer made on a view appears on that
+  view rather than nowhere;
+- **Add to this view**, on a subject in the rail's Model tree or on one drawn
+  but not listed (`relationships: connected` takes the other end of a
+  relationship with it);
+- **Remove from view**, which rewrites one projection and leaves every other
+  view — and the subject itself — alone. It is a different item, in a different
+  group, from **Delete from model…**, which takes every relationship naming the
+  subject with it.
+
+Neither item appears where the active view has no list to edit.
+
+The reducer composes the amendment, not the caller. Staged view rows replace by
+path, so a second membership edit composed from the SAVED document would
+silently drop the first; composing where both the saved views and the pending
+rows are held is the only place it cannot be forgotten. An edit that returns the
+document to what is on disk drops the row rather than staging a write that
+changes nothing, and a rename staged underneath it survives that.
+
+The tray names what a row moved rather than which file it writes:
+`write-view · Payment flow · +fraud-screening`, badged `view`.
+
 ### Nesting
 
 `presentation.nesting` names the relationship kinds that draw as containment in

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -652,17 +652,26 @@ const landPlanned = (
 ): ApplyOutcome => {
   if (planned !== null && !planned.ok) return planned.outcome;
   const writes = [...(planned?.writes ?? []), ...viewWrites];
+  const viewPaths = viewWrites.map((write) => write.path);
   const outcome: ApplyOutcome =
     planned === null
       ? {
           ok: true,
           sources: [],
-          result: noModelChange(
-            workspaceId,
-            viewWrites.map((write) => write.path),
-          ),
+          result: noModelChange(workspaceId, viewPaths),
         }
-      : planned.outcome;
+      : {
+          ...planned.outcome,
+          // Core names the documents IT rewrote, which is the model's half.
+          // The projections went out in the same `writeAll`, so a receipt that
+          // named only Core's half would report one file where two landed -
+          // and a mixed batch is the ordinary case now that creating a subject
+          // also puts it in the view that created it (#255).
+          result: {
+            ...planned.outcome.result,
+            documents: [...planned.outcome.result.documents, ...viewPaths],
+          },
+        };
   if (writes.length === 0) return outcome;
   const written = store.writeAll(writes);
   if (written.ok) return outcome;

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -152,3 +152,100 @@ export const composeProjection = (input: {
     description: input.description,
   },
 });
+
+/**
+ * Whether a view can be told which subjects it holds.
+ *
+ * Only a view that ENUMERATES `subjects:` can. A view that describes its
+ * subjects with facets — a layer, a kind, a state — already includes anything
+ * matching them and excludes anything that does not, so there is nothing for a
+ * membership edit to say to it: the subject is in or out by what it is, and
+ * saying otherwise means editing the query rather than a list (#255).
+ */
+export const enumeratesSubjects = (
+  query: ProjectionQuery,
+): query is ProjectionQuery & { readonly subjects: readonly string[] } =>
+  query.subjects !== undefined;
+
+/**
+ * The same view, holding one more subject or one fewer.
+ *
+ * `null` when there is nothing to stage: the view describes its subjects
+ * rather than listing them, or the list already says what was asked for.
+ * Returning the absence rather than an unchanged document is what keeps a
+ * no-op out of the changeset, where a row that writes a file back exactly as
+ * it was is a row the reviewer has to read and discard for nothing.
+ */
+export const withMembership = (
+  projection: ProjectionDefinition,
+  subjectId: string,
+  membership: "add" | "remove",
+): ProjectionDefinition | null => {
+  if (!enumeratesSubjects(projection.query)) return null;
+  const subjects = projection.query.subjects;
+  const holds = subjects.includes(subjectId);
+  if (membership === "add" ? holds : !holds) return null;
+  return {
+    ...projection,
+    query: {
+      ...projection.query,
+      subjects:
+        membership === "add"
+          ? // Appended rather than sorted in: the list is the author's, and
+            // reordering it would rewrite lines nobody touched.
+            [...subjects, subjectId]
+          : subjects.filter((id) => id !== subjectId),
+    },
+  };
+};
+
+/**
+ * What a membership edit did to a view, as the tray reads it: `+id` for a
+ * subject this row adds, `-id` for one it drops, against the document the
+ * workspace holds. Empty when the row changed something else — a title, a
+ * query, a presentation flag — which the row says by other means.
+ */
+export const membershipDelta = (
+  saved: ProjectionQuery,
+  staged: ProjectionQuery,
+): readonly string[] => {
+  if (!enumeratesSubjects(saved) || !enumeratesSubjects(staged)) return [];
+  return [
+    ...staged.subjects
+      .filter((id) => !saved.subjects.includes(id))
+      .map((id) => `+${id}`),
+    ...saved.subjects
+      .filter((id) => !staged.subjects.includes(id))
+      .map((id) => `-${id}`),
+  ];
+};
+
+/**
+ * Two projection documents, compared by what they SAY rather than by how they
+ * are written.
+ *
+ * Key order is the author's: a document read back off YAML holds its fields in
+ * the order someone wrote them, and one composed here holds them in the order
+ * this file writes them. Comparing the two as text reports every view as
+ * changed the moment anything touches it.
+ */
+export const sameDocument = (
+  left: ProjectionDefinition,
+  right: ProjectionDefinition,
+): boolean => canonical(left) === canonical(right);
+
+const canonical = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    // Order is meaningful inside a list - a subjects list is the author's own
+    // ordering - so only object keys are sorted.
+    return `[${value.map(canonical).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+};

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1202,6 +1202,14 @@ export const planOperations = (
   const revisions = new Map<string, string>()
   const sources: WorkspaceSource[] = []
   for (const path of [
+    // Profiles included, because `applyOperations` reads NOTHING: a source it
+    // is not handed does not exist as far as it is concerned, and it compiles
+    // the candidate workspace from `[...profiles, ...documents]`. Leaving them
+    // out handed the compiler an empty string where a profile should be, which
+    // parses to `null` and is not a document at all - every commit against a
+    // workspace that declares a profile died on it. No operation can target a
+    // profile, so they are read to be COMPILED against, never to be written.
+    ...input.workspace.profiles,
     ...input.workspace.documents,
     ...input.workspace.projections,
     ...input.workspace.evidence,

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -30,6 +30,7 @@ import type {
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
 import { useVisualSession } from "./session-client.js";
+import { activeViewMembership } from "./state.js";
 import type { VisualAppRecord, VisualAppState } from "./state.js";
 import {
   conversationWidthBounds,
@@ -315,6 +316,7 @@ const DiagramWorkspace = ({
   onConnectTarget,
   onConnectCancel,
   onConnectStage,
+  onDraftStage,
   draftingSubject,
   onDraftSubject,
   onDraftSubjectClose,
@@ -338,6 +340,12 @@ const DiagramWorkspace = ({
   readonly onConnectTarget: (id: string) => void;
   readonly onConnectCancel: () => void;
   readonly onConnectStage: (operation: YarramateOperation) => void;
+  /**
+   * Staging for a subject the reviewer is CREATING, which is not the same
+   * motion as staging a relationship or a deletion: a created subject also
+   * joins the view that created it (#255).
+   */
+  readonly onDraftStage: (operation: YarramateOperation) => void;
   readonly draftingSubject: boolean;
   readonly onDraftSubject: () => void;
   readonly onDraftSubjectClose: () => void;
@@ -413,7 +421,7 @@ const DiagramWorkspace = ({
               state.model.documents[0] ??
               ""
             }
-            onStage={onConnectStage}
+            onStage={onDraftStage}
             onCancel={onDraftSubjectClose}
           />
         )}
@@ -892,6 +900,7 @@ export const App = () => {
     clearFilter,
     setQuickFilterText,
     stageViewChange,
+    stageViewMembership,
     saveLayout,
     discardChange,
     stageChange,
@@ -1048,6 +1057,7 @@ export const App = () => {
           relationshipKinds: state.model?.vocabulary.relationshipKinds ?? [],
           activeViewId: state.activeView,
           filtered: state.activeFilter !== null,
+          membership: activeViewMembership(state),
         });
 
   /**
@@ -1111,6 +1121,18 @@ export const App = () => {
       }
       case "canvas.draft-subject":
         dispatchWorkspace({ type: "subject.draft.opened" });
+        return;
+      case "view.add-subject":
+      case "view.remove-subject":
+        // Always the ACTIVE view: the menu only offers these where that view
+        // has a membership list, and `activeViewMembership` is what decided
+        // which of the two it offered.
+        stageViewMembership(
+          state.activeView,
+          intent.id,
+          intent.type === "view.add-subject" ? "add" : "remove",
+        );
+        dispatchWorkspace({ type: "menu.dismissed" });
         return;
       case "view.open":
         navigate(intent.id);
@@ -1294,6 +1316,21 @@ export const App = () => {
             dispatchWorkspace({ type: "connection.cancelled" })
           }
           onConnectStage={stageChange}
+          onDraftStage={(operation) => {
+            stageChange(operation);
+            // A view that LISTS its subjects cannot match one that did not
+            // exist when the list was written, so it has to be told. A view
+            // that describes them with facets already knows, and the reducer
+            // is what decides which this is - the shell states the intent and
+            // holds no copy of the rule.
+            if (operation.op === "add-concept") {
+              stageViewMembership(
+                state.activeView,
+                operation.concept.id,
+                "add",
+              );
+            }
+          }}
           draftingSubject={workspace.draftingSubject}
           onDraftSubject={() =>
             dispatchWorkspace({ type: "subject.draft.opened" })

--- a/src/visual-app/changeset-tray.tsx
+++ b/src/visual-app/changeset-tray.tsx
@@ -2,7 +2,9 @@ import type {
   VisualChangesetCommitPayload,
   VisualDiagnostic,
   VisualViewOperation,
+  VisualViewSummary,
 } from '../adapters/visual/protocol-contract.js'
+import { membershipDelta } from '../adapters/visual/view-identity.js'
 import { summarise } from './faults.js'
 import type { CanvasGraph } from '../graph-projection.js'
 import type { YarramateOperation } from '../operations.js'
@@ -64,30 +66,55 @@ export interface ChangesetRowDescription {
 export const changesetRows = (
   changeset: VisualChangesetCommitPayload,
   graph: CanvasGraph | null,
+  views: readonly VisualViewSummary[],
 ): readonly ChangesetRowDescription[] => [
   ...changeset.operations.map((operation) =>
     describeChangesetRow(operation, graph),
   ),
-  ...changeset.viewOperations.map(describeViewRow),
+  ...changeset.viewOperations.map((operation) =>
+    describeViewRow(operation, views),
+  ),
 ]
 
 /**
  * A staged view, reduced the same way. The document's path is the subject:
  * a view has no id on the canvas to resolve a name from, and the path is what
  * the reviewer picked the folder of.
+ *
+ * A row that moves the view's MEMBERSHIP says which subjects it moves rather
+ * than which file it writes: `+fraud-screening` is what the reviewer did, and
+ * the path is what every other view row already says. Read against the saved
+ * view, so a second membership edit reports both subjects and not just the
+ * latest one - staged rows replace by path, and one row can carry several
+ * subjects (#255).
  */
 export const describeViewRow = (
   operation: VisualViewOperation,
-): ChangesetRowDescription => ({
-  verb: operation.op,
-  subjectName:
-    operation.op === 'write-view'
-      ? (operation.projection.presentation?.title ?? operation.projection.id)
-      : operation.path,
-  fields: operation.op === 'write-view' ? [operation.path] : [],
-  removedFields: [],
-  scope: 'view',
-})
+  views: readonly VisualViewSummary[],
+): ChangesetRowDescription => {
+  if (operation.op === 'delete-view') {
+    return {
+      verb: operation.op,
+      subjectName: operation.path,
+      fields: [],
+      removedFields: [],
+      scope: 'view',
+    }
+  }
+  const saved = views.find((view) => view.path === operation.path)
+  const membership =
+    saved === undefined
+      ? []
+      : membershipDelta(saved.query, operation.projection.query)
+  return {
+    verb: operation.op,
+    subjectName:
+      operation.projection.presentation?.title ?? operation.projection.id,
+    fields: membership.length > 0 ? membership : [operation.path],
+    removedFields: [],
+    scope: 'view',
+  }
+}
 
 export const describeChangesetRow = (
   operation: YarramateOperation,
@@ -288,7 +315,7 @@ export const ChangesetTray = ({
   // Both lists, as one: a changeset holding only a staged view is not an empty
   // one, and a tray that hid it would let the reviewer commit a write they
   // could not see.
-  const rows = changesetRows(state.pendingChangeset, graph)
+  const rows = changesetRows(state.pendingChangeset, graph, state.views)
   // History keeps the tray mounted even with nothing staged: undoing the last
   // row back to an empty set must leave Redo reachable, and discarding all of
   // them must leave Undo reachable.

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -62,7 +62,13 @@ export type ContextMenuIntent =
   | { readonly type: "view.duplicate"; readonly id: string }
   | { readonly type: "view.copy-path"; readonly id: string }
   | { readonly type: "canvas.export-png" }
-  | { readonly type: "view.delete"; readonly id: string };
+  | { readonly type: "view.delete"; readonly id: string }
+  /**
+   * One subject into or out of the ACTIVE view's membership list. Only a view
+   * that enumerates `subjects:` has one — see `ContextMenuContext.membership`.
+   */
+  | { readonly type: "view.add-subject"; readonly id: string }
+  | { readonly type: "view.remove-subject"; readonly id: string };
 
 /** Which half of the split an operation belongs to. */
 export type ContextMenuScope = "view" | "model";
@@ -96,6 +102,49 @@ export interface ContextMenuContext {
   readonly activeViewId: string;
   /** Whether anything at all is narrowing the canvas right now. */
   readonly filtered: boolean;
+  /**
+   * The active view's own membership list, or `null`.
+   *
+   * `null` covers both "no view is active" and "the active view describes its
+   * subjects with facets": in neither case is there a list to put a subject
+   * into or take it out of, so neither offers a membership item at all rather
+   * than offering one that would do nothing (#255).
+   */
+  readonly membership: readonly string[] | null;
+}
+
+/**
+ * Putting a subject into the active view, or taking it out — whichever the
+ * view's list does not already say. One group, because a subject is either in
+ * the list or not and only one of the two items is ever true.
+ */
+const membershipGroup = (
+  id: string,
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => {
+  if (context.membership === null) return [];
+  const held = context.membership.includes(id);
+  return [
+    {
+      key: "view",
+      scope: "view",
+      label: "View",
+      destructive: false,
+      items: [
+        held
+          ? {
+              key: "view.remove-subject",
+              label: "Remove from view",
+              intent: { type: "view.remove-subject", id },
+            }
+          : {
+              key: "view.add-subject",
+              label: "Add to this view",
+              intent: { type: "view.add-subject", id },
+            },
+      ],
+    },
+  ];
 }
 
 const NEW_VIEW: ContextMenuItem = {
@@ -128,6 +177,10 @@ const subjectMenu = (
   const node = context.graph?.nodes.find((candidate) => candidate.id === id);
   if (node === undefined) return [];
   return [
+    // Removing a subject from a view rewrites one projection; deleting it from
+    // the model takes every relationship naming it. View first, destructive
+    // last, and the two never neighbours.
+    ...membershipGroup(id, context),
     {
       key: "model",
       scope: "model",
@@ -328,6 +381,9 @@ const modelRowMenu = (
   const node = context.graph?.nodes.find((candidate) => candidate.id === id);
   if (node === undefined) return [];
   return [
+    // The rail's own answer to "add this one to the view I am looking at",
+    // which is what the design draws as a drag from this tree onto the canvas.
+    ...membershipGroup(id, context),
     {
       key: "model",
       scope: "model",

--- a/src/visual-app/session-client.tsx
+++ b/src/visual-app/session-client.tsx
@@ -47,6 +47,13 @@ export interface VisualSession {
   readonly clearFilter: () => void
   readonly setQuickFilterText: (text: string) => void
   readonly stageViewChange: (operation: VisualViewOperation) => void
+  /** One subject into or out of a view's own membership list, composed on top
+   * of whatever is already staged for that view. */
+  readonly stageViewMembership: (
+    viewId: string,
+    subjectId: string,
+    membership: 'add' | 'remove',
+  ) => void
   readonly stageChange: (operation: YarramateOperation) => void
   readonly discardChange: (index: number) => void
   readonly clearChangeset: () => void
@@ -238,6 +245,13 @@ export const useVisualSession = (): VisualSession => {
     dispatch({ type: 'changeset.viewStaged', operation })
   }, [])
 
+  const stageViewMembership = useCallback(
+    (viewId: string, subjectId: string, membership: 'add' | 'remove') => {
+      dispatch({ type: 'changeset.viewMembership', viewId, subjectId, membership })
+    },
+    [],
+  )
+
   const discardChange = useCallback((index: number) => {
     dispatch({ type: 'changeset.discarded', index })
   }, [])
@@ -288,6 +302,7 @@ export const useVisualSession = (): VisualSession => {
     clearFilter,
     setQuickFilterText,
     stageViewChange,
+    stageViewMembership,
     stageChange,
     discardChange,
     clearChangeset,

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -13,6 +13,12 @@ import {
   type VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
 
+import {
+  composeProjection,
+  enumeratesSubjects,
+  sameDocument,
+  withMembership,
+} from "../adapters/visual/view-identity.js";
 import type { YarramateOperation } from "../operations.js";
 import type { ProjectionQuery } from "../projection.js";
 import type {
@@ -175,6 +181,22 @@ export type VisualAppAction =
   | {
       readonly type: "changeset.viewStaged";
       readonly operation: VisualViewOperation;
+    }
+  /**
+   * One subject into or out of one view's own membership list.
+   *
+   * Not a `write-view` composed by the caller, because a second membership
+   * edit has to be composed on top of the first: rows replace by path, so a
+   * caller that composed from the SAVED document would silently drop the
+   * subject it staged a moment ago. The reducer holds both the saved views and
+   * the pending rows, so composing here is the only place it cannot be
+   * forgotten.
+   */
+  | {
+      readonly type: "changeset.viewMembership";
+      readonly viewId: string;
+      readonly subjectId: string;
+      readonly membership: "add" | "remove";
     }
   | { readonly type: "changeset.discarded"; readonly index: number }
   | { readonly type: "changeset.cleared" }
@@ -632,6 +654,50 @@ const transition = (
         commitNotice: null,
       };
     }
+    case "changeset.viewMembership": {
+      const view = state.views.find(({ id }) => id === action.viewId);
+      if (view === undefined) return state;
+      // On top of what is already staged for this document, or on the saved
+      // document when nothing is.
+      const pending = state.pendingChangeset.viewOperations.find(
+        (operation) => operation.path === view.path,
+      );
+      const saved = composeProjection({
+        id: view.id,
+        title: view.title,
+        description: view.description,
+        query: view.query,
+        presentation: view.presentation,
+      });
+      const base = pending?.op === "write-view" ? pending.projection : saved;
+      const amended = withMembership(base, action.subjectId, action.membership);
+      // A view that describes its subjects has nothing to be told, and a list
+      // that already says this has nothing to change.
+      if (amended === null) return state;
+      const others = state.pendingChangeset.viewOperations.filter(
+        (operation) => operation.path !== view.path,
+      );
+      // Back to what the workspace already holds: the row goes rather than
+      // staging a write that changes nothing. The WHOLE document is compared,
+      // not just the list, so a membership edit undone by hand leaves a rename
+      // staged beneath it standing.
+      const undone = sameDocument(amended, saved);
+      return {
+        ...state,
+        pendingChangeset: restage(state.pendingChangeset, state.model, {
+          viewOperations: undone
+            ? others
+            : [
+                ...others,
+                { op: "write-view", path: view.path, projection: amended },
+              ],
+        }),
+        undoStack: [...state.undoStack, state.pendingChangeset],
+        redoStack: [],
+        commitDiagnostics: null,
+        commitNotice: null,
+      };
+    }
     case "changeset.discarded": {
       // The tray shows one list, so the reviewer discards by one index. Which
       // of the two underlying lists that row came from is arithmetic, done
@@ -853,6 +919,30 @@ export const visualBrowserInputFor = (
  * query put back underneath them, and a chat-issued filter must not start
  * reporting itself as the reviewer's own.
  */
+/**
+ * The active view's membership list, as the menus must read it.
+ *
+ * `null` where there is no list to edit: no view is active, or the view
+ * describes its subjects with facets rather than naming them.
+ *
+ * Read through the PENDING row when one is staged, not off the saved document.
+ * A reviewer who has just added a subject and right-clicks it again must be
+ * offered "Remove from view"; a menu built from the saved list would offer
+ * "Add to this view" a second time and stage nothing.
+ */
+export const activeViewMembership = (
+  state: VisualAppState,
+): readonly string[] | null => {
+  const view = state.views.find(({ id }) => id === state.activeView);
+  if (view === undefined) return null;
+  const pending = state.pendingChangeset.viewOperations.find(
+    (operation) => operation.path === view.path,
+  );
+  const query =
+    pending?.op === "write-view" ? pending.projection.query : view.query;
+  return enumeratesSubjects(query) ? query.subjects : null;
+};
+
 export const filterToReresolve = (
   frame: VisualServerFrame,
   state: VisualAppState,
@@ -864,8 +954,22 @@ export const filterToReresolve = (
   // No filter standing is "everything is drawn", which a new subject joins by
   // existing. There is nothing to re-ask.
   if (state.activeFilter === null) return null;
+  // A commit can land a change to the VIEW'S OWN QUERY - putting the subject
+  // the reviewer just created into the list (#255) - and the browser is still
+  // holding that query as it was before the commit. Re-asking the held one
+  // draws the view as it was: the commit reports success, the projection on
+  // disk names the new subject, and the canvas does not change. So the view's
+  // query is re-read off the frame that replaced the model.
+  //
+  // Only for a filter the view itself issued. A reviewer holding their own
+  // panel filter must not have the view's query put back underneath them,
+  // which is the same rule `source` exists for.
+  const landed = frame.views.find(({ id }) => id === state.activeView);
   return {
-    query: state.activeFilter.query,
+    query:
+      state.activeFilter.source === "view" && landed !== undefined
+        ? landed.query
+        : state.activeFilter.query,
     source: state.activeFilter.source,
   };
 };

--- a/test/apply-operations.test.ts
+++ b/test/apply-operations.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   applyOperations,
   landOperations,
+  planOperations,
   posixDirectoryOf,
 } from '../src/apply-command.js'
 import { createFileSystemStore } from '../src/source-store.js'
@@ -654,5 +655,140 @@ relationships: []
     if (!outcome.ok) throw new Error(JSON.stringify(outcome.diagnostics))
     expect(read('architecture/other.yaml')).toBe(other)
     expect(outcome.result.documents).not.toContain('architecture/other.yaml')
+  })
+})
+
+/**
+ * A commit through a store must read the workspace's PROFILES as well as its
+ * documents.
+ *
+ * `applyOperations` reads nothing (ADR 0100): a source it is not handed does
+ * not exist as far as it is concerned. `planOperations` gathered documents,
+ * projections, evidence and adapter mappings and left the profiles out, so the
+ * compile inside it was shown an empty string where a profile should be. An
+ * empty document parses to `null`, and the compiler asks a document for its
+ * `profile` - so every commit against a workspace that declares one died with
+ * `Cannot read properties of null`, and the visual editor could not commit
+ * anything to this repository at all.
+ *
+ * Every fixture in this file declared `profiles: []`, which is exactly why a
+ * green suite never saw it.
+ */
+describe('planOperations reads every source the workspace resolves to', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'yarramate-apply-profiles-'))
+    mkdirSync(join(cwd, 'architecture'), { recursive: true })
+    mkdirSync(join(cwd, 'profiles'), { recursive: true })
+    writeFileSync(
+      join(cwd, 'profiles/house.yaml'),
+      `format: yarramate/profile/v1
+id: house/style
+version: "0.1"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: house-service
+    name: House service
+    parent: yarramate/core@0.1#applicationService
+relationshipKinds: []
+`,
+      'utf8',
+    )
+    writeFileSync(
+      join(cwd, 'architecture/main.yaml'),
+      `format: yarramate/v1
+id: main
+profile: house/style@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+relationships: []
+`,
+      'utf8',
+    )
+    writeFileSync(
+      join(cwd, 'workspace.yaml'),
+      `format: yarramate/workspace/v1
+id: profile-fixture
+documents:
+  - architecture/main.yaml
+profiles:
+  - profiles/house.yaml
+projections: []
+adapterMappings: []
+evidence: []
+`,
+      'utf8',
+    )
+  })
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('plans a batch against a workspace that declares a profile', () => {
+    const loaded = loadWorkspaceManifest(
+      { path: 'workspace.yaml', source: readFileSync(join(cwd, 'workspace.yaml'), 'utf8') },
+      cwd,
+    )
+    if (!loaded.ok) throw new Error('fixture manifest did not load')
+
+    const planned = planOperations(createFileSystemStore(cwd), {
+      workspace: loaded.workspace,
+      operations: {
+        path: 'changeset.yaml',
+        source: `format: yarramate/operations/v1
+operations:
+  - op: add-concept
+    document: architecture/main.yaml
+    concept:
+      id: billing
+      kind: house-service
+      name: Billing
+`,
+      },
+      manifestDirectory: posixDirectoryOf('workspace.yaml'),
+    })
+
+    expect(planned.ok).toBe(true)
+    // The kind is the PROFILE's, so a plan that compiled without the profile
+    // could not have accepted it even if it had survived the null.
+    expect(planned.ok && planned.writes.map(({ path }) => path)).toEqual([
+      'architecture/main.yaml',
+    ])
+  })
+
+  it('never offers a profile as something the batch writes', () => {
+    // Read to be compiled against, never written: no operation can target a
+    // profile, and a plan that offered one would be offering to rewrite the
+    // vocabulary a batch was checked against.
+    const loaded = loadWorkspaceManifest(
+      { path: 'workspace.yaml', source: readFileSync(join(cwd, 'workspace.yaml'), 'utf8') },
+      cwd,
+    )
+    if (!loaded.ok) throw new Error('fixture manifest did not load')
+
+    const planned = planOperations(createFileSystemStore(cwd), {
+      workspace: loaded.workspace,
+      operations: {
+        path: 'changeset.yaml',
+        source: `format: yarramate/operations/v1
+operations:
+  - op: add-concept
+    document: architecture/main.yaml
+    concept:
+      id: billing
+      kind: house-service
+      name: Billing
+`,
+      },
+      manifestDirectory: posixDirectoryOf('workspace.yaml'),
+    })
+
+    expect(
+      planned.ok && planned.writes.some(({ path }) => path.startsWith('profiles/')),
+    ).toBe(false)
   })
 })

--- a/test/changeset-tray.test.ts
+++ b/test/changeset-tray.test.ts
@@ -5,6 +5,7 @@ import type {
   VisualChangesetCommitPayload,
   VisualDiagnostic,
   VisualViewOperation,
+  VisualViewSummary,
 } from '../src/adapters/visual/protocol-contract.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
 import type { YarramateOperation } from '../src/operations.js'
@@ -12,6 +13,7 @@ import type { VisualAppState } from '../src/visual-app/state.js'
 import {
   ChangesetTray,
   changesetRowLabel,
+  describeViewRow,
   describeChangesetRow,
   partitionDiagnostics,
   resolveSubjectName,
@@ -529,5 +531,61 @@ describe('what a refusal says it could not show', () => {
     })
 
     expect(markup).toContain('1 problem: 0 marked on the diagram, 1 not on it.')
+  })
+})
+
+describe('a staged view row says what it moved', () => {
+  const view: VisualViewSummary = {
+    id: 'payment-flow',
+    title: 'Payment flow',
+    description: 'The hop',
+    query: { subjects: ['checkout', 'ledger'] },
+    presentation: { title: 'Payment flow' },
+    path: '.yarramate/projections/payment-flow.yaml',
+    subjectCount: 2,
+  }
+
+  const write = (subjects: readonly string[]): VisualViewOperation => ({
+    op: 'write-view',
+    path: view.path,
+    projection: {
+      format: 'yarramate/projection/v1',
+      id: view.id,
+      version: '1.0',
+      query: { subjects },
+      presentation: { title: 'Payment flow' },
+    },
+  })
+
+  it('names the subjects a membership edit moves, not the file it writes', () => {
+    const row = describeViewRow(write(['checkout', 'ledger', 'fraud-screening']), [view])
+
+    expect(changesetRowLabel(row)).toBe(
+      'write-view · Payment flow · +fraud-screening',
+    )
+    expect(row.scope).toBe('view')
+  })
+
+  it('names every subject one row moved, because rows replace by path', () => {
+    const row = describeViewRow(write(['checkout', 'fraud-screening']), [view])
+
+    expect(changesetRowLabel(row)).toBe(
+      'write-view · Payment flow · +fraud-screening, -ledger',
+    )
+  })
+
+  it('falls back to the path for a row that moved something else', () => {
+    // A rename, a query edit, a presentation flag: the row is about the
+    // document, and the membership has nothing to report.
+    expect(changesetRowLabel(describeViewRow(write(['checkout', 'ledger']), [view]))).toBe(
+      'write-view · Payment flow · .yarramate/projections/payment-flow.yaml',
+    )
+  })
+
+  it('falls back to the path for a view the workspace has never seen', () => {
+    // A brand new view has nothing to be compared against.
+    expect(
+      describeViewRow(write(['checkout']), []).fields,
+    ).toEqual(['.yarramate/projections/payment-flow.yaml'])
   })
 })

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { buildPayload } from '../src/visual-app/save-view.js'
-import type { ProjectionQuery } from '../src/projection.js'
+import type {
+  ProjectionDefinition,
+  ProjectionQuery,
+} from '../src/projection.js'
 import {
   directoryOf,
   duplicateView,
+  membershipDelta,
   renameView,
+  withMembership,
 } from '../src/adapters/visual/view-identity.js'
 
 const query: ProjectionQuery = { kinds: ['yarramate/core@0.1#businessActor'] }
@@ -199,5 +204,76 @@ describe('renaming and duplicating a view', () => {
       '.yarramate/projections/current',
     )
     expect(directoryOf('a.yaml')).toBe('')
+  })
+})
+
+describe('view membership', () => {
+  const listed: ProjectionDefinition = {
+    format: 'yarramate/projection/v1',
+    id: 'payment-flow',
+    version: '1.0',
+    query: { subjects: ['checkout', 'ledger'], relationships: 'between' },
+    presentation: { title: 'Payment flow', description: 'The hop' },
+  }
+
+  const described: ProjectionDefinition = {
+    ...listed,
+    query: { layers: ['application'] },
+  }
+
+  it('adds a subject to a view that lists its subjects', () => {
+    expect(
+      withMembership(listed, 'fraud-screening', 'add')?.query.subjects,
+    ).toEqual(['checkout', 'ledger', 'fraud-screening'])
+  })
+
+  it('appends rather than sorting, because the list belongs to its author', () => {
+    // Sorting it in would rewrite lines nobody touched, and a projection
+    // document is read by people as well as by the compiler.
+    expect(withMembership(listed, 'a-first-alphabetically', 'add')?.query.subjects)
+      .toEqual(['checkout', 'ledger', 'a-first-alphabetically'])
+  })
+
+  it('takes a subject out of the list', () => {
+    expect(withMembership(listed, 'ledger', 'remove')?.query.subjects).toEqual([
+      'checkout',
+    ])
+  })
+
+  it('has nothing to say to a view that describes its subjects', () => {
+    // A facet query already includes anything matching it: membership is
+    // decided by what the subject IS, so there is no list to amend.
+    expect(withMembership(described, 'checkout', 'add')).toBeNull()
+    expect(withMembership(described, 'checkout', 'remove')).toBeNull()
+  })
+
+  it('has nothing to say when the list already says it', () => {
+    // Not an unchanged document: the absence, so no row reaches the tray for
+    // a reviewer to read and discard for nothing.
+    expect(withMembership(listed, 'checkout', 'add')).toBeNull()
+    expect(withMembership(listed, 'fraud-screening', 'remove')).toBeNull()
+  })
+
+  it('carries every other field of the document through untouched', () => {
+    const amended = withMembership(listed, 'fraud-screening', 'add')
+
+    expect(amended?.query.relationships).toBe('between')
+    expect(amended?.presentation?.title).toBe('Payment flow')
+    expect(amended?.id).toBe('payment-flow')
+  })
+
+  it('reports what a row moved, as the tray reads it', () => {
+    expect(
+      membershipDelta(listed.query, {
+        subjects: ['checkout', 'fraud-screening'],
+      }),
+    ).toEqual(['+fraud-screening', '-ledger'])
+  })
+
+  it('reports nothing where the membership did not move', () => {
+    // A rename or a presentation edit is a row about something else, and says
+    // so by other means.
+    expect(membershipDelta(listed.query, listed.query)).toEqual([])
+    expect(membershipDelta(described.query, described.query)).toEqual([])
   })
 })

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -21,10 +21,14 @@ import {
   visualAppSnapshotFrom,
   visualBrowserInputFor,
   type VisualAppAction,
+  activeViewMembership,
   type VisualAppState,
 } from "../src/visual-app/state.js";
 import type { ProjectionQuery } from "../src/projection.js";
-import type { VisualViewOperation } from "../src/adapters/visual/protocol-contract.js";
+import type {
+  VisualViewOperation,
+  VisualViewSummary,
+} from "../src/adapters/visual/protocol-contract.js";
 
 /** A rendered model with an empty canvas graph — only initialView matters here. */
 const model = (
@@ -1653,6 +1657,69 @@ describe("filterToReresolve", () => {
     },
   );
 
+  it("re-asks a view with the query the commit just landed, not the held one", () => {
+    // The defect: creating a subject stages the model row AND a row putting it
+    // into the view's own `subjects:` list (#255). Both land, the projection on
+    // disk names the new subject - and the browser re-asked the query it was
+    // holding, which is the list as it was. The commit reported success and the
+    // canvas did not change.
+    const landedViews: readonly VisualViewSummary[] = [
+      {
+        id: "payment-flow",
+        title: "Payment flow",
+        description: "The hop",
+        query: { subjects: ["checkout", "fraud-screening"] },
+        presentation: {},
+        path: ".yarramate/projections/payment-flow.yaml",
+        subjectCount: 2,
+      },
+    ];
+
+    expect(
+      filterToReresolve(
+        { kind: "model", model: model("all"), views: landedViews },
+        {
+          ...standing("view"),
+          activeView: "payment-flow",
+          activeFilter: {
+            query: { subjects: ["checkout"] },
+            matchedIds: ["checkout"],
+            source: "view",
+          },
+        },
+      ),
+    ).toEqual({
+      query: { subjects: ["checkout", "fraud-screening"] },
+      source: "view",
+    });
+  });
+
+  it("leaves a panel filter alone when a view's query lands underneath it", () => {
+    // A reviewer holding their own query must not have the view's put back.
+    const held = { kinds: ["yarramate/core@0.1#applicationComponent"] };
+
+    expect(
+      filterToReresolve(
+        {
+          kind: "model",
+          model: model("all"),
+          views: [
+            {
+              id: "payment-flow",
+              title: "Payment flow",
+              description: "",
+              query: { subjects: ["checkout", "fraud-screening"] },
+              presentation: {},
+              path: ".yarramate/projections/payment-flow.yaml",
+              subjectCount: 2,
+            },
+          ],
+        },
+        { ...standing("panel"), activeView: "payment-flow" },
+      ),
+    ).toEqual({ query: held, source: "panel" });
+  });
+
   it("has nothing to re-ask when no filter is standing", () => {
     // Unfiltered draws everything, which a new subject joins by existing.
     expect(filterToReresolve(modelFrame, initialVisualAppState)).toBeNull();
@@ -1682,5 +1749,253 @@ describe("filterToReresolve", () => {
     ] as unknown as VisualServerFrame[]) {
       expect(filterToReresolve(frame, standing("view"))).toBeNull();
     }
+  });
+});
+
+/**
+ * A subject into or out of one view's own membership list (#255).
+ *
+ * Composed by the reducer rather than by the caller, because a second edit has
+ * to be composed on top of the first: view rows replace by path, so a caller
+ * composing from the saved document would drop the subject it staged a moment
+ * ago and never say so.
+ */
+describe("visualAppReducer view membership", () => {
+  const PATH = ".yarramate/projections/payment-flow.yaml";
+
+  const view = (
+    query: VisualViewSummary["query"],
+  ): VisualViewSummary => ({
+    id: "payment-flow",
+    title: "Payment flow",
+    description: "The hop",
+    query,
+    presentation: { title: "Payment flow", description: "The hop" },
+    path: PATH,
+    subjectCount: 2,
+  });
+
+  const on = (
+    query: VisualViewSummary["query"] = { subjects: ["checkout", "ledger"] },
+  ): VisualAppState => ({
+    ...initialVisualAppState,
+    activeView: "payment-flow",
+    views: [view(query)],
+  });
+
+  const stage = (
+    state: VisualAppState,
+    subjectId: string,
+    membership: "add" | "remove",
+  ) =>
+    visualAppReducer(state, {
+      type: "changeset.viewMembership",
+      viewId: "payment-flow",
+      subjectId,
+      membership,
+    });
+
+  const subjectsOf = (state: VisualAppState) => {
+    const operation = state.pendingChangeset.viewOperations[0];
+    return operation?.op === "write-view"
+      ? operation.projection.query.subjects
+      : undefined;
+  };
+
+  it("stages the view's document with one more subject in it", () => {
+    const state = stage(on(), "fraud-screening", "add");
+
+    expect(state.pendingChangeset.viewOperations).toHaveLength(1);
+    expect(state.pendingChangeset.viewOperations[0]?.path).toBe(PATH);
+    expect(subjectsOf(state)).toEqual([
+      "checkout",
+      "ledger",
+      "fraud-screening",
+    ]);
+  });
+
+  it("composes a second edit on top of the first, not on the saved document", () => {
+    // The defect this exists to close: rows replace by path, so composing the
+    // second edit from the saved view would silently drop the first.
+    const twice = stage(stage(on(), "fraud-screening", "add"), "refunds", "add");
+
+    expect(twice.pendingChangeset.viewOperations).toHaveLength(1);
+    expect(subjectsOf(twice)).toEqual([
+      "checkout",
+      "ledger",
+      "fraud-screening",
+      "refunds",
+    ]);
+  });
+
+  it("drops the row when the membership comes back to what is on disk", () => {
+    // Adding and then removing is not a write that changes nothing; it is no
+    // change at all, and a row nobody can act on should not be in the tray.
+    const undone = stage(
+      stage(on(), "fraud-screening", "add"),
+      "fraud-screening",
+      "remove",
+    );
+
+    expect(undone.pendingChangeset.viewOperations).toEqual([]);
+  });
+
+  it("says nothing to a view that describes its subjects with facets", () => {
+    // The rule lives here rather than in the shell: a caller that had to know
+    // which views enumerate is a caller that can forget.
+    const described = stage(on({ layers: ["application"] }), "checkout", "add");
+
+    expect(described.pendingChangeset.viewOperations).toEqual([]);
+    expect(described.undoStack).toEqual([]);
+  });
+
+  it("says nothing when no view is active, or the view has gone", () => {
+    const noView = visualAppReducer(initialVisualAppState, {
+      type: "changeset.viewMembership",
+      viewId: "",
+      subjectId: "checkout",
+      membership: "add",
+    });
+
+    expect(noView).toBe(initialVisualAppState);
+  });
+
+  it("says nothing when the list already holds the subject", () => {
+    expect(stage(on(), "checkout", "add").pendingChangeset.viewOperations).toEqual(
+      [],
+    );
+  });
+
+  it("is undoable like every other staged row", () => {
+    const state = stage(on(), "fraud-screening", "add");
+    const undone = visualAppReducer(state, { type: "changeset.undone" });
+
+    expect(undone.pendingChangeset.viewOperations).toEqual([]);
+    expect(
+      visualAppReducer(undone, { type: "changeset.redone" }).pendingChangeset
+        .viewOperations,
+    ).toHaveLength(1);
+  });
+
+  it("keeps the view's other fields, so a membership edit is not a rewrite", () => {
+    const state = stage(
+      on({ subjects: ["checkout"], relationships: "connected" }),
+      "ledger",
+      "add",
+    );
+    const operation = state.pendingChangeset.viewOperations[0];
+
+    expect(operation?.op === "write-view" ? operation.projection : null)
+      .toMatchObject({
+        id: "payment-flow",
+        query: { relationships: "connected" },
+        presentation: { title: "Payment flow" },
+      });
+  });
+});
+
+describe("activeViewMembership", () => {
+  const PATH = ".yarramate/projections/payment-flow.yaml";
+  const summary: VisualViewSummary = {
+    id: "payment-flow",
+    title: "Payment flow",
+    description: "The hop",
+    query: { subjects: ["checkout"] },
+    presentation: {},
+    path: PATH,
+    subjectCount: 1,
+  };
+
+  it("is the active view's list", () => {
+    expect(
+      activeViewMembership({
+        ...initialVisualAppState,
+        activeView: "payment-flow",
+        views: [summary],
+      }),
+    ).toEqual(["checkout"]);
+  });
+
+  it("is null where no view is active, or the view describes its subjects", () => {
+    expect(
+      activeViewMembership({ ...initialVisualAppState, views: [summary] }),
+    ).toBeNull();
+    expect(
+      activeViewMembership({
+        ...initialVisualAppState,
+        activeView: "payment-flow",
+        views: [{ ...summary, query: { layers: ["application"] } }],
+      }),
+    ).toBeNull();
+  });
+
+  it("reads through the staged row, so a menu never offers the same edit twice", () => {
+    // A reviewer who has just added a subject and right-clicks it again must
+    // be offered Remove; the saved list would offer Add a second time and
+    // stage nothing.
+    const staged = visualAppReducer(
+      { ...initialVisualAppState, activeView: "payment-flow", views: [summary] },
+      {
+        type: "changeset.viewMembership",
+        viewId: "payment-flow",
+        subjectId: "ledger",
+        membership: "add",
+      },
+    );
+
+    expect(activeViewMembership(staged)).toEqual(["checkout", "ledger"]);
+  });
+});
+
+describe("a membership edit under a rename", () => {
+  const PATH = ".yarramate/projections/payment-flow.yaml";
+  const summary: VisualViewSummary = {
+    id: "payment-flow",
+    title: "Payment flow",
+    description: "The hop",
+    query: { subjects: ["checkout"] },
+    presentation: { title: "Payment flow", description: "The hop" },
+    path: PATH,
+    subjectCount: 1,
+  };
+  const renamed: VisualViewOperation = {
+    op: "write-view",
+    path: PATH,
+    projection: {
+      format: "yarramate/projection/v1",
+      id: "payment-flow",
+      version: "1.0",
+      query: { subjects: ["checkout"] },
+      presentation: { title: "Payments", description: "The hop" },
+    },
+  };
+
+  it("keeps the rename when the membership is put back", () => {
+    // One row per document, so the two edits share a row. Dropping it because
+    // the LIST came back to what is on disk would silently discard a rename
+    // the reviewer never undid.
+    const base: VisualAppState = {
+      ...initialVisualAppState,
+      activeView: "payment-flow",
+      views: [summary],
+    };
+    const withRename = visualAppReducer(base, {
+      type: "changeset.viewStaged",
+      operation: renamed,
+    });
+    const added = visualAppReducer(withRename, {
+      type: "changeset.viewMembership",
+      viewId: "payment-flow",
+      subjectId: "ledger",
+      membership: "add",
+    });
+    const removed = visualAppReducer(added, {
+      type: "changeset.viewMembership",
+      viewId: "payment-flow",
+      subjectId: "ledger",
+      membership: "remove",
+    });
+
+    expect(removed.pendingChangeset.viewOperations).toEqual([renamed]);
   });
 });

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -96,6 +96,7 @@ const context = (
   relationshipKinds: VOCABULARY,
   activeViewId: "",
   filtered: false,
+  membership: null,
   ...overrides,
 });
 
@@ -415,5 +416,53 @@ describe("what the menu draws", () => {
 
   it("draws nothing at all for a target that has gone", () => {
     expect(render({ kind: "subject", id: "gone" })).toBe("");
+  });
+});
+
+/**
+ * Membership is a VIEW operation on a MODEL subject, which is exactly the pair
+ * the split exists to keep apart: removing a subject from a view rewrites one
+ * projection, and the item one group below it takes the subject out of the
+ * model entirely (#255).
+ */
+describe("putting a subject into a view, and taking it out", () => {
+  const held = context({ membership: ["api", "ui"] });
+  const notHeld = context({ membership: ["ui"] });
+
+  it("offers Remove from view for a subject the view lists", () => {
+    expect(labels(contextMenuFor({ kind: "subject", id: "api" }, held))).toEqual(
+      ["Remove from view", "Properties", "Connect from here…", "Delete from model…"],
+    );
+  });
+
+  it("offers Add to this view for one it does not", () => {
+    // A subject can be DRAWN without being listed - `relationships: connected`
+    // takes the other end of a relationship with it - so what is on the canvas
+    // does not settle what the list says.
+    expect(
+      labels(contextMenuFor({ kind: "subject", id: "api" }, notHeld)),
+    ).toContain("Add to this view");
+  });
+
+  it("offers neither where the view has no list to edit", () => {
+    // No view active, or a view that describes its subjects with facets: an
+    // item that could only ever do nothing is worse than no item.
+    const groups = contextMenuFor({ kind: "subject", id: "api" }, context());
+    expect(labels(groups)).not.toContain("Remove from view");
+    expect(labels(groups)).not.toContain("Add to this view");
+    expect(groups.every((group) => group.scope === "model")).toBe(true);
+  });
+
+  it("gives the rail's model rows the same offer, which is what a drag would do", () => {
+    expect(
+      labels(contextMenuFor({ kind: "model-row", id: "api" }, notHeld)),
+    ).toEqual(["Add to this view", "Properties", "Delete from model…"]);
+  });
+
+  it("keeps the membership item in the view half, above the model's", () => {
+    const groups = contextMenuFor({ kind: "subject", id: "api" }, held);
+    expect(groups[0]?.scope).toBe("view");
+    expect(groups[0]?.label).toBe("View");
+    expect(groups[groups.length - 1]?.destructive).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #255. Part of #244.

Two commits, and the first is the one to read.

## `2cb5a31` — a commit died on any workspace that declares a profile

Found by pressing **Commit** in the browser, which is the only place it could be
found.

`applyOperations` reads nothing (ADR 0100) — a source it is not handed does not
exist as far as it is concerned — and it compiles the candidate workspace from
`[...profiles, ...documents]`. `planOperations`, the store-backed caller **the
visual adapter uses**, gathered documents, projections, evidence and adapter
mappings and left the PROFILES out. The compile was handed an empty string where
a profile should be; an empty document parses to `null`; the compiler asked that
`null` for its `profile`.

The browser reported `YMVS307 … Cannot read properties of null (reading
'profile')` and nothing landed. **This repository's own workspace declares a
profile, so the visual editor could not commit anything to it at all** — not a
subject, not a view, not a relationship.

Every fixture in `apply-operations.test.ts` declares `profiles: []`. That is
exactly why a green suite never saw it, and the new regression test reproduces
the crash without the one-line fix.

## `fa5953f` — view membership (#255)

#254 made the browser re-ask its standing filter after a commit, so a created
subject appears on any view whose *query* matches it: 14 of this repo's 22
projections. The other 8 enumerate `subjects:`, and a list written before the
subject existed can never match it.

Creating a subject now stages two rows, and the tray tells them apart:

```
add-concept · fraud-screening · kind, name                            [model]
write-view · YarraMate Core contract foundation · +fraud-screening    [view]
```

**Remove from view** and **Add to this view** stage the same amendment from the
subject menu and the rail's Model rows, in the view group, above the model's and
well away from **Delete from model…**.

**Only a view that enumerates `subjects:` can be told.** One that describes its
subjects with facets already includes anything matching them, so there is
nothing a membership edit could say to it. Neither item appears there, and the
reducer no-ops rather than trusting a caller to know.

**The reducer composes the amendment, not the caller.** Staged view rows replace
by path, so a second edit composed from the saved document would silently drop
the first. An edit that returns the document to what is on disk drops the row
instead of staging a write that changes nothing — comparing the whole document,
so a rename staged underneath it survives.

### Two more defects the browser found

1. A commit that landed a change to the active view's own query **re-asked the
   query the browser was holding**. The projection on disk named the new
   subject, the commit reported success, and the canvas did not change.
2. A commit that wrote model documents *and* projections reported only the
   model's half: "Committed · 1 file" where two landed.

## A call worth challenging

**Drag from the Model tree onto the canvas is deliberately not built.** The
design draws the capability as a drag; this ships it as a menu item on the same
rows. The reason is testability — this repo has no DOM test environment, and
HTML5 drag-and-drop onto a cytoscape canvas is exercisable by neither
`renderToStaticMarkup` nor a synthetic event. Say the word and it can be added
on top; nothing here would change.

## Verification

`pnpm verify` green: 85 files, 1437 tests, `self:check` clean, LikeC4 valid.

Driven live end to end: created a subject on a view that enumerates its
subjects, committed, watched it appear on that canvas with the row going 11 → 12
and the receipt naming both files; then removed it from the view and watched it
leave the canvas and stay in the model. Every workspace edit made during that
run was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)