### PR TITLE
feat: a declared constraint is checked against the graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 1.1.0
 
+- **Added.** A declared constraint can be checked. A subject may carry
+  `forbids`, naming relationship shapes it rules out, and a violation is a
+  `check` error (YM415).
+  [ADR 0108](docs/adr/0108-a-constraint-nothing-tests-is-a-comment.md).
+
+  ADR 0083 found that a kind nothing constrains is a label; the same held one
+  level up. A shipped model declared "no component reads repository storage
+  directly", recorded three edges doing exactly that, and passed
+  `check --strict`. Its only wiring in the graph was two `association` edges.
+
+  Deliberately narrow: forbid a relationship kind between named endpoints, with
+  exceptions. That covers "everything goes through X" and needs no traversal,
+  so it stays inside the no-derivation boundary. Additive, and a new field, so
+  no existing model can violate a rule it never declared.
+
 - **Added.** An absence can now be audited. A `not-observed` observation may
   record `searched`, the globs and greps that found nothing, and any
   observation may record `measured`, a figure with the method that produced it.

--- a/docs/adr/0108-a-constraint-nothing-tests-is-a-comment.md
+++ b/docs/adr/0108-a-constraint-nothing-tests-is-a-comment.md
@@ -1,0 +1,92 @@
+# A constraint nothing tests is a comment
+
+Status: accepted
+
+[ADR 0083](0083-a-kind-nothing-constrains-is-a-label.md) found that a kind
+nothing constrains is a label. The same argument applies one level up, and the
+GitLab showcase demonstrated it.
+
+That model declared:
+
+> `git-io-through-gitaly` — "No component reads repository storage directly;
+> every git operation crosses Gitaly's RPC surface."
+
+and then recorded three `access` edges to `git-repositories` from subjects that
+were not Gitaly. `yarramate check --strict` returned green. The constraint's
+only wiring in the graph was two `association` edges. It constrained nothing.
+
+This is worse than a missing feature, because the constraint's presence is
+actively misleading. A reader reasonably concludes the rule holds, since the
+tool checked the model and said nothing. The tool never looked.
+
+[ADR 0097](0097-relationship-endpoints-are-validated-against-the-archimate-relationship-table.md)
+made every relationship answerable against the ArchiMate table, so a
+relationship can no longer be silently wrong. A constraint still could.
+
+## Decided
+
+**A subject may declare `forbids`: relationship shapes ruled out, checked
+against the graph. A violation is a `check` error, YM415.**
+
+```yaml
+- id: git-io-through-gitaly
+  kind: constraint
+  name: Git I/O crosses Gitaly
+  forbids:
+    - relationship: access
+      to: git-repositories
+      exceptFrom: [gitaly]
+```
+
+Deliberately narrow: forbid a relationship kind between named endpoints, with
+exceptions. That covers "everything goes through X", which is the most common
+architectural rule anyone writes, and it needs no traversal, so it stays inside
+the no-derivation boundary [ADR 0003](0003-native-document-and-compiler-foundation.md)
+drew and [ADR 0083](0083-a-kind-nothing-constrains-is-a-label.md) reaffirmed.
+
+## Why this one is a check error when the absence rule is not
+
+[ADR 0107](0107-a-recorded-search-makes-an-absence-auditable.md) declined to
+make an unsupported `not-observed` fail the gate, on ADR 0083's reasoning that
+a new rule must not fail existing repositories on upgrade. That reasoning does
+not apply here, and the difference is worth being explicit about.
+
+`forbids` is a **new field**. No existing model has one, so no existing model
+can violate one. The error can only fire on a rule someone deliberately wrote,
+which makes it opt-in by authoring rather than imposed by upgrade. An author who
+writes a rule is asking for it to be enforced; that is the whole point of
+writing it.
+
+And unlike an unverifiable absence, a violated constraint **is** a
+contradiction: the model states a rule and then states a fact that breaks it.
+That is exactly what the gate is for.
+
+## A rule is about the graph, not about who wrote it down
+
+`forbids` is honoured wherever it is declared, and the diagnostic names the
+declaring subject. Putting it on a `constraint` is the idiom and what the field
+description recommends, but the check does not require it: the rule constrains
+the graph, and refusing to evaluate one because it sits on the wrong kind would
+be the same failure this ADR is fixing, arriving from the other direction.
+
+## Deliberately not done
+
+- **No `requires`.** "Every component must be hosted" is a real rule and a
+  different shape: it quantifies over subjects rather than filtering
+  relationships, and it overlaps what the interview already asks. Worth its own
+  decision once `forbids` has been used in anger.
+- **No traversal.** A rule cannot say "reaches X through any path". That would
+  be derivation, which ADR 0003 excludes and ADR 0083's lineage reaffirms.
+- **`principle` is unchanged.** A principle is usually not mechanically
+  testable, and that may be exactly the distinction worth keeping between it
+  and a constraint.
+
+## Consequences
+
+- Additive. A constraint with no `forbids` behaves exactly as before, so every
+  existing model still checks the same way.
+- The GitLab showcase's rule is expressible: it now describes the route through
+  `git-storage-service` in prose, and can be tightened to a predicate once this
+  ships.
+- A rule that can be written down and never fires is now visibly inert, which
+  is a better problem than one that cannot be written down at all.

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -127,6 +127,24 @@
         "supersedes": {
           "$ref": "#/$defs/successionReferences"
         },
+        "forbids": {
+          "description": "Relationship shapes this subject rules out, checked against the graph. A constraint nothing tests is a comment. Deliberately narrow: forbid a relationship kind between named endpoints, with exceptions, which covers \"everything goes through X\" and needs no traversal.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["relationship"],
+            "anyOf": [{ "required": ["from"] }, { "required": ["to"] }],
+            "properties": {
+              "relationship": { "type": "string", "minLength": 1 },
+              "from": { "type": "string", "minLength": 1 },
+              "to": { "type": "string", "minLength": 1 },
+              "exceptFrom": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+              "exceptTo": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+            }
+          }
+        },
         "constraints": {
           "type": "array",
           "items": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -98,6 +98,23 @@ interface NativeConcept {
     readonly ref: string
     readonly expects?: NativeExpectedObservation
   }>
+  /**
+   * Relationship shapes this subject rules out, checked against the graph.
+   *
+   * A constraint nothing tests is a comment: it reads like a rule, survives
+   * review because the prose is true, and never once contradicts the model it
+   * is attached to (ADR 0108). Deliberately narrow: forbid a relationship kind
+   * between named endpoints, with exceptions. That covers "everything goes
+   * through X", the most common architectural rule anyone writes, and needs no
+   * traversal, so it stays inside the no-derivation boundary of ADR 0003.
+   */
+  readonly forbids?: ReadonlyArray<{
+    readonly relationship: string
+    readonly from?: string
+    readonly to?: string
+    readonly exceptFrom?: readonly string[]
+    readonly exceptTo?: readonly string[]
+  }>
   readonly references?: readonly NativeIdentifiedReference[]
   readonly presentIn?: readonly string[]
   readonly attestations?: ReadonlyArray<{
@@ -1060,6 +1077,19 @@ function compileWorkspaceResolved(
     seenDocumentIds.add(value.id)
   }
 
+  // Every `forbids` rule in the workspace, with the subject that declared it.
+  // A rule is about the graph, not about who wrote it down, so it is applied
+  // wherever it was declared and the message names the declarer (ADR 0108).
+  interface ForbidRule {
+    readonly declaredBy: string
+    readonly relationship: string
+    readonly from?: string
+    readonly to?: string
+    readonly exceptFrom: ReadonlySet<string>
+    readonly exceptTo: ReadonlySet<string>
+  }
+  const forbidRules: ForbidRule[] = []
+
   const conceptByQualifiedId = new Map<
     string,
     {
@@ -1082,6 +1112,20 @@ function compileWorkspaceResolved(
       ),
     ),
   )
+  for (const { value } of documents) {
+    for (const concept of value.concepts) {
+      for (const rule of concept.forbids ?? []) {
+        forbidRules.push({
+          declaredBy: concept.id,
+          relationship: rule.relationship,
+          ...(rule.from === undefined ? {} : { from: rule.from }),
+          ...(rule.to === undefined ? {} : { to: rule.to }),
+          exceptFrom: new Set(rule.exceptFrom ?? []),
+          exceptTo: new Set(rule.exceptTo ?? []),
+        })
+      }
+    }
+  }
   // Subject identity is the authored id, unique across the workspace, so a
   // reference resolves as written. Kept as a named step rather than inlined
   // because every reference in the model passes through here, and that is
@@ -1817,6 +1861,30 @@ function compileWorkspaceResolved(
             candidates.length === 0
               ? ''
               : `; ArchiMate 3.2 permits: ${candidates.join(', ')}`
+          // A declared rule about the graph, checked against the graph. The
+          // field is new, so no existing model can violate one: this can only
+          // fire on a rule someone deliberately wrote (ADR 0108).
+          for (const rule of forbidRules) {
+            const kindMatches =
+              rule.relationship === relationship.kind ||
+              rule.relationship === policy.coreKind
+            if (!kindMatches) continue
+            if (rule.from !== undefined && rule.from !== relationship.from) {
+              continue
+            }
+            if (rule.to !== undefined && rule.to !== relationship.to) continue
+            if (rule.exceptFrom.has(relationship.from)) continue
+            if (rule.exceptTo.has(relationship.to)) continue
+            const pointer = `/relationships/${index}/kind`
+            diagnostics.push({
+              severity: 'error',
+              code: 'YM415',
+              message:
+                `Relationship "${relationship.kind}" from "${relationship.from}" ` +
+                `to "${relationship.to}" is forbidden by "${rule.declaredBy}"`,
+              ...location(['relationships', index, 'kind'], pointer),
+            })
+          }
           if (!permitted.has(policy.coreKind)) {
             const pointer = `/relationships/${index}/kind`
             const source = location(['relationships', index, 'kind'], pointer)

--- a/test/constraint-predicates.test.ts
+++ b/test/constraint-predicates.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { compileWorkspace } from '../src/index.js'
+
+// A constraint nothing tests is a comment. ADR 0083 made the same argument one
+// level down: a kind nothing constrains is a label. These pin that a declared
+// rule about the graph is now checked against the graph (ADR 0108).
+
+const profile = 'yarramate/core@0.1'
+
+const document = (forbids: string, extraRelationships = '') =>
+  [
+    'format: yarramate/v1',
+    'id: main',
+    `profile: ${profile}`,
+    'concepts:',
+    '  - id: git-io-through-gitaly',
+    '    kind: constraint',
+    '    name: Git I/O crosses Gitaly',
+    forbids,
+    '  - id: gitaly',
+    '    kind: applicationComponent',
+    '    name: Gitaly',
+    '  - id: search-indexer',
+    '    kind: applicationComponent',
+    '    name: Search indexer',
+    '  - id: git-repositories',
+    '    kind: artifact',
+    '    name: Git repositories',
+    'relationships:',
+    '  - id: gitaly-accesses-repositories',
+    '    kind: access',
+    '    from: gitaly',
+    '    to: git-repositories',
+    '    mode: read-write',
+    extraRelationships,
+    '',
+  ]
+    .filter((line) => line !== '')
+    .join('\n')
+
+const rule = [
+  '    forbids:',
+  '      - relationship: access',
+  '        to: git-repositories',
+  '        exceptFrom: ["gitaly"]',
+].join('\n')
+
+const violation = [
+  '  - id: indexer-accesses-repositories',
+  '    kind: access',
+  '    from: search-indexer',
+  '    to: git-repositories',
+  '    mode: read',
+].join('\n')
+
+const compile = (source: string) =>
+  compileWorkspace([{ path: 'architecture/main.yaml', source }])
+
+describe('a declared constraint is checked against the graph', () => {
+  it('passes when only the excepted subject reaches the target', () => {
+    const result = compile(document(rule))
+    expect(result.ok, JSON.stringify('diagnostics' in result ? result.diagnostics : [])).toBe(true)
+  })
+
+  it('fails, naming the rule and the relationship, when another subject does', () => {
+    const result = compile(document(rule, violation))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    const forbidden = result.diagnostics.filter(({ code }) => code === 'YM415')
+    expect(forbidden).toHaveLength(1)
+    expect(forbidden[0]?.message).toContain('search-indexer')
+    expect(forbidden[0]?.message).toContain('git-repositories')
+    expect(forbidden[0]?.message).toContain('git-io-through-gitaly')
+  })
+
+  it('is inert when the model declares no rule, so nothing existing breaks', () => {
+    const result = compile(document('    description: A rule with no predicate.', violation))
+    expect(result.ok, JSON.stringify('diagnostics' in result ? result.diagnostics : [])).toBe(true)
+  })
+
+  it('honours exceptTo as well as exceptFrom', () => {
+    const scoped = [
+      '    forbids:',
+      '      - relationship: access',
+      '        from: search-indexer',
+      '        exceptTo: ["git-repositories"]',
+    ].join('\n')
+    const result = compile(document(scoped, violation))
+    expect(result.ok, JSON.stringify('diagnostics' in result ? result.diagnostics : [])).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #280. Found by the phase-2 audit of the GitLab showcase.

## The gap

[ADR 0083](docs/adr/0083-a-kind-nothing-constrains-is-a-label.md) found that a kind nothing constrains is a label. The same argument applies one level up.

The GitLab model declared:

> `git-io-through-gitaly` — "No component reads repository storage directly; every git operation crosses Gitaly's RPC surface."

and then recorded three `access` edges to `git-repositories` from subjects that were not Gitaly. **`check --strict` returned green.** The constraint's only wiring in the graph was two `association` edges.

That is worse than a missing feature, because the constraint's presence is actively misleading. A reader reasonably concludes the rule holds, since the tool checked the model and said nothing. The tool never looked.

ADR 0097 made every relationship answerable against the ArchiMate table, so a relationship can no longer be silently wrong. A constraint still could.

## What ships

```yaml
- id: git-io-through-gitaly
  kind: constraint
  name: Git I/O crosses Gitaly
  forbids:
    - relationship: access
      to: git-repositories
      exceptFrom: [gitaly]
```

A violation is a `check` error, **YM415**, anchored at the offending relationship and naming the rule that forbids it.

Deliberately narrow: forbid a relationship kind between named endpoints, with exceptions. That covers "everything goes through X", the most common architectural rule anyone writes, and it needs no traversal, so it stays inside the no-derivation boundary [ADR 0003](docs/adr/0003-native-document-and-compiler-foundation.md) drew and ADR 0083's lineage reaffirmed.

## Why this gates when #279 did not

I made opposite calls on two issues that look similar, so [ADR 0108](docs/adr/0108-a-constraint-nothing-tests-is-a-comment.md) states the difference explicitly rather than leaving it to read as inconsistency:

| | #279 unsupported absence | #280 violated constraint |
|---|---|---|
| Enforcement | counted in the summary | **`check` error** |
| Can an existing model trip it? | yes, on upgrade | **no**, the field is new |
| Is it a contradiction? | no, an unverifiable claim | **yes**, the model breaks its own stated rule |

`forbids` is a new field, so no existing model can violate a rule it never declared. The error is opt-in by authoring rather than imposed by upgrade, which is exactly the objection ADR 0083 raised against gating `unconstrained-kind`. An author who writes a rule is asking for it to be enforced.

## A rule is about the graph, not about who wrote it down

`forbids` is honoured wherever it is declared, and the diagnostic names the declaring subject. Putting it on a `constraint` is the idiom, but the check does not require it: refusing to evaluate a rule because it sat on the wrong kind would be this same failure arriving from the other direction.

## Deliberately not done

**No `requires`** ("every component must be hosted" quantifies over subjects rather than filtering relationships, and overlaps what the interview already asks). **No traversal** (that would be derivation). **`principle` unchanged** — a principle is usually not mechanically testable, which may be the distinction worth keeping between it and a constraint.

## Verification

Clean-slate `rm -rf dist && pnpm verify`: **92 files, 1554 passed, 1 skipped, exit 0.**

Four tests: it fires on a violation naming both the rule and the relationship, stays quiet when only the excepted subject reaches the target, honours `exceptTo` as well as `exceptFrom`, and is inert when a constraint declares no predicate, so nothing existing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)