### PR TITLE
feat: the interrogation engine is public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.1.0
+
+- **Added.** The interrogation engine is public API. `evaluateCatalogue`,
+  `loadQuestionCatalogue`, `renderQuestion` and `renderInterrogationReport`
+  are exported from the package entry, with the catalogue and report types
+  named alongside them (`QuestionCatalogue`, `CatalogueQuestion`,
+  `CatalogueSelector`, `CatalogueCondition`, `CatalogueLoadResult`,
+  `InterrogationReport`, `InterrogationSummary`, `ReportWave`,
+  `ReportQuestion`, `OpenSubject`). The question-catalogue and
+  interrogation-report schemas were already published, so the contract was
+  legible to consumers who had no way to run the engine behind it.
+
+- **Added.** `yarramate/interrogation`, a subpath carrying that engine on its
+  own. The `.` barrel reaches `node:fs`, `node:path` and `node:child_process`
+  through workspace loading, the filesystem source store and git-derived
+  attestation staleness, so a consumer evaluating catalogues inside a Worker
+  or a Durable Object could not take the engine from it without dragging Node
+  in behind. The subpath is pinned free of Node builtins by the same purity
+  test that guards `yarramate/adapter/visual-graph`, and reaches the compiler
+  for types only. Prefer it wherever the runtime is not Node.
+
+  No CLI porcelain joins either surface: a command runner takes a working
+  directory and returns an exit code, which is not a contract this package
+  offers. A test pins that too.
+
 ## 1.0.0
 
 - **Added.** The mountable visual editor (#252):

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "types": "./dist/notation/archimate.d.ts",
       "import": "./dist/notation/archimate.js"
     },
+    "./interrogation": {
+      "types": "./dist/interrogation-entry.d.ts",
+      "import": "./dist/interrogation-entry.js"
+    },
     "./visual-app": {
       "types": "./dist/visual-app-lib/editor.d.ts",
       "import": "./dist/visual-app-lib/editor.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,3 +146,19 @@ export {
   draftDeletion,
   type DeletionBlocker,
 } from './deletion-drafting.js'
+export {
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+  renderInterrogationReport,
+  renderQuestion,
+  type CatalogueCondition,
+  type CatalogueLoadResult,
+  type CatalogueQuestion,
+  type CatalogueSelector,
+  type InterrogationReport,
+  type InterrogationSummary,
+  type OpenSubject,
+  type QuestionCatalogue,
+  type ReportQuestion,
+  type ReportWave,
+} from './interrogate-command.js'

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -1,10 +1,10 @@
 import Ajv2020Module from 'ajv/dist/2020.js'
-import {
-  type Diagnostic,
-  type GraphClaim,
-  type ResolvedProfileContext,
-  type SemanticGraph,
-  type WorkspaceSource,
+import type {
+  Diagnostic,
+  GraphClaim,
+  ResolvedProfileContext,
+  SemanticGraph,
+  WorkspaceSource,
 } from './compiler.js'
 import {
   loadSourceDocument,
@@ -27,14 +27,14 @@ const validateCatalogue = new Ajv2020({ allErrors: true }).compile(
   catalogueSchema,
 )
 
-interface CatalogueSelector {
+export interface CatalogueSelector {
   readonly kinds: readonly string[]
   readonly kindMatching?: 'exact' | 'descendants'
   readonly statuses?: readonly string[]
   readonly documents?: readonly string[]
 }
 
-type CatalogueCondition =
+export type CatalogueCondition =
   | { readonly condition: 'missing-claim'; readonly predicate: string }
   | {
       readonly condition: 'missing-relationship'
@@ -116,13 +116,13 @@ export interface QuestionCatalogue {
   readonly questions: readonly CatalogueQuestion[]
 }
 
-interface OpenSubject {
+export interface OpenSubject {
   readonly id: string
   readonly name?: string
   readonly question: string
 }
 
-interface ReportQuestion {
+export interface ReportQuestion {
   readonly id: string
   readonly scope: 'workspace' | 'subject'
   readonly authority: 'human' | 'agent' | 'either'
@@ -134,20 +134,24 @@ interface ReportQuestion {
   readonly subjects?: readonly OpenSubject[]
 }
 
+export interface ReportWave {
+  readonly id: string
+  readonly name: string
+  readonly questions: readonly ReportQuestion[]
+}
+
+export interface InterrogationSummary {
+  readonly questions: number
+  readonly openQuestions: number
+  readonly open: number
+}
+
 export interface InterrogationReport {
   readonly format: 'yarramate/interrogation-report/v1'
   readonly workspace: string
   readonly catalogue: string
-  readonly summary: {
-    readonly questions: number
-    readonly openQuestions: number
-    readonly open: number
-  }
-  readonly waves: readonly {
-    readonly id: string
-    readonly name: string
-    readonly questions: readonly ReportQuestion[]
-  }[]
+  readonly summary: InterrogationSummary
+  readonly waves: readonly ReportWave[]
 }
 
 interface GraphIndex {

--- a/src/interrogation-entry.ts
+++ b/src/interrogation-entry.ts
@@ -1,0 +1,25 @@
+// The interrogation engine as a runtime-neutral entry point.
+//
+// The `.` barrel reaches node:fs, node:path and node:child_process through
+// workspace, source-store and attestation-staleness, so a consumer running
+// inside a Worker or a Durable Object cannot take the engine from there
+// without dragging Node in behind it. This subpath carries the pure engine
+// alone: catalogue loading takes a WorkspaceSource, evaluation takes an
+// in-memory graph, and a test pins the import graph free of Node builtins.
+// The same shape the visual-graph projector uses (`./adapter/visual-graph`).
+export {
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+  renderInterrogationReport,
+  renderQuestion,
+  type CatalogueCondition,
+  type CatalogueLoadResult,
+  type CatalogueQuestion,
+  type CatalogueSelector,
+  type InterrogationReport,
+  type InterrogationSummary,
+  type OpenSubject,
+  type QuestionCatalogue,
+  type ReportQuestion,
+  type ReportWave,
+} from './interrogate-command.js'

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -59,6 +59,14 @@ describe('package export purity', () => {
     const { hits } = runtimeImportGraph('notation/archimate.ts')
     expect(hits).toEqual([])
   })
+
+  it('interrogation import graph stays free of Node, ws, session, and compiler runtime', () => {
+    // The engine is the one piece a Durable Object runs on every model write,
+    // so the compiler's Ajv/YAML weight and every Node builtin have to stay
+    // out of its import graph. The compiler is reached for types only.
+    const { hits } = runtimeImportGraph('interrogation-entry.ts')
+    expect(hits).toEqual([])
+  })
 })
 
 describe('adapter/visual-graph barrel', () => {

--- a/test/export-surface.test.ts
+++ b/test/export-surface.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+// The barrel is a contract: what it names, consumers may hold. Porcelain that
+// takes a cwd or returns an exit code is not part of that contract, and the
+// way it leaks is a re-export added for one convenient call site. This pins
+// both directions, so widening the surface has to be deliberate.
+describe('package entry surface', () => {
+  it('exports the interrogation engine', async () => {
+    const barrel = await import('../src/index.js')
+    for (const name of [
+      'evaluateCatalogue',
+      'loadQuestionCatalogue',
+      'renderQuestion',
+      'renderInterrogationReport',
+    ]) {
+      expect(typeof (barrel as Record<string, unknown>)[name]).toBe('function')
+    }
+  })
+
+  it('does not export CLI porcelain', async () => {
+    const barrel = await import('../src/index.js')
+    const names = Object.keys(barrel)
+    for (const forbidden of [
+      'runAskCommand',
+      'runInterrogateCommand',
+      'runCli',
+      'runDesignCommand',
+      'runCheckCommand',
+      'runApplyCommand',
+      'runExportCommand',
+      'versionResult',
+    ]) {
+      expect(names).not.toContain(forbidden)
+    }
+    // Nothing shaped like a command runner, so a newly added one is caught
+    // even though this list cannot know its name.
+    expect(names.filter((name) => /^run[A-Z]/.test(name))).toEqual([])
+  })
+})
+
+describe('interrogation subpath entry', () => {
+  it('re-exports the engine on its own entry point', async () => {
+    // Dynamic import intentionally exercises the module-loading boundary for
+    // the published subpath, as the visual-graph entry does.
+    const entry = await import('../src/interrogation-entry.js')
+    expect(typeof entry.evaluateCatalogue).toBe('function')
+    expect(typeof entry.loadQuestionCatalogue).toBe('function')
+    expect(typeof entry.renderQuestion).toBe('function')
+    expect(typeof entry.renderInterrogationReport).toBe('function')
+  })
+})

--- a/test/interrogation-api.test.ts
+++ b/test/interrogation-api.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+  renderInterrogationReport,
+  renderQuestion,
+  type InterrogationReport,
+} from '../src/index.js'
+
+// The engine is reached the way a package consumer reaches it, through the
+// barrel, and driven entirely from strings: nothing here hands it a path to
+// read. The only file this test opens is the published schema it asserts
+// against, which is the contract, not an input to the engine.
+const Ajv2020 = Ajv2020Module.default
+
+const repositoryRoot = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+)
+
+const reportSchema = JSON.parse(
+  readFileSync(
+    join(repositoryRoot, 'schema/yarramate-interrogation-report.schema.json'),
+    'utf8',
+  ),
+) as object
+
+const validateReport = new Ajv2020({ allErrors: true }).compile(reportSchema)
+
+const document =
+  'format: yarramate/v1\n' +
+  'id: main\n' +
+  'profile: yarramate/core@0.1\n' +
+  'concepts:\n' +
+  '  - id: architect\n' +
+  '    kind: businessActor\n' +
+  '    name: Lead architect\n' +
+  '  - id: checkout\n' +
+  '    kind: applicationComponent\n' +
+  '    name: Checkout\n' +
+  '    attestations:\n' +
+  '      - topic: adequacy\n' +
+  '        by: architect\n' +
+  '        on: "2026-01-01"\n' +
+  '  - id: billing\n' +
+  '    kind: applicationComponent\n' +
+  '    name: Billing\n' +
+  'relationships:\n' +
+  '  - id: checkout-serves-billing\n' +
+  '    kind: serving\n' +
+  '    from: checkout\n' +
+  '    to: billing\n'
+
+// Two questions, one per required condition, each written so exactly one of
+// the two components triggers it: an assertion that only counts openings
+// cannot tell a working condition from one that fires on everything.
+const catalogue =
+  'format: yarramate/question-catalogue/v1\n' +
+  'id: aperturex-fixture\n' +
+  'version: "1.0"\n' +
+  'profile: yarramate/core@0.1\n' +
+  'waves:\n' +
+  '  - id: structure\n' +
+  '    name: Structure\n' +
+  '  - id: assurance\n' +
+  '    name: Assurance\n' +
+  'questions:\n' +
+  '  - id: component-serves-nothing\n' +
+  '    wave: structure\n' +
+  '    scope: subject\n' +
+  '    subjects:\n' +
+  '      kinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+  '    trigger:\n' +
+  '      - condition: missing-relationship\n' +
+  '        kinds: ["yarramate/core@0.1#serving"]\n' +
+  '        direction: outgoing\n' +
+  '    question: What does {subject.name} serve?\n' +
+  '    materiality: A component serving nothing has no stated consumer.\n' +
+  '    authority: agent\n' +
+  '    resolution: Add a serving relationship.\n' +
+  '  - id: component-unattested\n' +
+  '    wave: assurance\n' +
+  '    scope: subject\n' +
+  '    subjects:\n' +
+  '      kinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+  '    trigger:\n' +
+  '      - condition: missing-attestation\n' +
+  '        topic: adequacy\n' +
+  '    question: Who signed off {subject.name}?\n' +
+  '    materiality: An unattested component carries nobody judgment.\n' +
+  '    authority: human\n' +
+  '    resolution: Record an adequacy attestation.\n'
+
+const evaluate = (): InterrogationReport => {
+  const compilation = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source: document },
+  ])
+  if (!compilation.ok) {
+    throw new Error(
+      `fixture did not compile: ${compilation.diagnostics.map(({ message }) => message).join('; ')}`,
+    )
+  }
+  const loaded = loadQuestionCatalogue({
+    path: 'catalogue.yaml',
+    source: catalogue,
+  })
+  if (!loaded.ok) {
+    throw new Error(
+      `fixture catalogue did not load: ${loaded.diagnostics.map(({ message }) => message).join('; ')}`,
+    )
+  }
+  return {
+    workspace: 'aperturex-fixture',
+    ...evaluateCatalogue(
+      loaded.catalogue,
+      compilation.graph,
+      compilation.profileContext,
+    ),
+  }
+}
+
+const questionById = (report: InterrogationReport, id: string) => {
+  const found = report.waves
+    .flatMap(({ questions }) => questions)
+    .find((question) => question.id === id)
+  if (found === undefined) throw new Error(`no question ${id} in report`)
+  return found
+}
+
+describe('interrogation engine as public API', () => {
+  it('evaluates an in-memory workspace with no filesystem access', () => {
+    const report = evaluate()
+    expect(report.catalogue).toBe('aperturex-fixture@1.0')
+    expect(report.summary.questions).toBe(2)
+    expect(report.summary.openQuestions).toBe(2)
+  })
+
+  it('produces a report that validates against the published schema', () => {
+    const report = evaluate()
+    const valid = validateReport(report)
+    expect(validateReport.errors ?? []).toEqual([])
+    expect(valid).toBe(true)
+  })
+
+  it('triggers missing-relationship on the component that serves nothing', () => {
+    const question = questionById(evaluate(), 'component-serves-nothing')
+    expect(question.open).toBe(true)
+    // checkout serves billing, so only billing is left without an outgoing
+    // serving edge.
+    expect(question.subjects?.map(({ id }) => id)).toEqual(['billing'])
+    expect(question.subjects?.[0]?.question).toBe('What does Billing serve?')
+  })
+
+  it('triggers missing-attestation on the component nobody signed off', () => {
+    const question = questionById(evaluate(), 'component-unattested')
+    expect(question.open).toBe(true)
+    expect(question.subjects?.map(({ id }) => id)).toEqual(['billing'])
+  })
+
+  it('round-trips authority from the catalogue into the report', () => {
+    const report = evaluate()
+    expect(questionById(report, 'component-serves-nothing').authority).toBe(
+      'agent',
+    )
+    expect(questionById(report, 'component-unattested').authority).toBe('human')
+  })
+
+  it('renders the report and a single question through the exported renderers', () => {
+    expect(renderInterrogationReport(evaluate())).toContain('== Structure ==')
+    expect(renderQuestion('Who owns {subject.name}?', 'billing', 'Billing')).toBe(
+      'Who owns Billing?',
+    )
+  })
+})

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -17,13 +17,20 @@ import { describe, expect, it } from 'vitest'
 
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 
-// `npm pack --json` runs the `prepack` build, whose pnpm and vite output
-// shares stdout with the JSON report, so parse from the array delimiter
-// rather than the first byte. Returns the packed tarball path.
+// `--ignore-scripts` because `prepack` is `pnpm build`, and a build here
+// rewrites the repository's `dist/` underneath every other test file that
+// reads it: `vite build` empties `dist/visual-app-lib` before rewriting it,
+// so a concurrent reader sees the gap and fails on an artifact that exists
+// either side of it. `verify` builds before it tests, so the tree this packs
+// is already the built one, and `prepack` itself is asserted below by
+// declaration rather than by running it.
+//
+// npm's own output still shares stdout with the JSON report, so parse from
+// the array delimiter rather than the first byte. Returns the tarball path.
 const packTarball = (destination: string): string => {
   const stdout = execFileSync(
     'npm',
-    ['pack', '--json', '--pack-destination', destination],
+    ['pack', '--json', '--ignore-scripts', '--pack-destination', destination],
     {
       cwd: repositoryRoot,
       encoding: 'utf8',


### PR DESCRIPTION
The question-catalogue and interrogation-report schemas are already published, so a consumer could read the contract but had no way to run the engine behind it. The engine itself was always pure; it was simply never named in the exports map.

Raised by **ApertureX**, a Cloudflare Workers product consuming yarramate strictly as an npm dependency (never vendored, never patched). It evaluates question catalogues inside a Durable Object on every model write, compiling in memory via `compileWorkspaceWithProfileContext`.

## The finding that shaped this

**The `.` barrel is not runtime-neutral, and never was.** Built, `dist/index.js` reaches 38 files and **seven** Node builtin imports:

| Module | Builtin |
|---|---|
| `workspace.js` | `node:fs`, `node:path` |
| `attestation-staleness.js` | `node:child_process` |
| `changed.js` | `node:child_process` |
| `source-store.js` | `node:crypto`, `node:fs`, `node:path` |

So a barrel re-export **alone** could not give a Worker a usable engine. This PR does both:

- **`.` barrel** re-exports the engine, as requested.
- **`yarramate/interrogation`** carries the engine alone: **5 files, zero Node builtins**, verified against the built output. This is the shape [`yarramate/adapter/visual-graph`](../blob/main/src/adapters/visual-graph-entry.ts) already uses for exactly this problem, and it is pinned by the same `export-purity` test.

A consumer whose runtime is not Node should import the subpath.

## Exported

`evaluateCatalogue`, `loadQuestionCatalogue`, `renderQuestion`, `renderInterrogationReport`.

Types: `QuestionCatalogue`, `CatalogueQuestion`, `CatalogueLoadResult`, `InterrogationReport`, plus `CatalogueSelector`, `CatalogueCondition`, `OpenSubject`, `ReportQuestion` promoted from file-private, and `ReportWave` / `InterrogationSummary` named out of inline positions. A consumer cannot describe the shape of an exported interface using types it cannot import, which is why the selector and condition types are promoted beyond the original list.

## Two premises that did not hold

**No file needed splitting.** `interrogate-command.ts` imports no CLI support and no Node builtin, and reaches the compiler for types only. That import is now written `import type` so the purity checker can *see* the elision it was already getting rather than trust it. Behaviour-identical: the emitted JS was already free of it.

**`runInterrogateCommand` does not exist** anywhere in the codebase. The engine's CLI callers are `ask-command.ts` and `design-command.ts` (`ask --open`), not an interrogate verb.

## No CLI porcelain

A command runner takes a working directory and returns an exit code, which is not a contract this package offers. The surface test pins absence both by name and by shape (nothing matching `/^run[A-Z]/`), so a future one is caught without anyone remembering to add it to a list.

## Tests

- `test/interrogation-api.test.ts` — compiles an in-memory workspace and evaluates a catalogue driven entirely from strings, then validates the report against the published `yarramate/schema/interrogation-report` with ajv. `evaluateCatalogue` returns `Omit<InterrogationReport, 'workspace'>`, so the test supplies `workspace` before validating. Both required conditions (`missing-relationship`, `missing-attestation`) are written so **exactly one of two components** triggers each: an assertion that only counts openings cannot tell a working condition from one that fires on everything. `authority` round-trips for both `agent` and `human`.
- `test/export-surface.test.ts` — the engine is exported, the porcelain is not, and the subpath entry loads.
- `test/export-purity.test.ts` — a case pinning the interrogation import graph free of Node builtins and of the compiler at runtime.

Also verified by package name against the built `dist`, which is how a consumer actually reaches it:

```
barrel  : function function
subpath : function function
open    : 1 subject: billing
```

## Verification

`pnpm verify` exits 0. **1546 passed, 1 skipped, across 90 files.**

## Semver

Minor, purely additive: no existing signature changes. `CHANGELOG.md` gains `## 1.1.0`. `package.json` stays at `1.0.0` because `docs/RELEASING.md` selects and bumps the version at release time.

## Not done: the pure attestation-staleness variant

Skipped deliberately, and it is worse than contentious. Two blockers, the second decisive:

1. An injected `(documentPath) => date` cannot work. The algorithm needs per-revision **changed line ranges** (`git diff --unified=0 <sha>` intersected against the name/description spans), plus a repo-state probe for the absent/shallow notes. Recency alone is not enough.
2. `StaleAttestationFinding` pins `provider: 'git'` as a TypeScript literal, **and the published reconciliation-report schema pins `"provider": { "const": "git" }`**, with evidence URIs `git:<sha>` / `git:worktree`. A non-git provider cannot emit a schema-valid finding without widening a published output schema.

The shape I would propose is a history port (`revisions(path)`, `changedSince(path, revisionId)`, plus an availability reason), with the existing `deriveAttestationStaleness(cwd, documents)` reimplemented on top and its signature untouched. It needs the schema decision first.

## Backport to 0.23.x

Cheap. Checked against `v0.23.1`: the module is structurally identical (same imports, same private `OpenSubject`/`ReportQuestion`, same exported functions), and that tag already ships both `adapters/visual-graph-entry.ts` and `test/export-purity.test.ts` as precedent. Its barrel reaches `workspace` and `attestation-staleness` too, so the subpath matters there equally. Essentially a clean cherry-pick if we want to unblock the consumer before their 1.0 adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)