### PR TITLE
The right column becomes a stack of sections, and chat owns the session's button (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## 1.0.0
 
+- **Changed.** The right column is a stack of collapsible sections — element
+  properties, changes, chat — split by handles a pointer or the arrow keys can
+  drag, with chat pinned at the foot (#249). There is no open/closed mode for
+  the column any more: a shut section header still says what is behind it (the
+  selected subject, the staged count, whose turn it is) where a shut column
+  said nothing, which is also why an unread count now appears only while
+  **Chat** is shut.
+
+- **Breaking.** The command strip carries identity and nothing else. Its
+  controls went to the things they act on: the **quick filter** to the canvas
+  it narrows, **Save view** to the form the rail and the menus already open,
+  **End** to the chat section that owns the conversation. The **Details**
+  disclosure is gone — it only ever revealed one sentence, and a sentence about
+  what the session *is* now sits beside the name. **Conversation** is gone with
+  the mode it toggled.
+
+- **Changed.** `End` is **Return to agent**, which is what it always did — its
+  own notice has always read "Returning control to the main agent". One button:
+  the design draws `End session` beside it for a handback that leaves the
+  session live, nothing can do that yet, and a button that claimed to would be
+  lying about the lifecycle.
+
+- **Changed.** **New view…** seeds from the query on screen instead of clearing
+  it first. Saving a view is keeping what you are looking at, and the strip
+  button that used to do that is gone; this reverses the call #245 made when
+  the menu item was the only way to reach the form.
+
 - **Changed.** A folder is something the author declares, not where the file
   sits (#261, ADR 0104). `presentation.folder` on a projection and `folder` on
   a concept, both labels nested with `/`, both optional, neither resolved

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -80,6 +80,39 @@ canonical; see
 for what changed and why a mechanical operation batch is not an inferred
 model.
 
+## The shell
+
+Three columns, and the middle one is the diagram.
+
+**The command strip carries identity and nothing else** (#249): the session's
+name, its beta badge, the authority line, the connection state, and one line of
+description. Every control it used to hold has gone to the thing it acts on —
+the quick filter to the canvas it narrows, saving a view to the rail that lists
+views, ending the session to the chat section that owns the conversation. The
+`Details` disclosure went with them: it only ever revealed a sentence, and a
+sentence about what the session *is* belongs beside the name.
+
+**The right column is a stack of collapsible sections**, split by handles a
+pointer or the arrow keys can drag:
+
+1. **Element properties** — the subject form. Its header names the selected
+   subject; selecting one opens the section, because that is what selecting was
+   for.
+2. **Changes** — the staged rows, and how many are staged.
+3. **Chat** — pinned at the foot, owning the session's own control.
+
+There is no open/closed mode for the column. The sections collapse one at a
+time, and a shut header still says what is behind it — the selected subject,
+the staged count, whose turn it is — where a shut column said nothing at all.
+That is also why an unread count only appears while **Chat** is shut: a reply
+that lands in front of the reviewer needs no number standing in for it.
+
+**`Return to agent` is one button, and it does what it always did**: hand
+control back to the main agent, which is what the notice it writes has always
+said. The design draws a second, `End session`, for a handback that leaves the
+session live. Nothing can do that yet — `session.end` freezes the session — and
+a button that claimed otherwise would be lying about the lifecycle.
+
 ## Layout is presentation the repository keeps
 
 Dragging a node saves absolute positions to an adapter-owned sidecar,

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -3,7 +3,7 @@ import type { PresentationFlag } from "./query-fields.js";
 import { QueryPanel, type BottomPanelTabId } from "./query-panel.js";
 import { QuickFilterBox } from "./quick-filter.js";
 import { ViewTree } from "./view-tree.js";
-import { SaveViewControl } from "./save-view.js";
+import { SaveViewDialog } from "./save-view.js";
 import { describeQuery } from "./describe-query.js";
 import { ChangesetTray } from "./changeset-tray.js";
 import { ConceptForm, RelationshipForm } from "./subject-form.js";
@@ -30,6 +30,7 @@ import type {
   VisualViewOperation,
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
+import { Section, SectionSplitter } from "./section-stack.js";
 import { useVisualSession } from "./session-client.js";
 import { activeViewMembership } from "./state.js";
 import type { VisualAppRecord, VisualAppState } from "./state.js";
@@ -43,6 +44,7 @@ import {
   viewNeedingApplication,
   visualWorkspaceReducer,
   type ConnectionDraft,
+  type RightSectionId,
   type SelectedDiagramSubject,
 } from "./workspace-state.js";
 import { ConnectionPanel } from "./connection-panel.js";
@@ -111,48 +113,25 @@ const endTransitionStatus = (state: VisualAppState): string => {
   return "Ending conversation — preparing a handoff for the main agent.";
 };
 
+/**
+ * Identity, and nothing else (#249).
+ *
+ * Every control the strip used to carry has gone to the thing it acts on: the
+ * quick filter to the canvas it narrows, saving a view to the rail that lists
+ * views, ending the session to the chat section that owns the conversation. A
+ * strip that carried them put the session's most consequential button as far
+ * from the conversation as the window allows.
+ *
+ * The description sits here rather than behind a `Details` disclosure. It is
+ * one line about what this session IS, which is identity - and a button that
+ * only ever revealed a sentence was a control the strip had no reason to keep.
+ */
 const CommandStrip = ({
   state,
   connection,
-  detailsOpen,
-  conversationOpen,
-  unread,
-  layout,
-  views,
-  onToggleDetails,
-  onToggleConversation,
-  onSelectLayout,
-  showLifecycle,
-  showEvidence,
-  showOwnership,
-  quickFilterText,
-  onQuickFilterChange,
-  saveViewOpen,
-  saveViewFolder,
-  onToggleSaveView,
-  onStageView,
-  onEnd,
 }: {
   readonly state: VisualAppState;
   readonly connection: string;
-  readonly detailsOpen: boolean;
-  readonly conversationOpen: boolean;
-  readonly unread: number;
-  readonly layout: "layered";
-  readonly views: readonly VisualViewSummary[];
-  readonly onToggleDetails: () => void;
-  readonly onToggleConversation: () => void;
-  readonly onSelectLayout: (layout: "layered") => void;
-  readonly showLifecycle: boolean;
-  readonly showEvidence: boolean;
-  readonly showOwnership: boolean;
-  readonly quickFilterText: string;
-  readonly onQuickFilterChange: (text: string) => void;
-  readonly saveViewOpen: boolean;
-  readonly saveViewFolder: string | undefined;
-  readonly onToggleSaveView: () => void;
-  readonly onStageView: (operation: VisualViewOperation) => void;
-  readonly onEnd: () => void;
 }) => (
   <header className="command-strip">
     <div className="command-identity">
@@ -163,68 +142,11 @@ const CommandStrip = ({
         {connection}
       </span>
     </div>
-    <div className="command-actions">
-      <span
-        className="end-transition-status"
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        {endTransitionStatus(state)}
-      </span>
-      <QuickFilterBox value={quickFilterText} onChange={onQuickFilterChange} />
-      <SaveViewControl
-        views={views}
-        activeViewId={state.activeView}
-        query={state.activeFilter?.query ?? null}
-        layout={layout}
-        showLifecycle={showLifecycle}
-        showEvidence={showEvidence}
-        showOwnership={showOwnership}
-        open={saveViewOpen}
-        folder={saveViewFolder}
-        onToggle={onToggleSaveView}
-        onStage={onStageView}
-      />
-      <button
-        type="button"
-        aria-expanded={detailsOpen}
-        aria-controls="session-details"
-        onClick={onToggleDetails}
-      >
-        Details
-      </button>
-      <button
-        type="button"
-        aria-expanded={conversationOpen}
-        aria-controls="conversation-panel"
-        onClick={onToggleConversation}
-      >
-        Conversation
-        {unread === 0 ? null : (
-          <span className="attention-count">{unread}</span>
-        )}
-      </button>
-      <button
-        type="button"
-        className="end-session"
-        onClick={onEnd}
-        disabled={state.lifecycle !== "active"}
-      >
-        {state.lifecycle === "ending" || state.lifecycle === "closed"
-          ? "Ending…"
-          : "End"}
-      </button>
-    </div>
-    {/* Static prose is not worth the canvas: the disclosure is laid over the
-        workspace from the strip rather than taking a row of its own, so opening
-        it never reflows the diagram or the conversation. */}
-    <div id="session-details" className="session-details" hidden={!detailsOpen}>
-      <p>{state.description}</p>
-      <button type="button" className="details-close" onClick={onToggleDetails}>
-        Close details
-      </button>
-    </div>
+    {state.description === "" ? null : (
+      <p className="session-description" title={state.description}>
+        {state.description}
+      </p>
+    )}
   </header>
 );
 
@@ -313,6 +235,7 @@ const DiagramWorkspace = ({
   onClearFilter,
   onSaveLayout,
   onCanvasReady,
+  onQuickFilterChange,
   view,
   bottomPanel,
   onTogglePresentation,
@@ -355,6 +278,7 @@ const DiagramWorkspace = ({
   readonly onClearFilter: () => void;
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void;
   readonly onCanvasReady: (png: (() => string) | null) => void;
+  readonly onQuickFilterChange: (text: string) => void;
   readonly view: VisualViewSummary | null;
   readonly bottomPanel: {
     readonly open: boolean;
@@ -407,13 +331,22 @@ const DiagramWorkspace = ({
       ) : null}
       <div className="canvas">
         {state.model === null ? null : (
-          <button
-            type="button"
-            className="subject-draft-open"
-            onClick={onDraftSubject}
-          >
-            Add subject
-          </button>
+          // On the canvas, because the canvas is what it narrows. It used to
+          // sit in the command strip, as far from the diagram as the window
+          // allows, next to controls that had nothing to do with it (#249).
+          <div className="canvas-controls">
+            <QuickFilterBox
+              value={state.quickFilterText}
+              onChange={onQuickFilterChange}
+            />
+            <button
+              type="button"
+              className="subject-draft-open"
+              onClick={onDraftSubject}
+            >
+              Add subject
+            </button>
+          </div>
         )}
         {!draftingSubject || state.model === null ? null : (
           <SubjectDraftPanel
@@ -678,42 +611,45 @@ const SelectedSubjectInspector = ({
   );
 };
 
-const ConversationPanel = ({
+/**
+ * The chat section: the transcript, the composer, and the session's own
+ * control (#249).
+ *
+ * `Return to agent` lives HERE, beside the conversation it ends, rather than in
+ * a strip that carries identity and nothing else. It is one button and it does
+ * what it always did - hand control back to the main agent, which is what the
+ * notice it writes has always said. The design draws a second, `End session`,
+ * for a handback that leaves the session live; nothing can do that yet, and a
+ * button that claimed to would be lying about the lifecycle.
+ */
+/**
+ * What the Chat header says while it is shut, which is whose turn it is. A
+ * count belongs there only when something arrived unread; the rest of the time
+ * the useful word is what the agent is doing.
+ */
+const chatMeta = (state: VisualAppState): string =>
+  state.lifecycle !== "active"
+    ? "closed"
+    : state.awaitingAgent
+      ? (STATUS_WORDS[state.agentStatus?.state ?? "thinking"] ?? "working")
+      : "agent idle";
+
+const ChatSection = ({
   state,
-  hidden,
   disabled,
   selectedSubject,
-  descriptionExpanded,
   onSend,
   onChoice,
-  onToggleDescription,
   onClearSubject,
-  onConnect,
-  onDelete,
-  onDiscardChange,
-  onStageChange,
-  onClearChangeset,
-  onUndoChangeset,
-  onRedoChangeset,
-  onCommitChangeset,
+  onEnd,
 }: {
   readonly state: VisualAppState;
-  readonly hidden: boolean;
   readonly disabled: boolean;
   readonly selectedSubject: SelectedDiagramSubject | null;
-  readonly descriptionExpanded: boolean;
   readonly onSend: (text: string) => void;
   readonly onChoice: (optionId: string) => void;
-  readonly onToggleDescription: () => void;
   readonly onClearSubject: () => void;
-  readonly onConnect: (from: string) => void;
-  readonly onDelete: (id: string) => void;
-  readonly onDiscardChange: (index: number) => void;
-  readonly onStageChange: (operation: YarramateOperation) => void;
-  readonly onClearChangeset: () => void;
-  readonly onUndoChangeset: () => void;
-  readonly onRedoChangeset: () => void;
-  readonly onCommitChangeset: () => void;
+  readonly onEnd: () => void;
 }) => {
   const [draft, setDraft] = useState("");
   const agentWaiting = state.lifecycle === "active" && state.awaitingAgent;
@@ -735,36 +671,8 @@ const ConversationPanel = ({
   };
 
   return (
-    <section
-      id="conversation-panel"
-      className="talk"
-      aria-label="Conversation"
-      hidden={hidden}
-    >
+    <div className="talk">
       <div className="conversation-scroll">
-        {selectedSubject === null || state.model === null ? null : (
-          <SelectedSubjectInspector
-            subject={selectedSubject}
-            model={state.model}
-            operations={state.pendingChangeset.operations}
-            expanded={descriptionExpanded}
-            onToggleDescription={onToggleDescription}
-            onClear={onClearSubject}
-            onConnect={onConnect}
-            onDelete={onDelete}
-            onStageChange={onStageChange}
-          />
-        )}
-
-        <ChangesetTray
-          state={state}
-          onDiscardChange={onDiscardChange}
-          onClearChangeset={onClearChangeset}
-          onUndoChangeset={onUndoChangeset}
-          onRedoChangeset={onRedoChangeset}
-          onCommitChangeset={onCommitChangeset}
-        />
-
         <ol className="ledger" role="log" aria-live="polite">
           {state.transcript.length === 0 ? (
             <li className="empty">
@@ -851,8 +759,28 @@ const ConversationPanel = ({
             Send
           </button>
         </div>
+        <div className="session-foot">
+          <span
+            className="end-transition-status"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {endTransitionStatus(state)}
+          </span>
+          <button
+            type="button"
+            className="end-session"
+            onClick={onEnd}
+            disabled={state.lifecycle !== "active"}
+          >
+            {state.lifecycle === "ending" || state.lifecycle === "closed"
+              ? "Returning…"
+              : "Return to agent"}
+          </button>
+        </div>
       </form>
-    </section>
+    </div>
   );
 };
 
@@ -943,13 +871,17 @@ export const App = () => {
 
   const [workspace, dispatchWorkspace] = useReducer(
     visualWorkspaceReducer,
-    window.innerWidth,
-    createVisualWorkspaceState,
+    // Both dimensions: the column's width is clamped against one and the
+    // sections' heights against the other, and a stack seeded with no height
+    // clamps every splitter to its floor (#249).
+    { width: window.innerWidth, height: window.innerHeight },
+    ({ width, height }) => createVisualWorkspaceState(width, height),
   );
 
   const [layoutWaiting, setLayoutWaiting] = useState<string | null>(null);
-  // The save-view form has two openers now — its own toggle in the strip and
-  // the tree's new-view button — so the shell owns whether it is open.
+  // The save-view form has several openers - the rail's new-view button and
+  // three context-menu items - and none of them is the form, so the shell owns
+  // whether it is open.
   const [saveViewOpen, setSaveViewOpen] = useState(false);
   // Which folder a new view is saved into. Set by "New view in this folder…"
   // and cleared by every other opener, so the default directory is what a
@@ -970,6 +902,7 @@ export const App = () => {
       dispatchWorkspace({
         type: "viewport.resized",
         viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
       });
     window.addEventListener("resize", resized);
     return () => window.removeEventListener("resize", resized);
@@ -1059,13 +992,26 @@ export const App = () => {
         ? "Reading the session"
         : "No model to draw";
 
-  const conversationOpen = workspace.conversation.mode === "open";
+  const stagedCount =
+    state.pendingChangeset.operations.length +
+    state.pendingChangeset.viewOperations.length;
+  const sectionOpen = (section: RightSectionId) =>
+    !workspace.conversation.collapsed.includes(section);
   const treeCollapsed = useMemo(
     () => new Set(workspace.tree.collapsed),
     [workspace.tree.collapsed],
   );
   const shellStyle = {
     "--conversation-width": `${workspace.conversation.width}px`,
+    // The two sections that have a height of their own; properties takes what
+    // is left. A shut section is its header and nothing more, so the height it
+    // was dragged to waits for it to open again.
+    "--changes-height": sectionOpen("changes")
+      ? `${workspace.conversation.changesHeight}px`
+      : "auto",
+    "--chat-height": sectionOpen("chat")
+      ? `${workspace.conversation.chatHeight}px`
+      : "auto",
   } as CSSProperties;
 
   const openMenu = (
@@ -1176,10 +1122,9 @@ export const App = () => {
         dispatchWorkspace({ type: "menu.dismissed" });
         return;
       case "view.new":
-        // Same two motions the rail's own new-view button makes: a new view
-        // starts from the whole model, and the form seeds itself from what is
-        // active, so clearing first is what makes its fields blank.
-        clearFilter();
+        // Same motion the rail's own new-view button makes, and seeded the
+        // same way: from the query on the canvas, because that is what a
+        // reviewer reaching for "new view" is usually keeping (#249).
         setSaveViewFolder(undefined);
         setSaveViewOpen(true);
         dispatchWorkspace({ type: "menu.dismissed" });
@@ -1217,7 +1162,6 @@ export const App = () => {
         // the filesystem is involved: both documents sit beside every other
         // projection and say which folder they belong to (ADR 0104).
         setSaveViewFolder(declaredFolder(view));
-        clearFilter();
         setSaveViewOpen(true);
         dispatchWorkspace({ type: "menu.dismissed" });
         return;
@@ -1258,37 +1202,8 @@ export const App = () => {
 
   return (
     <main className="visual-shell" style={shellStyle}>
-      <CommandStrip
-        state={state}
-        connection={connectionOf(state, connected)}
-        detailsOpen={workspace.detailsOpen}
-        conversationOpen={conversationOpen}
-        unread={workspace.conversation.unread}
-        layout={workspace.layout}
-        showLifecycle={workspace.showLifecycle}
-        showEvidence={workspace.showEvidence}
-        showOwnership={workspace.showOwnership}
-        views={state.views}
-        onToggleDetails={() => dispatchWorkspace({ type: "details.toggled" })}
-        onToggleConversation={() =>
-          dispatchWorkspace({ type: "conversation.toggled" })
-        }
-        onSelectLayout={(layout) =>
-          dispatchWorkspace({ type: "layout.set", layout })
-        }
-        quickFilterText={state.quickFilterText}
-        onQuickFilterChange={setQuickFilterText}
-        saveViewOpen={saveViewOpen}
-        saveViewFolder={saveViewFolder}
-        onToggleSaveView={() => setSaveViewOpen((open) => !open)}
-        onStageView={stageViewChange}
-        onEnd={end}
-      />
-      <div
-        className={`workspace workspace-conversation-${
-          conversationOpen ? "open" : "closed"
-        }`}
-      >
+      <CommandStrip state={state} connection={connectionOf(state, connected)} />
+      <div className="workspace">
         <ViewTree
           views={state.views}
           activeViewId={state.activeView}
@@ -1310,10 +1225,12 @@ export const App = () => {
           onSelectView={(id) => navigate(id)}
           onClearView={clearFilter}
           onNewView={() => {
-            // A new view starts from the whole model rather than from whatever
-            // the last one narrowed to, and the form seeds itself from the
-            // active view — so clearing first is what makes its fields blank.
-            clearFilter();
+            // Seeded from what is on the canvas, not from a blank model. The
+            // strip's `Save view` button was how a reviewer kept the query they
+            // were looking at, and the strip carries identity only now (#249) -
+            // so this is that motion, and clearing the filter first would throw
+            // away the thing being saved. It reverses the call #245 made when
+            // this item was the only way to reach the form.
             setSaveViewFolder(undefined);
             setSaveViewOpen(true);
           }}
@@ -1397,6 +1314,7 @@ export const App = () => {
           onCanvasReady={(png) => {
             canvasPngRef.current = png;
           }}
+          onQuickFilterChange={setQuickFilterText}
           view={
             state.views.find((candidate) => candidate.id === state.activeView) ??
             null
@@ -1416,40 +1334,121 @@ export const App = () => {
           onApplyFilter={(query) => filter(query, "editor")}
           onStageView={stageViewChange}
         />
-        {conversationOpen ? (
-          <ConversationSeparator
-            width={workspace.conversation.width}
-            viewportWidth={workspace.viewportWidth}
-            onResize={(width) =>
-              dispatchWorkspace({ type: "conversation.resized", width })
+        <ConversationSeparator
+          width={workspace.conversation.width}
+          viewportWidth={workspace.viewportWidth}
+          onResize={(width) =>
+            dispatchWorkspace({ type: "conversation.resized", width })
+          }
+        />
+        <aside className="section-stack" aria-label="Session">
+          <Section
+            id="properties"
+            label="Element properties"
+            meta={workspace.selectedSubject?.id}
+            open={sectionOpen("properties")}
+            onToggle={() =>
+              dispatchWorkspace({ type: "section.toggled", section: "properties" })
+            }
+          >
+            {workspace.selectedSubject === null || state.model === null ? (
+              <p className="section-empty">
+                Nothing selected. Pick a subject on the canvas or in the rail.
+              </p>
+            ) : (
+              <SelectedSubjectInspector
+                subject={workspace.selectedSubject}
+                model={state.model}
+                operations={state.pendingChangeset.operations}
+                expanded={workspace.descriptionExpanded}
+                onToggleDescription={() =>
+                  dispatchWorkspace({ type: "description.toggled" })
+                }
+                onClear={() => dispatchWorkspace({ type: "subject.cleared" })}
+                onConnect={(from) =>
+                  dispatchWorkspace({ type: "connection.started", from })
+                }
+                onDelete={(id) =>
+                  dispatchWorkspace({ type: "deletion.asked", id })
+                }
+                onStageChange={stageChange}
+              />
+            )}
+          </Section>
+          <SectionSplitter
+            label="Resize the changes section"
+            height={workspace.conversation.changesHeight}
+            viewportHeight={workspace.viewportHeight}
+            onResize={(height) =>
+              dispatchWorkspace({
+                type: "section.resized",
+                section: "changes",
+                height,
+              })
             }
           />
-        ) : null}
-        <ConversationPanel
-          state={state}
-          hidden={!conversationOpen}
-          disabled={!state.composerEnabled}
-          selectedSubject={workspace.selectedSubject}
-          descriptionExpanded={workspace.descriptionExpanded}
-          onSend={(text) =>
-            ask(formatContextualQuestion(text, workspace.selectedSubject))
-          }
-          onChoice={choose}
-          onToggleDescription={() =>
-            dispatchWorkspace({ type: "description.toggled" })
-          }
-          onClearSubject={() => dispatchWorkspace({ type: "subject.cleared" })}
-          onConnect={(from) =>
-            dispatchWorkspace({ type: "connection.started", from })
-          }
-          onDelete={(id) => dispatchWorkspace({ type: "deletion.asked", id })}
-          onDiscardChange={discardChange}
-          onStageChange={stageChange}
-          onClearChangeset={clearChangeset}
-          onUndoChangeset={undoChangeset}
-          onRedoChangeset={redoChangeset}
-          onCommitChangeset={commitChangeset}
-        />
+          <Section
+            id="changes"
+            label="Changes"
+            meta={stagedCount === 0 ? "nothing staged" : `${stagedCount} staged`}
+            open={sectionOpen("changes")}
+            onToggle={() =>
+              dispatchWorkspace({ type: "section.toggled", section: "changes" })
+            }
+          >
+            <ChangesetTray
+              state={state}
+              onDiscardChange={discardChange}
+              onClearChangeset={clearChangeset}
+              onUndoChangeset={undoChangeset}
+              onRedoChangeset={redoChangeset}
+              onCommitChangeset={commitChangeset}
+            />
+          </Section>
+          <SectionSplitter
+            label="Resize the chat section"
+            height={workspace.conversation.chatHeight}
+            viewportHeight={workspace.viewportHeight}
+            onResize={(height) =>
+              dispatchWorkspace({
+                type: "section.resized",
+                section: "chat",
+                height,
+              })
+            }
+          />
+          <Section
+            id="chat"
+            label="Chat"
+            meta={
+              workspace.conversation.unread === 0 ? (
+                chatMeta(state)
+              ) : (
+                <span className="attention-count">
+                  {workspace.conversation.unread}
+                </span>
+              )
+            }
+            open={sectionOpen("chat")}
+            onToggle={() =>
+              dispatchWorkspace({ type: "section.toggled", section: "chat" })
+            }
+          >
+            <ChatSection
+              state={state}
+              disabled={!state.composerEnabled}
+              selectedSubject={workspace.selectedSubject}
+              onSend={(text) =>
+                ask(formatContextualQuestion(text, workspace.selectedSubject))
+              }
+              onChoice={choose}
+              onClearSubject={() =>
+                dispatchWorkspace({ type: "subject.cleared" })
+              }
+              onEnd={end}
+            />
+          </Section>
+        </aside>
       </div>
       {/* At the shell, not inside the canvas or the rail: a menu opened on the
           last row of the rail has to be able to hang past the rail's edge. */}
@@ -1462,6 +1461,21 @@ export const App = () => {
           onDismiss={() => dispatchWorkspace({ type: "menu.dismissed" })}
         />
       )}
+      <SaveViewDialog
+        views={state.views}
+        activeViewId={state.activeView}
+        // Seeded from what the canvas is drawing: saving a view is keeping the
+        // query on screen, which is why nothing clears it on the way in.
+        query={state.activeFilter?.query ?? null}
+        layout={workspace.layout}
+        showLifecycle={workspace.showLifecycle}
+        showEvidence={workspace.showEvidence}
+        showOwnership={workspace.showOwnership}
+        open={saveViewOpen}
+        folder={saveViewFolder}
+        onClose={() => setSaveViewOpen(false)}
+        onStage={stageViewChange}
+      />
       {!namingFolder ? null : (
         <PromptDialog
           title="New folder"
@@ -1477,7 +1491,6 @@ export const App = () => {
             // with no view in it is a folder no document declares, and so not
             // a folder at all.
             setSaveViewFolder(named);
-            clearFilter();
             setSaveViewOpen(true);
           }}
           onCancel={() => setNamingFolder(false)}

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -10,7 +10,7 @@ import {
   viewIdFrom,
 } from "../adapters/visual/view-identity.js";
 
-export interface SaveViewControlProps {
+export interface SaveViewDialogProps {
   readonly views: readonly VisualViewSummary[];
   readonly activeViewId: string;
   readonly query: ProjectionQuery | null;
@@ -19,9 +19,10 @@ export interface SaveViewControlProps {
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
   /**
-   * Openness is the caller's, not the panel's: the tree's new-view button
-   * opens this form from the other side of the shell, and two components
-   * cannot both own one boolean.
+   * Openness is the caller's, not the form's: every way in is somewhere else -
+   * the rail's new-view button, three context-menu items - and two components
+   * cannot both own one boolean. The strip's own `Save view` button is gone
+   * with the rest of the strip's controls (#249).
    */
   readonly open: boolean;
   /**
@@ -30,7 +31,7 @@ export interface SaveViewControlProps {
    * folder…", which names one that does not exist yet. Undefined is no folder.
    */
   readonly folder: string | undefined;
-  readonly onToggle: () => void;
+  readonly onClose: () => void;
   /** Stages the write. Nothing is on disk until the changeset is committed. */
   readonly onStage: (operation: VisualViewOperation) => void;
 }
@@ -129,6 +130,7 @@ interface SaveViewFormProps {
     title: string,
     description: string,
   ) => void;
+  readonly onCancel: () => void;
 }
 
 /**
@@ -140,7 +142,7 @@ interface SaveViewFormProps {
  * an overwrite of the active view with nothing retyped, and closing it
  * discard a half-typed name that was never workspace state.
  */
-function SaveViewForm({ activeView, onSubmit }: SaveViewFormProps) {
+function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
   const [title, setTitle] = useState(activeView?.title ?? "");
   const [description, setDescription] = useState(activeView?.description ?? "");
 
@@ -196,6 +198,9 @@ function SaveViewForm({ activeView, onSubmit }: SaveViewFormProps) {
             >
               Save As New
             </button>
+            <button type="button" onClick={onCancel}>
+              Cancel
+            </button>
           </div>
         </form>
       </div>
@@ -215,7 +220,7 @@ function SaveViewForm({ activeView, onSubmit }: SaveViewFormProps) {
  * reviewer can read, discard and undo before it lands, which is a better
  * answer than a dialog.
  */
-export function SaveViewControl({
+export function SaveViewDialog({
   views,
   activeViewId,
   query,
@@ -225,9 +230,9 @@ export function SaveViewControl({
   showOwnership,
   open,
   folder,
-  onToggle,
+  onClose,
   onStage,
-}: SaveViewControlProps) {
+}: SaveViewDialogProps) {
   const activeView = views.find((view) => view.id === activeViewId) ?? null;
 
   const submit = (
@@ -265,26 +270,20 @@ export function SaveViewControl({
     );
   };
 
+  if (!open) return null;
   return (
     <div className="save-view-control">
-      <button
-        type="button"
-        className="save-view-toggle"
-        aria-expanded={open}
-        aria-controls="save-view-panel-body"
-        onClick={onToggle}
-      >
-        Save view
-      </button>
-      {open ? (
-        <SaveViewForm
-          // Remount when the reviewer switches view with the panel open, so
-          // the fields describe the view the Save button would overwrite.
-          key={activeViewId}
-          activeView={activeView}
-          onSubmit={submit}
-        />
-      ) : null}
+      <SaveViewForm
+        // Remount when the reviewer switches view with the form open, so the
+        // fields describe the view the Save button would overwrite.
+        key={activeViewId}
+        activeView={activeView}
+        onSubmit={(id, title, description) => {
+          submit(id, title, description);
+          onClose();
+        }}
+        onCancel={onClose}
+      />
     </div>
   );
 }

--- a/src/visual-app/section-stack.tsx
+++ b/src/visual-app/section-stack.tsx
@@ -1,0 +1,144 @@
+import { useRef, type KeyboardEvent, type PointerEvent, type ReactNode } from "react";
+import {
+  sectionHeightBounds,
+  type RightSectionId,
+} from "./workspace-state.js";
+
+/**
+ * The right column's furniture: a collapsible section, and the handle between
+ * two of them (#249).
+ *
+ * The column used to be one panel with the subject form and the changeset tray
+ * stacked inside it and no way to give any of the three more room than the
+ * others happened to leave. It is a stack of named sections now, because more
+ * are coming and because a reviewer reading a long changeset should not have to
+ * scroll past a subject form to reach the commit button.
+ *
+ * A section says what it holds even while it is shut - the header carries a
+ * label and a line of meta - which is the whole reason the column no longer has
+ * an open/closed toggle of its own. A closed strip button said nothing; three
+ * closed headers say what is behind each of them.
+ */
+
+export interface SectionProps {
+  readonly id: RightSectionId;
+  readonly label: string;
+  /** A word about what is inside, read while the section is shut: the selected
+   * subject's id, how many rows are staged, whether the agent is idle. */
+  readonly meta?: ReactNode;
+  readonly open: boolean;
+  readonly onToggle: () => void;
+  readonly children: ReactNode;
+}
+
+export function Section({
+  id,
+  label,
+  meta,
+  open,
+  onToggle,
+  children,
+}: SectionProps) {
+  return (
+    <section className={`stack-section stack-section-${id}`}>
+      <h2 className="section-head">
+        <button
+          type="button"
+          className="section-toggle"
+          aria-expanded={open}
+          aria-controls={`section-${id}`}
+          onClick={onToggle}
+        >
+          <span className="section-chevron" aria-hidden="true">
+            {open ? "▾" : "▸"}
+          </span>
+          <span className="section-label">{label}</span>
+        </button>
+        {meta === undefined ? null : (
+          <span className="section-meta">{meta}</span>
+        )}
+      </h2>
+      <div className="section-body" id={`section-${id}`} hidden={!open}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The handle between two sections.
+ *
+ * Drags the section BELOW it, which is the one with a height: the sections
+ * above take what is left, so a handle that grew the upper one would have to
+ * decide which of them gave the room up. Keyboard-reachable with the arrow
+ * keys, for the same reason the conversation's own separator is: a control
+ * only a pointer can reach is a control some reviewers do not have.
+ */
+export function SectionSplitter({
+  label,
+  height,
+  viewportHeight,
+  onResize,
+}: {
+  readonly label: string;
+  readonly height: number;
+  readonly viewportHeight: number;
+  readonly onResize: (height: number) => void;
+}) {
+  const bounds = sectionHeightBounds(viewportHeight);
+  const drag = useRef<{
+    readonly pointerId: number;
+    readonly startY: number;
+    readonly startHeight: number;
+  } | null>(null);
+
+  const pointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const active = drag.current;
+    if (active?.pointerId !== event.pointerId) return;
+    // Dragging UP grows the section below, so the delta is inverted the same
+    // way the conversation separator inverts its own.
+    onResize(active.startHeight + active.startY - event.clientY);
+  };
+
+  const pointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    drag.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startHeight: height,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const pointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (drag.current?.pointerId !== event.pointerId) return;
+    drag.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const keyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+    event.preventDefault();
+    const step = event.shiftKey ? 32 : 8;
+    onResize(height + (event.key === "ArrowUp" ? step : -step));
+  };
+
+  return (
+    <div
+      className="section-splitter"
+      role="separator"
+      aria-label={label}
+      aria-orientation="horizontal"
+      aria-valuenow={Math.round(height)}
+      aria-valuemin={bounds.min}
+      aria-valuemax={Math.round(bounds.max)}
+      tabIndex={0}
+      onPointerDown={pointerDown}
+      onPointerMove={pointerMove}
+      onPointerUp={pointerUp}
+      onPointerCancel={pointerUp}
+      onKeyDown={keyDown}
+    />
+  );
+}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -111,6 +111,20 @@ body {
   gap: var(--step);
 }
 
+/* One line about what this session IS, which is identity. It sits beside the
+   name rather than behind a disclosure, because a button that only ever
+   revealed a sentence was a control the strip had no reason to keep (#249). */
+.session-description {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  font-size: 13px;
+  color: var(--quiet);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .command-identity {
   /* Shrinks — the title ellipsises — down to a floor that still reads as a
      session name. Below it the actions take their own row rather than
@@ -343,14 +357,13 @@ body {
   overflow: hidden;
 }
 
-.workspace-conversation-open {
+/* Rail, canvas, splitter, sections. The right column has no open/closed mode:
+   its sections collapse one by one, and three shut headers say more than a
+   hidden column did (#249). */
+.workspace {
   grid-template-columns: var(--rail-width) minmax(0, 1fr) auto var(
       --conversation-width
     );
-}
-
-.workspace-conversation-closed {
-  grid-template-columns: var(--rail-width) minmax(0, 1fr);
 }
 
 /* ------------------------------------------------------------- view tree */
@@ -520,6 +533,18 @@ body {
   background: var(--paper);
 }
 
+/* The canvas's own controls, top-right: the quick filter narrows what is
+   drawn, so it sits with the drawing rather than in a strip across the window
+   (#249). */
+.canvas-controls {
+  position: absolute;
+  inset: var(--step) var(--step) auto auto;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: var(--step);
+}
+
 /* Cytoscape measures the element it mounts into and draws nothing when that
    box collapses, so the container is sized here rather than left to the
    canvas element it creates inside. */
@@ -625,6 +650,120 @@ body {
 
 /* ------------------------------------------------------------------ talk */
 
+/* ------------------------------------------------------------ section stack */
+
+/* Properties takes what is left; changes and chat hold the heights their
+   splitters were dragged to, and chat is last because it is pinned at the foot
+   (#249). A shut section contributes only its header, which is what `auto`
+   means once its body is hidden. */
+.section-stack {
+  display: grid;
+  grid-template-rows:
+    minmax(0, 1fr) auto var(--changes-height, 200px) auto
+    var(--chat-height, 246px);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--rule);
+  background: var(--sheet);
+}
+
+.stack-section {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  gap: var(--step);
+  min-height: 32px;
+  margin: 0;
+  padding-right: calc(var(--step) * 1.5);
+  border-bottom: 1px solid var(--rule);
+  font-size: inherit;
+  font-weight: 400;
+}
+
+.section-toggle {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--step) * 0.75);
+  min-height: 32px;
+  padding: 0 calc(var(--step) * 1.5);
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.section-chevron {
+  color: var(--quiet);
+  font-size: 10px;
+}
+
+/* What the section holds, readable while it is shut: the selected subject, how
+   many rows are staged, whose turn it is. */
+.section-meta {
+  margin-left: auto;
+  overflow: hidden;
+  font-family: var(--utility);
+  font-size: 11px;
+  color: var(--quiet);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.section-body {
+  min-height: 0;
+  overflow: auto;
+}
+
+.section-body[hidden] {
+  display: none;
+}
+
+.section-empty {
+  margin: 0;
+  padding: calc(var(--step) * 1.5);
+  font-size: 13px;
+  color: var(--quiet);
+}
+
+/* The grab strip between two sections. Same anatomy as the conversation's own
+   separator, turned through ninety degrees. */
+.section-splitter {
+  position: relative;
+  height: 7px;
+  border: none;
+  background: transparent;
+  cursor: row-resize;
+}
+
+/* The grab area is 7px so it can be hit; what it DRAWS is a hairline, because
+   a seven-pixel bar between two sections reads as a section of its own. */
+.section-splitter::after {
+  content: "";
+  position: absolute;
+  inset: 3px 0;
+  background: var(--rule);
+}
+
+.section-splitter:hover::after,
+.section-splitter:focus-visible::after {
+  inset: 2px 0;
+  background: var(--cobalt);
+}
+
+.section-splitter:focus-visible {
+  outline: none;
+}
+
 .talk {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -632,8 +771,19 @@ body {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-left: 1px solid var(--rule);
   background: var(--sheet);
+}
+
+/* The session's own control, under the composer it belongs beside. */
+.session-foot {
+  display: flex;
+  align-items: center;
+  gap: var(--step);
+  padding: 0 calc(var(--step) * 1.5) calc(var(--step) * 1.5);
+}
+
+.session-foot .end-session {
+  margin-left: auto;
 }
 
 .talk[hidden] {
@@ -770,11 +920,37 @@ body {
 }
 
 .subject-draft-open {
-  position: absolute;
-  z-index: 2;
-  top: calc(var(--step) * 1.5);
-  right: calc(var(--step) * 1.5);
   min-height: 28px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  background: var(--sheet);
+  color: var(--ink);
+  cursor: pointer;
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.subject-draft-open:hover {
+  border-color: var(--cobalt);
+}
+
+/* The quick filter, sized for the canvas rather than for a strip. */
+.canvas-controls .quick-filter {
+  min-height: 28px;
+  width: min(220px, 30vw);
+  padding: 0 0.6rem;
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  background: var(--sheet);
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 12px;
+}
+
+.canvas-controls .quick-filter::placeholder {
+  color: var(--quiet);
 }
 
 .subject-draft-panel {
@@ -1440,12 +1616,10 @@ body {
     max-height: 30dvh;
   }
 
-  .talk {
+  .section-stack {
     max-height: 56dvh;
     border-top: 1px solid var(--rule);
     border-left: 0;
-    border-radius: 18px 18px 0 0;
-    box-shadow: 0 -12px 36px rgb(19 35 57 / 14%);
   }
 }
 
@@ -1485,15 +1659,20 @@ body {
   cursor: not-allowed;
 }
 
+.save-view-control {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklab, var(--ink) 22%, transparent);
+}
+
 .save-view-panel {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
   background: var(--sheet);
   border: 1px solid var(--rule-firm);
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  z-index: 10;
+  box-shadow: 0 8px 28px rgb(19 35 57 / 18%);
 }
 
 .save-view-panel-body {

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -7,8 +7,6 @@ import { DEFAULT_NESTING, type NestingKind } from "../nesting.js";
 import type { ContextMenuTarget } from "./context-menu-model.js";
 import type { BottomPanelTabId } from "./query-panel.js";
 
-export type ConversationMode = "auto" | "open" | "closed";
-
 export interface SelectedElement {
   readonly type: "element";
   readonly id: string;
@@ -101,16 +99,61 @@ const nextRelationship = (
     : normalizeSelectedRelationship(edge, nodeTitlesOf(graph));
 };
 
+/**
+ * The right column's sections, in the order they stack (#249, ADR-free: the
+ * design settles the order and nothing derives it).
+ *
+ * Chat is last because it is pinned at the foot and owns the session's own
+ * control - the reviewer ends the conversation beside the conversation, not
+ * from a strip that carries identity and nothing else.
+ */
+export const RIGHT_SECTIONS = ["properties", "changes", "chat"] as const;
+
+export type RightSectionId = (typeof RIGHT_SECTIONS)[number];
+
+/** How short a section may be dragged before it is just a header. */
+export const SECTION_MIN_HEIGHT = 96;
+/** Room the sections above one must keep, however far it is dragged. */
+export const SECTION_HEADROOM = 160;
+
+export const sectionHeightBounds = (viewportHeight: number) => ({
+  min: SECTION_MIN_HEIGHT,
+  max: Math.max(SECTION_MIN_HEIGHT, viewportHeight - SECTION_HEADROOM),
+});
+
+export const clampSectionHeight = (
+  height: number,
+  viewportHeight: number,
+): number => {
+  const { min, max } = sectionHeightBounds(viewportHeight);
+  return Math.min(max, Math.max(min, height));
+};
+
 export const CONVERSATION_MIN_WIDTH = 320;
 export const CONVERSATION_MAX_WIDTH = 640;
 /** The share of the viewport the approved design lets the conversation take. */
 const CONVERSATION_MAX_VIEWPORT_SHARE = 0.45;
 
 export interface VisualWorkspaceState {
+  /**
+   * The right column: one width, and the sections stacked inside it.
+   *
+   * There is no longer an open/closed mode. The column is always drawn,
+   * because the sections are collapsible one by one and a reviewer who wants
+   * the canvas back shuts the sections rather than the column - which leaves
+   * three headers saying what is behind them instead of a strip button
+   * saying nothing (#249).
+   */
   readonly conversation: {
-    readonly mode: ConversationMode;
     readonly width: number;
     readonly unread: number;
+    /** The sections the reviewer has shut. Held as what is CLOSED so a
+     * section added later arrives open rather than hidden behind a default
+     * nobody chose - the same rule the rail's branches follow. */
+    readonly collapsed: readonly RightSectionId[];
+    /** Heights for the two sections that have one; properties takes the rest. */
+    readonly changesHeight: number;
+    readonly chatHeight: number;
   };
   /**
    * The viewport this state was last clamped against. Presentation reads its
@@ -118,6 +161,11 @@ export interface VisualWorkspaceState {
    * reaches the separator's reported minimum and maximum.
    */
   readonly viewportWidth: number;
+  /** The viewport the SECTION heights are clamped against, held for the same
+   * reason the width is: a shorter window changes what a splitter may be
+   * dragged to, and a render that read the live global would only say so by
+   * accident. */
+  readonly viewportHeight: number;
   readonly selectedSubject: SelectedDiagramSubject | null;
   /** The relationship being drawn, or null when the tool is not in use. */
   readonly connection: ConnectionDraft | null;
@@ -193,9 +241,21 @@ export interface VisualWorkspaceState {
 }
 
 export type VisualWorkspaceAction =
-  | { readonly type: "conversation.toggled" }
+  | {
+      readonly type: "section.toggled";
+      readonly section: RightSectionId;
+    }
+  | {
+      readonly type: "section.resized";
+      readonly section: "changes" | "chat";
+      readonly height: number;
+    }
   | { readonly type: "conversation.resized"; readonly width: number }
-  | { readonly type: "viewport.resized"; readonly viewportWidth: number }
+  | {
+      readonly type: "viewport.resized";
+      readonly viewportWidth: number;
+      readonly viewportHeight?: number;
+    }
   | { readonly type: "attention.received" }
   | {
       readonly type: "connection.started";
@@ -371,13 +431,23 @@ const clampInitialConversationWidth = (
 
 export const createVisualWorkspaceState = (
   viewportWidth: number,
+  viewportHeight = 0,
 ): VisualWorkspaceState => ({
   conversation: {
-    mode: "auto",
     width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
     unread: 0,
+    // Every section open: the reviewer has not shut anything yet, and a stack
+    // that opened closed would say nothing about what is in it.
+    collapsed: [],
+    changesHeight: 200,
+    // Measured rather than taken from the design's 246: the composer, its
+    // status row and the session's own button come to about 180, and a chat
+    // section that fits them with no room left for the transcript pushes
+    // `Return to agent` under the fold at rest.
+    chatHeight: 300,
   },
   viewportWidth,
+  viewportHeight,
   selectedSubject: null,
   descriptionExpanded: false,
   detailsOpen: false,
@@ -404,16 +474,33 @@ export const visualWorkspaceReducer = (
   action: VisualWorkspaceAction,
 ): VisualWorkspaceState => {
   switch (action.type) {
-    case "conversation.toggled": {
-      const mode = state.conversation.mode === "open" ? "closed" : "open";
+    case "section.toggled": {
+      const shut = state.conversation.collapsed.includes(action.section);
       return {
         ...state,
         conversation: {
           ...state.conversation,
-          mode,
-          unread: mode === "open" ? 0 : state.conversation.unread,
+          collapsed: shut
+            ? state.conversation.collapsed.filter(
+                (section) => section !== action.section,
+              )
+            : [...state.conversation.collapsed, action.section],
+          // Opening chat is reading it, so the count it carried goes with the
+          // reason it was there.
+          unread:
+            action.section === "chat" && shut ? 0 : state.conversation.unread,
         },
       };
+    }
+    case "section.resized": {
+      const height = clampSectionHeight(action.height, state.viewportHeight);
+      const key = action.section === "chat" ? "chatHeight" : "changesHeight";
+      return state.conversation[key] === height
+        ? state
+        : {
+            ...state,
+            conversation: { ...state.conversation, [key]: height },
+          };
     }
     case "conversation.resized": {
       const width = clampConversationWidth(action.width, state.viewportWidth);
@@ -426,30 +513,46 @@ export const visualWorkspaceReducer = (
         state.conversation.width,
         action.viewportWidth,
       );
+      const viewportHeight = action.viewportHeight ?? state.viewportHeight;
+      const changesHeight = clampSectionHeight(
+        state.conversation.changesHeight,
+        viewportHeight,
+      );
+      const chatHeight = clampSectionHeight(
+        state.conversation.chatHeight,
+        viewportHeight,
+      );
       return width === state.conversation.width &&
-        action.viewportWidth === state.viewportWidth
+        changesHeight === state.conversation.changesHeight &&
+        chatHeight === state.conversation.chatHeight &&
+        action.viewportWidth === state.viewportWidth &&
+        viewportHeight === state.viewportHeight
         ? state
         : {
             ...state,
-            conversation: { ...state.conversation, width },
+            conversation: {
+              ...state.conversation,
+              width,
+              changesHeight,
+              chatHeight,
+            },
             viewportWidth: action.viewportWidth,
+            viewportHeight,
           };
     }
     case "attention.received":
-      if (state.conversation.mode === "open") return state;
-      if (state.conversation.mode === "auto") {
-        return {
-          ...state,
-          conversation: { ...state.conversation, mode: "open", unread: 0 },
-        };
-      }
-      return {
-        ...state,
-        conversation: {
-          ...state.conversation,
-          unread: state.conversation.unread + 1,
-        },
-      };
+      // Chat is on screen unless the reviewer shut it, so an arriving reply
+      // needs no count to stand in for it. A shut section is the only case
+      // where something happened out of sight.
+      return state.conversation.collapsed.includes("chat")
+        ? {
+            ...state,
+            conversation: {
+              ...state.conversation,
+              unread: state.conversation.unread + 1,
+            },
+          }
+        : state;
     // A menu is dismissed by everything it can lead to, and by the commit that
     // can take its target away, rather than by a blanket rule over every
     // action: a reviewer who right-clicks and then reads an agent's reply
@@ -521,7 +624,15 @@ export const visualWorkspaceReducer = (
     case "subject.selected":
       return {
         ...state,
-        conversation: { ...state.conversation, mode: "open", unread: 0 },
+        // Selecting a subject opens the section that describes it, because
+        // that is what the selection was for. Nothing else about the stack
+        // moves - a reviewer who shut Changes did not ask for it back.
+        conversation: {
+          ...state.conversation,
+          collapsed: state.conversation.collapsed.filter(
+            (section) => section !== "properties",
+          ),
+        },
         selectedSubject: action.subject,
         descriptionExpanded: false,
         contextMenu: null,

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -146,7 +146,7 @@ describe('visual conversation rendering', () => {
     expect(markup).toContain('Awaiting agent response')
   })
 
-  it('explains that End is preparing the main-agent handoff', () => {
+  it('explains that returning to the agent is preparing the handoff', () => {
     const markup = renderSession({ lifecycle: 'ending', handoff: null })
 
     expect(markup).toContain('class="end-transition-status"')
@@ -154,7 +154,7 @@ describe('visual conversation rendering', () => {
     expect(markup).toContain(
       'Ending conversation — preparing a handoff for the main agent.',
     )
-    expect(markup).toContain('>Ending…</button>')
+    expect(markup).toContain('>Returning…</button>')
   })
 
   it('reports when the handoff is ready for the main agent', () => {
@@ -189,12 +189,12 @@ describe('visual conversation rendering', () => {
   })
 
   it.each(['connecting', 'disconnected'] as const)(
-    'keeps the End label before an End request while %s',
+    'keeps the Return label before a return is requested while %s',
     (lifecycle) => {
       const markup = renderSession({ lifecycle })
 
-      expect(markup).toContain('>End</button>')
-      expect(markup).not.toContain('>Ending…</button>')
+      expect(markup).toContain('>Return to agent</button>')
+      expect(markup).not.toContain('>Returning…</button>')
     },
   )
 
@@ -321,11 +321,16 @@ describe('visual conversation rendering', () => {
     )
   })
 
-  it('renders the quick-filter box with the current quickFilterText as its value', () => {
-    const markup = renderSession({ quickFilterText: 'checkout' })
+  it('puts the quick filter on the canvas it narrows, not in the strip', () => {
+    // It used to sit in the command strip, as far from the diagram as the
+    // window allows, beside controls with nothing to do with it (#249).
+    const markup = renderSession({ model: renderedModel, quickFilterText: 'checkout' })
 
+    expect(markup).toContain('class="canvas-controls"')
     expect(markup).toContain('class="quick-filter"')
     expect(markup).toContain('value="checkout"')
+    const strip = markup.slice(0, markup.indexOf('</header>'))
+    expect(strip).not.toContain('quick-filter')
   })
 
   it('edits the query at the foot of the canvas, not in a dropdown over it', () => {
@@ -368,5 +373,74 @@ describe('command strip', () => {
     expect(markup).not.toContain('Top-Down')
     expect(markup).not.toContain('Left-Right')
     expect(markup).not.toContain('direction-notice')
+  })
+})
+
+/**
+ * The shell the design asks for (#249): identity in the strip, three sections
+ * in the right column, and the session's own control beside the conversation.
+ */
+describe('the right column, as a stack of sections', () => {
+  it('draws all three sections, chat last', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('class="section-stack"')
+    const order = ['properties', 'changes', 'chat'].map((id) =>
+      markup.indexOf(`stack-section-${id}`),
+    )
+    expect(order.every((at) => at !== -1)).toBe(true)
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+  })
+
+  it('says what a section holds while it is shut', () => {
+    // A closed strip button said nothing. A closed header says whose turn it
+    // is, how many rows are staged, and which subject is selected.
+    const markup = renderSession()
+
+    expect(markup).toContain('>Element properties</span>')
+    expect(markup).toContain('class="section-meta">nothing staged</span>')
+  })
+
+  it('gives each pair of sections a handle a keyboard can reach', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('aria-label="Resize the changes section"')
+    expect(markup).toContain('aria-label="Resize the chat section"')
+    expect(markup).toContain('aria-orientation="horizontal"')
+    expect(markup).toContain('tabindex="0"')
+  })
+
+  it('leaves the command strip carrying identity and nothing else', () => {
+    const markup = renderSession()
+    const strip = markup.slice(0, markup.indexOf('</header>'))
+
+    expect(strip).toContain('class="command-identity"')
+    for (const gone of [
+      '>Details</button>',
+      '>Conversation</button>',
+      '>Save view</button>',
+      'class="quick-filter"',
+      'class="end-session"',
+    ]) {
+      expect(strip, `${gone} has left the strip`).not.toContain(gone)
+    }
+  })
+
+  it('ends the session from the chat section, and calls it what it does', () => {
+    // One button, not two. The design draws `End session` beside it for a
+    // handback that leaves the session live; nothing can do that yet, and a
+    // button that claimed to would be lying about the lifecycle.
+    const markup = renderSession()
+    const chat = markup.slice(markup.indexOf('stack-section-chat'))
+
+    expect(chat).toContain('>Return to agent</button>')
+    expect(markup).not.toContain('>End session</button>')
+  })
+
+  it('reads the session description in the strip rather than behind a disclosure', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('class="session-description"')
+    expect(markup).not.toContain('id="session-details"')
   })
 })

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { CanvasEdge, CanvasNode } from "../src/graph-projection.js";
 import {
+  RIGHT_SECTIONS,
   conversationWidthBounds,
+  sectionHeightBounds,
   createVisualWorkspaceState,
   formatContextualQuestion,
   normalizeSelectedElement,
@@ -9,7 +11,9 @@ import {
   presentationActionsFor,
   viewNeedingApplication,
   visualWorkspaceReducer,
+  type RightSectionId,
   type SelectedDiagramSubject,
+  type VisualWorkspaceState,
 } from "../src/visual-app/workspace-state.js";
 
 const canvasNode = (overrides: Partial<CanvasNode> = {}): CanvasNode => ({
@@ -64,43 +68,51 @@ const elementSubject: SelectedDiagramSubject = {
 };
 
 describe("visual workspace state", () => {
-  it("starts collapsed at the responsive default width", () => {
+  it("starts with every section open, at the responsive default width", () => {
     const state = createVisualWorkspaceState(1568);
     expect(state.conversation).toEqual({
-      mode: "auto",
       width: expect.closeTo(439.04, 2),
       unread: 0,
+      collapsed: [],
+      changesHeight: 200,
+      chatHeight: 300,
     });
   });
 
   it("caps the default width at 480px on wide viewports", () => {
-    const state = createVisualWorkspaceState(1920);
-    expect(state.conversation).toEqual({
-      mode: "auto",
+    expect(createVisualWorkspaceState(1920).conversation).toMatchObject({
       width: 480,
-      unread: 0,
     });
   });
 
-  it("opens automatically for first activity but respects a manual close", () => {
+  it("counts an arriving reply only while chat is shut", () => {
+    // Chat is a section on screen now, not a panel behind a toggle (#249), so
+    // a reply that lands in front of the reviewer needs no count standing in
+    // for it. A shut section is the only case where something happened out of
+    // sight, and opening it is reading it.
     const initial = createVisualWorkspaceState(1568);
-    const opened = visualWorkspaceReducer(initial, {
+    const seen = visualWorkspaceReducer(initial, {
       type: "attention.received",
     });
-    expect(opened.conversation.mode).toBe("open");
+    expect(seen.conversation.unread).toBe(0);
 
-    const closed = visualWorkspaceReducer(opened, {
-      type: "conversation.toggled",
+    const shut = visualWorkspaceReducer(initial, {
+      type: "section.toggled",
+      section: "chat",
     });
-    const waiting = visualWorkspaceReducer(closed, {
+    const waiting = visualWorkspaceReducer(shut, {
       type: "attention.received",
     });
-    expect(waiting.conversation).toMatchObject({ mode: "closed", unread: 1 });
+    expect(waiting.conversation).toMatchObject({
+      collapsed: ["chat"],
+      unread: 1,
+    });
 
     const reopened = visualWorkspaceReducer(waiting, {
-      type: "conversation.toggled",
+      type: "section.toggled",
+      section: "chat",
     });
-    expect(reopened.conversation).toMatchObject({ mode: "open", unread: 0 });
+    expect(reopened.conversation).toMatchObject({ collapsed: [], unread: 0 });
   });
 
   it("re-reads a held subject from the replacement model and drops it only when removed", () => {
@@ -108,7 +120,8 @@ describe("visual workspace state", () => {
       type: "subject.selected",
       subject: elementSubject,
     });
-    expect(selected.conversation.mode).toBe("open");
+    // Selecting opens the section that describes the selection.
+    expect(selected.conversation.collapsed).not.toContain("properties");
     expect(selected.selectedSubject).toEqual(elementSubject);
 
     // A commit that renamed the held subject: the inspector follows the edit
@@ -122,7 +135,7 @@ describe("visual workspace state", () => {
       id: "system.api",
       title: "Gateway API",
     });
-    expect(renamed.conversation.mode).toBe("open");
+    expect(renamed.conversation.collapsed).not.toContain("properties");
 
     // A commit that deleted it, and a session with no model at all: nothing
     // left to point at either way.
@@ -132,7 +145,7 @@ describe("visual workspace state", () => {
         graph,
       });
       expect(gone.selectedSubject).toBeNull();
-      expect(gone.conversation.mode).toBe("open");
+      expect(gone.conversation.collapsed).not.toContain("properties");
     }
   });
 
@@ -804,5 +817,101 @@ describe("the canvas column's bottom panel", () => {
         tab: "view-query",
       }),
     ).toBe(opened);
+  });
+});
+
+/**
+ * The right column's sections (#249). The column has no open/closed mode any
+ * more: the sections collapse one by one, and three shut headers say what is
+ * behind each of them where a shut column said nothing.
+ */
+describe("the right column's sections", () => {
+  const state = createVisualWorkspaceState(1568, 900);
+
+  const toggle = (
+    from: VisualWorkspaceState,
+    section: RightSectionId,
+  ): VisualWorkspaceState =>
+    visualWorkspaceReducer(from, { type: "section.toggled", section });
+
+  it("stacks properties, changes and chat, with chat last", () => {
+    // Chat is pinned at the foot because it owns the session's own control -
+    // the reviewer ends the conversation beside the conversation.
+    expect(RIGHT_SECTIONS).toEqual(["properties", "changes", "chat"]);
+  });
+
+  it("shuts and reopens one section without touching the others", () => {
+    const shut = toggle(state, "changes");
+    expect(shut.conversation.collapsed).toEqual(["changes"]);
+
+    const both = toggle(shut, "properties");
+    expect(both.conversation.collapsed).toEqual(["changes", "properties"]);
+
+    expect(toggle(both, "changes").conversation.collapsed).toEqual([
+      "properties",
+    ]);
+  });
+
+  it("holds what is CLOSED, so a section added later arrives open", () => {
+    // The same rule the rail's branches follow: a default nobody chose should
+    // not hide something nobody has seen.
+    expect(state.conversation.collapsed).toEqual([]);
+  });
+
+  it("drags the height of the section below the handle", () => {
+    const dragged = visualWorkspaceReducer(state, {
+      type: "section.resized",
+      section: "chat",
+      height: 320,
+    });
+
+    expect(dragged.conversation.chatHeight).toBe(320);
+    expect(dragged.conversation.changesHeight).toBe(
+      state.conversation.changesHeight,
+    );
+  });
+
+  it("keeps a section from being dragged shorter than a header or past the window", () => {
+    const bounds = sectionHeightBounds(900);
+    expect(bounds).toEqual({ min: 96, max: 740 });
+
+    expect(
+      visualWorkspaceReducer(state, {
+        type: "section.resized",
+        section: "chat",
+        height: 10,
+      }).conversation.chatHeight,
+    ).toBe(96);
+    expect(
+      visualWorkspaceReducer(state, {
+        type: "section.resized",
+        section: "chat",
+        height: 5_000,
+      }).conversation.chatHeight,
+    ).toBe(740);
+  });
+
+  it("re-clamps the sections when the window gets shorter", () => {
+    // Held against the viewport the state was clamped for, never read live:
+    // a shorter window changes what a splitter may be dragged to, and a render
+    // that read the global would only say so by accident.
+    const short = visualWorkspaceReducer(state, {
+      type: "viewport.resized",
+      viewportWidth: 1568,
+      viewportHeight: 400,
+    });
+
+    expect(short.conversation.chatHeight).toBe(240);
+    expect(short.viewportHeight).toBe(400);
+  });
+
+  it("changes nothing when a drag lands on the height it already has", () => {
+    expect(
+      visualWorkspaceReducer(state, {
+        type: "section.resized",
+        section: "chat",
+        height: state.conversation.chatHeight,
+      }),
+    ).toBe(state);
   });
 });


### PR DESCRIPTION
Closes #249. Part of #244. Second-to-last of the redesign; only #252 is left.

## The stack

The right side was one panel with the subject form and the changeset tray
stacked inside it, and no way to give any of the three more room than the others
happened to leave. It is three named, collapsible sections now — **Element
properties**, **Changes**, **Chat** — split by handles a pointer or the arrow
keys can drag, chat pinned at the foot.

**No open/closed mode for the column.** Sections collapse one at a time, and a
shut header still says what is behind it: the selected subject, the staged
count, whose turn it is. A shut column said nothing. That is also why an unread
count now appears only while **Chat** is shut.

## The strip carries identity and nothing else

| Control | Where it went |
|---|---|
| Quick filter | The canvas it narrows |
| Save view | The form the rail and three menu items already open — now a dialog |
| End | The chat section, beside the conversation it ends |
| Details | Nowhere; its one sentence sits beside the session name |
| Conversation | Nowhere, with the mode it toggled |

## `Return to agent`, and only that

Your call, and the honest one. `End` already did exactly this — its notice has
read *"Returning control to the main agent"* since it shipped — so it is renamed,
not re-behaved. The design's second button, `End session`, would promise a
handback that leaves the session live; nothing can do that (`session.end`
freezes the session), so it waits for an agent that can act on one rather than
shipping a button that lies about the lifecycle.

## `New view…` seeds from what is drawn

Saving a view is keeping what you are looking at, and the strip button that did
that is gone. This reverses the small call #245 made when the menu item was the
only route to the form.

## Two things the browser caught before this shipped

1. The design's **246px chat section** fits the composer, its status row and the
   session button with nothing left for the transcript — which put `Return to
   agent` under the fold at rest. Measured and raised to 300.
2. A **7px splitter that painted its whole grab area** read as a section of its
   own. The grab area stays 7px; what it draws is a hairline.

## Verification

`pnpm verify` green: 86 files, 1504 tests, `self:check` clean, LikeC4 valid.

Driven live: collapsed and reopened a section without moving the others, dragged
a splitter by keyboard within its clamps, narrowed the canvas from the filter in
its own corner, and staged a new view from the rail carrying the query that was
on screen. Nothing was written to the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)