### PR TITLE
The editor mounts in someone else's product (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.0.0
 
+- **Added.** The mountable visual editor (#252):
+  `yarramate/visual-app` exports `mountEditor`, `mountEditorWith`, and
+  `createLocalHost`, with styles at `yarramate/visual-app/styles.css`. Its
+  self-contained browser engine mounts over a caller-owned synchronous
+  `SourceStore` and resolved workspace; the caller declares the right-column
+  sections and normally omits `chat` when no agent exists. The supplied
+  `yarramate-visual` socket/session path is unchanged.
+
 - **Changed.** The right column is a stack of collapsible sections — element
   properties, changes, chat — split by handles a pointer or the arrow keys can
   drag, with chat pinned at the foot (#249). There is no open/closed mode for

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -232,6 +232,54 @@ the notation module is the rendering vocabulary for that mode; the element
 vocabulary and relationship table themselves are implemented in the core
 profile (ADR 0097).
 
+### Mount the visual editor
+
+Mount the packaged editor when the consuming product owns the sources and
+already has a resolved workspace:
+
+```ts
+import { mountEditor } from 'yarramate/visual-app'
+import 'yarramate/visual-app/styles.css'
+
+const editor = mountEditor(document.querySelector('#editor')!, {
+  store,
+  workspace,
+  sections: ['properties', 'changes'],
+})
+
+// Later, when the owning screen is removed:
+editor.unmount()
+```
+
+`store` is the caller's synchronous `SourceStore`; `workspace` is the caller's
+pre-resolved `ResolvedWorkspace`. The local host compiles, projects, filters,
+commits and saves layouts over that store. A changeset's model and view writes
+land together in one compare-and-swap batch; the caller therefore owns
+persistence. An asynchronous product fetches into a synchronous in-memory
+store before mounting and flushes writes itself, per
+[ADR 0100](adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md).
+
+The stylesheet ships beside the bundle and is not imported by it, so a host
+attaches it one of two ways. A bundler takes the `import` above; because that
+import is a `.css` file rather than a module, TypeScript needs the ambient
+declaration a bundler project already carries (`vite/client` for Vite,
+`next-env.d.ts` for Next, or `declare module '*.css'`), and reports TS2882
+without one. A plain page has no bundler to answer an `import`, and links it
+instead:
+
+```html
+<link rel="stylesheet" href="/path/to/yarramate/dist/visual-app-lib/styles.css">
+```
+
+The browser bundle is self-contained: the host supplies no React. The declared
+sections omit `chat` because a local host has no agent, choices, handoff,
+journal or session end. A product with its own protocol-compatible server or
+transport instead imports `mountEditorWith` from `yarramate/visual-app` and
+mounts it with its `EditorHost`; `yarramate-visual` remains the supplied
+socket/session host.
+
+[...]
+
 ## MCP server for agent harnesses
 
 Harnesses that load MCP servers can connect the bundled read-only adapter:

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -18,6 +18,25 @@ sibling binary beside `yarramate-likec4`, `yarramate-graphify`, and
 `yarramate` CLI, and never a second claim origin. YarraMate Core does not
 depend on it and stays unaware of any session.
 
+## Host seam
+
+The editor's seam is the existing visual protocol: a host delivers server
+frames and accepts browser inputs. The socket/session host behind
+`yarramate-visual` is one implementation, preserving the conversation journey,
+session lifecycle and journal. The mounted local host is another: it runs the
+same browser engine over a caller-owned synchronous `SourceStore` and
+pre-resolved `ResolvedWorkspace`, with no server.
+
+Both hosts compile and project the workspace, evaluate filters, commit changes,
+and save layouts. The local host sends model and view writes from one changeset
+to its store in one compare-and-swap batch. It cannot provide chat, choices, a
+journal, handoff, or session end; consumers omit the `chat` section when they
+mount it. An asynchronous product fetches into a synchronous in-memory store
+and flushes writes itself, as [ADR 0100](adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md)
+decides.
+
+[...]
+
 ## Editing is mechanical, and it lands through `apply`
 
 A rendered model is always `canonical` — the projection of a real workspace

--- a/docs/adr/0105-the-editor-is-a-mountable-component-and-a-session-is-one-host.md
+++ b/docs/adr/0105-the-editor-is-a-mountable-component-and-a-session-is-one-host.md
@@ -1,0 +1,89 @@
+# The editor is a mountable component, and a session is one host
+
+Status: accepted
+
+The visual editor is a browser component, not the screen of one Node process.
+`yarramate-visual` remains the loopback conversation product, but its socket
+session server is now one implementation of the editor's host seam rather than
+the editor's only way to run.
+
+## Why
+
+**The socket made a reusable editor depend on a conversation.** The browser
+owned a WebSocket, session fetch and reconnect loop, so a product that wanted
+the canvas had to bring a Node session server, a journal and an agent journey
+with it. A product that already owns its documents needs the engine and the
+editor, not a second session lifecycle.
+
+**The protocol is already the contract.** The editor reducer consumes
+`VisualServerFrame` and sends `VisualBrowserInput`. Those are the published,
+versioned frames from [ADR 0081](0081-a-visual-conversation-is-an-adapter-with-a-published-protocol.md).
+A host seam made of a new set of editor verbs would create two contracts for
+one browser and leave them to drift. A host instead delivers the frames and
+accepts the inputs the editor already knows.
+
+**ADR 0100 made the local engine possible without making Core asynchronous.**
+A `SourceStore` owns reads and compare-and-swap writes, while Core works from
+sources and an already-resolved workspace. The shipped interface is synchronous
+on purpose: an asynchronous product fetches into an in-memory synchronous
+store, runs the engine, then flushes the writes it receives. The same rule lets
+the browser engine compile and persist over a store its caller owns.
+
+**Chat is an agent capability, not a canvas dependency.** Filters, commits and
+layout saves are engine work. Chat messages, choices, handoff and ending a
+session need an agent and a session lifecycle. Making the latter mandatory
+would make a reusable editor falsely claim it could converse.
+
+## Decided
+
+**The host seam is protocol frames and browser inputs.** `EditorHost` opens by
+delivering `VisualServerFrame` values and accepts `VisualBrowserInput` values.
+The socket host used by `yarramate-visual` implements that seam over the
+existing session protocol. A product with its own compatible transport may use
+that same seam; no second editor protocol is introduced.
+
+**The package also ships a local host.** `mountEditor(element, { store,
+workspace, sections? })` synchronously creates it over the caller's
+`SourceStore` and `ResolvedWorkspace`, mounts the editor, and returns
+`{ unmount }`. The workspace is resolved before the call because expanding a
+manifest's globs is a filesystem concern, not browser-engine work.
+`mountEditorWith(element, host, sections?)` is the alternative for a caller that
+supplies an `EditorHost` itself. `createLocalHost` is exported for callers that
+need the local host separately.
+
+**The mounted bundle is self-contained.** Consumers import
+`yarramate/visual-app` and `yarramate/visual-app/styles.css`; a host does not
+supply React. Sections are declared by the caller. A local product normally
+uses `['properties', 'changes']`: omitting `chat` is an honest declaration that
+there is no agent behind the editor, not a reduced engine.
+
+## Consequences
+
+- The local host compiles and projects the supplied workspace, evaluates
+  filters, commits changes and saves layouts through the caller's synchronous
+  store. Model and view writes from one changeset reach `writeAll` in one
+  compare-and-swap batch.
+- The caller owns persistence. An asynchronous backing service must fetch
+  before mounting into a synchronous in-memory store and flush the writes it
+  receives; the editor does not turn `SourceStore` into an asynchronous API.
+- The local host has no chat, choices, journal, handoff or session end. It is
+  not a replacement for a conversation server.
+- `yarramate-visual` remains the socket/session host, including its agent
+  journey and session lifecycle. Existing session clients keep their path.
+
+## Rejected
+
+**Keeping the editor inseparable from the socket session.** That preserves one
+runtime at the price of forcing every embedded product to run a server and an
+agent for mechanical editor work.
+
+**Inventing a local-only callback or command API.** It would duplicate the
+published protocol and give the reducer two ways to express the same input.
+
+**Making `SourceStore` asynchronous.** This repeats the rejected alternative in
+ADR 0100: it would make the shipped CLI, adapters and tests asynchronous for
+stores that are not shipped. Fetching and flushing at an asynchronous product's
+boundary is the narrower seam.
+
+**Rendering a chat section without an agent.** A composer with nobody to answer
+and no handoff to make is a broken promise, not a capability.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
       "types": "./dist/notation/archimate.d.ts",
       "import": "./dist/notation/archimate.js"
     },
+    "./visual-app": {
+      "types": "./dist/visual-app-lib/editor.d.ts",
+      "import": "./dist/visual-app-lib/editor.js"
+    },
+    "./visual-app/styles.css": "./dist/visual-app-lib/styles.css",
     "./schema/document": "./schema/yarramate-document.schema.json",
     "./schema/profile": "./schema/yarramate-profile.schema.json",
     "./schema/projection": "./schema/yarramate-projection.schema.json",
@@ -107,7 +112,7 @@
   },
   "scripts": {
     "build:node": "tsc -p tsconfig.build.json",
-    "build:visual": "vite build --config vite.visual.config.ts --logLevel warn",
+    "build:visual": "vite build --config vite.visual.config.ts --logLevel warn && vite build --config vite.visual-lib.config.ts --logLevel warn && tsc --project tsconfig.visual-lib.json",
     "build": "pnpm build:node && pnpm build:visual",
     "prepack": "pnpm build",
     "docs:dev": "pnpm self:export:likec4 && likec4 serve .yarramate-out/likec4",

--- a/src/adapter-mapping.ts
+++ b/src/adapter-mapping.ts
@@ -14,7 +14,14 @@ import adapterMappingSchema from '../schema/yarramate-adapter-mapping.schema.jso
   type: 'json',
 }
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. One shape for all of
+// them, so which modules a browser happens to reach is not a thing anyone has
+// to keep track of (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateSchema = new Ajv2020({ allErrors: true }).compile(
   adapterMappingSchema,
 )

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -61,12 +61,22 @@ import {
 } from "./session-store.js";
 import {
   loadProjection,
-  evaluateProjection,
-  explainProjection,
   type ProjectionDefinition,
   type ProjectionExclusion,
   type ProjectionQuery,
 } from "../../projection.js";
+export { VISUAL_SERVER_DOCUMENT } from "./workspace-model.js";
+import {
+  VISUAL_SERVER_DOCUMENT,
+  adoptLandedViews,
+  exclusionsOf,
+  matchedIdsOf,
+  planViewWrites,
+  published,
+  renderedWorkspaceOf,
+  serverDiagnostic,
+  viewSummaryOf,
+} from "./workspace-model.js";
 import {
   compileWorkspaceWithProfileContext,
   withDiagnosticSubjects,
@@ -85,16 +95,10 @@ import type { PendingWrite, SourceStore } from "../../source-store.js";
 import type { YarramateApplyResult } from "../../operations.js";
 import { DEFAULT_PROJECTION_DIRECTORY } from "./view-identity.js";
 import { createFileSystemStore } from "../../source-store.js";
-import { projectGraphForCanvas } from "../../graph-projection.js";
-import { kindLabelOf } from "../../kind-label.js";
 import {
   loadWorkspaceManifest,
   type ResolvedWorkspace,
 } from "../../workspace.js";
-import type {
-  VisualKindOption,
-  VisualViewOperation,
-} from "./protocol-contract.js";
 import type {
   VisualRenderedModel,
   VisualServerFrame,
@@ -123,13 +127,6 @@ export type {
   VisualSessionSnapshot,
   VisualTranscriptRecord,
 };
-
-/**
- * Document name reported by diagnostics the server itself raises — a refused
- * frame, a frozen queue, or a transport violation that no protocol document
- * owns.
- */
-export const VISUAL_SERVER_DOCUMENT = "visual-session-server";
 
 /**
  * Returned on every response. The policy admits no external origin at all, so
@@ -384,25 +381,6 @@ const serverError = (code: string, message: string) =>
  * derivation was written for and never did, so every diagnostic it sent to a
  * browser arrived anchored to a byte offset the browser cannot use.
  */
-const published = (
-  diagnostics: readonly Diagnostic[],
-  sources: readonly { readonly path: string; readonly source: string }[],
-): readonly VisualDiagnostic[] =>
-  withDiagnosticSubjects(diagnostics, sources) as readonly VisualDiagnostic[];
-
-const serverDiagnostic = (
-  code: string,
-  message: string,
-  pointer = "/",
-): VisualDiagnostic => ({
-  severity: "error",
-  code,
-  message,
-  path: VISUAL_SERVER_DOCUMENT,
-  pointer,
-  line: 1,
-  column: 1,
-});
 
 /**
  * Compares two capabilities without leaking where they differ, or how long the
@@ -508,105 +486,6 @@ const eventFrom = (
   }
 };
 
-/**
- * Whether the workspace would load a projection written at this path.
- *
- * This is a DIRECTORY check, not a pattern match, and deliberately so: ADR
- * 0100 recorded that the manifest's pattern dialect has never been named - it
- * is whatever `globSync` happens to support, undocumented and untested past
- * one wildcard - so a matcher written here would be inventing the dialect
- * rather than honouring it. A directory that already holds a projection the
- * manifest resolved is a directory the manifest demonstrably reaches.
- *
- * A workspace with no projections at all has nothing to demonstrate, so the
- * default directory is allowed: refusing there would make the first view in a
- * fresh workspace impossible to create.
- */
-const projectionDirectoryIsCovered = (
-  path: string,
-  workspace: ResolvedWorkspace,
-): boolean => {
-  if (workspace.projections.length === 0) {
-    return posixDirectoryOf(path) === DEFAULT_PROJECTION_DIRECTORY;
-  }
-  const covered = new Set(workspace.projections.map(posixDirectoryOf));
-  return covered.has(posixDirectoryOf(path));
-};
-
-/**
- * Turns staged view operations into pending writes, refusing before anything
- * is written (ADR 0103).
- *
- * A `write-view` is validated through the same `loadProjection` the CLI's own
- * projection writes go through, so a document the schema would reject never
- * reaches the store. A `delete-view` names a revision, which is what makes a
- * removal refusable rather than a silent success on a file someone else
- * already changed.
- */
-const planViewWrites = (
-  operations: readonly VisualViewOperation[],
-  workspace: ResolvedWorkspace,
-  store: SourceStore,
-):
-  | { readonly ok: true; readonly writes: readonly PendingWrite[] }
-  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] } => {
-  const writes: PendingWrite[] = [];
-  const diagnostics: VisualDiagnostic[] = [];
-  for (const operation of operations) {
-    const held = store.read(operation.path);
-    if (operation.op === "delete-view") {
-      if (held === undefined) {
-        diagnostics.push(
-          serverDiagnostic(
-            "YMVS314",
-            `View "${operation.path}" is already gone`,
-          ),
-        );
-        continue;
-      }
-      writes.push({
-        path: operation.path,
-        source: null,
-        expected: held.revision,
-      });
-      continue;
-    }
-    if (
-      held === undefined &&
-      !projectionDirectoryIsCovered(operation.path, workspace)
-    ) {
-      // A projection no pattern reaches is a file the workspace never loads,
-      // which is worse than a refusal because nothing later says so (ADR 0043).
-      diagnostics.push(
-        serverDiagnostic(
-          "YMVS315",
-          `The workspace manifest covers no projection in "${posixDirectoryOf(
-            operation.path,
-          )}", so a view saved there would never load`,
-        ),
-      );
-      continue;
-    }
-    const source = stringify(operation.projection);
-    const loaded = loadProjection({ path: operation.path, source });
-    if (!loaded.ok) {
-      // The composed document is the only source these are about, so they are
-      // published against it rather than against the workspace.
-      diagnostics.push(
-        ...published(loaded.diagnostics, [{ path: operation.path, source }]),
-      );
-      continue;
-    }
-    writes.push({
-      path: operation.path,
-      source,
-      expected: held?.revision ?? null,
-    });
-  }
-  return diagnostics.length > 0
-    ? { ok: false, diagnostics }
-    : { ok: true, writes };
-};
 
 /**
  * What a batch that changes no subject reports.
@@ -771,9 +650,9 @@ export const startVisualServer = async (
    * or that the schema refuses — a broken saved view skips rather than failing
    * the session, the same way a broken layout sidecar does.
    *
-   * `subjectCount` is left at zero here and filled in by `recountViews`:
-   * counting needs the compiled graph, which does not exist yet when the
-   * session builds its first list.
+   * `subjectCount` is left at zero here and refreshed by
+   * `renderedWorkspaceOf`: counting needs the compiled graph, which does not
+   * exist yet when the session builds its first list.
    */
   const readViewSummary = (
     projectionPath: string,
@@ -788,16 +667,7 @@ export const startVisualServer = async (
         source: projectionSource,
       });
       if (!loaded.ok) return undefined;
-      const { projection } = loaded;
-      return {
-        id: projection.id,
-        title: projection.presentation?.title ?? projection.id,
-        description: projection.presentation?.description ?? "",
-        query: projection.query,
-        presentation: projection.presentation,
-        path: projectionPath,
-        subjectCount: 0,
-      };
+      return viewSummaryOf(loaded.projection, projectionPath);
     } catch {
       return undefined;
     }
@@ -950,29 +820,10 @@ export const startVisualServer = async (
         graph: compiled.graph,
         profileContext: compiled.profileContext,
       };
-      // `[0]` is the nearest declared ancestor, the same reading
-      // `projectGraphForCanvas` gives an authored subject its `coreKindLabel`.
-      // A kind with no lineage IS a core kind and stands for itself.
-      const optionsFrom = (
-        lineages: ReadonlyMap<string, readonly string[]>,
-      ): readonly VisualKindOption[] =>
-        [...lineages.keys()].map((id) => ({
-          id,
-          label: kindLabelOf(id),
-          coreLabel: kindLabelOf(lineages.get(id)?.[0] ?? id),
-        }));
-      const conceptKinds = optionsFrom(
-        compiled.profileContext.conceptKindLineages,
-      );
-      const relationshipKinds = optionsFrom(
-        compiled.profileContext.relationshipKindLineages,
-      );
-      rendered = {
+      const workspaceModel = renderedWorkspaceOf(compiledWorkspace, views, {
         authority: rendered.authority,
         initialView: rendered.initialView,
-        graph: projectGraphForCanvas(compiled.graph, compiled.profileContext),
         documents: resolvedWorkspace.documents,
-        vocabulary: { conceptKinds, relationshipKinds },
         layouts: rendered.layouts,
         // Minted from the bytes this compile just read, so what the browser
         // renders and what it can later claim it rendered are the same read.
@@ -984,7 +835,11 @@ export const startVisualServer = async (
         // that. A staged view operation pins against these (ADR 0103), and a
         // projection missing from the map is one the commit will create.
         projectionDigests: projectionDigestsNow(),
-      };
+      });
+      // Closures below retain this array, so refresh its contents without
+      // replacing the identity the session started with.
+      views.splice(0, views.length, ...workspaceModel.views);
+      rendered = workspaceModel.model;
       return true;
     } catch {
       compiledWorkspace = undefined;
@@ -993,15 +848,14 @@ export const startVisualServer = async (
   };
   recompileWorkspace();
 
-  const filterMatchedIds = (query: ProjectionQuery): readonly string[] => {
-    if (compiledWorkspace === undefined) return [];
-    const result = evaluateProjection(
-      compiledWorkspace.graph,
-      { format: "yarramate/projection/v1", id: "ad-hoc", version: "0", query },
-      compiledWorkspace.profileContext,
-    );
-    return result.subjects.map(({ id }) => id);
-  };
+  const filterMatchedIds = (query: ProjectionQuery): readonly string[] =>
+    compiledWorkspace === undefined
+      ? []
+      : matchedIdsOf(
+          compiledWorkspace.graph,
+          query,
+          compiledWorkspace.profileContext,
+        );
 
   /**
    * Why a query dropped what it dropped, as the editor's "excluded, and why"
@@ -1016,78 +870,14 @@ export const startVisualServer = async (
    */
   const filterExclusions = (
     query: ProjectionQuery,
-  ): readonly ProjectionExclusion[] => {
-    if (compiledWorkspace === undefined) return [];
-    return explainProjection(
-      compiledWorkspace.graph,
-      { format: "yarramate/projection/v1", id: "ad-hoc", version: "0", query },
-      compiledWorkspace.profileContext,
-    );
-  };
-
-  /**
-   * How many CONCEPTS a query matches, which is not the size of its match set.
-   *
-   * A `SemanticGraph`'s `subjects` are concepts and relationships together, so
-   * `filterMatchedIds` returns both — right for narrowing a canvas that draws
-   * edges as well as nodes, and wrong for a number sitting beside a view
-   * called its subject count. A view over three application components with
-   * two relationships between them would read as five, and the reviewer
-   * counting boxes on the canvas would find three.
-   */
-  const conceptCount = (query: ProjectionQuery): number => {
-    if (compiledWorkspace === undefined) return 0;
-    const result = evaluateProjection(
-      compiledWorkspace.graph,
-      { format: "yarramate/projection/v1", id: "ad-hoc", version: "0", query },
-      compiledWorkspace.profileContext,
-    );
-    return result.subjects.filter(({ type }) => type === "concept").length;
-  };
-
-  /**
-   * Brings `views` into line with the view operations a commit just landed.
-   *
-   * Nothing else does this. `resolvedWorkspace` is resolved once at startup, so
-   * a recompile learns nothing about a projection that has just appeared or
-   * gone; `recountViews` recounts what this list already holds rather than
-   * discovering what it should. A view is read back off disk rather than
-   * reconstructed from the operation, so what the rail shows is what landed.
-   */
-  const adoptLandedViews = (
-    operations: readonly VisualViewOperation[],
-  ): void => {
-    for (const operation of operations) {
-      const at = views.findIndex((view) => view.path === operation.path);
-      if (operation.op === "delete-view") {
-        if (at !== -1) views.splice(at, 1);
-        continue;
-      }
-      const summary = readViewSummary(operation.path);
-      if (summary === undefined) continue;
-      if (at === -1) views.push(summary);
-      else views[at] = summary;
-    }
-  };
-
-  /**
-   * Every view's `subjectCount`, against the graph as it stands now.
-   *
-   * A count is not a property of a projection document — it is what that
-   * document's query matches in this workspace — so landing a changeset moves
-   * it. Callers refresh the whole list rather than reading a number recorded
-   * when the session opened: the snapshot a connection is handed, and every
-   * `model` frame a recompile broadcasts. A view saved mid-session is counted
-   * here too, since it joins `views` rather than the manifest's already
-   * expanded projection list.
-   */
-  const recountViews = (): readonly VisualViewSummary[] => {
-    for (let index = 0; index < views.length; index += 1) {
-      const view = views[index]!;
-      views[index] = { ...view, subjectCount: conceptCount(view.query) };
-    }
-    return views;
-  };
+  ): readonly ProjectionExclusion[] =>
+    compiledWorkspace === undefined
+      ? []
+      : exclusionsOf(
+          compiledWorkspace.graph,
+          query,
+          compiledWorkspace.profileContext,
+        );
 
   let listening = false;
   let bootstrapSpent = false;
@@ -1291,7 +1081,7 @@ export const startVisualServer = async (
     webSocketUrl,
     model: rendered,
     transcript: [...transcript],
-    views: recountViews(),
+    views,
     agentTurnOpen: openTurn(),
     pendingChoice,
     styleNonce,
@@ -1733,7 +1523,7 @@ export const startVisualServer = async (
             result: { ok: false, diagnostics: refused },
           });
           if (recompileWorkspace())
-            broadcast({ kind: "model", model: rendered, views: recountViews() });
+            broadcast({ kind: "model", model: rendered, views });
           return;
         }
         const operationsSource = stringify({
@@ -1822,14 +1612,22 @@ export const startVisualServer = async (
         // nothing about a projection this batch just created or removed. The
         // rail, `layout.save`'s id check, and a reconnecting browser all read
         // this list, so leaving it stale is how they come to disagree with the
-        // disk.
-        adoptLandedViews(event.payload.viewOperations);
+        // disk. Preserve the mutable list identity that session closures hold.
+        views.splice(
+          0,
+          views.length,
+          ...adoptLandedViews(
+            views,
+            event.payload.viewOperations,
+            readViewSummary,
+          ),
+        );
         sendFrame(socket, {
           kind: "apply-result",
           result: { ok: true, result: outcome.result },
         });
         if (recompileWorkspace()) {
-          broadcast({ kind: "model", model: rendered, views: recountViews() });
+          broadcast({ kind: "model", model: rendered, views });
           return;
         }
         // A post-write compile failure is a bug, not a user error: the batch

--- a/src/adapters/visual/workspace-model.ts
+++ b/src/adapters/visual/workspace-model.ts
@@ -1,0 +1,318 @@
+import { stringify } from "yaml";
+import { loadProjection } from "../../projection.js";
+import { withDiagnosticSubjects } from "../../compiler.js";
+import type { Diagnostic } from "../../compiler.js";
+import { posixDirectoryOf } from "../../apply-command.js";
+import type { PendingWrite, SourceStore } from "../../source-store.js";
+import type { ResolvedWorkspace } from "../../workspace.js";
+import { projectGraphForCanvas } from "../../graph-projection.js";
+import { DEFAULT_PROJECTION_DIRECTORY } from "./view-identity.js";
+import type {
+  VisualDiagnostic,
+  VisualViewOperation,
+} from "./protocol-contract.js";
+import { evaluateProjection, explainProjection } from "../../projection.js";
+import type {
+  ProjectionDefinition,
+  ProjectionExclusion,
+  ProjectionQuery,
+} from "../../projection.js";
+import type {
+  ResolvedProfileContext,
+  SemanticGraph,
+} from "../../compiler.js";
+import { kindLabelOf } from "../../kind-label.js";
+import type { VisualKindOption, VisualViewSummary } from "./protocol-contract.js";
+import type { VisualRenderedModel } from "./wire.js";
+
+/**
+ * What a workspace looks like to the editor, however the editor is being run
+ * (#252).
+ *
+ * These were the session server's, and the session server is one host now: an
+ * embedder mounting the editor over its own store computes the same model, the
+ * same vocabulary and the same view counts, and two definitions of any of them
+ * would be two answers to the same question. So the arithmetic lives here and
+ * the orchestration - which bytes to read, which digests to pin, what a layout
+ * sidecar says - stays with whoever owns those.
+ *
+ * Browser-safe: no `node:`, no filesystem, no session. Everything is a pure
+ * function of a compile result.
+ */
+
+/**
+ * The kinds a browser may offer, each with the core kind it descends from.
+ *
+ * `[0]` is the nearest declared ancestor, the same reading
+ * `projectGraphForCanvas` gives an authored subject its `coreKindLabel`. A kind
+ * with no lineage IS a core kind and stands for itself. Without the core label
+ * an editor can read a palette but cannot judge it: the ArchiMate table is
+ * keyed on core kinds, so offering an extension kind unchecked puts a `YM404`
+ * one click away.
+ */
+export const kindOptionsOf = (
+  lineages: ReadonlyMap<string, readonly string[]>,
+): readonly VisualKindOption[] =>
+  [...lineages.keys()].map((id) => ({
+    id,
+    label: kindLabelOf(id),
+    coreLabel: kindLabelOf(lineages.get(id)?.[0] ?? id),
+  }));
+
+/**
+ * How many SUBJECTS a query matches, which is not the size of its match set.
+ *
+ * A `SemanticGraph`'s subjects are concepts and relationships together, so the
+ * match set returns both — right for narrowing a canvas that draws edges as
+ * well as nodes, and wrong for a number sitting beside a view called its
+ * subject count. A view over three components with two relationships between
+ * them would read as five, and the reviewer counting boxes would find three.
+ */
+export const conceptCountOf = (
+  graph: SemanticGraph,
+  query: ProjectionQuery,
+  profileContext: ResolvedProfileContext,
+): number =>
+  evaluateProjection(graph, adHoc(query), profileContext).subjects.filter(
+    ({ type }) => type === "concept",
+  ).length;
+
+/**
+ * Rebuilds the shared editor workspace from one successful compile.
+ *
+ * The caller owns metadata which cannot be inferred from a graph (authority,
+ * source revisions, layouts, and initial view); this helper owns all derived
+ * canvas, vocabulary, and view-count arithmetic.
+ */
+export const renderedWorkspaceOf = (
+  compiled: {
+    readonly graph: SemanticGraph;
+    readonly profileContext: ResolvedProfileContext;
+  },
+  views: readonly VisualViewSummary[],
+  metadata: Omit<VisualRenderedModel, "graph" | "vocabulary">,
+): {
+  readonly model: VisualRenderedModel;
+  readonly views: readonly VisualViewSummary[];
+} => {
+  const refreshedViews = views.map((view) => ({
+    ...view,
+    subjectCount: conceptCountOf(
+      compiled.graph,
+      view.query,
+      compiled.profileContext,
+    ),
+  }));
+  return {
+    model: {
+      ...metadata,
+      graph: projectGraphForCanvas(compiled.graph, compiled.profileContext),
+      vocabulary: {
+        conceptKinds: kindOptionsOf(compiled.profileContext.conceptKindLineages),
+        relationshipKinds: kindOptionsOf(
+          compiled.profileContext.relationshipKindLineages,
+        ),
+      },
+    },
+    views: refreshedViews,
+  };
+};
+
+/** Every subject a query draws, concepts and relationships alike. */
+export const matchedIdsOf = (
+  graph: SemanticGraph,
+  query: ProjectionQuery,
+  profileContext: ResolvedProfileContext,
+): readonly string[] =>
+  evaluateProjection(graph, adHoc(query), profileContext).subjects.map(
+    ({ id }) => id,
+  );
+
+/** Every concept a query dropped, and the facet that dropped it (#248). */
+export const exclusionsOf = (
+  graph: SemanticGraph,
+  query: ProjectionQuery,
+  profileContext: ResolvedProfileContext,
+): readonly ProjectionExclusion[] =>
+  explainProjection(graph, adHoc(query), profileContext);
+
+/**
+ * A query on its own is not a projection, and every evaluator here wants one.
+ * The id is a placeholder that never reaches a document.
+ */
+const adHoc = (query: ProjectionQuery): ProjectionDefinition => ({
+  format: "yarramate/projection/v1",
+  id: "ad-hoc",
+  version: "0",
+  query,
+});
+
+/**
+ * One saved view, as the rail reads it. `subjectCount` is the caller's,
+ * because counting needs a compiled graph and a session builds its first list
+ * before it has one.
+ */
+export const viewSummaryOf = (
+  projection: ProjectionDefinition,
+  path: string,
+  subjectCount = 0,
+): VisualViewSummary => ({
+  id: projection.id,
+  title: projection.presentation?.title ?? projection.id,
+  description: projection.presentation?.description ?? "",
+  query: projection.query,
+  presentation: projection.presentation,
+  path,
+  subjectCount,
+});
+
+/**
+ * Applies a landed view batch to a host-owned list.
+ *
+ * Writes are read back through the callback, so a malformed or otherwise
+ * unreadable landed document cannot become a fabricated summary.
+ */
+export const adoptLandedViews = (
+  views: readonly VisualViewSummary[],
+  operations: readonly VisualViewOperation[],
+  readSummary: (path: string) => VisualViewSummary | undefined,
+): readonly VisualViewSummary[] => {
+  const next = [...views];
+  for (const operation of operations) {
+    const at = next.findIndex((view) => view.path === operation.path);
+    if (operation.op === "delete-view") {
+      if (at !== -1) next.splice(at, 1);
+      continue;
+    }
+    const summary = readSummary(operation.path);
+    if (summary === undefined) continue;
+    if (at === -1) next.push(summary);
+    else next[at] = summary;
+  }
+  return next;
+};
+
+/**
+ * The document a diagnostic the runtime minted itself points at. Not a file:
+ * these are about the session rather than about anything the workspace holds.
+ */
+export const VISUAL_SERVER_DOCUMENT = "visual-session-server";
+
+export const published = (
+  diagnostics: readonly Diagnostic[],
+  sources: readonly { readonly path: string; readonly source: string }[],
+): readonly VisualDiagnostic[] =>
+  withDiagnosticSubjects(diagnostics, sources) as readonly VisualDiagnostic[];
+
+export const serverDiagnostic = (
+  code: string,
+  message: string,
+  pointer = "/",
+): VisualDiagnostic => ({
+  severity: "error",
+  code,
+  message,
+  path: VISUAL_SERVER_DOCUMENT,
+  pointer,
+  line: 1,
+  column: 1,
+});
+/**
+ * Whether the workspace would load a projection written at this path.
+ *
+ * This is a DIRECTORY check, not a pattern match, and deliberately so: ADR
+ * 0100 recorded that the manifest's pattern dialect has never been named - it
+ * is whatever `globSync` happens to support, undocumented and untested past
+ * one wildcard - so a matcher written here would be inventing the dialect
+ * rather than honouring it. A directory that already holds a projection the
+ * manifest resolved is a directory the manifest demonstrably reaches.
+ *
+ * A workspace with no projections at all has nothing to demonstrate, so the
+ * default directory is allowed: refusing there would make the first view in a
+ * fresh workspace impossible to create.
+ */
+export const projectionDirectoryIsCovered = (
+  path: string,
+  workspace: ResolvedWorkspace,
+): boolean => {
+  if (workspace.projections.length === 0) {
+    return posixDirectoryOf(path) === DEFAULT_PROJECTION_DIRECTORY;
+  }
+  const covered = new Set(workspace.projections.map(posixDirectoryOf));
+  return covered.has(posixDirectoryOf(path));
+};
+
+/**
+ * Turns staged view operations into pending writes, refusing before anything
+ * is written (ADR 0103).
+ *
+ * A `write-view` is validated through the same `loadProjection` the CLI's own
+ * projection writes go through, so a document the schema would reject never
+ * reaches the store. A `delete-view` names a revision, which is what makes a
+ * removal refusable rather than a silent success on a file someone else
+ * already changed.
+ */
+export const planViewWrites = (
+  operations: readonly VisualViewOperation[],
+  workspace: ResolvedWorkspace,
+  store: SourceStore,
+):
+  | { readonly ok: true; readonly writes: readonly PendingWrite[] }
+  | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] } => {
+  const writes: PendingWrite[] = [];
+  const diagnostics: VisualDiagnostic[] = [];
+  for (const operation of operations) {
+    const held = store.read(operation.path);
+    if (operation.op === "delete-view") {
+      if (held === undefined) {
+        diagnostics.push(
+          serverDiagnostic(
+            "YMVS314",
+            `View "${operation.path}" is already gone`,
+          ),
+        );
+        continue;
+      }
+      writes.push({
+        path: operation.path,
+        source: null,
+        expected: held.revision,
+      });
+      continue;
+    }
+    if (
+      held === undefined &&
+      !projectionDirectoryIsCovered(operation.path, workspace)
+    ) {
+      // A projection no pattern reaches is a file the workspace never loads,
+      // which is worse than a refusal because nothing later says so (ADR 0043).
+      diagnostics.push(
+        serverDiagnostic(
+          "YMVS315",
+          `The workspace manifest covers no projection in "${posixDirectoryOf(
+            operation.path,
+          )}", so a view saved there would never load`,
+        ),
+      );
+      continue;
+    }
+    const source = stringify(operation.projection);
+    const loaded = loadProjection({ path: operation.path, source });
+    if (!loaded.ok) {
+      // The composed document is the only source these are about, so they are
+      // published against it rather than against the workspace.
+      diagnostics.push(
+        ...published(loaded.diagnostics, [{ path: operation.path, source }]),
+      );
+      continue;
+    }
+    writes.push({
+      path: operation.path,
+      source,
+      expected: held?.revision ?? null,
+    });
+  }
+  return diagnostics.length > 0
+    ? { ok: false, diagnostics }
+    : { ok: true, writes };
+};

--- a/src/apply-cli.ts
+++ b/src/apply-cli.ts
@@ -1,0 +1,102 @@
+/**
+ * The `apply` command, and the only part of applying a batch that touches a
+ * filesystem.
+ *
+ * It lives apart from `./apply-command.js` for the reason `./nesting.js` and
+ * `./kind-label.js` state for their own values: the engine half is reachable
+ * from a browser now (#252), and a top-level `node:fs` import is a bundle
+ * failure whether or not the function that uses it is ever called. Core reads
+ * nothing (ADR 0100) - this is the caller that reads for it.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parseDocument } from 'yaml'
+import { landOperations, posixDirectoryOf } from './apply-command.js'
+import { createFileSystemStore } from './source-store.js'
+import { loadWorkspaceManifest } from './workspace.js'
+import { diagnosticJson, humanDiagnostics, usage } from './cli-support.js'
+import type { CliResult } from './cli-support.js'
+
+export function runApplyCommand(
+  options: readonly string[],
+  cwd: string,
+): CliResult {
+  const json = options.includes('--json')
+  const rest = options.filter((option) => option !== '--json')
+  const [operationsPath, workspacePath] = rest
+  if (
+    rest.length !== 2 ||
+    operationsPath === undefined ||
+    workspacePath === undefined ||
+    rest.some((option) => option.startsWith('-'))
+  ) {
+    return { exitCode: 2, stdout: '', stderr: usage }
+  }
+
+  try {
+    const manifestSource = readFileSync(resolve(cwd, workspacePath), 'utf8')
+    if (
+      parseDocument(manifestSource).get('format') !== 'yarramate/workspace/v1'
+    ) {
+      return {
+        exitCode: 2,
+        stdout: '',
+        stderr:
+          'apply requires an explicit workspace manifest (yarramate/workspace/v1)\n',
+      }
+    }
+    const operationsSource = readFileSync(
+      resolve(cwd, operationsPath),
+      'utf8',
+    )
+    const loadedWorkspace = loadWorkspaceManifest(
+      { path: workspacePath, source: manifestSource },
+      cwd,
+    )
+    if (!loadedWorkspace.ok) {
+      return {
+        exitCode: 1,
+        stdout: json
+          ? diagnosticJson(loadedWorkspace.diagnostics)
+          : humanDiagnostics(loadedWorkspace.diagnostics),
+        stderr: '',
+      }
+    }
+    const outcome = landOperations(createFileSystemStore(cwd), {
+      workspace: loadedWorkspace.workspace,
+      operations: { path: operationsPath, source: operationsSource },
+      manifestDirectory: posixDirectoryOf(workspacePath),
+    })
+    if (!outcome.ok) {
+      return {
+        exitCode: 1,
+        stdout: json
+          ? diagnosticJson(outcome.diagnostics)
+          : humanDiagnostics(outcome.diagnostics),
+        stderr: '',
+      }
+    }
+    const { result } = outcome
+    if (json) {
+      return {
+        exitCode: 0,
+        stdout: `${JSON.stringify(result, null, 2)}\n`,
+        stderr: '',
+      }
+    }
+    // Every counter, summed by iteration rather than by hand, so a new
+    // operation kind cannot silently report zero work.
+    const applied = Object.values(result.applied).reduce(
+      (total, count) => total + count,
+      0,
+    )
+    return {
+      exitCode: 0,
+      stdout: `Applied ${applied} operation${applied === 1 ? '' : 's'} to ${result.documents.join(', ')}\n`,
+      stderr: '',
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { exitCode: 2, stdout: '', stderr: `${message}\n` }
+  }
+}

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -11,12 +11,6 @@ import {
 import Ajv2020Module from 'ajv/dist/2020.js'
 import { loadAdapterMapping } from './adapter-mapping.js'
 import {
-  diagnosticJson,
-  humanDiagnostics,
-  usage,
-  type CliResult,
-} from './cli-support.js'
-import {
   compileWorkspace,
   withDiagnosticSubjects,
   type Diagnostic,
@@ -34,10 +28,7 @@ import {
   scanSubjectReferences,
   type SubjectReferenceGroup,
 } from './subject-references.js'
-import {
-  loadWorkspaceManifest,
-  type ResolvedWorkspace,
-} from './workspace.js'
+import type { ResolvedWorkspace } from './workspace.js'
 import {
   type PendingWrite,
   type SourceStore,

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1,5 +1,3 @@
-import { readFileSync, writeFileSync } from 'node:fs'
-import { resolve, sep } from 'node:path'
 import {
   isMap,
   isScalar,
@@ -41,7 +39,6 @@ import {
   type ResolvedWorkspace,
 } from './workspace.js'
 import {
-  createFileSystemStore,
   type PendingWrite,
   type SourceStore,
   type WriteConflict,
@@ -50,9 +47,13 @@ import {
 /**
  * The directory part of a workspace path, in the `/`-separated terms a
  * manifest is written in rather than the platform's.
+ *
+ * Both separators by hand rather than `node:path`'s `sep`: this module is
+ * reachable from a browser (#252), where there is no platform separator to
+ * ask about, and a manifest path is `/`-separated wherever it is read.
  */
 export const posixDirectoryOf = (path: string): string => {
-  const normalised = path.split(sep).join('/')
+  const normalised = path.split(/[\\/]/).join('/')
   const cut = normalised.lastIndexOf('/')
   return cut === -1 ? '' : normalised.slice(0, cut)
 }
@@ -71,7 +72,13 @@ import type {
   YarramateOperation,
 } from './operations.js'
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler sees the unwrapped class, and this file is
+// reachable from a browser through `./apply-operations.js` (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 // `discriminator` routes a batch entry to the single branch its `op` names, so
 // one malformed operation reports one fault instead of ten near-misses.
 const validateOperations = new Ajv2020({
@@ -1298,89 +1305,5 @@ export const landOperations = (
       written.conflicts,
       input.operations.path,
     ),
-  }
-}
-
-export function runApplyCommand(
-  options: readonly string[],
-  cwd: string,
-): CliResult {
-  const json = options.includes('--json')
-  const rest = options.filter((option) => option !== '--json')
-  const [operationsPath, workspacePath] = rest
-  if (
-    rest.length !== 2 ||
-    operationsPath === undefined ||
-    workspacePath === undefined ||
-    rest.some((option) => option.startsWith('-'))
-  ) {
-    return { exitCode: 2, stdout: '', stderr: usage }
-  }
-
-  try {
-    const manifestSource = readFileSync(resolve(cwd, workspacePath), 'utf8')
-    if (
-      parseDocument(manifestSource).get('format') !== 'yarramate/workspace/v1'
-    ) {
-      return {
-        exitCode: 2,
-        stdout: '',
-        stderr:
-          'apply requires an explicit workspace manifest (yarramate/workspace/v1)\n',
-      }
-    }
-    const operationsSource = readFileSync(
-      resolve(cwd, operationsPath),
-      'utf8',
-    )
-    const loadedWorkspace = loadWorkspaceManifest(
-      { path: workspacePath, source: manifestSource },
-      cwd,
-    )
-    if (!loadedWorkspace.ok) {
-      return {
-        exitCode: 1,
-        stdout: json
-          ? diagnosticJson(loadedWorkspace.diagnostics)
-          : humanDiagnostics(loadedWorkspace.diagnostics),
-        stderr: '',
-      }
-    }
-    const outcome = landOperations(createFileSystemStore(cwd), {
-      workspace: loadedWorkspace.workspace,
-      operations: { path: operationsPath, source: operationsSource },
-      manifestDirectory: posixDirectoryOf(workspacePath),
-    })
-    if (!outcome.ok) {
-      return {
-        exitCode: 1,
-        stdout: json
-          ? diagnosticJson(outcome.diagnostics)
-          : humanDiagnostics(outcome.diagnostics),
-        stderr: '',
-      }
-    }
-    const { result } = outcome
-    if (json) {
-      return {
-        exitCode: 0,
-        stdout: `${JSON.stringify(result, null, 2)}\n`,
-        stderr: '',
-      }
-    }
-    // Every counter, summed by iteration rather than by hand, so a new
-    // operation kind cannot silently report zero work.
-    const applied = Object.values(result.applied).reduce(
-      (total, count) => total + count,
-      0,
-    )
-    return {
-      exitCode: 0,
-      stdout: `Applied ${applied} operation${applied === 1 ? '' : 's'} to ${result.documents.join(', ')}\n`,
-      stderr: '',
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    return { exitCode: 2, stdout: '', stderr: `${message}\n` }
   }
 }

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -29,7 +29,14 @@ import {
   type EvidenceFinding,
 } from './reconciliation.js'
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. One shape for all of
+// them, so which modules a browser happens to reach is not a thing anyone has
+// to keep track of (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 
 const strictFindingMessage = (finding: EvidenceFinding): string => {
   const observed =

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import {
 import { runAskCommand } from './ask-command.js'
 import { runCheckCommand } from './check-command.js'
 import { runExportCommand } from './export-command.js'
-import { runApplyCommand } from './apply-command.js'
+import { runApplyCommand } from './apply-cli.js'
 import { runDesignCommand } from './design-command.js'
 import {
   evaluateEvidenceWorkspace,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -350,21 +350,31 @@ const immutableMap = <K, V>(
 const compareById = <T extends { readonly id: string }>(left: T, right: T) =>
   left.id.localeCompare(right.id)
 
+const utf8Encoder = new TextEncoder()
+
+const utf8Hex = (value: string): string => {
+  let hex = ''
+  for (const byte of utf8Encoder.encode(value)) {
+    hex += byte.toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
 const presenceClaimId = (subject: string, state: string) =>
-  `${subject}~present-in-${Buffer.from(state, 'utf8').toString('hex')}`
+  `${subject}~present-in-${utf8Hex(state)}`
 
 // Alternative labels and distinctness records are unordered sets, not
 // authored lists with ids. Hex-encoding the value the way presence
 // encodes its state keeps the claim id derived from content rather than
 // position, so reordering the YAML leaves the graph byte-identical.
 const aliasClaimId = (subject: string, alias: string) =>
-  `${subject}~alias-${Buffer.from(alias, 'utf8').toString('hex')}`
+  `${subject}~alias-${utf8Hex(alias)}`
 
 const distinctFromClaimId = (subject: string, other: string) =>
-  `${subject}~distinct-from-${Buffer.from(other, 'utf8').toString('hex')}`
+  `${subject}~distinct-from-${utf8Hex(other)}`
 
 const supersedesClaimId = (subject: string, predecessor: string) =>
-  `${subject}~supersedes-${Buffer.from(predecessor, 'utf8').toString('hex')}`
+  `${subject}~supersedes-${utf8Hex(predecessor)}`
 
 export {
   ATTESTATION_PREDICATE_PREFIX,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,4 +1,4 @@
-import { createRequire } from 'node:module'
+import Ajv2020Import from 'ajv/dist/2020.js'
 import type Ajv2020Type from 'ajv/dist/2020.js'
 import { LineCounter, parse, parseDocument } from 'yaml'
 import {
@@ -32,14 +32,21 @@ import {
 } from './shipped-profile.js'
 
 const coreProfile = 'yarramate/core@0.1'
-// `ajv/dist/2020.js` is CJS. Its default-export shape is resolved
+// `ajv/dist/2020.js` is CJS, and its default-export shape is resolved
 // differently under this repo's two tsconfigs: NodeNext (root) sees the raw
 // `module.exports` (needs `.default`), Bundler+esModuleInterop
-// (tsconfig.visual.json) sees the already-unwrapped class. `require()`
-// sidesteps the value-level ambiguity; the type is normalized the same way.
+// (tsconfig.visual.json) sees the already-unwrapped class. The `??` picks
+// whichever arrived; the type is normalized the same way.
+//
+// A STATIC import, never `createRequire`. A bundler cannot follow
+// `createRequire`, so loading Ajv that way put `(0, cre.createRequire)(...)`
+// into the browser bundle, where it is not a function - which is exactly how
+// this module became unimportable from a browser, and why the editor could
+// only ever run behind a Node process (#252).
 type Ajv2020Ctor = typeof Ajv2020Type extends { default: infer D } ? D : typeof Ajv2020Type
-const require = createRequire(import.meta.url)
-const ajv2020Module = require('ajv/dist/2020.js') as { default?: Ajv2020Ctor } & Ajv2020Ctor
+const ajv2020Module = Ajv2020Import as unknown as {
+  default?: Ajv2020Ctor
+} & Ajv2020Ctor
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateDocument = new Ajv2020({ allErrors: true }).compile(documentSchema)
 const validateProfile = new Ajv2020({ allErrors: true }).compile(profileSchema)

--- a/src/core-contract.ts
+++ b/src/core-contract.ts
@@ -10,7 +10,14 @@ import coreContractSchema from '../schema/yarramate-core-contract.schema.json' w
   type: 'json',
 }
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. One shape for all of
+// them, so which modules a browser happens to reach is not a thing anyone has
+// to keep track of (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateCoreContract = new Ajv2020({ allErrors: true }).compile(
   coreContractSchema,
 )

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -14,7 +14,14 @@ import evidenceSchema from '../schema/yarramate-evidence.schema.json' with {
   type: 'json',
 }
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. One shape for all of
+// them, so which modules a browser happens to reach is not a thing anyone has
+// to keep track of (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateEvidenceSchema = new Ajv2020({ allErrors: true }).compile(
   evidenceSchema,
 )

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -15,7 +15,14 @@ import catalogueSchema from '../schema/yarramate-question-catalogue.schema.json'
   type: 'json',
 }
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. One shape for all of
+// them, so which modules a browser happens to reach is not a thing anyone has
+// to keep track of (#252).
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateCatalogue = new Ajv2020({ allErrors: true }).compile(
   catalogueSchema,
 )

--- a/src/kind-label.ts
+++ b/src/kind-label.ts
@@ -1,8 +1,9 @@
 /**
  * A kind identity is `<profile>#<local id>`, and its label is that local id.
  *
- * This lives apart from `graph-projection.ts` because the browser needs it:
- * the projection imports the compiler, and the compiler reaches for Ajv
- * through `node:module` at load, which a bundle cannot honour.
+ * This lives apart from `graph-projection.ts` because the browser needs it,
+ * and the projection imports the compiler, which loads Ajv and two schemas at
+ * module scope. That is importable from a browser now (#252) and was not
+ * before; it is still a lot of bundle for one label.
  */
 export const kindLabelOf = (kind: string): string => kind.slice(kind.lastIndexOf('#') + 1)

--- a/src/nesting.ts
+++ b/src/nesting.ts
@@ -2,11 +2,13 @@
  * What a view nests, kept in a module that imports nothing.
  *
  * These live apart from `projection.ts` because the browser needs the value,
- * not only the type, and `projection.ts` reaches for `node:module` to load
- * Ajv. A value import of it from `src/visual-app` therefore pulls
- * `createRequire` into the browser bundle, where it is not a function and the
- * whole app fails to mount (ADR 0101 introduced the constant; this is where it
- * belongs). `projection.ts` re-exports both, so nothing else has to know.
+ * not only the type. `projection.ts` used to reach for `node:module` to load
+ * Ajv, so importing it from `src/visual-app` shipped `createRequire` into the
+ * bundle, where it is not a function and the whole app failed to mount. That
+ * import is static now (#252) and the bundle survives it - but it still drags
+ * Ajv and the projection schema in for one constant, so the split earns its
+ * place on weight rather than on breakage (ADR 0101 introduced the constant;
+ * this is where it belongs). `projection.ts` re-exports both.
  */
 export type NestingKind = 'composition' | 'assignment'
 

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,4 +1,4 @@
-import { createRequire } from 'node:module'
+import Ajv2020Import from 'ajv/dist/2020.js'
 import type Ajv2020Type from 'ajv/dist/2020.js'
 import { isDeclaredNonGoal } from './brief.js'
 import type {
@@ -13,14 +13,21 @@ import projectionSchema from '../schema/yarramate-projection.schema.json' with {
   type: 'json',
 }
 
-// `ajv/dist/2020.js` is CJS. Its default-export shape is resolved
+// `ajv/dist/2020.js` is CJS, and its default-export shape is resolved
 // differently under this repo's two tsconfigs: NodeNext (root) sees the raw
 // `module.exports` (needs `.default`), Bundler+esModuleInterop
-// (tsconfig.visual.json) sees the already-unwrapped class. `require()`
-// sidesteps the value-level ambiguity; the type is normalized the same way.
+// (tsconfig.visual.json) sees the already-unwrapped class. The `??` picks
+// whichever arrived; the type is normalized the same way.
+//
+// A STATIC import, never `createRequire`. A bundler cannot follow
+// `createRequire`, so loading Ajv that way put `(0, cre.createRequire)(...)`
+// into the browser bundle, where it is not a function - which is exactly how
+// this module became unimportable from a browser, and why the editor could
+// only ever run behind a Node process (#252).
 type Ajv2020Ctor = typeof Ajv2020Type extends { default: infer D } ? D : typeof Ajv2020Type
-const require = createRequire(import.meta.url)
-const ajv2020Module = require('ajv/dist/2020.js') as { default?: Ajv2020Ctor } & Ajv2020Ctor
+const ajv2020Module = Ajv2020Import as unknown as {
+  default?: Ajv2020Ctor
+} & Ajv2020Ctor
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateProjection = new Ajv2020({ allErrors: true }).compile(
   projectionSchema,
@@ -87,9 +94,9 @@ export interface ProjectionDefinition {
 /**
  * A relationship kind a view may draw as nesting, and the default. Defined in
  * `./nesting.js`, which imports nothing, and re-exported here so a consumer
- * that already reads projection types keeps finding them. The browser must
- * import them from there rather than from here: this module reaches for
- * `node:module` to load Ajv (ADR 0101).
+ * that already reads projection types keeps finding them. The browser should
+ * still import them from there rather than from here: this module loads Ajv
+ * and a schema, which is a great deal of bundle for one constant (ADR 0101).
  */
 export { DEFAULT_NESTING, type NestingKind } from './nesting.js'
 import type { NestingKind } from './nesting.js'

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -30,7 +30,8 @@ import type {
   VisualViewOperation,
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
-import { Section, SectionSplitter } from "./section-stack.js";
+import type { EditorHost } from "./editor-host.js";
+import { Section, SectionSplitter, stackRows } from "./section-stack.js";
 import { useVisualSession } from "./session-client.js";
 import { activeViewMembership } from "./state.js";
 import type { VisualAppRecord, VisualAppState } from "./state.js";
@@ -44,6 +45,7 @@ import {
   viewNeedingApplication,
   visualWorkspaceReducer,
   type ConnectionDraft,
+  RIGHT_SECTIONS,
   type RightSectionId,
   type SelectedDiagramSubject,
 } from "./workspace-state.js";
@@ -847,7 +849,22 @@ const ConversationSeparator = ({
   );
 };
 
-export const App = () => {
+/**
+ * The editor.
+ *
+ * It takes a HOST rather than opening a session of its own (#252): the same
+ * component runs against the session server over a websocket and against an
+ * embedder's own store with no server at all. `sections` is what the host
+ * wants shown - a product with no agent behind it leaves `chat` out, and the
+ * section and the session button go with it.
+ */
+export const App = ({
+  host,
+  sections = RIGHT_SECTIONS,
+}: {
+  readonly host: EditorHost;
+  readonly sections?: readonly RightSectionId[];
+}) => {
   const {
     state,
     connected,
@@ -867,7 +884,7 @@ export const App = () => {
     redoChangeset,
     commitChangeset,
     end,
-  } = useVisualSession();
+  } = useVisualSession(host);
 
   const [workspace, dispatchWorkspace] = useReducer(
     visualWorkspaceReducer,
@@ -1342,112 +1359,129 @@ export const App = () => {
           }
         />
         <aside className="section-stack" aria-label="Session">
-          <Section
-            id="properties"
-            label="Element properties"
-            meta={workspace.selectedSubject?.id}
-            open={sectionOpen("properties")}
-            onToggle={() =>
-              dispatchWorkspace({ type: "section.toggled", section: "properties" })
-            }
-          >
-            {workspace.selectedSubject === null || state.model === null ? (
-              <p className="section-empty">
-                Nothing selected. Pick a subject on the canvas or in the rail.
-              </p>
-            ) : (
-              <SelectedSubjectInspector
-                subject={workspace.selectedSubject}
-                model={state.model}
-                operations={state.pendingChangeset.operations}
-                expanded={workspace.descriptionExpanded}
-                onToggleDescription={() =>
-                  dispatchWorkspace({ type: "description.toggled" })
-                }
-                onClear={() => dispatchWorkspace({ type: "subject.cleared" })}
-                onConnect={(from) =>
-                  dispatchWorkspace({ type: "connection.started", from })
-                }
-                onDelete={(id) =>
-                  dispatchWorkspace({ type: "deletion.asked", id })
-                }
-                onStageChange={stageChange}
-              />
-            )}
-          </Section>
-          <SectionSplitter
-            label="Resize the changes section"
-            height={workspace.conversation.changesHeight}
-            viewportHeight={workspace.viewportHeight}
-            onResize={(height) =>
-              dispatchWorkspace({
-                type: "section.resized",
-                section: "changes",
-                height,
-              })
-            }
-          />
-          <Section
-            id="changes"
-            label="Changes"
-            meta={stagedCount === 0 ? "nothing staged" : `${stagedCount} staged`}
-            open={sectionOpen("changes")}
-            onToggle={() =>
-              dispatchWorkspace({ type: "section.toggled", section: "changes" })
-            }
-          >
-            <ChangesetTray
-              state={state}
-              onDiscardChange={discardChange}
-              onClearChangeset={clearChangeset}
-              onUndoChangeset={undoChangeset}
-              onRedoChangeset={redoChangeset}
-              onCommitChangeset={commitChangeset}
-            />
-          </Section>
-          <SectionSplitter
-            label="Resize the chat section"
-            height={workspace.conversation.chatHeight}
-            viewportHeight={workspace.viewportHeight}
-            onResize={(height) =>
-              dispatchWorkspace({
-                type: "section.resized",
-                section: "chat",
-                height,
-              })
-            }
-          />
-          <Section
-            id="chat"
-            label="Chat"
-            meta={
-              workspace.conversation.unread === 0 ? (
-                chatMeta(state)
-              ) : (
-                <span className="attention-count">
-                  {workspace.conversation.unread}
-                </span>
-              )
-            }
-            open={sectionOpen("chat")}
-            onToggle={() =>
-              dispatchWorkspace({ type: "section.toggled", section: "chat" })
-            }
-          >
-            <ChatSection
-              state={state}
-              disabled={!state.composerEnabled}
-              selectedSubject={workspace.selectedSubject}
-              onSend={(text) =>
-                ask(formatContextualQuestion(text, workspace.selectedSubject))
-              }
-              onChoice={choose}
-              onClearSubject={() =>
-                dispatchWorkspace({ type: "subject.cleared" })
-              }
-              onEnd={end}
-            />
-          </Section>
+          {stackRows(
+            sections,
+            {
+              properties: (
+                <Section
+                  id="properties"
+                  label="Element properties"
+                  meta={workspace.selectedSubject?.id}
+                  open={sectionOpen("properties")}
+                  onToggle={() =>
+                    dispatchWorkspace({ type: "section.toggled", section: "properties" })
+                  }
+                >
+                  {workspace.selectedSubject === null || state.model === null ? (
+                    <p className="section-empty">
+                      Nothing selected. Pick a subject on the canvas or in the rail.
+                    </p>
+                  ) : (
+                    <SelectedSubjectInspector
+                      subject={workspace.selectedSubject}
+                      model={state.model}
+                      operations={state.pendingChangeset.operations}
+                      expanded={workspace.descriptionExpanded}
+                      onToggleDescription={() =>
+                        dispatchWorkspace({ type: "description.toggled" })
+                      }
+                      onClear={() => dispatchWorkspace({ type: "subject.cleared" })}
+                      onConnect={(from) =>
+                        dispatchWorkspace({ type: "connection.started", from })
+                      }
+                      onDelete={(id) =>
+                        dispatchWorkspace({ type: "deletion.asked", id })
+                      }
+                      onStageChange={stageChange}
+                    />
+                  )}
+                </Section>
+              ),
+              changes: (
+                <Section
+                  id="changes"
+                  label="Changes"
+                  meta={stagedCount === 0 ? "nothing staged" : `${stagedCount} staged`}
+                  open={sectionOpen("changes")}
+                  onToggle={() =>
+                    dispatchWorkspace({ type: "section.toggled", section: "changes" })
+                  }
+                >
+                  <ChangesetTray
+                    state={state}
+                    onDiscardChange={discardChange}
+                    onClearChangeset={clearChangeset}
+                    onUndoChangeset={undoChangeset}
+                    onRedoChangeset={redoChangeset}
+                    onCommitChangeset={commitChangeset}
+                  />
+                </Section>
+              ),
+              chat: (
+                <Section
+                  id="chat"
+                  label="Chat"
+                  meta={
+                    workspace.conversation.unread === 0 ? (
+                      chatMeta(state)
+                    ) : (
+                      <span className="attention-count">
+                        {workspace.conversation.unread}
+                      </span>
+                    )
+                  }
+                  open={sectionOpen("chat")}
+                  onToggle={() =>
+                    dispatchWorkspace({ type: "section.toggled", section: "chat" })
+                  }
+                >
+                  <ChatSection
+                    state={state}
+                    disabled={!state.composerEnabled}
+                    selectedSubject={workspace.selectedSubject}
+                    onSend={(text) =>
+                      ask(formatContextualQuestion(text, workspace.selectedSubject))
+                    }
+                    onChoice={choose}
+                    onClearSubject={() =>
+                      dispatchWorkspace({ type: "subject.cleared" })
+                    }
+                    onEnd={end}
+                  />
+                </Section>
+              ),
+            },
+            {
+              changes: (
+                <SectionSplitter
+                  label="Resize the changes section"
+                  height={workspace.conversation.changesHeight}
+                  viewportHeight={workspace.viewportHeight}
+                  onResize={(height) =>
+                    dispatchWorkspace({
+                      type: "section.resized",
+                      section: "changes",
+                      height,
+                    })
+                  }
+                />
+              ),
+              chat: (
+                <SectionSplitter
+                  label="Resize the chat section"
+                  height={workspace.conversation.chatHeight}
+                  viewportHeight={workspace.viewportHeight}
+                  onResize={(height) =>
+                    dispatchWorkspace({
+                      type: "section.resized",
+                      section: "chat",
+                      height,
+                    })
+                  }
+                />
+              ),
+            },
+          )}
         </aside>
       </div>
       {/* At the shell, not inside the canvas or the rail: a menu opened on the

--- a/src/visual-app/editor-host.ts
+++ b/src/visual-app/editor-host.ts
@@ -1,0 +1,69 @@
+import type { VisualBrowserInput } from '../adapters/visual/protocol-contract.js'
+import type { VisualServerFrame } from '../adapters/visual/wire.js'
+
+/**
+ * Where the editor's answers come from (#252).
+ *
+ * The editor used to be inseparable from one WebSocket: `session-client.tsx`
+ * owned the socket, the session fetch and the reconnect loop, and the only way
+ * to run the editor was to host the Node process behind them. A product that
+ * wanted the canvas had to take the session server with it.
+ *
+ * A host is the seam. **The contract is the protocol that already exists** -
+ * `VisualServerFrame` in, `VisualBrowserInput` out (ADR 0081) - rather than a
+ * new interface of verbs, for three reasons. The reducer is already a pure
+ * function of frames, so nothing above this line changes. The protocol is
+ * already published and versioned, so there is one contract rather than two
+ * that must be kept in step. And "the session server becomes one
+ * implementation of the host contract" is then literally what happens: it
+ * implements the protocol it already speaks.
+ *
+ * Two hosts ship. `socket-host.ts` is the session server over a websocket, and
+ * is what `yarramate-visual` mounts. `local-host.ts` runs the engine in the
+ * browser over a `SourceStore` the embedder owns, and needs no server at all.
+ */
+export interface EditorHostEvents {
+  /** One frame, exactly as the wire defines it. */
+  readonly frame: (frame: VisualServerFrame) => void
+  /**
+   * Whether the editor may send right now. A local host is connected from the
+   * moment it opens and never stops being; a socket host reports what the
+   * socket is doing.
+   */
+  readonly connected: (connected: boolean) => void
+  /**
+   * The transport dropped and may come back. A host that has given up says so
+   * with a `closing` frame instead, which is how the reducer already learns a
+   * session is over.
+   */
+  readonly lost: () => void
+  /**
+   * What the editor has seen, for a host that has to resume.
+   *
+   * The reducer owns both facts and neither is the transport's to keep: a
+   * socket resuming after a drop bootstraps from the sequence this browser
+   * acknowledged, and stops retrying once the session is over. A host with
+   * nothing to resume never asks.
+   */
+  readonly session: () => { readonly lastSequence: number; readonly closed: boolean }
+}
+
+export interface EditorHost {
+  /**
+   * Starts the host. Every frame it will ever deliver arrives through
+   * `events`, including the opening snapshot - which a socket host fetches and
+   * a local host computes, and which both report as the `ready` frame the
+   * reducer already knows how to read.
+   *
+   * Returns the stop. Calling it releases the transport and guarantees no
+   * further event.
+   */
+  readonly open: (events: EditorHostEvents) => () => void
+  /**
+   * One input, already stamped with the sequence this browser has seen. A host
+   * that cannot take it right now drops it rather than queueing: the editor
+   * disables what it cannot send, and a queue would land an intent the
+   * reviewer has stopped meaning.
+   */
+  readonly send: (input: VisualBrowserInput) => void
+}

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -1,0 +1,402 @@
+import {
+  compileWorkspaceWithProfileContext,
+  type ResolvedProfileContext,
+  type SemanticGraph,
+  type WorkspaceSource,
+} from '../compiler.js'
+import { planOperations } from '../apply-command.js'
+import type { SourceStore, WriteOutcome } from '../source-store.js'
+import type { ResolvedWorkspace } from '../workspace.js'
+import { loadProjection } from '../projection.js'
+import { VISUAL_PROTOCOL_VERSION } from '../adapters/visual/protocol-contract.js'
+import type {
+  VisualBrowserInput,
+  VisualDiagnostic,
+  VisualViewSummary,
+} from '../adapters/visual/protocol-contract.js'
+import type { VisualRenderedModel } from '../adapters/visual/wire.js'
+import {
+  adoptLandedViews,
+  exclusionsOf,
+  matchedIdsOf,
+  planViewWrites,
+  published,
+  renderedWorkspaceOf,
+  serverDiagnostic,
+  viewSummaryOf,
+} from '../adapters/visual/workspace-model.js'
+import { stringify } from 'yaml'
+import type { EditorHost, EditorHostEvents } from './editor-host.js'
+
+/**
+ * The editor with no server behind it (#252).
+ *
+ * The session server answers three of the seven browser inputs itself, inline,
+ * without ever waking an agent: a filter, a commit and a layout save are
+ * questions for the ENGINE. The other four - a chat message, a choice, a
+ * navigation, an end - are questions for an AGENT. This host answers the
+ * engine's three over a store the embedder owns, and says plainly that it
+ * cannot answer the rest.
+ *
+ * That split is why the issue says chat is the section a host leaves out. It is
+ * not a feature withheld: with no agent there is nobody to talk to and nothing
+ * to hand control back to.
+ *
+ * SYNCHRONOUS, per ADR 0100. An embedder whose backing store is asynchronous -
+ * D1, S3 - fetches its sources, builds a store over what it fetched, and writes
+ * back what `writeAll` is given. That is the shape the ADR chose over an async
+ * interface, and it is the shape this host is built for.
+ */
+export interface LocalHostOptions {
+  /** Where the sources come from and where a commit lands (ADR 0100). */
+  readonly store: SourceStore
+  /**
+   * The manifest, already resolved. Resolving one means expanding globs
+   * against a filesystem, which is the one part of the engine that cannot run
+   * here - so the embedder resolves and hands over the result.
+   */
+  readonly workspace: ResolvedWorkspace
+  /** What the editor calls this model. Cosmetic; nothing is derived from it. */
+  readonly title?: string
+  readonly description?: string
+  /** Told after every landed commit, so a host can persist what it was given. */
+  readonly onCommit?: (documents: readonly string[]) => void
+}
+
+const EMPTY_MODEL: VisualRenderedModel = {
+  authority: 'canonical',
+  initialView: '',
+  graph: { nodes: [], edges: [] },
+  documents: [],
+  vocabulary: { conceptKinds: [], relationshipKinds: [] },
+  layouts: {},
+  sourceDigests: {},
+  projectionDigests: {},
+}
+
+export const createLocalHost = (options: LocalHostOptions): EditorHost => {
+  const { store, workspace } = options
+  let compiled:
+    | {
+        readonly graph: SemanticGraph
+        readonly profileContext: ResolvedProfileContext
+      }
+    | undefined
+  let model: VisualRenderedModel = EMPTY_MODEL
+  const readViewSummary = (path: string): VisualViewSummary | undefined => {
+    const held = store.read(path)
+    if (held === undefined) return undefined
+    const loaded = loadProjection({ path, source: held.source })
+    // A broken saved view skips rather than failing the editor, the same way
+    // the session server treats one.
+    return loaded.ok ? viewSummaryOf(loaded.projection, path) : undefined
+  }
+  // `ResolvedWorkspace` is static, so this starts from its projections once;
+  // successful view operations keep the live list current afterwards.
+  let views: readonly VisualViewSummary[] = workspace.projections.flatMap(
+    (path) => {
+      const summary = readViewSummary(path)
+      return summary === undefined ? [] : [summary]
+    },
+  )
+  let deliver: EditorHostEvents | undefined
+
+  /**
+   * Every source the workspace resolves to, read once per compile.
+   *
+   * PROFILES INCLUDED. `applyOperations` reads nothing it is not handed
+   * (ADR 0100) and compiles from `[...profiles, ...documents]`, so a compile
+   * shown no profile is shown an empty string where one should be.
+   */
+  const sourcesOf = (): readonly WorkspaceSource[] =>
+    [...workspace.profiles, ...workspace.documents].flatMap((path) => {
+      const held = store.read(path)
+      return held === undefined ? [] : [{ path, source: held.source }]
+    })
+
+  const revisionsOf = (
+    paths: readonly string[],
+  ): Readonly<Record<string, string>> =>
+    Object.fromEntries(
+      paths.flatMap((path) => {
+        const held = store.read(path)
+        return held === undefined ? [] : [[path, held.revision] as const]
+      }),
+    )
+
+  /**
+   * Recompiles and rebuilds what the canvas draws. `false` when the workspace
+   * does not compile, which leaves the previous model standing rather than
+   * blanking the canvas under the reviewer.
+   */
+  const recompile = (): boolean => {
+    const sources = sourcesOf()
+    const result = compileWorkspaceWithProfileContext(sources)
+    if (!result.ok) {
+      compiled = undefined
+      return false
+    }
+    const refreshed = {
+      graph: result.graph,
+      profileContext: result.profileContext,
+    }
+    compiled = refreshed
+    const workspaceModel = renderedWorkspaceOf(refreshed, views, {
+      authority: 'canonical',
+      initialView: views[0]?.id ?? '',
+      documents: workspace.documents,
+      layouts: model.layouts,
+      // THE STORE'S OWN REVISIONS, not a sha256 of the bytes. A revision is
+      // opaque and only the store that minted it may compare two (ADR 0100),
+      // which is exactly what `planOperations` does at commit time - so the
+      // browser carries what the store said rather than a hash this host
+      // would have to invent a crypto library to compute.
+      sourceDigests: revisionsOf([
+        ...workspace.profiles,
+        ...workspace.documents,
+      ]),
+      // The manifest's resolved projections are static. Pins belong to the
+      // live list so a view created or removed during this editor session is
+      // represented exactly as it is in the rail.
+      projectionDigests: revisionsOf(views.map(({ path }) => path)),
+    })
+    views = workspaceModel.views
+    model = workspaceModel.model
+    return true
+  }
+
+  const refuse = (
+    input: VisualBrowserInput,
+    diagnostics: readonly VisualDiagnostic[],
+  ): void => deliver?.frame({ kind: 'rejected', refused: input.type, diagnostics })
+
+  const noAgent = (input: VisualBrowserInput): void =>
+    refuse(input, [
+      serverDiagnostic(
+        'YMVS316',
+        `This editor has no agent behind it, so "${input.type}" cannot be answered`,
+      ),
+    ])
+
+  const commit = (input: VisualBrowserInput): void => {
+    if (input.type !== 'changeset.commit') return
+    const { operations, viewOperations } = input.payload
+    // The browser's pins are not checked here, and deliberately: the store's
+    // own compare-and-swap is a stronger form of the same question, asked at
+    // the moment of writing rather than a compile earlier (ADR 0100). The
+    // session server checks pins because its store is a filesystem other
+    // writers share; an embedder's store answers for itself.
+    const planned =
+      operations.length === 0
+        ? null
+        : planOperations(store, {
+            workspace,
+            operations: {
+              path: 'changeset.yaml',
+              source: stringify({
+                format: 'yarramate/operations/v1',
+                operations,
+              }),
+            },
+            manifestDirectory: '',
+          })
+    if (planned !== null && !planned.ok) {
+      deliver?.frame({
+        kind: 'apply-result',
+        result: {
+          ok: false,
+          diagnostics: published(planned.outcome.diagnostics, sourcesOf()),
+        },
+      })
+      return
+    }
+    const viewWrites = planViewWrites(viewOperations, workspace, store)
+    if (!viewWrites.ok) {
+      deliver?.frame({
+        kind: 'apply-result',
+        result: { ok: false, diagnostics: viewWrites.diagnostics },
+      })
+      return
+    }
+    const writes = [...(planned?.writes ?? []), ...viewWrites.writes]
+    // Nothing to write is not a conflict; a store asked to write nothing is
+    // a store asked a question it should not have to answer.
+    const written =
+      writes.length === 0
+        ? ({ ok: true, revisions: new Map() } satisfies WriteOutcome)
+        : store.writeAll(writes)
+    if (!written.ok) {
+      deliver?.frame({
+        kind: 'apply-result',
+        result: {
+          ok: false,
+          diagnostics: [
+            serverDiagnostic(
+              'YMVS317',
+              'A document changed after this batch was staged; nothing was written',
+            ),
+          ],
+        },
+      })
+      return
+    }
+    views = adoptLandedViews(views, viewOperations, readViewSummary)
+    const documents = writes.map(({ path }) => path)
+    const result = planned?.outcome.ok === true ? planned.outcome.result : undefined
+    deliver?.frame({
+      kind: 'apply-result',
+      result:
+        result === undefined
+          ? { ok: true, result: emptyResult(workspace.id, documents) }
+          : { ok: true, result: { ...result, documents } },
+    })
+    options.onCommit?.(documents)
+    if (recompile()) deliver?.frame({ kind: 'model', model, views })
+  }
+
+  /** What a batch that changed no subject reports. */
+  const emptyResult = (id: string, documents: readonly string[]) => ({
+    format: 'yarramate/apply-result/v1' as const,
+    workspace: id,
+    applied: {
+      addedConcepts: 0,
+      addedRelationships: 0,
+      updatedConcepts: 0,
+      updatedRelationships: 0,
+      deletedConcepts: 0,
+      deletedRelationships: 0,
+      renamedConcepts: 0,
+      renamedRelationships: 0,
+      addedObservations: 0,
+      updatedObservations: 0,
+      deletedObservations: 0,
+    },
+    documents,
+  })
+
+  return {
+    open: (events: EditorHostEvents) => {
+      deliver = events
+      recompile()
+      events.connected(true)
+      events.frame({
+        kind: 'ready',
+        snapshot: {
+          protocolVersion: VISUAL_PROTOCOL_VERSION,
+          sessionId: 'local',
+          authority: 'canonical',
+          title: options.title ?? workspace.id,
+          description: options.description ?? '',
+          // No agent, so no chat and no choices. The editor reads this and the
+          // composer never offers to send.
+          chatEnabled: false,
+          capabilities: {
+            chat: false,
+            choices: false,
+            navigation: true,
+            transcript: false,
+          },
+          webSocketUrl: '',
+          model,
+          transcript: [],
+          views,
+          agentTurnOpen: false,
+          pendingChoice: null,
+          styleNonce: '',
+          lastSequence: 0,
+          frozen: false,
+        },
+      })
+      return () => {
+        deliver = undefined
+      }
+    },
+
+    send: (input: VisualBrowserInput) => {
+      switch (input.type) {
+        case 'filter.query':
+          deliver?.frame({
+            kind: 'filter-result',
+            result: {
+              query: input.payload.query,
+              matchedIds:
+                compiled === undefined
+                  ? []
+                  : matchedIdsOf(
+                      compiled.graph,
+                      input.payload.query,
+                      compiled.profileContext,
+                    ),
+              excluded:
+                compiled === undefined
+                  ? []
+                  : exclusionsOf(
+                      compiled.graph,
+                      input.payload.query,
+                      compiled.profileContext,
+                    ),
+            },
+          })
+          return
+        case 'changeset.commit':
+          commit(input)
+          return
+        case 'layout.save': {
+          const { projectionId, positions } = input.payload
+          if (!views.some((view) => view.id === projectionId)) {
+            deliver?.frame({
+              kind: 'layout-save-result',
+              result: {
+                ok: false,
+                message: `"${projectionId}" is not a known view id`,
+              },
+            })
+            return
+          }
+          const path = `.yarramate/visual-layout/${projectionId}.yaml`
+          const held = store.read(path)
+          const written = store.writeAll([
+            {
+              path,
+              source: stringify({
+                format: 'yarramate/visual-layout/v1',
+                projectionId,
+                positions,
+              }),
+              expected: held?.revision ?? null,
+            },
+          ])
+          if (!written.ok) {
+            deliver?.frame({
+              kind: 'layout-save-result',
+              result: {
+                ok: false,
+                message: `Layout for "${projectionId}" changed before it could be saved`,
+              },
+            })
+            return
+          }
+          model = {
+            ...model,
+            layouts: { ...model.layouts, [projectionId]: positions },
+          }
+          deliver?.frame({
+            kind: 'layout-save-result',
+            result: { ok: true, path },
+          })
+          return
+        }
+        case 'view.navigate':
+          // Nothing to tell: navigation is the browser's own state, and the
+          // session server only journals it so an agent can read where the
+          // reviewer went.
+          return
+        case 'chat.message':
+        case 'choice.selected':
+        case 'session.end':
+          noAgent(input)
+          return
+      }
+    },
+  }
+}

--- a/src/visual-app/main.tsx
+++ b/src/visual-app/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App.js'
+import { createSocketHost } from './socket-host.js'
 import './styles.css'
 
 const mount = document.getElementById('visual-session')
@@ -7,6 +8,14 @@ if (mount === null) {
   throw new Error('The visual session page has no mount point')
 }
 
+/**
+ * The page `yarramate-visual` serves: the editor, over the session server.
+ *
+ * One of two entries now (#252). This one has a server behind it and every
+ * section on; `mount.tsx` is the one an embedder calls, with a store instead of
+ * a socket and only the sections it asked for.
+ */
+
 // No StrictMode: its double mount would open the session socket twice, and this
 // bundle only ever runs as the production build the session server serves.
-createRoot(mount).render(<App />)
+createRoot(mount).render(<App host={createSocketHost()} />)

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -1,0 +1,78 @@
+import { createRoot } from 'react-dom/client'
+import { App } from './App.js'
+import { createLocalHost, type LocalHostOptions } from './local-host.js'
+import type { EditorHost } from './editor-host.js'
+import { RIGHT_SECTIONS, type RightSectionId } from './workspace-state.js'
+import './styles.css'
+
+/**
+ * Mount the editor in someone else's product (#252).
+ *
+ * The tree, the canvas, the query panel and the section stack, in an element
+ * the host owns, over a store the host owns. No Node process, no session
+ * server, no websocket, no journal: `yarramate-visual` is one way to run this
+ * and no longer the only one.
+ *
+ * ```ts
+ * import { mountEditor } from 'yarramate/visual-app'
+ * import 'yarramate/visual-app/styles.css'
+ *
+ * const editor = mountEditor(document.querySelector('#editor')!, {
+ *   store,                              // read / writeAll (ADR 0100)
+ *   workspace,                          // a resolved manifest
+ *   sections: ['properties', 'changes'],
+ * })
+ * // later
+ * editor.unmount()
+ * ```
+ *
+ * `sections` is what the host wants shown. Chat is the one a product usually
+ * leaves out: with no agent behind it there is nobody to talk to and nothing to
+ * hand control back to, so the section and the session button go together.
+ */
+export interface MountOptions extends LocalHostOptions {
+  /**
+   * Which sections the right column carries, in the stack's own order however
+   * they are written here. Defaults to all three - which only makes sense with
+   * a host that has an agent, so a product supplying a store will almost always
+   * name the two it wants.
+   */
+  readonly sections?: readonly RightSectionId[]
+}
+
+export interface MountedEditor {
+  /** Releases the host and takes the editor out of the element. */
+  readonly unmount: () => void
+}
+
+export const mountEditor = (
+  element: Element,
+  options: MountOptions,
+): MountedEditor => mountEditorWith(element, createLocalHost(options), options.sections)
+
+/**
+ * The same editor over a host the caller built.
+ *
+ * Exported for the case `mountEditor` does not cover: a product that already
+ * speaks the visual protocol - to its own server, over its own transport - and
+ * wants the editor in front of it. The protocol is the contract (ADR 0081), so
+ * anything that answers it is a host.
+ */
+export const mountEditorWith = (
+  element: Element,
+  host: EditorHost,
+  sections: readonly RightSectionId[] = RIGHT_SECTIONS,
+): MountedEditor => {
+  // No StrictMode: its double mount would open the host twice, and a host with
+  // a socket behind it would open two.
+  const root = createRoot(element)
+  root.render(<App host={host} sections={sections} />)
+  return {
+    unmount: () => root.unmount(),
+  }
+}
+
+export type { EditorHost, EditorHostEvents } from './editor-host.js'
+export type { LocalHostOptions } from './local-host.js'
+export { createLocalHost } from './local-host.js'
+export { RIGHT_SECTIONS, type RightSectionId } from './workspace-state.js'

--- a/src/visual-app/section-stack.tsx
+++ b/src/visual-app/section-stack.tsx
@@ -1,5 +1,12 @@
-import { useRef, type KeyboardEvent, type PointerEvent, type ReactNode } from "react";
 import {
+  Fragment,
+  useRef,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import {
+  RIGHT_SECTIONS,
   sectionHeightBounds,
   type RightSectionId,
 } from "./workspace-state.js";
@@ -142,3 +149,35 @@ export function SectionSplitter({
     />
   );
 }
+
+/**
+ * The stack's rows: the sections a host asked for, in the stack's own order,
+ * with a handle between each adjacent pair (#252).
+ *
+ * The order is `RIGHT_SECTIONS`, never the order the host happened to write:
+ * the sections mean something as a sequence - properties above changes above
+ * chat, which is pinned at the foot - and a host should not reorder the shell
+ * by writing its array differently.
+ *
+ * A handle sits BETWEEN two sections, so the first present section never gets
+ * one. That is the whole rule, and it is why this is a function rather than
+ * three conditionals in the markup: with `chat` alone there is nothing to
+ * resize against, and a stray handle at the top of the column is the kind of
+ * thing that only shows up in the one configuration nobody rendered.
+ */
+export const stackRows = (
+  sections: readonly RightSectionId[],
+  bodies: Readonly<Record<RightSectionId, ReactNode>>,
+  splitters: Readonly<Partial<Record<RightSectionId, ReactNode>>>,
+): readonly ReactNode[] =>
+  RIGHT_SECTIONS.filter((id) => sections.includes(id)).flatMap(
+    (id, index): readonly ReactNode[] => {
+      const splitter = index === 0 ? undefined : splitters[id];
+      return [
+        ...(splitter === undefined
+          ? []
+          : [<Fragment key={`splitter-${id}`}>{splitter}</Fragment>]),
+        <Fragment key={id}>{bodies[id]}</Fragment>,
+      ];
+    },
+  );

--- a/src/visual-app/session-client.tsx
+++ b/src/visual-app/session-client.tsx
@@ -1,22 +1,17 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
-import type {
-  VisualServerFrame,
-  VisualSessionSnapshot,
-} from '../adapters/visual/wire.js'
 import type { ProjectionQuery } from '../projection.js'
 import type {
   VisualLayoutSavePayload,
   VisualViewOperation,
 } from '../adapters/visual/protocol-contract.js'
 import type { YarramateOperation } from '../operations.js'
+import type { EditorHost } from './editor-host.js'
 import {
-  canReconnect,
   changesetIsEmpty,
   initialVisualAppState,
   filterToReresolve,
   visualAppActionsForFrame,
   visualAppReducer,
-  visualAppSnapshotFrom,
   visualBrowserInputFor,
   type FilterSource,
   type VisualAppIntent,
@@ -24,19 +19,15 @@ import {
 } from './state.js'
 
 /**
- * The session as the page holds it: one reducer, one socket, and nothing that
+ * The session as the page holds it: one reducer, one host, and nothing that
  * decides anything on its own.
  *
- * Both routes are same-origin, so the session cookie the server minted at
- * bootstrap authenticates them without this code ever seeing it. Nothing here
- * reads or writes a credential, and nothing puts an identifier in the URL.
+ * The transport moved out (#252). What stays is everything that is true of the
+ * editor whatever is answering it: the reducer, the sequence every input is
+ * stamped with, which surface asked for the standing filter, and the re-ask
+ * that keeps a matched set from outliving the model it was resolved against.
+ * A host that owned those would have to reimplement them to be a host at all.
  */
-
-const SESSION_ROUTE = '/api/session'
-const SOCKET_ROUTE = '/socket'
-
-/** Long enough not to hammer a restarting socket, short enough to feel live. */
-const RETRY_MS = 1000
 
 export interface VisualSession {
   readonly state: VisualAppState
@@ -65,10 +56,9 @@ export interface VisualSession {
   readonly end: () => void
 }
 
-export const useVisualSession = (): VisualSession => {
+export const useVisualSession = (host: EditorHost): VisualSession => {
   const [state, dispatch] = useReducer(visualAppReducer, initialVisualAppState)
   const [connected, setConnected] = useState(false)
-  const socketRef = useRef<WebSocket | null>(null)
   // Senders read the settled state rather than a render's copy of it, so every
   // frame carries the sequence this browser has actually seen acknowledged.
   const stateRef = useRef(state)
@@ -79,48 +69,14 @@ export const useVisualSession = (): VisualSession => {
   // result is not a view this browser can claim to be showing.
   const filterOriginRef = useRef<FilterSource>('panel')
 
+  // The host is opened once. Everything it reports is a frame, so the only
+  // thing this has to decide is what a frame means - which `state.ts` already
+  // answers, purely, for every kind the wire defines.
+  const hostRef = useRef(host)
+  hostRef.current = host
   useEffect(() => {
-    let stopped = false
-    let timer: ReturnType<typeof setTimeout> | undefined
-    let lostAt: number | null = null
-
-    const socketUrl = () => {
-      const url = new URL(SOCKET_ROUTE, window.location.href)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
-      // Bootstrap for a resumed socket: where this browser's record stops. The
-      // per-frame acknowledgement is what admission checks against.
-      url.searchParams.set('after', String(stateRef.current.lastSequence))
-      return url
-    }
-
-    const reconnect = () => {
-      if (stopped) return
-      lostAt ??= Date.now()
-      // Past the grace the server has already recovered the handoff, so there
-      // is nothing left to reconnect to.
-      if (!canReconnect(lostAt, Date.now())) {
-        dispatch({ type: 'session.closed', reason: 'browser-timeout' })
-        return
-      }
-      timer = setTimeout(connect, RETRY_MS)
-    }
-
-    const connect = () => {
-      if (stopped) return
-      const socket = new WebSocket(socketUrl())
-      socketRef.current = socket
-      socket.addEventListener('open', () => {
-        lostAt = null
-        setConnected(true)
-      })
-      socket.addEventListener('message', (event: MessageEvent<unknown>) => {
-        if (typeof event.data !== 'string') return
-        let frame: VisualServerFrame
-        try {
-          frame = JSON.parse(event.data) as VisualServerFrame
-        } catch {
-          return
-        }
+    const stop = hostRef.current.open({
+      frame: (frame) => {
         for (const action of visualAppActionsForFrame(
           frame,
           filterOriginRef.current,
@@ -133,63 +89,33 @@ export const useVisualSession = (): VisualSession => {
         // existed. `stateRef` holds the state before this frame's actions
         // commit, which is exactly right: the standing filter is the one that
         // needs re-asking, not one this frame produced.
+        //
+        // It lives here rather than in the transport because it is true of the
+        // editor, not of the socket: a host with no wire at all invalidates a
+        // matched set the same way.
         const stale = filterToReresolve(frame, stateRef.current)
         if (stale !== null) {
           filterOriginRef.current = stale.source
-          socket.send(
-            JSON.stringify(
-              visualBrowserInputFor(
-                { kind: 'filter', query: stale.query },
-                stateRef.current,
-              ),
+          hostRef.current.send(
+            visualBrowserInputFor(
+              { kind: 'filter', query: stale.query },
+              stateRef.current,
             ),
           )
         }
-      })
-      socket.addEventListener('close', () => {
-        setConnected(false)
-        socketRef.current = null
-        if (stopped || stateRef.current.lifecycle === 'closed') return
-        dispatch({ type: 'connection.lost' })
-        reconnect()
-      })
-      socket.addEventListener('error', () => socket.close())
-    }
-
-    const load = async () => {
-      const response = await fetch(SESSION_ROUTE, {
-        credentials: 'same-origin',
-        headers: { Accept: 'application/json' },
-      })
-      if (!response.ok) {
-        throw new Error(`Session request answered ${response.status}`)
-      }
-      const snapshot = (await response.json()) as VisualSessionSnapshot
-      if (stopped) return
-      dispatch({
-        type: 'session.loaded',
-        snapshot: visualAppSnapshotFrom(snapshot),
-      })
-      connect()
-    }
-
-    void load().catch(() => {
-      if (stopped) return
-      dispatch({ type: 'connection.lost' })
-      reconnect()
+      },
+      connected: setConnected,
+      lost: () => dispatch({ type: 'connection.lost' }),
+      session: () => ({
+        lastSequence: stateRef.current.lastSequence,
+        closed: stateRef.current.lifecycle === 'closed',
+      }),
     })
-
-    return () => {
-      stopped = true
-      if (timer !== undefined) clearTimeout(timer)
-      socketRef.current?.close()
-    }
+    return stop
   }, [])
 
   const send = useCallback((intent: VisualAppIntent) => {
-    const socket = socketRef.current
-    if (socket === null || socket.readyState !== WebSocket.OPEN) return
-    socket.send(JSON.stringify(visualBrowserInputFor(intent, stateRef.current)))
+    hostRef.current.send(visualBrowserInputFor(intent, stateRef.current))
   }, [])
 
   const ask = useCallback(

--- a/src/visual-app/socket-host.ts
+++ b/src/visual-app/socket-host.ts
@@ -1,0 +1,120 @@
+import type {
+  VisualBrowserInput,
+} from '../adapters/visual/protocol-contract.js'
+import type {
+  VisualServerFrame,
+  VisualSessionSnapshot,
+} from '../adapters/visual/wire.js'
+import type { EditorHost, EditorHostEvents } from './editor-host.js'
+import { canReconnect } from './state.js'
+
+/**
+ * The session server, as one host (#252).
+ *
+ * Everything the socket used to do inside `session-client.tsx` is here, and
+ * nothing else moved: same two same-origin routes, same reconnect grace, same
+ * `?after=` bootstrap. The session cookie the server minted authenticates both
+ * without this code ever seeing it; nothing here reads or writes a credential,
+ * and nothing puts an identifier in a URL.
+ *
+ * The opening snapshot arrives over HTTP and is reported as the `ready` FRAME
+ * the reducer already reads, rather than as a second kind of event. A host has
+ * one way to say things, which is what lets a host with no wire at all
+ * (`local-host.ts`) be the same shape.
+ */
+
+const SESSION_ROUTE = '/api/session'
+const SOCKET_ROUTE = '/socket'
+
+/** Long enough not to hammer a restarting socket, short enough to feel live. */
+const RETRY_MS = 1000
+
+export const createSocketHost = (): EditorHost => {
+  let socket: WebSocket | null = null
+
+  return {
+    open: (events: EditorHostEvents) => {
+      let stopped = false
+      let timer: ReturnType<typeof setTimeout> | undefined
+      let lostAt: number | null = null
+
+      const socketUrl = () => {
+        const url = new URL(SOCKET_ROUTE, window.location.href)
+        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+        // Read at connect time rather than captured: a reconnect bootstraps
+        // from what has landed since, not from where the last one started.
+        url.searchParams.set('after', String(events.session().lastSequence))
+        return url
+      }
+
+      const reconnect = () => {
+        if (stopped) return
+        lostAt ??= Date.now()
+        // Past the grace the server has already recovered the handoff, so
+        // there is nothing left to reconnect to.
+        if (!canReconnect(lostAt, Date.now())) {
+          events.frame({ kind: 'closing', reason: 'browser-timeout' })
+          return
+        }
+        timer = setTimeout(connect, RETRY_MS)
+      }
+
+      const connect = () => {
+        if (stopped) return
+        const opened = new WebSocket(socketUrl())
+        socket = opened
+        opened.addEventListener('open', () => {
+          lostAt = null
+          events.connected(true)
+        })
+        opened.addEventListener('message', (event: MessageEvent<unknown>) => {
+          if (typeof event.data !== 'string') return
+          try {
+            events.frame(JSON.parse(event.data) as VisualServerFrame)
+          } catch {
+            // A frame this browser cannot parse is one it cannot act on.
+          }
+        })
+        opened.addEventListener('close', () => {
+          events.connected(false)
+          socket = null
+          if (stopped || events.session().closed) return
+          events.lost()
+          reconnect()
+        })
+        opened.addEventListener('error', () => opened.close())
+      }
+
+      const load = async () => {
+        const response = await fetch(SESSION_ROUTE, {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+        if (!response.ok) {
+          throw new Error(`Session request answered ${response.status}`)
+        }
+        const snapshot = (await response.json()) as VisualSessionSnapshot
+        if (stopped) return
+        events.frame({ kind: 'ready', snapshot })
+        connect()
+      }
+
+      void load().catch(() => {
+        if (stopped) return
+        events.lost()
+        reconnect()
+      })
+
+      return () => {
+        stopped = true
+        if (timer !== undefined) clearTimeout(timer)
+        socket?.close()
+      }
+    },
+
+    send: (input: VisualBrowserInput) => {
+      if (socket === null || socket.readyState !== WebSocket.OPEN) return
+      socket.send(JSON.stringify(input))
+    },
+  }
+}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -654,13 +654,14 @@ body {
 
 /* Properties takes what is left; changes and chat hold the heights their
    splitters were dragged to, and chat is last because it is pinned at the foot
-   (#249). A shut section contributes only its header, which is what `auto`
-   means once its body is hidden. */
+   (#249). A shut section contributes only its header.
+
+   A COLUMN rather than a fixed row template: a host declares which sections it
+   wants (#252), so the stack has to hold any subset of them without a template
+   that counts five rows and gets three. */
 .section-stack {
-  display: grid;
-  grid-template-rows:
-    minmax(0, 1fr) auto var(--changes-height, 200px) auto
-    var(--chat-height, 246px);
+  display: flex;
+  flex-direction: column;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -673,6 +674,27 @@ body {
   grid-template-rows: auto minmax(0, 1fr);
   min-height: 0;
   overflow: hidden;
+}
+
+/* Properties takes the slack; the other two keep what they were dragged to.
+   A shut section is its header, whatever height it holds when open. */
+.stack-section-properties {
+  flex: 1 1 auto;
+}
+
+.stack-section-changes {
+  flex: 0 0 var(--changes-height, 200px);
+}
+
+.stack-section-chat {
+  flex: 0 0 var(--chat-height, 300px);
+}
+
+/* With properties absent there is no slack-taker, so the section above the
+   foot takes it instead - otherwise a two-section stack leaves a gap under
+   the last one. */
+.section-stack > .stack-section:first-child {
+  flex: 1 1 auto;
 }
 
 .section-head {
@@ -739,6 +761,7 @@ body {
    separator, turned through ninety degrees. */
 .section-splitter {
   position: relative;
+  flex: 0 0 7px;
   height: 7px;
   border: none;
   background: transparent;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -16,7 +16,15 @@ import workspaceSchema from '../schema/yarramate-workspace.schema.json' with {
   type: 'json',
 }
 
-const Ajv2020 = Ajv2020Module.default
+// `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
+// `module.exports` and a bundler the unwrapped class. This file resolves a
+// manifest's globs against a real filesystem and so is never bundled, but the
+// two shapes cost one `??` and a reader should not have to work out which of
+// the engine's four Ajv sites is the odd one.
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 const validateWorkspace = new Ajv2020({ allErrors: true }).compile(
   workspaceSchema,
 )

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -172,6 +172,7 @@ relationships: []
           object: { ref: 'baseline' },
         }),
         expect.objectContaining({
+          id: 'payments~present-in-746172676574',
           subject: 'payments',
           predicate: 'yarramate/state/present-in',
           object: { ref: 'target' },

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -63,6 +63,13 @@ describe('consumer package contract', () => {
     expect(
       packageJson.exports['./schema/visual-diagnostic-result'],
     ).toBe('./schema/yarramate-visual-diagnostic-result.schema.json')
+    expect(packageJson.exports['./visual-app']).toEqual({
+      types: './dist/visual-app-lib/editor.d.ts',
+      import: './dist/visual-app-lib/editor.js',
+    })
+    expect(packageJson.exports['./visual-app/styles.css']).toBe(
+      './dist/visual-app-lib/styles.css',
+    )
 
     const consumerGuide = readFileSync(
       join(repositoryRoot, 'docs/CONSUMING-YARRAMATE.md'),
@@ -118,6 +125,9 @@ describe('consumer package contract', () => {
         'package/skills/yarramate-architecture/references/visual-conversations.md',
       )
       expect(files).toContain('package/dist/adapters/visual-cli.js')
+      expect(files).toContain('package/dist/visual-app-lib/editor.js')
+      expect(files).toContain('package/dist/visual-app-lib/editor.d.ts')
+      expect(files).toContain('package/dist/visual-app-lib/styles.css')
       expect(files).toContain('package/dist/visual-app/index.html')
       // The eleven standalone visual documents a consumer validates against,
       // each exported under `./schema/visual-*`.
@@ -481,6 +491,109 @@ views:
     } finally {
       rmSync(consumer, { recursive: true, force: true })
     }
+    },
+  )
+
+  it(
+    'typechecks a local editor consumer without React',
+    { timeout: 30_000 },
+    () => {
+      const consumer = mkdtempSync(
+        join(tmpdir(), 'yarramate-editor-consumer-'),
+      )
+      try {
+        const archive = packTarball(consumer)
+        const packagePath = join(consumer, 'node_modules/yarramate')
+        mkdirSync(packagePath, { recursive: true })
+        execFileSync(
+          'tar',
+          [
+            '-xzf',
+            archive,
+            '-C',
+            packagePath,
+            '--strip-components=1',
+          ],
+        )
+        writeFileSync(
+          join(consumer, 'editor.ts'),
+          `import {
+  createLocalHost,
+  mountEditor,
+  type EditorHost,
+  type LocalHostOptions,
+  type MountOptions,
+  type MountedEditor,
+  type RightSectionId,
+} from 'yarramate/visual-app'
+import 'yarramate/visual-app/styles.css'
+
+const options: LocalHostOptions = {
+  store: {
+    list: () => [],
+    read: () => undefined,
+    writeAll: () => ({ ok: true, revisions: new Map() }),
+  },
+  workspace: {
+    id: 'consumer',
+    documents: [],
+    profiles: [],
+    projections: [],
+    adapterMappings: [],
+    evidence: [],
+    contracts: [],
+  },
+}
+const host: EditorHost = createLocalHost(options)
+const sections: readonly RightSectionId[] = ['properties', 'changes']
+const mountOptions: MountOptions = { ...options, sections }
+const mounted: MountedEditor = mountEditor(
+  document.createElement('main'),
+  mountOptions,
+)
+
+void host
+mounted.unmount()
+`,
+        )
+        // The one ambient declaration a bundler-based TypeScript project
+        // already carries - vite consumers get it from `vite/client`, Next
+        // from `next-env.d.ts`. Without it the documented `import
+        // 'yarramate/visual-app/styles.css'` is TS2882: TypeScript resolves
+        // the export, finds a `.css`, and has no types for it. That is a
+        // property of importing CSS from TypeScript at all, not of this
+        // package, so the fixture states it the way a consumer would rather
+        // than dropping the line the docs publish.
+        writeFileSync(join(consumer, 'css.d.ts'), "declare module '*.css'\n")
+        writeFileSync(
+          join(consumer, 'tsconfig.json'),
+          JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+              module: 'ESNext',
+              moduleResolution: 'Bundler',
+              strict: true,
+              noEmit: true,
+              skipLibCheck: true,
+              types: [],
+            },
+            files: ['css.d.ts', 'editor.ts'],
+          }),
+        )
+
+        execFileSync(
+          process.execPath,
+          [
+            join(repositoryRoot, 'node_modules/typescript/bin/tsc'),
+            '--project',
+            join(consumer, 'tsconfig.json'),
+          ],
+          { cwd: consumer, encoding: 'utf8' },
+        )
+      } finally {
+        rmSync(consumer, { recursive: true, force: true })
+      }
     },
   )
 })

--- a/test/subject-identity.test.ts
+++ b/test/subject-identity.test.ts
@@ -184,6 +184,7 @@ concepts:
     name: Order Gateway
     aka:
       - OG
+      - café
       - the gateway
 relationships: []
 `)
@@ -192,10 +193,21 @@ relationships: []
     const aliases = result.graph.claims.filter(
       ({ predicate }) => predicate === 'yarramate/concept/alias',
     )
-    expect(aliases.map((claim) => ('value' in claim.object ? claim.object.value : ''))).toEqual([
-      'OG',
-      'the gateway',
-    ])
+    expect(
+      aliases.map((claim) => ('value' in claim.object ? claim.object.value : '')),
+    ).toEqual(['OG', 'café', 'the gateway'])
+    expect(aliases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'order-gateway~alias-4f47',
+          object: { value: 'OG' },
+        }),
+        expect.objectContaining({
+          id: 'order-gateway~alias-636166c3a9',
+          object: { value: 'café' },
+        }),
+      ]),
+    )
     expect(aliases.every(({ subject }) => subject === 'order-gateway')).toBe(true)
 
     const reordered = compile(`format: yarramate/v1
@@ -207,6 +219,7 @@ concepts:
     name: Order Gateway
     aka:
       - the gateway
+      - café
       - OG
 relationships: []
 `)
@@ -241,6 +254,9 @@ relationships: []
     if (!result.ok) return
     const claim = result.graph.claims.find(
       ({ predicate }) => predicate === 'yarramate/identity/distinct-from',
+    )
+    expect(claim?.id).toBe(
+      'order-gateway~distinct-from-6f72646572732d73657276696365',
     )
     expect(claim?.subject).toBe('order-gateway')
     expect(claim?.object).toEqual({ ref: 'orders-service' })

--- a/test/succession.test.ts
+++ b/test/succession.test.ts
@@ -39,6 +39,9 @@ concepts:
 relationships: []
 `)
     expect(claims).toHaveLength(1)
+    expect(claims[0]?.id).toBe(
+      'order-api~supersedes-6f726465722d67617465776179',
+    )
     expect(claims[0]?.subject).toBe('order-api')
     expect(claims[0]?.object).toEqual({ ref: 'order-gateway' })
     expect(claims[0]?.origin).toBe('declared')

--- a/test/visual-app-browser-safety.test.ts
+++ b/test/visual-app-browser-safety.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parseAst } from 'vite'
 import { describe, expect, it } from 'vitest'
 
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
@@ -112,5 +113,256 @@ describe('the visual app stays browser-safe', () => {
     expect(valueImports("import { A } from './a.js'")).toEqual(['./a.js'])
     expect(valueImports("import A from './a.js'")).toEqual(['./a.js'])
     expect(valueImports("import * as A from './a.js'")).toEqual(['./a.js'])
+  })
+})
+
+/**
+ * The same question asked of the BUILT bundle, which is where it is actually
+ * answered (#252).
+ *
+ * The import-graph walk above catches the shape the incident took: a relative
+ * import of a module that names `node:`. It cannot catch the class. It follows
+ * only relative specifiers, so a bare `import 'ajv'` that reached for
+ * `node:module` inside would pass; it greps for `from 'node:'`, so a
+ * `createRequire` obtained any other way would pass; and it never looks at
+ * what the bundler actually emitted.
+ *
+ * These read the artifact. A bundle that contains `createRequire(`, a `node:`
+ * specifier, or an untransformed Node global will not run in a browser,
+ * whatever the source looked like on the way in.
+ */
+describe('the built bundles carry no Node API', () => {
+  const built = (path: string): string | null => {
+    const file = resolve(repositoryRoot, path)
+    try {
+      return readFileSync(file, 'utf8')
+    } catch {
+      return null
+    }
+  }
+
+  const bundles = (): readonly (readonly [string, string])[] => {
+    const assets = resolve(repositoryRoot, 'dist/visual-app/assets')
+    let served: readonly string[] = []
+    try {
+      served = readdirSync(assets).filter((name) => name.endsWith('.js'))
+    } catch {
+      served = []
+    }
+    return [
+      ...served.map(
+        (name) =>
+          [`dist/visual-app/assets/${name}`, built(`dist/visual-app/assets/${name}`) ?? ''] as const,
+      ),
+      ['dist/visual-app-lib/editor.js', built('dist/visual-app-lib/editor.js') ?? ''] as const,
+    ].filter(([, source]) => source !== '')
+  }
+
+  it('has something built to check', () => {
+    // A green suite over no artifact is the failure mode this whole file
+    // exists to prevent, so the absence is itself a failure.
+    expect(bundles().length, 'run `pnpm build` first').toBeGreaterThanOrEqual(2)
+  })
+
+  type AstNode = Readonly<{
+    type: string
+    [property: string]: unknown
+  }>
+  type FormMatcher = (node: AstNode) => boolean
+
+  const isNode = (value: unknown): value is AstNode =>
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof value.type === 'string'
+
+  const propertyNamed = (node: unknown, propertyName: string) => {
+    if (!isNode(node) || node.type !== 'MemberExpression' || node.computed) {
+      return false
+    }
+    return (
+      isNode(node.property) &&
+      node.property.type === 'Identifier' &&
+      node.property.name === propertyName
+    )
+  }
+
+  const memberNamed = (
+    node: unknown,
+    objectName: string,
+    propertyName: string,
+  ) => {
+    if (!propertyNamed(node, propertyName) || !isNode(node)) return false
+    if (!isNode(node.object) || node.object.type !== 'Identifier') {
+      return false
+    }
+    return node.object.name === objectName
+  }
+
+  const isNodeSpecifier = (node: unknown) =>
+    isNode(node) &&
+    node.type === 'Literal' &&
+    typeof node.value === 'string' &&
+    node.value.startsWith('node:')
+
+  const isJsxDevCallee = (node: unknown): boolean => {
+    if (!isNode(node)) return false
+    if (node.type === 'Identifier') return node.name === 'jsxDEV'
+    if (propertyNamed(node, 'jsxDEV')) return true
+    return (
+      node.type === 'SequenceExpression' &&
+      Array.isArray(node.expressions) &&
+      isJsxDevCallee(node.expressions.at(-1))
+    )
+  }
+
+  const assignsUndefinedJsxDev = (node: AstNode) => {
+    if (
+      node.type !== 'AssignmentExpression' ||
+      !propertyNamed(node.left, 'jsxDEV') ||
+      !isNode(node.right)
+    ) {
+      return false
+    }
+    return (
+      (node.right.type === 'Identifier' && node.right.name === 'undefined') ||
+      (node.right.type === 'UnaryExpression' && node.right.operator === 'void')
+    )
+  }
+
+  const jsxDevMismatch = 'a jsxDEV call with an undefined production runtime'
+
+  const visit = (root: unknown, inspect: (node: AstNode) => void) => {
+    if (!isNode(root)) return
+    const pending = [root]
+    while (pending.length > 0) {
+      const node = pending.pop()!
+      inspect(node)
+      for (const value of Object.values(node)) {
+        if (isNode(value)) {
+          pending.push(value)
+        } else if (Array.isArray(value)) {
+          for (const child of value) {
+            if (isNode(child)) pending.push(child)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * A `node:` SPECIFIER, not the characters anywhere. A bundle legitimately
+   * carries `selector: "node:parent"` - cytoscape's - and a guard that flagged
+   * it would be turned off within a week.
+   */
+  const forms: readonly (readonly [string, FormMatcher])[] = [
+    [
+      'createRequire',
+      (node) =>
+        node.type === 'CallExpression' &&
+        isNode(node.callee) &&
+        node.callee.type === 'Identifier' &&
+        node.callee.name === 'createRequire',
+    ],
+    [
+      'an import of a node: module',
+      (node) =>
+        (node.type === 'ImportExpression' && isNodeSpecifier(node.source)) ||
+        (node.type === 'CallExpression' &&
+          isNode(node.callee) &&
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'require' &&
+          Array.isArray(node.arguments) &&
+          isNodeSpecifier(node.arguments[0])),
+    ],
+    [
+      'a re-export from a node: module',
+      (node) =>
+        (node.type === 'ImportDeclaration' ||
+          node.type === 'ExportNamedDeclaration' ||
+          node.type === 'ExportAllDeclaration') &&
+        isNodeSpecifier(node.source),
+    ],
+    [
+      'an executable Buffer.from call',
+      (node) =>
+        node.type === 'CallExpression' &&
+        memberNamed(node.callee, 'Buffer', 'from'),
+    ],
+    [
+      'an unreplaced process.env access',
+      (node) => memberNamed(node, 'process', 'env'),
+    ],
+  ]
+
+  const forbiddenForms = (source: string) => {
+    const offenders = new Set<string>()
+    let hasJsxDevCall = false
+    let hasUndefinedJsxDevRuntime = false
+    visit(parseAst(source), (node) => {
+      for (const [name, matches] of forms) {
+        if (matches(node)) offenders.add(name)
+      }
+      if (node.type === 'CallExpression' && isJsxDevCallee(node.callee)) {
+        hasJsxDevCall = true
+      }
+      if (assignsUndefinedJsxDev(node)) hasUndefinedJsxDevRuntime = true
+    })
+    if (hasJsxDevCall && hasUndefinedJsxDevRuntime) {
+      offenders.add(jsxDevMismatch)
+    }
+    return forms
+      .map(([name]) => name)
+      .concat(offenders.has(jsxDevMismatch) ? [jsxDevMismatch] : [])
+      .filter((name) => offenders.has(name))
+  }
+
+  const bundleOffenders = new Map<string, readonly string[]>()
+
+  it('distinguishes executable Node forms from permitted bundle text', () => {
+    expect(
+      forbiddenForms(`
+        const yamlError = "Buffer.from cannot be serialized"
+        const runtimeNote = "jsxDEV = void 0"
+        const selector = "node:parent"
+        gl.createBuffer()
+        if (typeof process !== "undefined") process.emit("warning")
+        const expression = /Buffer.from\\(/`)
+    ).toEqual([])
+    expect(forbiddenForms('Buffer.from(bytes)')).toEqual([
+      'an executable Buffer.from call',
+    ])
+    expect(forbiddenForms('process.env.MODE')).toEqual([
+      'an unreplaced process.env access',
+    ])
+    expect(
+      forbiddenForms(
+        'const runtime = {}; runtime.jsxDEV = void 0; runtime.jsxDEV({})',
+      ),
+    ).toEqual([jsxDevMismatch])
+  })
+
+  it.each(forms.map(([name]) => name))('contains no %s', (name) => {
+    for (const [path, source] of bundles()) {
+      let offenders = bundleOffenders.get(path)
+      if (offenders === undefined) {
+        offenders = forbiddenForms(source)
+        bundleOffenders.set(path, offenders)
+      }
+      expect(offenders, `${path} contains ${name}`).not.toContain(name)
+    }
+  })
+
+  it('does not call an undefined jsxDEV production runtime', () => {
+    for (const [path, source] of bundles()) {
+      let offenders = bundleOffenders.get(path)
+      if (offenders === undefined) {
+        offenders = forbiddenForms(source)
+        bundleOffenders.set(path, offenders)
+      }
+      expect(offenders, `${path} calls an undefined jsxDEV runtime`).not.toContain(
+        jsxDevMismatch,
+      )
+    }
   })
 })

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -4,6 +4,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import type { VisualAppState } from '../src/visual-app/state.js'
 import type { CanvasNode } from '../src/graph-projection.js'
 import type { VisualRenderedModel } from '../src/adapters/visual/wire.js'
+import type { EditorHost } from '../src/visual-app/editor-host.js'
+import type { RightSectionId } from '../src/visual-app/workspace-state.js'
 
 const session = vi.hoisted(() => {
   const baseState: VisualAppState = {
@@ -85,9 +87,20 @@ afterAll(() => {
     Object.defineProperty(globalThis, 'window', previousWindow)
   }
 })
-const renderSession = (overrides: Partial<VisualAppState> = {}): string => {
+// A host that answers nothing: `useVisualSession` is mocked above, so what
+// this exercises is that `App` takes one at all - the prop is the seam an
+// embedder supplies instead of a socket (#252).
+const idleHost: EditorHost = {
+  open: () => () => {},
+  send: () => {},
+}
+
+const renderSession = (
+  overrides: Partial<VisualAppState> = {},
+  props: { readonly sections?: readonly RightSectionId[] } = {},
+): string => {
   session.state = { ...session.baseState, ...overrides }
-  return renderToStaticMarkup(createElement(App))
+  return renderToStaticMarkup(createElement(App, { host: idleHost, ...props }))
 }
 
 const subject = (
@@ -442,5 +455,44 @@ describe('the right column, as a stack of sections', () => {
 
     expect(markup).toContain('class="session-description"')
     expect(markup).not.toContain('id="session-details"')
+  })
+})
+
+/**
+ * The sections a host declares (#252). A product with no agent behind it takes
+ * properties and changes and leaves chat out; the section and the session
+ * button go with it.
+ */
+describe('a host that asks for some of the sections', () => {
+  it('draws only what was asked for', () => {
+    const markup = renderSession({}, { sections: ['properties', 'changes'] })
+
+    expect(markup).toContain('stack-section-properties')
+    expect(markup).toContain('stack-section-changes')
+    expect(markup).not.toContain('stack-section-chat')
+  })
+
+  it('takes the session button out with the chat section', () => {
+    // There is nobody to hand control back to in a product that declined chat,
+    // so a button offering to would be lying about what it does.
+    const markup = renderSession({}, { sections: ['properties', 'changes'] })
+
+    expect(markup).not.toContain('>Return to agent</button>')
+    expect(markup).not.toContain('class="composer"')
+  })
+
+  it('gives a single section no handle to resize it against', () => {
+    const markup = renderSession({}, { sections: ['changes'] })
+
+    expect(markup).toContain('stack-section-changes')
+    expect(markup).not.toContain('class="section-splitter"')
+  })
+
+  it('draws all three when the host says nothing', () => {
+    const markup = renderSession()
+
+    for (const id of ['properties', 'changes', 'chat']) {
+      expect(markup).toContain(`stack-section-${id}`)
+    }
   })
 })

--- a/test/visual-local-host.test.ts
+++ b/test/visual-local-host.test.ts
@@ -1,0 +1,456 @@
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+import { createLocalHost } from '../src/visual-app/local-host.js'
+import type {
+  PendingWrite,
+  SourceStore,
+  StoredSource,
+  WriteOutcome,
+} from '../src/source-store.js'
+import type { ResolvedWorkspace } from '../src/workspace.js'
+import type { VisualServerFrame } from '../src/adapters/visual/wire.js'
+import type { VisualBrowserInput } from '../src/adapters/visual/protocol-contract.js'
+
+/**
+ * The editor with no server behind it (#252).
+ *
+ * These drive the host the way the browser does — one input in, frames out —
+ * over a store that is a `Map`. That the store is a Map rather than a disk is
+ * the whole point: ADR 0100 made Core a pure function from sources to sources
+ * so an embedder over D1 or an object store could hand the editor its own.
+ */
+
+const document = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: checkout
+    kind: applicationComponent
+    name: Checkout
+  - id: ledger
+    kind: applicationComponent
+    name: Ledger
+  - id: teller
+    kind: businessActor
+    name: Teller
+relationships:
+  - id: checkout-serves-teller
+    kind: serving
+    from: checkout
+    to: teller
+`
+
+const projection = `format: yarramate/projection/v1
+id: apps
+version: "1.0"
+query:
+  kinds: [yarramate/core@0.1#applicationComponent]
+presentation:
+  title: Applications
+  description: Every application component
+`
+
+/** A store over a Map, which is what an embedder builds after fetching. */
+const memoryStore = (
+  files: Readonly<Record<string, string>>,
+): SourceStore & {
+  readonly held: Map<string, string>
+  readonly writeBatches: PendingWrite[][]
+} => {
+  const writeBatches: PendingWrite[][] = []
+  const held = new Map(Object.entries(files))
+  // A revision is opaque and only its own store compares two (ADR 0100); a
+  // counter bumped on write is a perfectly good one.
+  const revisions = new Map<string, string>(
+    [...held.keys()].map((path) => [path, '1'] as const),
+  )
+  return {
+    held,
+    writeBatches,
+    list: () => [...held.keys()],
+    read: (path: string): StoredSource | undefined => {
+      const source = held.get(path)
+      return source === undefined
+        ? undefined
+        : { source, revision: revisions.get(path) ?? '1' }
+    },
+    writeAll: (writes: readonly PendingWrite[]): WriteOutcome => {
+      writeBatches.push([...writes])
+      for (const write of writes) {
+        const current = held.has(write.path)
+          ? (revisions.get(write.path) ?? '1')
+          : null
+        if (current !== write.expected) {
+          return {
+            ok: false,
+            conflicts: [{ path: write.path, reason: 'changed' }],
+          }
+        }
+      }
+      for (const write of writes) {
+        if (write.source === null) {
+          held.delete(write.path)
+          revisions.delete(write.path)
+          continue
+        }
+        held.set(write.path, write.source)
+        revisions.set(
+          write.path,
+          String(Number(revisions.get(write.path) ?? '0') + 1),
+        )
+      }
+      return { ok: true, revisions: new Map(revisions) }
+    },
+  }
+}
+
+const workspace: ResolvedWorkspace = {
+  id: 'embedded',
+  documents: ['architecture/main.yaml'],
+  profiles: [],
+  projections: ['projections/apps.yaml'],
+  adapterMappings: [],
+  evidence: [],
+  contracts: [],
+}
+
+const openHost = (
+  files: Readonly<Record<string, string>> = {
+    'architecture/main.yaml': document,
+    'projections/apps.yaml': projection,
+  },
+) => {
+  const store = memoryStore(files)
+  const host = createLocalHost({ store, workspace })
+  const frames: VisualServerFrame[] = []
+  const stop = host.open({
+    frame: (frame) => frames.push(frame),
+    connected: () => {},
+    lost: () => {},
+    session: () => ({ lastSequence: 0, closed: false }),
+  })
+  const send = (input: VisualBrowserInput) => host.send(input)
+  return { store, frames, send, stop }
+}
+
+const input = (
+  type: VisualBrowserInput['type'],
+  payload: unknown,
+): VisualBrowserInput =>
+  ({ type, lastAcknowledgedSequence: 0, payload }) as VisualBrowserInput
+
+describe('an editor over a store, with no server', () => {
+  it('compiles the workspace and opens on a ready frame', () => {
+    const { frames } = openHost()
+    const ready = frames[0]
+
+    expect(ready?.kind).toBe('ready')
+    if (ready?.kind !== 'ready') return
+    expect(ready.snapshot.model.graph.nodes.map(({ name }) => name)).toEqual([
+      'Checkout',
+      'Ledger',
+      'Teller',
+    ])
+    expect(ready.snapshot.views.map(({ title }) => title)).toEqual([
+      'Applications',
+    ])
+  })
+
+  it('counts a view by its SUBJECTS, not by its match set', () => {
+    // Concepts and relationships come back together; a view over two
+    // components would read as three if the relationship were counted.
+    const { frames } = openHost()
+    const ready = frames[0]
+    if (ready?.kind !== 'ready') throw new Error('no ready frame')
+
+    expect(ready.snapshot.views[0]?.subjectCount).toBe(2)
+  })
+
+  it('answers a filter with what matched and what it dropped', () => {
+    const { frames, send } = openHost()
+    send(
+      input('filter.query', {
+        query: { kinds: ['yarramate/core@0.1#businessActor'] },
+      }),
+    )
+    const result = frames.at(-1)
+
+    expect(result?.kind).toBe('filter-result')
+    if (result?.kind !== 'filter-result') return
+    expect(result.result.matchedIds).toContain('teller')
+    expect(
+      result.result.excluded.map(({ id, facet }) => `${id}:${facet}`),
+    ).toEqual(['checkout:kinds', 'ledger:kinds'])
+  })
+
+  it('lands a commit through the store and redraws from what landed', () => {
+    const { store, frames, send } = openHost()
+    send(
+      input('changeset.commit', {
+        operations: [
+          {
+            op: 'add-concept',
+            document: 'architecture/main.yaml',
+            concept: {
+              id: 'settlement',
+              kind: 'applicationComponent',
+              name: 'Settlement',
+            },
+          },
+        ],
+        viewOperations: [],
+        sourceDigests: {},
+      }),
+    )
+
+    const applied = frames.find((frame) => frame.kind === 'apply-result')
+    expect(applied?.kind === 'apply-result' && applied.result.ok).toBe(true)
+    expect(store.held.get('architecture/main.yaml')).toContain('settlement')
+
+    // The model frame that follows is what the canvas redraws from.
+    const model = frames.at(-1)
+    expect(model?.kind).toBe('model')
+    if (model?.kind !== 'model') return
+    expect(model.model.graph.nodes.map(({ name }) => name)).toContain(
+      'Settlement',
+    )
+    expect(model.views[0]?.subjectCount).toBe(3)
+  })
+
+  it('writes nothing when the batch would not compile', () => {
+    const { store, frames, send } = openHost()
+    const before = store.held.get('architecture/main.yaml')
+    send(
+      input('changeset.commit', {
+        operations: [
+          {
+            op: 'add-concept',
+            document: 'architecture/main.yaml',
+            concept: { id: 'nope', kind: 'notAKind', name: 'Nope' },
+          },
+        ],
+        viewOperations: [],
+        sourceDigests: {},
+      }),
+    )
+
+    const applied = frames.at(-1)
+    expect(applied?.kind).toBe('apply-result')
+    if (applied?.kind !== 'apply-result') return
+    expect(applied.result.ok).toBe(false)
+    expect(store.held.get('architecture/main.yaml')).toBe(before)
+  })
+
+  it('lands a staged view beside the model, in one write', () => {
+    const { store, frames, send } = openHost()
+    send(
+      input('changeset.commit', {
+        operations: [],
+        viewOperations: [
+          {
+            op: 'write-view',
+            path: 'projections/apps.yaml',
+            projection: {
+              format: 'yarramate/projection/v1',
+              id: 'apps',
+              version: '1.0',
+              query: { kinds: ['yarramate/core@0.1#businessActor'] },
+              presentation: { title: 'Actors', description: 'Who acts' },
+            },
+          },
+        ],
+        sourceDigests: {},
+      }),
+    )
+
+    expect(frames.find((frame) => frame.kind === 'apply-result')).toMatchObject({
+      result: { ok: true },
+    })
+    expect(store.held.get('projections/apps.yaml')).toContain('Actors')
+  })
+
+  it('persists a known view layout across the next model frame', () => {
+    const { store, frames, send } = openHost()
+    const positions = {
+      checkout: { x: 120, y: 80 },
+      ledger: { x: 360, y: 240 },
+    }
+
+    send(input('layout.save', { projectionId: 'apps', positions }))
+
+    const saved = frames.at(-1)
+    expect(saved?.kind).toBe('layout-save-result')
+    if (saved?.kind !== 'layout-save-result') return
+    expect(saved.result).toEqual({
+      ok: true,
+      path: '.yarramate/visual-layout/apps.yaml',
+    })
+    const sidecar = store.held.get('.yarramate/visual-layout/apps.yaml')
+    expect(sidecar).toBeDefined()
+    expect(store.writeBatches).toHaveLength(1)
+    expect(store.writeBatches[0]).toHaveLength(1)
+    expect(store.writeBatches[0]).toMatchObject([
+      { path: '.yarramate/visual-layout/apps.yaml', expected: null },
+    ])
+    expect(parse(sidecar ?? '')).toEqual({
+      format: 'yarramate/visual-layout/v1',
+      projectionId: 'apps',
+      positions,
+    })
+
+    send(
+      input('changeset.commit', {
+        operations: [
+          {
+            op: 'add-concept',
+            document: 'architecture/main.yaml',
+            concept: {
+              id: 'settlement',
+              kind: 'applicationComponent',
+              name: 'Settlement',
+            },
+          },
+        ],
+        viewOperations: [],
+        sourceDigests: {},
+      }),
+    )
+
+    const model = frames.at(-1)
+    expect(model?.kind).toBe('model')
+    if (model?.kind !== 'model') return
+    expect(model.model.layouts.apps).toEqual(positions)
+  })
+
+  it('refuses an unknown view layout without changing the store', () => {
+    const { store, frames, send } = openHost()
+    const before = [...store.held.entries()]
+
+    send(
+      input('layout.save', {
+        projectionId: 'missing',
+        positions: { checkout: { x: 120, y: 80 } },
+      }),
+    )
+
+    const refused = frames.at(-1)
+    expect(refused?.kind).toBe('layout-save-result')
+    if (refused?.kind !== 'layout-save-result') return
+    expect(refused.result.ok).toBe(false)
+    expect([...store.held.entries()]).toEqual(before)
+    expect(store.writeBatches).toHaveLength(0)
+  })
+
+  it('adds a manifest-covered new view to the next model frame', () => {
+    const { store, frames, send } = openHost()
+    const path = 'projections/joined.yaml'
+    send(
+      input('changeset.commit', {
+        operations: [],
+        viewOperations: [
+          {
+            op: 'write-view',
+            path,
+            projection: {
+              format: 'yarramate/projection/v1',
+              id: 'joined',
+              version: '1.0',
+              query: { kinds: ['yarramate/core@0.1#businessActor'] },
+              presentation: { title: 'Joined', description: 'Added in-session' },
+            },
+          },
+        ],
+        sourceDigests: {},
+      }),
+    )
+
+    const applied = frames.at(-2)
+    expect(applied?.kind).toBe('apply-result')
+    if (applied?.kind !== 'apply-result') return
+    expect(applied.result.ok).toBe(true)
+    expect(store.held.get(path)).toContain('Joined')
+    const model = frames.at(-1)
+    expect(model?.kind).toBe('model')
+    if (model?.kind !== 'model') return
+    expect(model.views.map(({ id }) => id)).toContain('joined')
+  })
+
+  it('removes a view that joined during this session from the next model frame', () => {
+    const { store, frames, send } = openHost()
+    const path = 'projections/joined.yaml'
+    const write = {
+      operations: [],
+      viewOperations: [
+        {
+          op: 'write-view' as const,
+          path,
+          projection: {
+            format: 'yarramate/projection/v1' as const,
+            id: 'joined',
+            version: '1.0',
+            query: { kinds: ['yarramate/core@0.1#businessActor'] },
+            presentation: { title: 'Joined', description: 'Added in-session' },
+          },
+        },
+      ],
+      sourceDigests: {},
+    }
+    send(input('changeset.commit', write))
+
+    const joined = frames.at(-1)
+    expect(joined?.kind).toBe('model')
+    if (joined?.kind !== 'model') return
+    expect(joined.views.map(({ id }) => id)).toContain('joined')
+
+    send(
+      input('changeset.commit', {
+        operations: [],
+        viewOperations: [{ op: 'delete-view', path }],
+        sourceDigests: {},
+      }),
+    )
+
+    const applied = frames.at(-2)
+    expect(applied?.kind).toBe('apply-result')
+    if (applied?.kind !== 'apply-result') return
+    expect(applied.result.ok).toBe(true)
+    expect(store.held.has(path)).toBe(false)
+    const model = frames.at(-1)
+    expect(model?.kind).toBe('model')
+    if (model?.kind !== 'model') return
+    expect(model.views.map(({ id }) => id)).not.toContain('joined')
+  })
+
+  it('says plainly that it has no agent, rather than going quiet', () => {
+    // Chat, a choice and an end are questions for an agent. There is not one,
+    // and a host that swallowed them would leave the reviewer waiting on a
+    // reply that is never coming.
+    const { frames, send } = openHost()
+    for (const type of ['chat.message', 'choice.selected', 'session.end'] as const) {
+      send(input(type, {}))
+      const refused = frames.at(-1)
+      expect(refused?.kind).toBe('rejected')
+      if (refused?.kind !== 'rejected') continue
+      expect(refused.refused).toBe(type)
+      expect(refused.diagnostics[0]?.code).toBe('YMVS316')
+    }
+  })
+
+  it('reports no chat capability, so the composer never offers to send', () => {
+    const { frames } = openHost()
+    const ready = frames[0]
+    if (ready?.kind !== 'ready') throw new Error('no ready frame')
+
+    expect(ready.snapshot.chatEnabled).toBe(false)
+    expect(ready.snapshot.capabilities.chat).toBe(false)
+  })
+
+  it('delivers nothing once it is stopped', () => {
+    const { frames, send, stop } = openHost()
+    const seen = frames.length
+    stop()
+    send(input('filter.query', { query: {} }))
+
+    expect(frames).toHaveLength(seen)
+  })
+})

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const root = vi.hoisted(() => ({
+  render: vi.fn(),
+  unmount: vi.fn(),
+}))
+const createRoot = vi.hoisted(() => vi.fn(() => root))
+
+vi.mock('react-dom/client', () => ({ createRoot }))
+import {
+  mountEditorWith,
+  type EditorHost,
+  type RightSectionId,
+} from '../src/visual-app/mount.js'
+
+const host: EditorHost = {
+  open: () => () => undefined,
+  send: () => undefined,
+}
+
+const sections: readonly RightSectionId[] = ['properties', 'changes']
+
+describe('mountEditorWith', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders into the host element and unmounts its rendered root', () => {
+    const element = {} as Element
+
+    const editor = mountEditorWith(element, host, sections)
+
+    expect(createRoot).toHaveBeenCalledWith(element)
+    expect(root.render).toHaveBeenCalledOnce()
+
+    editor.unmount()
+
+    expect(root.unmount).toHaveBeenCalledOnce()
+  })
+})

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -15,6 +15,7 @@ import {
   type SelectedDiagramSubject,
   type VisualWorkspaceState,
 } from "../src/visual-app/workspace-state.js";
+import { stackRows } from "../src/visual-app/section-stack.js";
 
 const canvasNode = (overrides: Partial<CanvasNode> = {}): CanvasNode => ({
   id: "system.api",
@@ -913,5 +914,63 @@ describe("the right column's sections", () => {
         height: state.conversation.chatHeight,
       }),
     ).toBe(state);
+  });
+});
+
+/**
+ * Which rows the stack draws, given the sections a host asked for (#252).
+ * A handle sits between two sections; the first present one never gets one.
+ */
+describe("stackRows", () => {
+  const bodies = {
+    properties: "properties-body",
+    changes: "changes-body",
+    chat: "chat-body",
+  } as const;
+  const splitters = {
+    changes: "changes-splitter",
+    chat: "chat-splitter",
+  } as const;
+  const rows = (sections: readonly RightSectionId[]) =>
+    stackRows(sections, bodies, splitters).map(
+      (row) => (row as { readonly key: string | null }).key,
+    );
+
+  it("draws every section and the handles between them by default", () => {
+    expect(rows(RIGHT_SECTIONS)).toEqual([
+      "properties",
+      "splitter-changes",
+      "changes",
+      "splitter-chat",
+      "chat",
+    ]);
+  });
+
+  it("takes a section's handle away with the section", () => {
+    expect(rows(["properties", "chat"])).toEqual([
+      "properties",
+      "splitter-chat",
+      "chat",
+    ]);
+  });
+
+  it("gives a lone section no handle at all", () => {
+    // Nothing to resize it against, and a stray handle at the top of the
+    // column is the kind of thing only the configuration nobody rendered has.
+    expect(rows(["chat"])).toEqual(["chat"]);
+    expect(rows(["properties"])).toEqual(["properties"]);
+  });
+
+  it("keeps the stack's own order, whatever order the host wrote", () => {
+    // The sequence means something - properties above changes above chat, which
+    // is pinned at the foot - so a host cannot reorder the shell by writing its
+    // array differently.
+    expect(rows(["chat", "properties", "changes"])).toEqual(
+      rows(RIGHT_SECTIONS),
+    );
+  });
+
+  it("draws nothing for a host that asked for nothing", () => {
+    expect(rows([])).toEqual([]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,8 @@
     "test/visual-context-menu.test.ts",
     "test/graph-canvas.test.ts",
     "test/query-fields.test.ts",
+    "test/visual-local-host.test.ts",
+    "test/visual-mount.test.ts",
     "test/query-panel.test.ts",
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",

--- a/tsconfig.visual-lib.json
+++ b/tsconfig.visual-lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.visual.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "rootDir": "./src",
+    "outDir": "./dist/visual-app-lib/types",
+    "noCheck": true
+  },
+  "files": ["src/visual-app/mount.tsx"],
+  "include": [],
+}

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -27,6 +27,8 @@
     "test/visual-context-menu.test.ts",
     "test/graph-canvas.test.ts",
     "test/query-fields.test.ts",
+    "test/visual-local-host.test.ts",
+    "test/visual-mount.test.ts",
     "test/query-panel.test.ts",
     "test/save-view.test.ts",
     "test/graph-canvas-layout.test.ts",

--- a/vite.visual-lib.config.ts
+++ b/vite.visual-lib.config.ts
@@ -1,0 +1,68 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+/**
+ * Builds the editor as a library someone else can mount (#252).
+ *
+ * SELF-CONTAINED, exactly like the served app: React, cytoscape and the engine
+ * are inside. A host calls `mountEditor(el, …)` and needs no React of its own,
+ * no peer dependencies, and no build configuration - which is what lets a
+ * product that is not a React application have the editor at all.
+ *
+ * `vite.visual.config.ts` still builds the page the session server serves.
+ * Neither output is derived from the other; they are two entries over the same
+ * source, and the served page is the one that must stay byte-addressable by
+ * the asset route.
+ *
+ * SIZE, measured rather than assumed: the library is 4.0 MB raw and 968 KB
+ * gzipped against the served page's 2.2 MB and 683 KB. The 285 KB gzipped
+ * difference is the engine - the compiler, Ajv and the schemas - which is what
+ * a host is buying: a canvas that compiles, projects and plans without a
+ * server. Lib mode leaves whitespace in whatever `minify` is set to, so the
+ * raw number reads worse than what ships; gzip is the honest one.
+ */
+export default defineConfig({
+  /**
+   * React's CJS entry picks its build with `process.env.NODE_ENV`, and library
+   * mode leaves that for the consumer's bundler to replace. This bundle is
+   * self-contained precisely so a host needs no bundler, so nobody would - and
+   * the page died on `process is not defined` before the editor drew anything.
+   * Defining it here also drops React's development half.
+   */
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+  // Keep Vite's JSX transform aligned with React's production runtime selected
+  // above; otherwise a `jsxDEV` call reaches a runtime that only exports `jsx`.
+  esbuild: { jsxDev: false },
+  plugins: [
+    {
+      name: 'editor-declaration-entry',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'editor.d.ts',
+          source: "export * from './types/visual-app/mount.js'\n",
+        })
+      },
+    },
+  ],
+  build: {
+    // NOT under `dist/visual-app/`: that directory is `emptyOutDir` for the
+    // served page's build, so a library written inside it survives only until
+    // the next app build - and only in the order `build:visual` happens to run
+    // them. A sibling directory owes nothing to that ordering.
+    outDir: fileURLToPath(new URL('./dist/visual-app-lib/', import.meta.url)),
+    emptyOutDir: true,
+    target: 'es2022',
+    sourcemap: false,
+    reportCompressedSize: false,
+    cssCodeSplit: false,
+    lib: {
+      entry: fileURLToPath(
+        new URL('./src/visual-app/mount.tsx', import.meta.url),
+      ),
+      formats: ['es'],
+      fileName: () => 'editor.js',
+      cssFileName: 'styles',
+    },
+  },
+})


### PR DESCRIPTION
Closes #252. This is the last issue in #244, so the 1.0.0 tag is unblocked once it lands.

## What this does

The read path already shipped. The **editor** did not: it existed only as a bundle served by `yarramate-visual start`, which brings a Node process, a session server, a WebSocket and a journal with it. A product that wanted the editor had to host all of that.

`yarramate/visual-app` now exports `mountEditor`, `mountEditorWith` and `createLocalHost`, with styles at `yarramate/visual-app/styles.css`. The bundle is self-contained, so the host supplies no React and the package gains no dependencies.

## The shape

- **The host contract is the protocol that already exists** (ADR 0081), not a new capability interface. The reducer was already frame-driven and pure, so `state.ts` is untouched and "the session server becomes one implementation" is literally true.
- **The seven browser inputs split cleanly.** `filter.query`, `changeset.commit` and `layout.save` are *engine* questions, answered inline over the store. `chat.message`, `choice.selected`, `view.navigate` and `session.end` are *agent* questions. A local host answers the first three and declines the rest, which is why chat is the section a product leaves out: with no agent there is nobody to talk to and nothing to hand control back to.
- **Synchronous throughout** (ADR 0100). An async embedder fetches its sources, builds an in-memory store, and writes back what `writeAll` is handed.

ADR 0105 records it.

## Two defects worth calling out

- **`Buffer` in the compiler.** Claim id suffixes were hex-encoded with Node's `Buffer` global, so the mounted editor died on `Buffer is not defined`. Now `TextEncoder`.
- **The browser-safety guard only ever caught `node:` *imports*, never Node *globals*.** It now parses the built bundles for executable Node forms (`Buffer.from`, `process.env`, `createRequire`, `node:` specifiers), which guards the class rather than the last shape of it.

## Verification

`pnpm verify` green: 88 files, 1536 tests, self-check and LikeC4 clean.

Driven in a real browser both ways, because a green suite says very little about a bundled UI:

- **Mounted, no server** (a scratch page over this repo's own `.yarramate/` sources as an in-memory store): canvas draws, a filter narrows it 11 → 10 through the host's own `filter.query`, Stage → Commit reaches `writeAll` with the projection path, and no chat section or session button appears. Zero console errors; the page fetched only the two files it was given, every icon being an inlined data URI.
- **Over the socket** (`yarramate-visual start`): same filter round-trip, and the same edit landed in `.yarramate/projections/core-contract-foundation.yaml` on disk. Chat and "Return to agent" are present here, which is exactly the declared-sections difference.

**Bundle budget:** served app 2,245,074 raw / 683,288 gzip against a 2,244,606 baseline, so **+468 bytes**: the host seam tree-shakes cleanly. The library is 3,496,038 raw / 842,447 gzip; the ~160 KB gzipped delta is the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)