### PR TITLE
The contact-update fixture models APIs at the grain architects author (#268 phase 0)

### DIFF
--- a/test/contact-update-fixture.test.ts
+++ b/test/contact-update-fixture.test.ts
@@ -54,9 +54,26 @@ const catalogue = (() => {
   return loaded.catalogue
 })()
 
+// The api-led profile is a workspace source like the documents: the
+// fixture's api groupings are kinded against it (yarrasys/api-led@1.0#api
+// extends grouping), so compiling without it is YM403.
+const profileFixture = (name: string): WorkspaceSource => ({
+  path: `profiles/${name}`,
+  source: readFileSync(
+    fileURLToPath(
+      new URL(
+        `./fixtures/journeys/contact-update/.yarramate/profiles/${name}`,
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  ),
+})
+
 const result = compileWorkspaceWithProfileContext([
   fixture('contact-update.yaml'),
   fixture('contact-update.policy.yaml'),
+  profileFixture('api-led.yaml'),
 ])
 
 // Narrowed once, so the three tests below read the graph without each

--- a/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/architecture/contact-update.yaml
@@ -1,6 +1,6 @@
 format: yarramate/v1
 id: contact-update
-profile: yarramate/core@0.1
+profile: yarrasys/api-led@1.0
 concepts:
   # ============================================================== motivation
   - id: crm-product-owner
@@ -299,6 +299,22 @@ concepts:
       The vendor's own runtime. Recorded so the CRM does not read as something
       this team deploys.
     status: current
+  - id: contact-experience-api
+    kind: api
+    name: Experience API
+    description: The experience-layer API a sales rep's client calls.
+  - id: contact-process-api
+    kind: api
+    name: Process API
+    description: The process-layer API that orchestrates a contact update.
+  - id: contact-system-api
+    kind: api
+    name: System API
+    description: The system-layer API over Salesforce.
+  - id: salesforce-contact-api
+    kind: api
+    name: Salesforce Contact API
+    description: The vendor API the system layer consumes.
 
 relationships:
   # --- components own the interfaces they expose (renders as nesting) -------
@@ -558,3 +574,77 @@ relationships:
     kind: realization
     from: salesforce-platform
     to: salesforce-crm
+  - id: contact-sys-api-flow-salesforce-crm
+    kind: flow
+    from: contact-sys-api
+    to: salesforce-crm
+  - id: contact-experience-api-aggregates-contact-exp-api
+    kind: aggregation
+    from: contact-experience-api
+    to: contact-exp-api
+  - id: contact-experience-api-aggregates-contact-exp-api-interface
+    kind: aggregation
+    from: contact-experience-api
+    to: contact-exp-api-interface
+  - id: contact-experience-api-aggregates-contact-update-service
+    kind: aggregation
+    from: contact-experience-api
+    to: contact-update-service
+  - id: contact-process-api-aggregates-contact-prc-api
+    kind: aggregation
+    from: contact-process-api
+    to: contact-prc-api
+  - id: contact-process-api-aggregates-contact-prc-api-interface
+    kind: aggregation
+    from: contact-process-api
+    to: contact-prc-api-interface
+  - id: contact-process-api-aggregates-contact-orchestration-service
+    kind: aggregation
+    from: contact-process-api
+    to: contact-orchestration-service
+  - id: contact-system-api-aggregates-contact-sys-api
+    kind: aggregation
+    from: contact-system-api
+    to: contact-sys-api
+  - id: contact-system-api-aggregates-contact-sys-api-interface
+    kind: aggregation
+    from: contact-system-api
+    to: contact-sys-api-interface
+  - id: contact-system-api-aggregates-salesforce-write-service
+    kind: aggregation
+    from: contact-system-api
+    to: salesforce-write-service
+  - id: salesforce-contact-api-aggregates-salesforce-crm
+    kind: aggregation
+    from: salesforce-contact-api
+    to: salesforce-crm
+  - id: salesforce-contact-api-aggregates-salesforce-contact-interface
+    kind: aggregation
+    from: salesforce-contact-api
+    to: salesforce-contact-interface
+  - id: salesforce-contact-api-aggregates-salesforce-contact-service
+    kind: aggregation
+    from: salesforce-contact-api
+    to: salesforce-contact-service
+  # API-grain commitments (#268 phase 0 interim). Each is the macro fact the
+  # pattern layer will one day expand through ports; today the member wiring
+  # beneath it is authored by hand and named in the description, which is the
+  # correspondence the phase-1 checker will verify instead of trusting.
+  - id: salesforce-api-serves-system-api
+    kind: serving
+    from: salesforce-contact-api
+    to: contact-system-api
+    description: >-
+      Met by salesforce-contact-service serving contact-sys-api.
+  - id: system-api-serves-process-api
+    kind: serving
+    from: contact-system-api
+    to: contact-process-api
+    description: >-
+      Met by salesforce-write-service serving contact-prc-api.
+  - id: process-api-serves-experience-api
+    kind: serving
+    from: contact-process-api
+    to: contact-experience-api
+    description: >-
+      Met by contact-orchestration-service serving contact-exp-api.

--- a/test/fixtures/journeys/contact-update/.yarramate/catalogues/api-led.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/catalogues/api-led.yaml
@@ -1,0 +1,98 @@
+format: yarramate/question-catalogue/v1
+id: api-led-shape
+version: "1.0"
+profile: yarrasys/api-led@1.0
+presentation:
+  title: API shape contract
+  description: >-
+    What the api kind promises and the vocabulary alone cannot enforce:
+    every API aggregates the component that implements it, the interface
+    it is called at, and the service that interface exposes. One question
+    per missing part, so an API missing two parts is asked twice rather
+    than once vaguely.
+waves:
+  - id: shape
+    name: Shape
+    description: Whether each declared API has the parts the kind promises.
+questions:
+  - id: api-no-component
+    wave: shape
+    since: "1.0"
+    scope: subject
+    subjects:
+      kinds:
+        - yarrasys/api-led@1.0#api
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#aggregation
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+    question: >-
+      What implements {subject.name}?
+    askPlain: >-
+      "{subject.name}" is declared as an API but aggregates no
+      application component. What actually implements it?
+    materiality: >-
+      An API with no implementing component is a name on a diagram: no
+      deployable realizes it, no evidence can attest it, and reconcile
+      has nothing to compare against the repository.
+    authority: human
+    resolution: >-
+      Add an aggregation from the API to the applicationComponent that
+      implements it, or retire the API.
+  - id: api-no-interface
+    wave: shape
+    since: "1.0"
+    scope: subject
+    subjects:
+      kinds:
+        - yarrasys/api-led@1.0#api
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#aggregation
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#applicationInterface
+    question: >-
+      Where is {subject.name} called?
+    askPlain: >-
+      "{subject.name}" aggregates no application interface. What do
+      consumers actually call: which verb, path, protocol, auth?
+    materiality: >-
+      Without an interface the API has no contract surface: nothing
+      carries the protocol binding, rate-limit attribution, or status
+      codes, so consumer questions cannot be interrogated.
+    authority: human
+    resolution: >-
+      Add an aggregation from the API to the applicationInterface that
+      exposes it.
+  - id: api-no-service
+    wave: shape
+    since: "1.0"
+    scope: subject
+    subjects:
+      kinds:
+        - yarrasys/api-led@1.0#api
+    trigger:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#aggregation
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#applicationService
+    question: >-
+      What does {subject.name} offer?
+    askPlain: >-
+      "{subject.name}" aggregates no application service. What promise
+      does the layer above actually consume?
+    materiality: >-
+      The service is the reason the API exists: without one, serving
+      edges have no source and the layer above depends on an
+      implementation detail instead of a promise.
+    authority: human
+    resolution: >-
+      Add an aggregation from the API to the applicationService it
+      offers.

--- a/test/fixtures/journeys/contact-update/.yarramate/profiles/api-led.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/profiles/api-led.yaml
@@ -1,0 +1,17 @@
+format: yarramate/profile/v1
+id: yarrasys/api-led
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  # An API in the API-led sense: one addressable unit of the layering,
+  # made of a component, the interface it composes, and the service that
+  # interface exposes. Extending grouping keeps it a spec-legal ArchiMate
+  # element (the 3.2 table's grouping row governs it, Archi export maps
+  # it), while giving the cluster an identity a requirement can point at,
+  # an owner can hold, and evidence can attest. The shape itself is
+  # enforced by the api-led question catalogue beside this profile, not
+  # by the vocabulary: a profile can only name the kind.
+  - id: api
+    name: API
+    parent: yarramate/core@0.1#grouping
+relationshipKinds: []

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-api-chain.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-api-chain.projection.yaml
@@ -1,0 +1,19 @@
+format: yarramate/projection/v1
+id: contact-update-api-chain
+version: "1.0"
+query:
+  kinds:
+    - yarramate/core@0.1#applicationComponent
+    - yarramate/core@0.1#applicationInterface
+    - yarramate/core@0.1#applicationService
+  relationships: between
+presentation:
+  title: Contact update — API chain
+  description: >-
+    The API-led chain at its authored grain. Each component composes its
+    interface, each interface exposes a service, and the service serves the
+    component above. Nothing here is a derived summary, so nothing can drift
+    from the model it summarises.
+  nesting:
+    - composition
+    - assignment

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-apis.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-apis.projection.yaml
@@ -1,0 +1,12 @@
+format: yarramate/projection/v1
+id: contact-update-apis
+version: "1.0"
+query:
+  kinds:
+    - yarrasys/api-led@1.0#api
+  relationships: between
+presentation:
+  title: Contact update — APIs
+  description: >-
+    The API-grain picture: one box per API, each an authored Grouping that
+    aggregates its component, interface and service (yarrasys/api-led@1.0#api).

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-context.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-context.projection.yaml
@@ -1,0 +1,22 @@
+format: yarramate/projection/v1
+id: contact-update-context
+version: "1.0"
+# Why the integration exists, for the audience that funds it rather than
+# builds it. Motivation plus business, so the drivers and the goal they
+# produce sit beside the actor whose work they are about.
+query:
+  layers:
+    - motivation
+    - business
+  excludeStatuses:
+    - retired
+  relationships: between
+presentation:
+  layout: layered
+  direction: top-down
+  title: Contact update — drivers and intent
+  description: >-
+    Duplicate contacts erode trust in the CRM, and the Salesforce API
+    allocation is shared org-wide. Together those two pressures produce the
+    goal of exactly one sanctioned write path, and the outcome of reps
+    updating contacts without opening Salesforce.

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-deployment.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-deployment.projection.yaml
@@ -1,0 +1,21 @@
+format: yarramate/projection/v1
+id: contact-update-deployment
+version: "1.0"
+query:
+  subjects:
+    - contact-exp-api
+    - contact-prc-api
+    - contact-sys-api
+    - salesforce-crm
+  relationships: between
+presentation:
+  layout: layered
+  direction: top-down
+  showLifecycle: true
+  showEvidence: true
+  showOwnership: false
+  title: High-Level Solution Design
+  description: Three Mule applications on CloudHub 2.0; the CRM on vendor-operated
+    infrastructure this team does not run, patch, or audit. Each node is
+    assigned the artifact it carries and the artifact realizes the component, so
+    the boundary between the two nodes is the boundary the integration crosses.

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-solution.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update-solution.projection.yaml
@@ -1,0 +1,28 @@
+format: yarramate/projection/v1
+id: contact-update-solution
+version: "1.0"
+# The headline integration view: API-led layering from the consumer through
+# Experience, Process, and System to the system of record.
+#
+# Selected by layer rather than by listing subjects, so a subject added to the
+# business or application layer joins this view automatically instead of the
+# view quietly going stale. `relationships: between` is what keeps it a
+# solution diagram rather than a dependency dump: an edge is drawn only when
+# both of its ends are in the view, so the motivation and technology layers
+# cannot leak in through a single relationship.
+query:
+  layers:
+    - business
+    - application
+  excludeStatuses:
+    - retired
+  relationships: between
+presentation:
+  layout: layered
+  direction: top-down
+  title: Contact update — API-led solution overview
+  description: >-
+    Sales Representative into Salesforce through three API layers. Each
+    component composes the interface it exposes and is assigned the process
+    that realizes its declared service; the request path is the flow chain
+    across the interfaces.

--- a/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/projections/contact-update.projection.yaml
@@ -1,6 +1,6 @@
 format: yarramate/projection/v1
 id: contact-update-slice
-version: "1.0"
+version: "1.1"
 query:
   subjects:
     - sales-rep
@@ -13,6 +13,8 @@ query:
     - contact-sys-api-interface
     - salesforce-contact-interface
     - cloudhub2
+    - contact-api-deployables
+    - salesforce-platform
     - accept-contact-update
     - orchestrate-contact-update
     - update-salesforce-contact
@@ -32,5 +34,7 @@ query:
     - salesforce-rest-api
   relationships: connected
 presentation:
+  layout: layered
+  direction: top-down
   title: Contact update hop
   description: Experience to process to Salesforce contact update, on CloudHub 2.0.

--- a/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-deployment.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-deployment.yaml
@@ -1,0 +1,114 @@
+format: yarramate/visual-layout/v1
+projectionId: contact-update-deployment
+positions:
+  accept-contact-update:
+    x: 277.9000000000001
+    y: 594.5
+  at-least-once-upsert:
+    x: 30.5
+    y: 52.5
+  cloudhub2:
+    x: 1704.2333333333336
+    y: 288.5
+  contact-api-contract:
+    x: 194.5
+    y: 448.5
+  contact-api-deployables:
+    x: 1636.0333333333335
+    y: 341.5
+  contact-exp-api:
+    x: 493.0040238450076
+    y: 431.3902136115251
+  contact-exp-api-interface:
+    x: 277.9000000000001
+    y: 448.5
+  contact-orchestration-service:
+    x: 758.4000000000002
+    y: 469.5
+  contact-prc-api:
+    x: 792.9057128663688
+    y: 431.451564828614
+  contact-prc-api-interface:
+    x: 961.5666666666668
+    y: 133.5
+  contact-record:
+    x: 91.5
+    y: 479.5
+  contact-sys-api:
+    x: 1109.437704918033
+    y: 429.87506209637365
+  contact-sys-api-interface:
+    x: 1126.9
+    y: 237.5
+  contact-update-service:
+    x: 194.5
+    y: 615.5
+  crm-product-owner:
+    x: 1636.0333333333335
+    y: 463.5
+  duplicate-contacts-erode-trust:
+    x: 1429.0333333333335
+    y: 517.5
+  experience-rate-limit:
+    x: 111.5
+    y: 52.5
+  gateway-oauth:
+    x: 192.5
+    y: 52.5
+  https-rest:
+    x: 273.5
+    y: 52.5
+  one-sanctioned-write-path:
+    x: 1251.5666666666668
+    y: 490.5
+  orchestrate-contact-update:
+    x: 1366.0333333333335
+    y: 639.5
+  reps-update-contacts-without-crm-logins:
+    x: 91.5
+    y: 540.5
+  sales-rep:
+    x: 91.5
+    y: 601.5
+  sales-systems-team:
+    x: 1366.0333333333335
+    y: 578.5
+  salesforce-allocation-is-shared:
+    x: 1460.5333333333335
+    y: 456.5
+  salesforce-api-limit:
+    x: 354.5
+    y: 52.5
+  salesforce-contact-interface:
+    x: 961.5666666666668
+    y: 237.5
+  salesforce-contact-service:
+    x: 805.1500000000002
+    y: 387.5
+  salesforce-crm:
+    x: 1413.0450761640864
+    y: 428.54168159140676
+  salesforce-jwt-bearer:
+    x: 435.5
+    y: 52.5
+  salesforce-platform:
+    x: 1460.5333333333335
+    y: 395.5
+  salesforce-rest-api:
+    x: 516.5
+    y: 52.5
+  salesforce-tenant-infrastructure:
+    x: 1636.0333333333335
+    y: 402.5
+  salesforce-write-service:
+    x: 961.5666666666668
+    y: 552.5
+  serve-contact-sobject:
+    x: 961.5666666666668
+    y: 395.5
+  update-salesforce-contact:
+    x: 1111.3166666666668
+    y: 552.5
+  work-an-account:
+    x: 30.5
+    y: 601.5

--- a/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-slice.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-slice.yaml
@@ -1,0 +1,108 @@
+format: yarramate/visual-layout/v1
+projectionId: contact-update-slice
+positions:
+  at-least-once-upsert:
+    x: 124
+    y: 86
+  experience-rate-limit:
+    x: 392
+    y: 86
+  gateway-oauth:
+    x: 660
+    y: 86
+  https-rest:
+    x: 928
+    y: 86
+  salesforce-api-limit:
+    x: 1196
+    y: 86
+  salesforce-jwt-bearer:
+    x: 1464
+    y: 86
+  salesforce-rest-api:
+    x: 1732
+    y: 86
+  accept-contact-update:
+    x: 568.6666666666666
+    y: 2410
+  cloudhub2:
+    x: 563
+    y: 820
+  contact-api-contract:
+    x: 2000
+    y: 86
+  contact-exp-api:
+    x: 568.6666666666666
+    y: 2212
+  contact-exp-api-interface:
+    x: 568.6666666666666
+    y: 2212
+  contact-orchestration-service:
+    x: 486
+    y: 1992
+  contact-prc-api:
+    x: 454.66666666666663
+    y: 1626
+  contact-prc-api-interface:
+    x: 454.66666666666663
+    y: 1626
+  contact-record:
+    x: 351.99999999999994
+    y: 2578
+  contact-sys-api:
+    x: 956.6226085315861
+    y: 998.4939608440823
+  contact-sys-api-interface:
+    x: 956.622608531586
+    y: 998.4939608440823
+  contact-update-service:
+    x: 600
+    y: 2578
+  crm-product-owner:
+    x: 1015.3333333333334
+    y: 820
+  duplicate-contacts-erode-trust:
+    x: 984
+    y: 1042.6666666666665
+  one-sanctioned-write-path:
+    x: 1303.5848295879618
+    y: 987.1518752805288
+  orchestrate-contact-update:
+    x: 454.66666666666663
+    y: 1824
+  reps-update-contacts-without-crm-logins:
+    x: 383.33333333333326
+    y: 2746
+  sales-rep:
+    x: 631.3333333333333
+    y: 2746
+  sales-systems-team:
+    x: 736
+    y: 1070
+  salesforce-allocation-is-shared:
+    x: 1232
+    y: 1029
+  salesforce-contact-interface:
+    x: 289.3333333333333
+    y: 454
+  salesforce-contact-service:
+    x: 289.3333333333333
+    y: 820
+  salesforce-crm:
+    x: 289.3333333333333
+    y: 454
+  salesforce-tenant-infrastructure:
+    x: 289.3333333333333
+    y: 234
+  salesforce-write-service:
+    x: 675.0337660641587
+    y: 1091.0491179546302
+  serve-contact-sobject:
+    x: 289.3333333333333
+    y: 652
+  update-salesforce-contact:
+    x: 1090.9076510236605
+    y: 1315.5475718601062
+  work-an-account:
+    x: 631.3333333333333
+    y: 2914

--- a/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-solution.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/visual-layout/contact-update-solution.yaml
@@ -1,0 +1,114 @@
+format: yarramate/visual-layout/v1
+projectionId: contact-update-solution
+positions:
+  accept-contact-update:
+    x: 1123.5026081996357
+    y: 2330.04457712641
+  at-least-once-upsert:
+    x: 124
+    y: 86
+  cloudhub2:
+    x: 192.33333333333334
+    y: 820
+  contact-api-contract:
+    x: -97.70213038129492
+    y: 2213.3832731156494
+  contact-api-deployables:
+    x: 433.33333333333314
+    y: 738
+  contact-exp-api:
+    x: 945.2932218499573
+    y: 2433.7951369486664
+  contact-exp-api-interface:
+    x: 767.0838355002788
+    y: 2328.6258797189034
+  contact-orchestration-service:
+    x: 1344.0011828417992
+    y: 1599.9322926114685
+  contact-prc-api:
+    x: 1478.3249164641948
+    y: 1689.8406252847353
+  contact-prc-api-interface:
+    x: 1612.6486500865901
+    y: 1595.9511297712859
+  contact-record:
+    x: 1001.1364979114757
+    y: 1177.5747676068916
+  contact-sys-api:
+    x: -18.223739934197198
+    y: 1039.4370851378094
+  contact-sys-api-interface:
+    x: 104.86405135230675
+    y: 932.9245810062291
+  contact-update-service:
+    x: 771.8862041674124
+    y: 2538.9643941784298
+  crm-product-owner:
+    x: 1015.3333333333334
+    y: 820
+  duplicate-contacts-erode-trust:
+    x: 984
+    y: 1042.6666666666665
+  experience-rate-limit:
+    x: 392
+    y: 86
+  gateway-oauth:
+    x: 660
+    y: 86
+  https-rest:
+    x: 928
+    y: 86
+  one-sanctioned-write-path:
+    x: 754.8
+    y: 1238
+  orchestrate-contact-update:
+    x: 1471.0070141698866
+    y: 1783.7301207981848
+  reps-update-contacts-without-crm-logins:
+    x: 984
+    y: 2746
+  sales-rep:
+    x: 124
+    y: 2914
+  sales-systems-team:
+    x: 736
+    y: 1070
+  salesforce-allocation-is-shared:
+    x: 1232
+    y: 1029
+  salesforce-api-limit:
+    x: 1196
+    y: 86
+  salesforce-contact-interface:
+    x: 570.3816197813926
+    y: 607.0828664593168
+  salesforce-contact-service:
+    x: 276.71006941747555
+    y: 606.3795579080784
+  salesforce-crm:
+    x: 423.5458445994341
+    y: 493.71352137236556
+  salesforce-jwt-bearer:
+    x: 1464
+    y: 86
+  salesforce-platform:
+    x: 423.3333333333333
+    y: 254
+  salesforce-rest-api:
+    x: 1732
+    y: 86
+  salesforce-tenant-infrastructure:
+    x: 499.33333333333337
+    y: 234
+  salesforce-write-service:
+    x: -40.07734304773046
+    y: 1145.9495892693894
+  serve-contact-sobject:
+    x: 428.4665967121375
+    y: 380.34417628541433
+  update-salesforce-contact:
+    x: -141.31153122070114
+    y: 940.7320786350097
+  work-an-account:
+    x: 124
+    y: 2914

--- a/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
@@ -2,7 +2,8 @@ format: yarramate/workspace/v1
 id: contact-update
 documents:
   - architecture/*.yaml
-profiles: []
+profiles:
+  - profiles/*.yaml
 projections:
   - projections/*.yaml
 adapterMappings: []


### PR DESCRIPTION
Phase 0 of #268, plus the fixture evolution a day of visual dogfooding produced. Fixture and test only; no engine or app code changes.

## What lands

- **`profiles/api-led.yaml`**: `api` kind extending `yarramate/core@0.1#grouping`. An API becomes a first-class subject (owner, status, evidence, referenceable) while staying spec-legal ArchiMate for export.
- **`catalogues/api-led.yaml`**: the shape contract the vocabulary cannot express: three `missing-linkage` questions requiring every `api` to aggregate a component, an interface, and a service. Verified both ways: the complete fixture interviews clean (3 questions, 0 open); an API authored with only a component opens two questions, leading with the interface.
- **Four `api` instances** over the existing clusters, and **three API-grain serving commitments** (`salesforce-api -> system-api -> process-api -> experience-api`), each `description` naming the member wiring that meets it. These are exactly what #268's ports would expand to, so phase 1 verifies the correspondence instead of rewriting it. The two component-grain serving duplicates are removed (the drift trap the macro grain avoids: same-grain duplication of the member chain).
- **Views at three grains**: `contact-update-apis` (4 boxes, 3 edges), `contact-update-api-chain` (members and services, `nesting: [composition, assignment]`), plus the editor-authored dogfooding views (drivers and intent, API-led solution overview, High-Level Solution Design) with their dragged-layout sidecars. Sidecars naming dead projections pruned.
- **`test/contact-update-fixture.test.ts`** feeds the profile as a workspace source (compiling the api-kinded documents without it is YM403).

## Verification

`pnpm verify` green: 88 files, 1536 tests, self-check and LikeC4 valid. Fixture `check`: 2 documents, 1 profile, 6 projections, 41 concepts, 70 relationships, no errors.

Everything here was driven end to end in the visual editor against a live session before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)