### PR TITLE
feat: a succession can be partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 1.1.0
 
+- **Added.** A succession can be partial. `supersedes` accepts
+  `{ subject, inRespectOf }` beside the bare id, and the interview asks for the
+  respect when a subject supersedes a predecessor that is still current
+  (`unscoped-succession`, catalogue 1.1).
+  [ADR 0109](docs/adr/0109-a-succession-can-be-partial.md).
+
+  Every succession the field could express was total. A shipped model claimed
+  Zoekt superseded the Elasticsearch indexer while the source it was built from
+  says Zoekt "does not replace" it for any scope but code search. The prose
+  carried the qualifier and the field could not, and `ask --compare` reads the
+  field, so the declared target architecture became the deletion of a component
+  nobody is deleting.
+
+  A selector may now omit `kinds`, which selects every concept: succession can
+  be declared on any subject, and enumerating the kinds that may carry it would
+  be a list nobody can keep right. Additive; the bare succession form and every
+  existing selector are unchanged.
+
 - **Added.** A declared constraint can be checked. A subject may carry
   `forbids`, naming relationship shapes it rules out, and a violation is a
   `check` error (YM415).

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "1.0"
+version: "1.1"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -1549,3 +1549,34 @@ questions:
       falsifiable. If nothing in scope is assigned to it, reclassify it
       to a kind that does carry a claim, or retire it with a description
       saying why it sits outside this architecture.
+
+  - id: succession-unscoped
+    wave: hygiene
+    since: "1.1"
+    scope: subject
+    subjects: {}
+    trigger:
+      - condition: unscoped-succession
+    question: >-
+      {subject.name} supersedes a predecessor that is still current. In what
+      respect does it supersede it, and what remains of the predecessor?
+    askPlain: >-
+      {subject.name} takes over from something that is still here. What part
+      does it take over, and what is the old one still needed for?
+    materiality: >-
+      A succession that replaced its predecessor outright says so by the
+      predecessor being gone. One where both are still current is usually
+      partial, and the part it does not cover is exactly what a reader
+      planning against the model needs to know. An unqualified claim reads
+      as a total replacement to every surface that consumes the field, and
+      `ask --compare` reads the field rather than the prose beside it, so a
+      partial succession recorded without its scope turns into a declared
+      removal of something nobody is removing.
+    authority: either
+    resolution: >-
+      Record the respect on the succession entry:
+      `supersedes: [{ subject: <predecessor>, inRespectOf: <the part taken
+      over> }]`. If the succession really is total, retire the predecessor,
+      which says the same thing without a qualifier. If the two subjects
+      simply coexist and neither takes over from the other, the succession
+      is the wrong claim; remove it.

--- a/docs/adr/0109-a-succession-can-be-partial.md
+++ b/docs/adr/0109-a-succession-can-be-partial.md
@@ -1,0 +1,93 @@
+# A succession can be partial
+
+Status: accepted
+
+`supersedes` took a list of predecessor ids and nothing else, so every
+succession it could express was total. Most real ones are not.
+
+## What it cost
+
+The GitLab showcase recorded, in structured fields:
+
+- `zoekt-search.supersedes: [es-indexer]`
+- `es-indexer.presentIn: [single-instance]` only
+
+GitLab's own `doc/integration/zoekt/_index.md:40`, at the commit that model was
+built from:
+
+> Zoekt handles only code search and **does not replace** Elasticsearch or
+> OpenSearch. For all other search scopes, including comments, commits, epics,
+> issues, merge requests, milestones, projects, users, and wikis, Elasticsearch
+> or OpenSearch is still required.
+
+The succession was real and **scoped**: true for code search, false for
+everything else. The subject was the indexer, which feeds exactly the scopes the
+doc lists, so the unqualified claim failed on its own terms.
+
+The author knew this. The `description` on both subjects carried "for code
+search" correctly. What the author could not do was put the qualifier anywhere
+the tool would read.
+
+Then the tooling amplified it. `ask --compare` reads the **fields**, not the
+prose, and reported the target architecture as `0 added, 4 removed`: the entire
+declared future consisted of deleting the one component that was not being
+deleted. A reader who trusts the structured surface over the prose beside it,
+which is the entire reason for having a structured surface, got the architecture
+backwards.
+
+## Decided
+
+**A succession entry may carry the respect in which it supersedes.**
+
+```yaml
+supersedes:
+  - subject: es-indexer
+    inRespectOf: code search
+```
+
+The bare string form is unchanged and still means a total succession.
+
+**The respect is a claim of its own**, `yarramate/lineage/supersedes-respect`,
+whose id is the succession claim's id suffixed with `~respect`. `GraphClaim` is
+a triple, and widening it to carry one optional string would widen the published
+graph schema for every claim in the model to serve one predicate.
+
+**The interview asks for it**: `unscoped-succession` fires when a subject
+supersedes a predecessor that is **not retired** and records no respect.
+
+## Why the trigger turns on the predecessor's status
+
+A succession that replaced its predecessor outright says so by the predecessor
+being gone. Asking that author for a qualifier would be a hum, which is exactly
+the failure [ADR 0083](0083-a-kind-nothing-constrains-is-a-label.md) warned of
+when it declined to ship a question firing 153 times.
+
+A succession where both subjects remain current is the interesting case: either
+the transition is in progress, which the model already permits and calls real,
+or the succession is partial. Both are worth a sentence, and neither is
+answerable from the graph.
+
+## A selector may now omit its kinds
+
+Succession can be declared on any subject, so the question needed a
+kind-agnostic selector. Enumerating the kinds that may carry `supersedes` would
+be a list nobody can keep right rather than a constraint, so `subjects.kinds`
+became optional and absent now means every concept. This is additive: every
+existing selector names its kinds and behaves exactly as before.
+
+## Consequences
+
+- Additive on every surface. The bare form still compiles, still means what it
+  meant, and every existing model checks the same way.
+- The catalogue goes 1.0 to 1.1, a minor: it adds a question and changes no
+  trigger, which is the rule `docs/INTERROGATION.md` sets.
+- `INTERROGATION_SEMANTICS_VERSION` does **not** move.
+  [ADR 0106](0106-a-report-says-which-engine-answered.md) bumps it only when an
+  existing question's answer can change for an unchanged model, and a new
+  condition changes no existing answer. The fingerprint in
+  `test/interrogation-semantics.test.ts` does move, because that fixture gained
+  a question, and its failure message now distinguishes the two causes rather
+  than telling every author to bump the version.
+- `ask --compare` still reports a removal rather than a scoped succession.
+  Recording the respect is what this ADR decides; teaching the comparison to
+  read it is a separate change, and the data has to exist first.

--- a/schema/yarramate-document.schema.json
+++ b/schema/yarramate-document.schema.json
@@ -255,7 +255,18 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "$ref": "#/$defs/reference"
+        "oneOf": [
+          { "$ref": "#/$defs/reference" },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["subject", "inRespectOf"],
+            "properties": {
+              "subject": { "$ref": "#/$defs/reference" },
+              "inRespectOf": { "$ref": "#/$defs/nonEmptyText" }
+            }
+          }
+        ]
       }
     },
     "relationship": {

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -104,9 +104,7 @@
       "description": "Which subjects a subject-scope question applies to. Field vocabulary mirrors the projection query selector (ADR 0017).",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "kinds"
-      ],
+      
       "properties": {
         "kinds": {
           "type": "array",
@@ -489,6 +487,19 @@
           "properties": {
             "condition": {
               "const": "unconstrained-kind"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject supersedes a predecessor that is still current, and does not say in what respect. A succession that replaced its predecessor outright says so by the predecessor being gone; one where both remain is usually partial, and the respect is the part a reader needs (ADR 0109).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unscoped-succession"
             }
           }
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -92,7 +92,7 @@ interface NativeConcept {
   readonly owner?: string
   readonly folder?: string
   readonly distinctFrom?: readonly string[]
-  readonly supersedes?: readonly string[]
+  readonly supersedes?: readonly NativeSuccession[]
   readonly constraints?: ReadonlyArray<{
     readonly id: string
     readonly ref: string
@@ -389,6 +389,29 @@ const aliasClaimId = (subject: string, alias: string) =>
 
 const distinctFromClaimId = (subject: string, other: string) =>
   `${subject}~distinct-from-${utf8Hex(other)}`
+
+/**
+ * A succession entry: a bare predecessor id, or one with the respect in which
+ * it was superseded.
+ *
+ * The scope is load-bearing rather than decorative. A model claimed that Zoekt
+ * superseded the Elasticsearch indexer, unqualified, while the source it was
+ * built from says Zoekt "handles only code search and does not replace
+ * Elasticsearch". The prose carried the qualifier and the field could not, and
+ * `ask --compare` reads the field, so the declared target architecture became
+ * the deletion of a component that is not being deleted (ADR 0109).
+ */
+export type NativeSuccession =
+  | string
+  | { readonly subject: string; readonly inRespectOf: string }
+
+export const successionSubject = (entry: NativeSuccession): string =>
+  typeof entry === 'string' ? entry : entry.subject
+
+export const successionScope = (
+  entry: NativeSuccession,
+): string | undefined =>
+  typeof entry === 'string' ? undefined : entry.inRespectOf
 
 const supersedesClaimId = (subject: string, predecessor: string) =>
   `${subject}~supersedes-${utf8Hex(predecessor)}`
@@ -1182,7 +1205,7 @@ function compileWorkspaceResolved(
               [
                 concept.id,
                 concept.supersedes.map((predecessor) =>
-                  qualifyReference(value.id, predecessor),
+                  qualifyReference(value.id, successionSubject(predecessor)),
                 ),
               ] as const,
             ],
@@ -1466,7 +1489,10 @@ function compileWorkspaceResolved(
         concept.supersedes ?? []
       ).entries()) {
         const pointer = `/concepts/${index}/supersedes/${supersedesIndex}`
-        const predecessorIdentity = qualifyReference(value.id, predecessor)
+        const predecessorIdentity = qualifyReference(
+          value.id,
+          successionSubject(predecessor),
+        )
         const subjectIdentity = concept.id
         if (!conceptByQualifiedId.has(predecessorIdentity)) {
           const source = location(
@@ -1476,7 +1502,7 @@ function compileWorkspaceResolved(
           diagnostics.push({
             severity: 'error',
             code: 'YM312',
-            message: `Unresolved succession reference "${predecessor}"`,
+            message: `Unresolved succession reference "${successionSubject(predecessor)}"`,
             path: input.path,
             pointer,
             line: source.line,
@@ -2035,18 +2061,37 @@ function compileWorkspaceResolved(
       for (const [supersedesIndex, predecessor] of (
         concept.supersedes ?? []
       ).entries()) {
-        const predecessorIdentity = qualifyReference(value.id, predecessor)
+        const predecessorIdentity = qualifyReference(
+          value.id,
+          successionSubject(predecessor),
+        )
+        const scope = successionScope(predecessor)
+        const successionSource = location(
+          ['concepts', index, 'supersedes', supersedesIndex],
+          `/concepts/${index}/supersedes/${supersedesIndex}`,
+        )
         claims.push({
           id: supersedesClaimId(subject, predecessorIdentity),
           subject,
           predicate: 'yarramate/lineage/supersedes',
           object: { ref: predecessorIdentity },
           origin: 'declared',
-          source: location(
-            ['concepts', index, 'supersedes', supersedesIndex],
-            `/concepts/${index}/supersedes/${supersedesIndex}`,
-          ),
+          source: successionSource,
         })
+        // The respect is a claim of its own rather than a field on the
+        // succession claim: `GraphClaim` is a triple, and widening it would
+        // widen the published graph schema for one optional string. Its id is
+        // the succession claim's, suffixed, so the two correlate.
+        if (scope !== undefined) {
+          claims.push({
+            id: `${supersedesClaimId(subject, predecessorIdentity)}~respect`,
+            subject,
+            predicate: 'yarramate/lineage/supersedes-respect',
+            object: { value: scope },
+            origin: 'declared',
+            source: successionSource,
+          })
+        }
       }
       if (concept.owner !== undefined) {
         claims.push({

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -50,7 +50,13 @@ const validateCatalogue = new Ajv2020({ allErrors: true }).compile(
 export const INTERROGATION_SEMANTICS_VERSION = '1'
 
 export interface CatalogueSelector {
-  readonly kinds: readonly string[]
+  /**
+   * Kinds to select. Absent selects every concept, which is what a
+   * kind-agnostic condition wants: succession can be declared on any subject,
+   * so enumerating the kinds that may carry it would be a list nobody can keep
+   * right rather than a constraint (ADR 0109).
+   */
+  readonly kinds?: readonly string[]
   readonly kindMatching?: 'exact' | 'descendants'
   readonly statuses?: readonly string[]
   readonly documents?: readonly string[]
@@ -106,6 +112,7 @@ export type CatalogueCondition =
   | { readonly condition: 'missing-attestation'; readonly topic: string }
   | { readonly condition: 'near-duplicate' }
   | { readonly condition: 'unconstrained-kind' }
+  | { readonly condition: 'unscoped-succession' }
 
 export interface CatalogueQuestion {
   readonly id: string
@@ -339,9 +346,17 @@ const selectSubjects = (
   // The schema's declared default for kindMatching is descendants, so a
   // profile-derived kind satisfies a catalogue written against its parent.
   const matching = selector.kindMatching ?? 'descendants'
-  let ids = [...index.concepts].filter((id) =>
-    kindMatches(index.kindOf.get(id), selector.kinds, matching, profileContext),
-  )
+  let ids =
+    selector.kinds === undefined
+      ? [...index.concepts]
+      : [...index.concepts].filter((id) =>
+          kindMatches(
+            index.kindOf.get(id),
+            selector.kinds!,
+            matching,
+            profileContext,
+          ),
+        )
   if (selector.statuses !== undefined) {
     const statuses = new Set(selector.statuses)
     ids = ids.filter((id) => {
@@ -468,6 +483,28 @@ const conditionHolds = (
       return !(index.claimsBySubject.get(subjectId!) ?? []).some(
         ({ predicate }) => predicate === condition.predicate,
       )
+    case 'unscoped-succession': {
+      // A succession that replaced its predecessor outright says so by the
+      // predecessor being gone. One where both subjects are still current is
+      // usually partial, and the respect is the part a reader needs: a model
+      // claimed Zoekt superseded the Elasticsearch indexer while the source
+      // said Zoekt "does not replace" it for any scope but code search
+      // (ADR 0109). Fires only where the qualifier is missing AND the
+      // predecessor is still current, so a completed replacement stays quiet.
+      const claims = index.claimsBySubject.get(subjectId!) ?? []
+      return claims.some((claim) => {
+        if (claim.predicate !== 'yarramate/lineage/supersedes') return false
+        if (!('ref' in claim.object)) return false
+        const scoped = claims.some(
+          (other) =>
+            other.predicate === 'yarramate/lineage/supersedes-respect' &&
+            other.id === `${claim.id}~respect`,
+        )
+        if (scoped) return false
+        const predecessorStatus = index.statusOf.get(claim.object.ref)
+        return predecessorStatus !== 'retired'
+      })
+    }
     case 'missing-relationship': {
       // Relationship kinds resolve through profile lineage by default, the
       // same rule as selectors: a catalogue written against core kinds must

--- a/src/subject-references.ts
+++ b/src/subject-references.ts
@@ -46,6 +46,14 @@ export const SUBJECT_REFERENCE_POSITIONS: readonly SubjectReferencePosition[] =
       path: ['concepts', '*', 'supersedes', '*'],
       form: 'reference',
     },
+    // The scoped succession form, `{ subject, inRespectOf }` (ADR 0109). A
+    // rename has to move this one too, or a scoped succession would silently
+    // keep pointing at the old address while the bare form beside it moved.
+    {
+      group: 'document',
+      path: ['concepts', '*', 'supersedes', '*', 'subject'],
+      form: 'reference',
+    },
     {
       group: 'document',
       path: ['concepts', '*', 'constraints', '*', 'ref'],

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -71,7 +71,7 @@ describe('core-enrichment 1.0 interaction wave', () => {
         id: string
       }[]
     }
-    expect(catalogue.version).toBe('1.0')
+    expect(catalogue.version).toBe('1.1')
     const added = catalogue.questions.filter((question) => question.since === '0.9')
     expect(added.length).toBeGreaterThan(0)
     for (const question of added) {

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -22,7 +22,7 @@ import {
 // existing question answers.
 
 const EXPECTED_SEMANTICS = '1'
-const EXPECTED_FINGERPRINT = '50f0a37db8ad99e1'
+const EXPECTED_FINGERPRINT = '86669858b84e4d8f'
 
 const profile = 'yarramate/core@0.1'
 
@@ -107,6 +107,7 @@ const conditions: readonly (readonly [string, readonly string[]])[] = [
   ['missing-attestation', ['      - condition: missing-attestation', '        topic: adequacy']],
   ['near-duplicate', ['      - condition: near-duplicate']],
   ['unconstrained-kind', ['      - condition: unconstrained-kind']],
+  ['unscoped-succession', ['      - condition: unscoped-succession']],
 ]
 
 const catalogue = [
@@ -181,11 +182,18 @@ describe('interrogation semantics are versioned and pinned', () => {
       .slice(0, 16)
     expect(
       fingerprint,
-      `Condition evaluation changed. If that was deliberate, bump ` +
-        `INTERROGATION_SEMANTICS_VERSION in src/interrogate-command.ts and ` +
-        `set EXPECTED_FINGERPRINT here to ${fingerprint}. If it was not ` +
-        `deliberate, an existing question now answers differently for an ` +
-        `unchanged model, which is a bug.`,
+      `The fingerprint moved. Two different causes, and they want ` +
+        `different responses.\n` +
+        `  ADDED A CONDITION: this fixture gained a question, so only ` +
+        `EXPECTED_FINGERPRINT changes. Set it to ${fingerprint}. Do NOT bump ` +
+        `INTERROGATION_SEMANTICS_VERSION: no existing question answers ` +
+        `differently.\n` +
+        `  CHANGED WHAT A CONDITION MEANS: an existing question now answers ` +
+        `differently for an unchanged model. Bump ` +
+        `INTERROGATION_SEMANTICS_VERSION in src/interrogate-command.ts, set ` +
+        `EXPECTED_SEMANTICS here to match, and set EXPECTED_FINGERPRINT to ` +
+        `${fingerprint}.\n` +
+        `  NEITHER: it is a bug. Answers moved and nothing asked them to.`,
     ).toBe(EXPECTED_FINGERPRINT)
   })
 

--- a/test/scoped-succession.test.ts
+++ b/test/scoped-succession.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { scanSubjectReferences } from '../src/subject-references.js'
+import {
+  compileWorkspace,
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// A succession that replaced its predecessor outright says so by the
+// predecessor being gone. One where both are still current is usually partial,
+// and the respect is the part a reader needs: a model claimed Zoekt superseded
+// the Elasticsearch indexer while the source it was built from says Zoekt
+// "does not replace" it for any scope but code search (ADR 0109).
+
+const model = (supersedes: string, predecessorStatus: string) =>
+  [
+    'format: yarramate/v1',
+    'id: main',
+    'profile: yarramate/core@0.1',
+    'concepts:',
+    '  - id: zoekt',
+    '    kind: applicationComponent',
+    '    name: Zoekt',
+    '    status: current',
+    supersedes,
+    '  - id: es-indexer',
+    '    kind: applicationComponent',
+    '    name: Elasticsearch indexer',
+    `    status: ${predecessorStatus}`,
+    'relationships: []',
+    '',
+  ].join('\n')
+
+const bare = ['    supersedes:', '      - es-indexer'].join('\n')
+const scoped = [
+  '    supersedes:',
+  '      - subject: es-indexer',
+  '        inRespectOf: code search',
+].join('\n')
+
+const compile = (source: string) =>
+  compileWorkspace([{ path: 'architecture/main.yaml', source }])
+
+const diagnosticsOf = (result: ReturnType<typeof compile>) =>
+  JSON.stringify('diagnostics' in result ? result.diagnostics : [])
+
+describe('a succession can say in what respect it supersedes', () => {
+  it('accepts the bare form, which is unchanged', () => {
+    const result = compile(model(bare, 'retired'))
+    expect(result.ok, diagnosticsOf(result)).toBe(true)
+  })
+
+  it('accepts the scoped form', () => {
+    const result = compile(model(scoped, 'current'))
+    expect(result.ok, diagnosticsOf(result)).toBe(true)
+  })
+
+  it('records the respect as its own claim, correlated by id', () => {
+    const result = compile(model(scoped, 'current'))
+    if (!result.ok) throw new Error('expected the fixture to compile')
+    const succession = result.graph.claims.find(
+      ({ predicate }) => predicate === 'yarramate/lineage/supersedes',
+    )
+    const respect = result.graph.claims.find(
+      ({ predicate }) => predicate === 'yarramate/lineage/supersedes-respect',
+    )
+    expect(succession).toBeDefined()
+    expect(respect?.id).toBe(`${succession?.id}~respect`)
+    expect(respect?.object).toEqual({ value: 'code search' })
+  })
+
+  it('still resolves the predecessor reference through the scoped form', () => {
+    const dangling = [
+      '    supersedes:',
+      '      - subject: no-such-subject',
+      '        inRespectOf: code search',
+    ].join('\n')
+    const result = compile(model(dangling, 'current'))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.diagnostics.some(({ code }) => code === 'YM312')).toBe(true)
+    expect(
+      result.diagnostics.some(({ message }) =>
+        message.includes('no-such-subject'),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('the interview asks for a respect the model did not record', () => {
+  const catalogue = [
+    'format: yarramate/question-catalogue/v1',
+    'id: probe',
+    'version: "1.0"',
+    'profile: yarramate/core@0.1',
+    'waves:',
+    '  - id: hygiene',
+    '    name: Hygiene',
+    'questions:',
+    '  - id: succession-unscoped',
+    '    wave: hygiene',
+    '    scope: subject',
+    '    subjects: {}',
+    '    trigger:',
+    '      - condition: unscoped-succession',
+    '    question: In what respect does {subject.name} supersede it?',
+    '    materiality: A partial succession reads as a total one.',
+    '    authority: either',
+    '    resolution: Record inRespectOf, or retire the predecessor.',
+    '',
+  ].join('\n')
+
+  const askedOf = (source: string) => {
+    const compilation = compileWorkspaceWithProfileContext([
+      { path: 'architecture/main.yaml', source },
+    ])
+    if (!compilation.ok) throw new Error('fixture did not compile')
+    const loaded = loadQuestionCatalogue({ path: 'c.yaml', source: catalogue })
+    if (!loaded.ok) throw new Error('fixture catalogue did not load')
+    const question = evaluateCatalogue(
+      loaded.catalogue,
+      compilation.graph,
+      compilation.profileContext,
+    ).waves
+      .flatMap(({ questions }) => questions)
+      .find(({ id }) => id === 'succession-unscoped')
+    return {
+      open: question?.open ?? false,
+      subjects: (question?.subjects ?? []).map(({ id }) => id),
+    }
+  }
+
+  it('opens when the predecessor is still current and no respect is given', () => {
+    const asked = askedOf(model(bare, 'current'))
+    expect(asked.open).toBe(true)
+    expect(asked.subjects).toEqual(['zoekt'])
+  })
+
+  it('closes once the respect is recorded', () => {
+    expect(askedOf(model(scoped, 'current')).open).toBe(false)
+  })
+
+  it('stays closed for a completed succession, where the predecessor is retired', () => {
+    // A total replacement says so by the predecessor being gone. Asking for a
+    // qualifier there would be a hum, which is the failure ADR 0083 warned of.
+    expect(askedOf(model(bare, 'retired')).open).toBe(false)
+  })
+})
+
+describe('a rename can find a scoped succession', () => {
+  it('scans the subject inside the object form as an address', () => {
+    // Registering the position is what makes a rename move it. Without this,
+    // a scoped succession would keep pointing at the old address while the
+    // bare form beside it moved, which is the worst kind of half-rename.
+    const hits = scanSubjectReferences(model(scoped, 'current'), 'document')
+    const found = hits.hits.filter(({ pointer }) =>
+      pointer.includes('supersedes'),
+    )
+    expect(found.map(({ address }) => address)).toContain('es-indexer')
+    expect(found.map(({ pointer }) => pointer)).toContain(
+      '/concepts/0/supersedes/0/subject',
+    )
+  })
+
+  it('scans the bare form too, so both spellings move together', () => {
+    const hits = scanSubjectReferences(model(bare, 'current'), 'document')
+    const bareHits = hits.hits.filter(({ pointer }) =>
+      pointer.includes('supersedes'),
+    )
+    expect(bareHits.map(({ address }) => address)).toContain('es-indexer')
+    expect(bareHits.map(({ pointer }) => pointer)).toContain(
+      '/concepts/0/supersedes/0',
+    )
+  })
+})


### PR DESCRIPTION
Closes #281. The last of the four issues from the phase-2 audit of the GitLab showcase.

## The gap

`supersedes` took a list of predecessor ids and nothing else, so every succession it could express was total. Most real ones are not.

The GitLab model recorded, in structured fields:

- `zoekt-search.supersedes: [es-indexer]`
- `es-indexer.presentIn: [single-instance]` only

GitLab's own `doc/integration/zoekt/_index.md:40`, at the pinned commit:

> Zoekt handles only code search and **does not replace** Elasticsearch or OpenSearch. For all other search scopes, including comments, commits, epics, issues, merge requests, milestones, projects, users, and wikis, Elasticsearch or OpenSearch is still required.

**The author knew this.** The `description` on both subjects carried "for code search" correctly. What the author could not do was put the qualifier anywhere the tool would read.

Then the tooling amplified it. `ask --compare` reads the **fields**, not the prose, and reported:

```
0 added, 4 removed
```

The entire declared target architecture was the deletion of the one component that is not being deleted.

## What ships

```yaml
supersedes:
  - subject: es-indexer
    inRespectOf: code search
```

The bare string form is unchanged and still means a total succession.

The respect is **a claim of its own**, `yarramate/lineage/supersedes-respect`, whose id is the succession claim's suffixed with `~respect`. `GraphClaim` is a triple, and widening it to carry one optional string would widen the published graph schema for every claim in the model to serve one predicate.

**The interview asks for it**: `unscoped-succession` fires when a subject supersedes a predecessor that is **not retired** and records no respect. The predecessor's status is the whole trigger. A succession that replaced its predecessor outright says so by the predecessor being gone, and asking that author for a qualifier would be exactly the hum ADR 0083 declined to ship.

**A selector may now omit `kinds`**, selecting every concept. Succession can be declared on any subject, so enumerating the kinds that may carry it would be a list nobody can keep right rather than a constraint. Additive: every existing selector names its kinds and behaves as before.

## The semantics version does not move

[ADR 0106](docs/adr/0106-a-report-says-which-engine-answered.md) bumps `INTERROGATION_SEMANTICS_VERSION` only when an **existing** question's answer can change for an unchanged model. A new condition changes no existing answer, so it stays at `1`.

The fingerprint in `test/interrogation-semantics.test.ts` does move, because that fixture gained a question. On its first real use the guard's message would have told me to bump the version, which would have been wrong. **The message now separates three cases**: added a condition (fingerprint only), changed what a condition means (bump both), or neither, which is a bug.

## A guard caught a real bug

`subject-references.test.ts` tracks every address-typed position across the schemas, and failed because `concepts/*/supersedes/*/subject` was unregistered. Unregistered means **`rename-concept` would not have moved it**: a rename would update the bare `supersedes: [x]` form and leave `{ subject: x, ... }` pointing at the old address. A silent half-rename. Registered, with tests asserting the scanner finds both spellings.

## Verification

Clean-slate `rm -rf dist && pnpm verify`: **92 files, 1559 passed, 1 skipped, exit 0.**

Nine tests: both forms compile, the respect lands as a correlated claim, a dangling reference through the object form still raises YM312, the interview opens only when the predecessor is current, closes once the respect is recorded, stays closed for a completed succession, and the scanner finds both spellings.

The catalogue goes 1.0 to 1.1: a minor, adding a question and changing no trigger, which is the rule `docs/INTERROGATION.md` sets. yarramate's own self-model stays fully closed at 1.1 (0 open of 44).

## Not done

`ask --compare` still reports a bare removal rather than a scoped succession. Recording the respect is what this decides; teaching the comparison to read it is a separate change, and the data has to exist first. [ADR 0109](docs/adr/0109-a-succession-can-be-partial.md) says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)