### PR TITLE
feat: a report says which engine answered, not only which catalogue asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## 1.1.0
 
+- **Added.** An interrogation report says which engine answered, not only which
+  catalogue asked. `semantics` carries the version of condition evaluation
+  itself, exported as `INTERROGATION_SEMANTICS_VERSION`, and it changes only
+  when an existing question's answer can change for an unchanged model. It is
+  not the package version: every patch bumps that and almost none change what a
+  condition means, and a signal that fires on noise gets discounted.
+  [ADR 0106](docs/adr/0106-a-report-says-which-engine-answered.md) records the
+  reasoning and what was deliberately left out.
+
+  A consumer holding stored answers can now tell an engine change from a model
+  change. Before this, it could attribute a flipped answer to the model, or to
+  the catalogue via `since`, but not to the engine, which is what ADR 0097 did
+  when it replaced four aspect rules with the ArchiMate 3.2 table and began
+  answering `missing-relationship` differently for unchanged models.
+
+  **Compatibility.** `semantics` is required, and the report schema and its
+  copy inside `ask-result` are both `additionalProperties: false`, so **output
+  from 1.1.0 fails validation against a pinned pre-1.1.0 schema**. The schemas
+  ship with the package and move with it, so only a consumer pinning a schema
+  copy independently of the runtime is affected. `design-step`, `reconcile`,
+  `check`, `rtm` and `apply` are unchanged.
+
+  The promise is enforced rather than remembered:
+  `test/interrogation-semantics.test.ts` exercises every condition against a
+  fixture and fingerprints the answers, so changing what a condition means
+  fails the suite and names the version to bump.
+
+
 - **Added.** The interrogation engine is public API. `evaluateCatalogue`,
   `loadQuestionCatalogue`, `renderQuestion` and `renderInterrogationReport`
   are exported from the package entry, with the catalogue and report types

--- a/docs/adr/0106-a-report-says-which-engine-answered.md
+++ b/docs/adr/0106-a-report-says-which-engine-answered.md
@@ -1,0 +1,105 @@
+# A report says which engine answered
+
+Status: accepted
+
+A report has always said which catalogue asked its questions: `catalogue`
+carries `id@version`, and every question carries `since`, the catalogue
+version it first appeared in ([ADR 0063](0063-the-catalogue-deepens-honestly.md)).
+Nothing said which engine answered them.
+
+That gap has a cost only one kind of reader pays, and it went unnoticed
+because yarramate had no such reader until now.
+
+## The three reasons an answer flips
+
+| Cause | Attributable before this ADR |
+| --- | --- |
+| The model changed | Yes. The model is the input. |
+| The catalogue deepened and added a question | Yes, via `since`. |
+| **The engine's condition semantics changed** | **No. Nothing recorded it.** |
+
+The third is not hypothetical. [ADR 0097](0097-relationship-endpoints-are-validated-against-the-archimate-relationship-table.md)
+replaced four aspect rules with the ArchiMate 3.2 relationship table, so
+`missing-relationship` began answering differently for an unchanged model and
+an unchanged question, with no `since` bump because no question was new.
+[ADR 0083](0083-a-kind-nothing-constrains-is-a-label.md) records the same
+effect from the other side: under the full table `unconstrained-kind` goes
+near-empty, so `kind-untested` closes en masse for reasons no model caused.
+Measured on a real workspace, `showcases/kafka` in the gallery checks clean
+under 0.22.0 and reports thirteen errors under 1.0.0, on a file neither
+version edited.
+
+## Why ADR 0063 did not already cover this
+
+ADR 0063 chose honest reopening, no pinning, and no stored state, and it was
+right. Its reader is **stateless**: it re-runs the interview and reads the
+current answer, so a re-baselined report costs nothing.
+
+The first consumer to persist the answers is ApertureX, which spawns each open
+question into a row in D1. There an engine change does not re-baseline a
+report, it mass-closes and reopens a live queue, which is a question-fatigue
+and trust failure rather than a cosmetic one. ADR 0063 did not contemplate
+that reader because it did not exist.
+
+## Decided
+
+**The interrogation report carries `semantics`, the version of condition
+evaluation itself.**
+
+- **It is not the package version.** Every patch bumps that and almost none
+  change what a condition means, so a consumer diffing on it re-baselines
+  constantly and learns to ignore it. A signal that fires on noise is worse
+  than no signal, because it is trusted once and then discounted.
+- **It bumps only when an existing question's answer can change for an
+  unchanged model.** Not for a release, not for a new condition, not for a
+  catalogue edit, not for a rendering change. ADR 0097 and ADR 0083 would
+  both have bumped it; every visual-editor release between them would not.
+- **It starts at `1`.** It cannot describe history it was not present for, so
+  `1` means "the semantics shipped in 1.1.0" and absence means "older than
+  that", which is all a consumer needs to know.
+- **It is required, not optional.** A field a consumer cannot rely on does not
+  solve the problem it was added for. The cost is stated below.
+
+## The compatibility cost, stated
+
+The report schema and the copy inside `ask-result` are both
+`additionalProperties: false`, so **output from 1.1.0 fails validation against
+a pinned pre-1.1.0 schema**. The schemas ship with the package, so the pair
+moves together for anyone who upgrades normally; only a consumer pinning a
+schema copy independently of the runtime is affected. This is a minor, and the
+changelog says so plainly rather than letting a consumer discover it.
+
+## The backstop, because the rule is otherwise unenforced
+
+A version that must be bumped by hand is a version someone forgets on exactly
+the commit that matters. `test/interrogation-semantics.test.ts` exercises every
+condition the engine understands against one fixture and fingerprints the
+answers. Changing what a condition means fails that test, and the failure names
+the version to bump and the new fingerprint to record.
+
+It deliberately fingerprints **answers**, not the report: adding a question, a
+wave, or a rendering leaves it alone, because none of those changes what an
+existing question answers. This is the same argument
+`scripts/check-changelog.mjs` makes for changelog entries, applied to a promise
+that is otherwise kept only by memory.
+
+## Deliberately not done
+
+- **`design-step` does not carry it.** Its `progress` is a flattened summary
+  rather than a report, and a design step is a turn in an interactive loop, not
+  an artifact anyone persists. Adding a field there would widen a published
+  contract for no reader. Revisit if a consumer ever stores design steps.
+- **`reconcile`, `check`, `rtm` and `apply` do not carry it.** A reconcile
+  finding has the same property in principle, and no consumer persists those
+  today. Doing all six at once would widen five contracts on speculation. The
+  shape here is reusable when a reader appears.
+- **The catalogue is not pinnable.** ADR 0063 refused that and this ADR does
+  not reopen it. Recording which engine answered is the opposite of pinning: it
+  lets a model age honestly while telling the reader why an answer moved.
+
+## Consequences
+
+A consumer holding stored answers compares the `semantics` it stored against
+the one it just received. Equal means a flip is about the model and belongs in
+front of a user. Different means the engine moved, and the right response is to
+re-baseline silently rather than to reopen someone's queue.

--- a/schema/yarramate-ask-result.schema.json
+++ b/schema/yarramate-ask-result.schema.json
@@ -522,6 +522,7 @@
             "format",
             "workspace",
             "catalogue",
+            "semantics",
             "summary",
             "waves"
           ],
@@ -533,6 +534,9 @@
               "type": "string"
             },
             "catalogue": {
+              "type": "string"
+            },
+            "semantics": {
               "type": "string"
             },
             "summary": {

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -4,7 +4,7 @@
   "title": "YarraMate interrogation report",
   "type": "object",
   "additionalProperties": false,
-  "required": ["format", "workspace", "catalogue", "summary", "waves"],
+  "required": ["format", "workspace", "catalogue", "semantics", "summary", "waves"],
   "properties": {
     "format": {
       "const": "yarramate/interrogation-report/v1"
@@ -16,6 +16,11 @@
     "catalogue": {
       "type": "string",
       "minLength": 1
+    },
+    "semantics": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The version of condition evaluation that produced this report, as distinct from the package version. It changes only when an existing question's answer can change for an unchanged model, so a consumer holding stored answers can tell an engine change from a model change. Absent on reports produced before yarramate 1.1.0."
     },
     "summary": {
       "type": "object",

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -1106,6 +1106,7 @@ export function runAskCommand(
         format: report.format,
         workspace: report.workspace,
         catalogue: report.catalogue,
+        semantics: report.semantics,
         summary: report.summary,
         waves: report.waves,
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ export {
   type DeletionBlocker,
 } from './deletion-drafting.js'
 export {
+  INTERROGATION_SEMANTICS_VERSION,
   evaluateCatalogue,
   loadQuestionCatalogue,
   renderInterrogationReport,

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -27,6 +27,28 @@ const validateCatalogue = new Ajv2020({ allErrors: true }).compile(
   catalogueSchema,
 )
 
+/**
+ * The version of condition evaluation itself, not of the package.
+ *
+ * A report says which catalogue asked its questions. It could not say which
+ * engine answered them, so a consumer holding stored answers could tell a
+ * model change from a catalogue deepening (via `since`) but not from a change
+ * in what a condition means. ADR 0097 replaced four aspect rules with the
+ * ArchiMate 3.2 table and flipped `missing-relationship` answers for unchanged
+ * models and unchanged questions; ADR 0083's `unconstrained-kind` goes
+ * near-empty under that same table. Neither was visible in any report.
+ *
+ * **Bump this when an existing question's answer can change for an unchanged
+ * model.** Do not bump it for anything else: not a release, not a new
+ * condition, not a catalogue edit, not a rendering change. A version that
+ * moves when answers did not is a version consumers learn to ignore.
+ *
+ * `test/interrogation-semantics.test.ts` fingerprints every condition against
+ * a fixture and fails if evaluation moves without this bumping, so the rule is
+ * enforced rather than remembered.
+ */
+export const INTERROGATION_SEMANTICS_VERSION = '1'
+
 export interface CatalogueSelector {
   readonly kinds: readonly string[]
   readonly kindMatching?: 'exact' | 'descendants'
@@ -150,6 +172,8 @@ export interface InterrogationReport {
   readonly format: 'yarramate/interrogation-report/v1'
   readonly workspace: string
   readonly catalogue: string
+  /** {@link INTERROGATION_SEMANTICS_VERSION} at the time of evaluation. */
+  readonly semantics: string
   readonly summary: InterrogationSummary
   readonly waves: readonly ReportWave[]
 }
@@ -753,6 +777,7 @@ export function evaluateCatalogue(
   return {
     format: 'yarramate/interrogation-report/v1',
     catalogue: `${catalogue.id}@${catalogue.version}`,
+    semantics: INTERROGATION_SEMANTICS_VERSION,
     summary: {
       questions: applicableQuestions.length,
       openQuestions,

--- a/src/interrogation-entry.ts
+++ b/src/interrogation-entry.ts
@@ -8,6 +8,7 @@
 // in-memory graph, and a test pins the import graph free of Node builtins.
 // The same shape the visual-graph projector uses (`./adapter/visual-graph`).
 export {
+  INTERROGATION_SEMANTICS_VERSION,
   evaluateCatalogue,
   loadQuestionCatalogue,
   renderInterrogationReport,

--- a/test/interrogation-api.test.ts
+++ b/test/interrogation-api.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import Ajv2020Module from 'ajv/dist/2020.js'
 import { describe, expect, it } from 'vitest'
 import {
+  INTERROGATION_SEMANTICS_VERSION,
   compileWorkspaceWithProfileContext,
   evaluateCatalogue,
   loadQuestionCatalogue,
@@ -160,6 +161,13 @@ describe('interrogation engine as public API', () => {
     const question = questionById(evaluate(), 'component-unattested')
     expect(question.open).toBe(true)
     expect(question.subjects?.map(({ id }) => id)).toEqual(['billing'])
+  })
+
+  it('stamps the engine semantics version the answers were produced under', () => {
+    // The catalogue says which questions were asked; this says which engine
+    // answered them, which is what a consumer holding stored answers needs in
+    // order to tell an engine change from a model change.
+    expect(evaluate().semantics).toBe(INTERROGATION_SEMANTICS_VERSION)
   })
 
   it('round-trips authority from the catalogue into the report', () => {

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -1,0 +1,195 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  INTERROGATION_SEMANTICS_VERSION,
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// The backstop for INTERROGATION_SEMANTICS_VERSION.
+//
+// That version is a promise: it changes when an existing question's answer can
+// change for an unchanged model, and does not change otherwise. A promise
+// nothing enforces is one someone forgets on the commit that matters, which is
+// how ADR 0097 flipped `missing-relationship` answers with nothing recording
+// it. So every condition the engine understands is exercised here against one
+// fixture, and the answers are fingerprinted. Change what a condition means and
+// this fails, naming the version you now have to bump.
+//
+// It deliberately fingerprints ANSWERS, not the report: adding a question, a
+// wave, or a rendering leaves it alone, because none of those changes what an
+// existing question answers.
+
+const EXPECTED_SEMANTICS = '1'
+const EXPECTED_FINGERPRINT = '50f0a37db8ad99e1'
+
+const profile = 'yarramate/core@0.1'
+
+const document = [
+  'format: yarramate/v1',
+  'id: main',
+  `profile: ${profile}`,
+  'states:',
+  '  - id: now',
+  '    kind: baseline',
+  '    name: Now',
+  'concepts:',
+  '  - id: owner-actor',
+  '    kind: businessActor',
+  '    name: Owner',
+  '  - id: served-component',
+  '    kind: applicationComponent',
+  '    name: Served component',
+  '    owner: owner-actor',
+  '    attestations:',
+  '      - topic: adequacy',
+  '        by: owner-actor',
+  '        on: "2026-01-01"',
+  '  - id: lonely-component',
+  '    kind: applicationComponent',
+  '    name: Lonely component',
+  '  - id: near-duplicate-component',
+  '    kind: applicationComponent',
+  '    name: Lonely componant',
+  '  - id: billing-service',
+  '    kind: applicationService',
+  '    name: Billing service',
+  '  - id: billing-function',
+  '    kind: applicationFunction',
+  '    name: Billing function',
+  '  - id: ledger-data',
+  '    kind: dataObject',
+  '    name: Ledger',
+  '  - id: quiet-flow-target',
+  '    kind: applicationComponent',
+  '    name: Flow target',
+  'relationships:',
+  '  - id: served-serves-target',
+  '    kind: serving',
+  '    from: served-component',
+  '    to: quiet-flow-target',
+  '  - id: component-assigned-function',
+  '    kind: assignment',
+  '    from: served-component',
+  '    to: billing-function',
+  '  - id: function-realizes-service',
+  '    kind: realization',
+  '    from: billing-function',
+  '    to: billing-service',
+  '  - id: function-accesses-ledger',
+  '    kind: access',
+  '    from: billing-function',
+  '    to: ledger-data',
+  '    mode: read-write',
+  '  - id: target-flows-served',
+  '    kind: flow',
+  '    from: quiet-flow-target',
+  '    to: served-component',
+  '',
+].join('\n')
+
+// One question per condition the engine understands. Several never fire
+// against this fixture, and that is the point: a condition that starts firing
+// when it did not before is exactly the drift this catches.
+const conditions: readonly (readonly [string, readonly string[]])[] = [
+  ['missing-claim', ['      - condition: missing-claim', '        predicate: yarramate/ownership/owner']],
+  ['missing-relationship', ['      - condition: missing-relationship', `        kinds: ["${profile}#serving"]`, '        direction: outgoing']],
+  ['isolated', ['      - condition: isolated']],
+  ['no-subject-of-kind', ['      - condition: no-subject-of-kind', `        kinds: ["${profile}#goal"]`]],
+  ['no-state-defined', ['      - condition: no-state-defined']],
+  ['missing-linkage', ['      - condition: missing-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`]],
+  ['has-linkage', ['      - condition: has-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`]],
+  ['exists-linkage', ['      - condition: exists-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationService"]`]],
+  ['missing-constraint', ['      - condition: missing-constraint', `        kinds: ["${profile}#applicationComponent"]`]],
+  ['missing-flow-content', ['      - condition: missing-flow-content']],
+  ['missing-reference', ['      - condition: missing-reference', '        predicate: yarramate/reference/spec', '        direction: outgoing']],
+  ['missing-attestation', ['      - condition: missing-attestation', '        topic: adequacy']],
+  ['near-duplicate', ['      - condition: near-duplicate']],
+  ['unconstrained-kind', ['      - condition: unconstrained-kind']],
+]
+
+const catalogue = [
+  'format: yarramate/question-catalogue/v1',
+  'id: semantics-fingerprint',
+  'version: "1.0"',
+  `profile: ${profile}`,
+  'waves:',
+  '  - id: all',
+  '    name: All conditions',
+  'questions:',
+  ...conditions.flatMap(([name, trigger]) => [
+    `  - id: cond-${name}`,
+    '    wave: all',
+    '    scope: subject',
+    '    subjects:',
+    `      kinds: ["${profile}#applicationComponent"]`,
+    '    trigger:',
+    ...trigger,
+    `    question: Probe for ${name} on {subject.name}?`,
+    `    materiality: Fingerprint probe for the ${name} condition.`,
+    '    authority: either',
+    '    resolution: Not a real question; this catalogue exists to pin evaluation.',
+  ]),
+  '',
+].join('\n')
+
+const answers = () => {
+  const compilation = compileWorkspaceWithProfileContext([
+    { path: 'architecture/main.yaml', source: document },
+  ])
+  if (!compilation.ok) {
+    throw new Error(
+      `fixture did not compile: ${compilation.diagnostics.map(({ message }) => message).join('; ')}`,
+    )
+  }
+  const loaded = loadQuestionCatalogue({
+    path: 'catalogue.yaml',
+    source: catalogue,
+  })
+  if (!loaded.ok) {
+    throw new Error(
+      `fixture catalogue did not load: ${loaded.diagnostics.map(({ message }) => message).join('; ')}`,
+    )
+  }
+  const report = evaluateCatalogue(
+    loaded.catalogue,
+    compilation.graph,
+    compilation.profileContext,
+  )
+  // Answers only: which questions are open, and about which subjects.
+  return report.waves
+    .flatMap(({ questions }) => questions)
+    .map((question) => ({
+      id: question.id,
+      open: question.open,
+      subjects: (question.subjects ?? []).map(({ id }) => id).sort(),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+describe('interrogation semantics are versioned and pinned', () => {
+  it('exercises every condition the engine understands', () => {
+    const seen = answers().map(({ id }) => id.replace('cond-', ''))
+    expect(seen.sort()).toEqual(conditions.map(([name]) => name).sort())
+  })
+
+  it('has not changed what an existing question answers', () => {
+    const fingerprint = createHash('sha256')
+      .update(JSON.stringify(answers()))
+      .digest('hex')
+      .slice(0, 16)
+    expect(
+      fingerprint,
+      `Condition evaluation changed. If that was deliberate, bump ` +
+        `INTERROGATION_SEMANTICS_VERSION in src/interrogate-command.ts and ` +
+        `set EXPECTED_FINGERPRINT here to ${fingerprint}. If it was not ` +
+        `deliberate, an existing question now answers differently for an ` +
+        `unchanged model, which is a bug.`,
+    ).toBe(EXPECTED_FINGERPRINT)
+  })
+
+  it('pins the semantics version this fingerprint belongs to', () => {
+    expect(INTERROGATION_SEMANTICS_VERSION).toBe(EXPECTED_SEMANTICS)
+  })
+})


### PR DESCRIPTION
Closes #278. Found by the phase-2 audit of the GitLab showcase, sharpened by ApertureX's P2 design.

## The gap

A report has always carried the catalogue that asked its questions, and each question the catalogue version it first appeared in ([ADR 0063](docs/adr/0063-the-catalogue-deepens-honestly.md)). Nothing carried the engine that answered them.

| Reason an answer flips | Attributable before this PR |
|---|---|
| The model changed | Yes |
| The catalogue deepened and added a question | Yes, via `since` |
| **The engine's condition semantics changed** | **No** |

The third is not hypothetical. ADR 0097 replaced four aspect rules with the ArchiMate 3.2 table, so `missing-relationship` began answering differently for an unchanged model and an unchanged question, with no `since` bump because no question was new. ADR 0083 records the same effect from the other side. Measured: `showcases/kafka` checks clean under 0.22.0 and reports thirteen errors under 1.0.0, on a file neither version edited.

## Why ADR 0063 did not already cover it

ADR 0063 chose honest reopening with no pinning and no stored state, and it was right. Its reader is **stateless**: it re-runs and reads the current answer, so a re-baselined report costs nothing.

The first consumer to **persist** the answers spawns each open question into a row. There an engine change does not re-baseline a report, it mass-closes and reopens a live queue. ADR 0063 did not contemplate that reader because it did not exist.

## What ships

`semantics` on the interrogation report, exported as `INTERROGATION_SEMANTICS_VERSION`, starting at `1`.

- **Not the package version.** Every patch bumps that and almost none change what a condition means. A signal that fires on noise is trusted once and discounted after.
- **Bumps only when an existing question's answer can change for an unchanged model.** ADR 0097 and ADR 0083 would both have bumped it; every visual-editor release between them would not.
- **Required**, because a field a consumer cannot rely on does not solve the problem it was added for.

## The backstop, because the rule is otherwise unenforced

A version bumped by hand is one someone forgets on exactly the commit that matters. `test/interrogation-semantics.test.ts` exercises **all fourteen conditions** the engine understands against one fixture and fingerprints the answers:

```
Condition evaluation changed. If that was deliberate, bump
INTERROGATION_SEMANTICS_VERSION in src/interrogate-command.ts and set
EXPECTED_FINGERPRINT here to <hash>. If it was not deliberate, an existing
question now answers differently for an unchanged model, which is a bug.
```

It fingerprints **answers**, not the report, so a new question, wave or rendering leaves it alone. The fixture discriminates rather than sitting uniformly closed, which is what makes the fingerprint worth anything: ten conditions open across subject counts of 2, 3 and 4, and four closed.

## Compatibility, stated rather than discovered

Both the report schema and its copy inside `ask-result` are `additionalProperties: false`, so **1.1.0 output fails validation against a pinned pre-1.1.0 schema**. The schemas ship with the package and move with it, so only a consumer pinning a schema independently of the runtime is affected. Semver minor. The changelog says this in the same words.

## Deliberately not done

`design-step` (its `progress` is a flattened summary, and a design step is a turn in a loop rather than something anyone persists), and `reconcile` / `check` / `rtm` / `apply` (same property in principle, no consumer persisting them today). [ADR 0106](docs/adr/0106-a-report-says-which-engine-answered.md) records both so the next reader knows they were considered rather than missed.

## One thing this surfaced

Typechecking caught that `ask-command.ts` builds the report **twice**: once by spreading `evaluateCatalogue`, and once as an explicit field-ordering literal a few lines below. The spread inherited the new field; the literal needed it by hand. That duplication is the same hazard as the schema copies #278 documents, now one field wider. Noted on the issue rather than folded in here.

## Verification

Clean-slate `rm -rf dist && pnpm verify`: **91 files, 1550 passed, 1 skipped, exit 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)