### PR TITLE
docs(bench): retire the nine suites whose showcase models no longer exist

### DIFF
--- a/docs/research/context-benchmark/README.md
+++ b/docs/research/context-benchmark/README.md
@@ -58,13 +58,34 @@ subject repos. That authoring is still outstanding (#56).
 Suites reference the models published in
 [yarramate-gallery](https://github.com/yarrasys/yarramate-gallery) at pinned
 source commits. `yarramate-self.yaml` is `headline: false` and reported
-separately (self-serving ground truth). The six external suites (fastify,
-httpie, miniflux, uptime-kuma, keycloak, kafka) cover every showcase currently
-in the gallery, clearing the **N ≥ 5** external-repository threshold for
-headline pooling. Keycloak and Kafka anchor the enterprise end of the gallery's
-CLI-to-enterprise spectrum; their comprehension tasks were authored multi-hop
-from the start (see "Suite versions" above on issue #56) rather than needing a
-later v2 errata round.
+separately (self-serving ground truth).
+
+⚠️ **Nine of the eleven suites are retired as of 2026-08-25.** The gallery
+narrowed to a small set of deep showcases
+([yarramate-gallery#10](https://github.com/yarrasys/yarramate-gallery/pull/10)):
+keeping a broad corpus of models current costs more than the breadth is worth,
+given how fast yarramate's vocabulary moves. The five external showcases those
+suites place under conditions B and C (fastify, httpie, miniflux, uptime-kuma,
+keycloak) no longer exist, so **B and C cannot run for them**, and with no B
+there is no comparative result to pool. Each affected suite carries a `retired`
+block naming the date, the reason, and the blocked conditions;
+`run-benchmark.mjs` refuses those conditions by name rather than failing later
+on a missing directory.
+
+What survives the retirement:
+
+- **The tasks and their ground truth.** They were verified against the subject
+  source at the pinned commit, never against the model, so they stay a valid
+  frozen corpus and condition A still runs. Nothing here is deleted, and the
+  published [2026-07-29 results](RESULTS-2026-07-29.md) stand as recorded.
+- **Two runnable suites**: `tasks/kafka.yaml` (external, `headline: true`) and
+  `tasks/yarramate-self.yaml` (`headline: false`, its model being the
+  repository's own `.yarramate`). All four `tasks/v2/` suites are retired, so
+  the v2 errata round has no runnable member left.
+
+This drops the corpus below the **N ≥ 5** external-repository threshold for
+headline pooling. A future headline sweep needs new suites authored against
+showcases that exist, which is part of the outstanding work in #56.
 
 ## Running
 
@@ -79,10 +100,10 @@ node runner/validate-suite.mjs yarramate-benchmark-suite.schema.json \
 node --test 'runner/*.test.mjs'
 
 # 3. inspect the matrix (no side effects, no cost)
-node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml --out /tmp/bench --dry-run
+node runner/run-benchmark.mjs --suite tasks/kafka.yaml --out /tmp/bench --dry-run
 
 # 4. live run — one suite, one condition, one capability tier (costs agent tokens)
-node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml \
+node runner/run-benchmark.mjs --suite tasks/kafka.yaml \
   --gallery ~/work/yarrasys/projects/yarramate-gallery \
   --toolchain <dir>/node_modules/.bin \
   --out results/2026-07-29 --conditions B --label sonnet \
@@ -90,7 +111,7 @@ node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml \
 
 # 5. deterministic scoring + adjudication queue
 node runner/score.mjs --runs results/2026-07-29/runs.jsonl \
-  --suite tasks/v2/miniflux.yaml --toolchain <dir>/node_modules/.bin
+  --suite tasks/kafka.yaml --toolchain <dir>/node_modules/.bin
 ```
 
 The harness command receives the composed prompt (condition instruction +

--- a/docs/research/context-benchmark/runner/run-benchmark.mjs
+++ b/docs/research/context-benchmark/runner/run-benchmark.mjs
@@ -62,6 +62,28 @@ const dryRun = flag('dry-run');
 const resume = flag('resume');
 const agentConfigPolicy = flag('keep-subject-agent-config') ? 'keep' : 'neutralize';
 
+// A retired suite has lost the model its model-bearing conditions place, so
+// those conditions would fail later on a missing directory. Refuse them here,
+// by name, and let any condition the suite still supports through: the tasks
+// were verified against the subject source at the pinned commit, not the model.
+if (suite.retired) {
+  const blocked = conditionIds.filter((id) => suite.retired.conditions.includes(id));
+  if (blocked.length) {
+    const message =
+      `suite ${suite.suite} was retired on ${suite.retired.since}; ` +
+      `condition${blocked.length > 1 ? 's' : ''} ${blocked.join(',')} cannot run.\n` +
+      `  ${suite.retired.reason.trim().replace(/\s+/g, ' ')}`;
+    // A dry run has no side effects and no cost, so it stays useful for
+    // inspecting a retired corpus; only a live run is refused.
+    if (dryRun) {
+      console.error(`run-benchmark: warning: ${message}`);
+    } else {
+      console.error(`run-benchmark: ${message}`);
+      process.exit(2);
+    }
+  }
+}
+
 const modelSourceDir = () => {
   if (suite.repository.gallery && !galleryDir) {
     console.error('run-benchmark: suite references a gallery model; pass --gallery <local clone of the gallery repo>');

--- a/docs/research/context-benchmark/runner/validate-suite.mjs
+++ b/docs/research/context-benchmark/runner/validate-suite.mjs
@@ -55,7 +55,12 @@ for (const suitePath of suitePaths) {
   for (const [family, count] of Object.entries(families)) {
     if (count < MIN_PER_FAMILY) fail(suitePath, `family ${family} has ${count} tasks, needs >= ${MIN_PER_FAMILY}`);
   }
-  if (!failed) console.log(`${suitePath}: ok (${suite.tasks.length} tasks, headline=${suite.headline})`);
+  if (!failed) {
+    const retired = suite.retired
+      ? ` RETIRED ${suite.retired.since} (conditions ${suite.retired.conditions.join(',')} cannot run)`
+      : '';
+    console.log(`${suitePath}: ok (${suite.tasks.length} tasks, headline=${suite.headline})${retired}`);
+  }
 }
 
 process.exit(failed ? 1 : 0);

--- a/docs/research/context-benchmark/tasks/fastify.yaml
+++ b/docs/research/context-benchmark/tasks/fastify.yaml
@@ -7,6 +7,18 @@
 type: yarramate/benchmark-suite/v1
 suite: fastify
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: fastify
   source: https://github.com/fastify/fastify

--- a/docs/research/context-benchmark/tasks/httpie.yaml
+++ b/docs/research/context-benchmark/tasks/httpie.yaml
@@ -4,6 +4,18 @@
 type: yarramate/benchmark-suite/v1
 suite: httpie
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: httpie
   source: https://github.com/httpie/cli

--- a/docs/research/context-benchmark/tasks/keycloak.yaml
+++ b/docs/research/context-benchmark/tasks/keycloak.yaml
@@ -25,6 +25,18 @@
 type: yarramate/benchmark-suite/v1
 suite: keycloak
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: keycloak
   source: https://github.com/keycloak/keycloak

--- a/docs/research/context-benchmark/tasks/miniflux.yaml
+++ b/docs/research/context-benchmark/tasks/miniflux.yaml
@@ -4,6 +4,18 @@
 type: yarramate/benchmark-suite/v1
 suite: miniflux
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: miniflux
   source: https://github.com/miniflux/v2

--- a/docs/research/context-benchmark/tasks/uptime-kuma.yaml
+++ b/docs/research/context-benchmark/tasks/uptime-kuma.yaml
@@ -6,6 +6,18 @@
 type: yarramate/benchmark-suite/v1
 suite: uptime-kuma
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: uptime-kuma
   source: https://github.com/louislam/uptime-kuma

--- a/docs/research/context-benchmark/tasks/v2/fastify.yaml
+++ b/docs/research/context-benchmark/tasks/v2/fastify.yaml
@@ -34,6 +34,18 @@
 type: yarramate/benchmark-suite/v2
 suite: fastify
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: fastify
   source: https://github.com/fastify/fastify

--- a/docs/research/context-benchmark/tasks/v2/httpie.yaml
+++ b/docs/research/context-benchmark/tasks/v2/httpie.yaml
@@ -19,6 +19,18 @@
 type: yarramate/benchmark-suite/v2
 suite: httpie
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: httpie
   source: https://github.com/httpie/cli

--- a/docs/research/context-benchmark/tasks/v2/miniflux.yaml
+++ b/docs/research/context-benchmark/tasks/v2/miniflux.yaml
@@ -30,6 +30,18 @@
 type: yarramate/benchmark-suite/v2
 suite: miniflux
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: miniflux
   source: https://github.com/miniflux/v2

--- a/docs/research/context-benchmark/tasks/v2/uptime-kuma.yaml
+++ b/docs/research/context-benchmark/tasks/v2/uptime-kuma.yaml
@@ -37,6 +37,18 @@
 type: yarramate/benchmark-suite/v2
 suite: uptime-kuma
 headline: true
+retired:
+  since: '2026-08-25'
+  reason: >-
+    The gallery showcase this suite points at was retired in
+    yarrasys/yarramate-gallery#10: keeping a broad set of models current costs
+    more than the breadth is worth, given how fast yarramate's vocabulary
+    moves. Conditions B and C have no model to place and cannot run. The tasks
+    in this suite and their ground truth remain valid, having been verified against the
+    subject source at the pinned commit and never against the model, so
+    condition A is still runnable. A comparative result needs B, so this suite
+    no longer contributes to headline pooling.
+  conditions: [B, C]
 repository:
   name: uptime-kuma
   source: https://github.com/louislam/uptime-kuma

--- a/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
+++ b/docs/research/context-benchmark/yarramate-benchmark-suite.schema.json
@@ -35,6 +35,22 @@
       "type": "array",
       "minItems": 6,
       "items": { "$ref": "#/$defs/task" }
+    },
+    "retired": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["since", "reason", "conditions"],
+      "description": "Present when the suite can no longer run in full. The tasks and their ground truth stay valid: they were verified against the subject source at the pinned commit, never against a model.",
+      "properties": {
+        "since": { "type": "string", "description": "ISO date the suite was retired." },
+        "reason": { "$ref": "#/$defs/nonEmptyText" },
+        "conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["A", "B", "C"] },
+          "description": "Condition ids that can no longer run. Any condition not listed is still runnable."
+        }
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
The gallery narrowed to a small set of deep showcases ([yarramate-gallery#10](https://github.com/yarrasys/yarramate-gallery/pull/10)): keeping a broad corpus of models current costs more than the breadth is worth, given how fast yarramate's vocabulary moves. Five external showcases went with it (fastify, httpie, miniflux, uptime-kuma, keycloak), so the nine suites that place those models under conditions B and C have nothing to place.

**Nothing is deleted.** The tasks and their ground truth were verified against the subject source at the pinned commit, never against the model, so they remain a valid frozen corpus and condition A still runs. `RESULTS-2026-07-29.md` stands as recorded.

What changes is that the loss is now **declared rather than discovered**. Before this, a condition-B run against a retired suite failed partway through on a missing directory.

## Changes

- The suite schema gains an optional `retired` block (`since`, `reason`, `conditions`), and the nine affected suites carry one.
- `run-benchmark.mjs` refuses a blocked condition **by name**, before doing any work. A `--dry-run` is let through with a warning instead, since it has no side effects and stays useful for inspecting the corpus.
- `validate-suite.mjs` reports retired status alongside the task count.

```
$ node runner/run-benchmark.mjs --suite tasks/v2/miniflux.yaml --conditions B ...
run-benchmark: suite miniflux was retired on 2026-08-25; condition B cannot run.
  The gallery showcase this suite points at was retired in yarrasys/yarramate-gallery#10 ...
$ echo $?
2
```

## What is left runnable

| Suite | Status |
|---|---|
| `tasks/kafka.yaml` | runnable, external, `headline: true` |
| `tasks/yarramate-self.yaml` | runnable, `headline: false` (its model is this repository's own `.yarramate`) |
| `tasks/{fastify,httpie,keycloak,miniflux,uptime-kuma}.yaml` | retired, conditions B and C |
| `tasks/v2/{fastify,httpie,miniflux,uptime-kuma}.yaml` | retired, conditions B and C |

All four `tasks/v2/` suites are retired, so the v2 errata round has no runnable member left. This also drops the corpus below the **N ≥ 5** external-repository threshold for headline pooling: a future headline sweep needs suites authored against showcases that exist, which is part of the outstanding work in #56.

## Verification

| Check | Outcome |
|---|---|
| `node runner/validate-suite.mjs …` | all 11 suites ok, 9 reported RETIRED |
| `node --test 'runner/*.test.mjs'` | 4 pass, 0 fail |
| live run of a retired suite at condition B | refused, exit 2 |
| `--dry-run` of a retired suite at condition B | warns, then prints the matrix |
| `--dry-run` of a retired suite at condition A | no warning (A is still runnable) |
| `tasks/kafka.yaml` at condition B | unaffected, exit 0 |

`pnpm verify` does not reach this tree; the suite validator and the runner's own tests are the coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)