### PR TITLE
feat: an open question carries its answer shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** An open question carries its machine-readable answer shape
+  (#289). Every interrogation-report question and design step now carries
+  `trigger`, the catalogue conditions that opened it, verbatim — so a
+  consumer builds its answering affordance (a prefilled form, an
+  operations stub) from the report instead of re-deriving the shape from
+  its own catalogue copy and drifting from engine semantics. The human
+  `yarramate design` output prints a prefilled `yarramate/operations/v1`
+  skeleton when the trigger maps unambiguously onto one operation
+  (`no-subject-of-kind` → `add-concept`; `missing-relationship` →
+  `add-relationship` with the direction-fixed endpoint prefilled).
+  [ADR 0110](docs/adr/0110-an-open-question-carries-its-answer-shape.md).
+
+  Compatibility: `trigger` is required and the report and design-step
+  schemas use `additionalProperties: false`, so output from this version
+  fails validation against pinned pre-change schemas. Consumers that
+  upgrade the package and its published schemas together are unaffected.
+  No semantics bump: no answer changes (ADR 0106's rule).
+
 ## 1.1.0
 
 - **Added.** A succession can be partial. `supersedes` accepts

--- a/docs/AGENT-INTERFACE.md
+++ b/docs/AGENT-INTERFACE.md
@@ -54,6 +54,12 @@ translates it into `apply` operations → re-invoke `design`.
   none, never blocking. Same step, same slice, same envelope: the JSON
   step carries `askPlain` additively whenever the catalogue provides
   one, so `--json` output is identical with or without the flag.
+- **The step carries its answer shape** (ADR 0110). `trigger` holds the
+  catalogue conditions that opened the question, verbatim, on the JSON
+  step and on every report question; the human output prints a prefilled
+  `yarramate/operations/v1` skeleton when the trigger maps unambiguously
+  onto one operation, so the first answer lands without the author
+  reverse-engineering the operations format.
 - Today's `interrogate` demotes to internal machinery; the full
   open-questions report remains reachable as a read (see `ask`).
 - Harness use: greenfield conception from a one-line idea; enrichment

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -50,7 +50,10 @@ questions. Each question binds:
   subject were reclassified to a kind of another aspect, so its kind is a
   label no check can contradict; see ADR 0083 as amended by ADR 0097).
   Relationship kinds in conditions resolve through profile lineage by
-  default, the same rule as subject selectors;
+  default, the same rule as subject selectors. The trigger rides reports
+  and design steps verbatim as the question's machine-readable answer
+  shape, so a consumer builds its answering affordance from the report
+  instead of re-deriving the shape from a catalogue copy (ADR 0110);
 - a **scope** — `workspace` (asked once) or `subject` (asked per matching
   subject, selected by kinds, statuses, and documents, with `descendants`
   kind matching by default so profile-derived kinds satisfy a catalogue

--- a/docs/adr/0110-an-open-question-carries-its-answer-shape.md
+++ b/docs/adr/0110-an-open-question-carries-its-answer-shape.md
@@ -1,0 +1,67 @@
+# An open question carries its answer shape
+
+Status: accepted
+
+A question has always travelled with everything a person needs — the
+phrasing, the materiality, a prose `resolution` hint — and nothing a
+machine can act on. The catalogue declares every trigger as typed
+conditions (`no-subject-of-kind`, `missing-relationship`, and the rest of
+the closed vocabulary in the catalogue schema), and evaluation erased
+them at reporting time: neither the interrogation report nor the design
+step said *why* a question was open, only that it was.
+
+That gap has a cost only an acting consumer pays, and two of them paid it
+on the same day. ApertureX, building prefilled answer forms per question
+card, had to re-derive the answer shape from its own copy of the
+catalogue — a copy that can silently drift from engine semantics — and
+named this its one upstream enhancement. The CLI's own cold-start
+dogfood paid the same cost from the other side: `design` said "add at
+least one goal or outcome concept" in prose, and landing the first
+concept took five failed `apply` rounds because the operations skeleton
+existed nowhere in the output.
+
+## Decision
+
+Both envelopes carry the catalogue trigger **verbatim**: `ReportQuestion`
+and the design step gain a required `trigger` field holding the
+conditions exactly as the catalogue declares them. The conditions are
+already a closed, schema-typed vocabulary; they *are* the machine-readable
+answer shape. A host maps them onto its own affordances — a form with the
+kind preselected, a relationship editor with one endpoint fixed — without
+holding a catalogue copy.
+
+The CLI renders the first such affordance itself: the human `design`
+output prints a prefilled `yarramate/operations/v1` skeleton when the top
+question's trigger has exactly one condition that maps unambiguously onto
+one operation — `no-subject-of-kind` onto `add-concept`,
+`missing-relationship` onto `add-relationship` with the direction-fixed
+endpoint prefilled with the subject. Every other trigger leaves the
+output exactly as before: a wrong skeleton is never offered. Extending
+coverage is one new mapping case.
+
+## Excluded options
+
+- **A normalized remedy DSL** on the report (`{op, kindOptions}` and
+  siblings): a second vocabulary whose alignment with the condition
+  vocabulary would itself need versioning. The conditions are already
+  typed and closed; hosts translate once.
+- **A `proposedOperations(question, subject)` helper in the engine**: it
+  couples interrogation to authoring shapes. If wanted later it layers on
+  top of the exposed trigger in the authoring toolkit, not in the engine.
+- **A semantics bump**: [ADR 0106](0106-a-report-says-which-engine-answered.md)'s
+  rule is answers-changed-only, and no answer changes — the same
+  questions open and close for the same models.
+- **An optional schema field**: the trigger exists for every catalogue
+  question, so an optional field would force every consumer to write an
+  absent-case branch for a case that cannot occur. It is required, with
+  the same compatibility note the 1.1.0 `semantics` field carried.
+
+## Consequences
+
+The report and design-step schemas gain a required field under
+`additionalProperties: false`, so output from this version fails
+validation against a pinned pre-change schema. The one consumer known to
+validate (ApertureX) upgrades schemas together with the package and is
+unaffected; the changelog carries the warning for anyone who pins
+separately. The condition definitions are copied into both output schemas
+from the catalogue schema, keeping each schema self-contained.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -83,7 +83,8 @@
             "authority",
             "question",
             "materiality",
-            "resolution"
+            "resolution",
+            "trigger"
           ],
           "properties": {
             "questionId": {
@@ -122,6 +123,14 @@
             "resolution": {
               "type": "string",
               "minLength": 1
+            },
+            "trigger": {
+              "description": "The catalogue trigger, verbatim: the conditions that opened this question, i.e. its machine-readable answer shape.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/condition"
+              }
             },
             "subject": {
               "type": "object",
@@ -162,6 +171,378 @@
     "slice": {
       "type": "string",
       "minLength": 1
+    }
+  },
+  "$defs": {
+    "condition": {
+      "description": "One deterministic trigger condition. All conditions in a trigger must hold (AND) for the question to be open.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "predicate"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-claim"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-relationship"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "incoming",
+                "outgoing",
+                "any"
+              ]
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "isolated"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-state-defined"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "exists-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-constraint"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject is an endpoint of at least one flow relationship that has no yarramate/flow/content claim.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-flow-content"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "predicate",
+            "direction"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-reference"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "topic"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-attestation"
+            },
+            "topic": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject resembles another subject of the same kind closely enough to be the same thing under two names, and no yarramate/identity/distinct-from claim dismisses the pair. Deterministic and lexical; the algorithm and thresholds are stated in ADR 0077. Questions using it may interpolate {counterparts}.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "near-duplicate"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject's kind is never tested by anything the compiler can check: it participates in no relationship whose kind pins the aspect at the subject's end, so reclassifying it to any other kind of any other aspect would still compile. The kind is a label rather than a constraint (ADR 0083).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unconstrained-kind"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject supersedes a predecessor that is still current, and does not say in what respect. A succession that replaced its predecessor outright says so by the predecessor being gone; one where both remain is usually partial, and the respect is the part a reader needs (ADR 0109).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unscoped-succession"
+            }
+          }
+        }
+      ]
+    },
+    "claimPredicate": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/@.#-]*$"
+    },
+    "qualifiedKind": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/-]*@[0-9][0-9A-Za-z.-]*#[A-Za-z][A-Za-z0-9-]*$"
     }
   }
 }

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -4,7 +4,14 @@
   "title": "YarraMate interrogation report",
   "type": "object",
   "additionalProperties": false,
-  "required": ["format", "workspace", "catalogue", "semantics", "summary", "waves"],
+  "required": [
+    "format",
+    "workspace",
+    "catalogue",
+    "semantics",
+    "summary",
+    "waves"
+  ],
   "properties": {
     "format": {
       "const": "yarramate/interrogation-report/v1"
@@ -25,11 +32,24 @@
     "summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["questions", "openQuestions", "open"],
+      "required": [
+        "questions",
+        "openQuestions",
+        "open"
+      ],
       "properties": {
-        "questions": { "type": "integer", "minimum": 0 },
-        "openQuestions": { "type": "integer", "minimum": 0 },
-        "open": { "type": "integer", "minimum": 0 }
+        "questions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "openQuestions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "open": {
+          "type": "integer",
+          "minimum": 0
+        }
       }
     },
     "waves": {
@@ -43,13 +63,25 @@
     "wave": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "questions"],
+      "required": [
+        "id",
+        "name",
+        "questions"
+      ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
         "questions": {
           "type": "array",
-          "items": { "$ref": "#/$defs/question" }
+          "items": {
+            "$ref": "#/$defs/question"
+          }
         }
       }
     },
@@ -63,33 +95,453 @@
         "open",
         "question",
         "materiality",
-        "resolution"
+        "resolution",
+        "trigger"
       ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "scope": { "enum": ["workspace", "subject"] },
-        "authority": { "enum": ["human", "agent", "either"] },
-        "open": { "type": "boolean" },
-        "question": { "type": "string", "minLength": 1 },
-        "materiality": { "type": "string", "minLength": 1 },
-        "resolution": { "type": "string", "minLength": 1 },
-        "since": { "type": "string" },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "enum": [
+            "workspace",
+            "subject"
+          ]
+        },
+        "authority": {
+          "enum": [
+            "human",
+            "agent",
+            "either"
+          ]
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "question": {
+          "type": "string",
+          "minLength": 1
+        },
+        "materiality": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolution": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trigger": {
+          "description": "The catalogue trigger, verbatim: the conditions that opened this question, i.e. its machine-readable answer shape.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/condition"
+          }
+        },
+        "since": {
+          "type": "string"
+        },
         "subjects": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/openSubject" }
+          "items": {
+            "$ref": "#/$defs/openSubject"
+          }
         }
       }
     },
     "openSubject": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "question"],
+      "required": [
+        "id",
+        "question"
+      ],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
-        "question": { "type": "string", "minLength": 1 }
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "question": {
+          "type": "string",
+          "minLength": 1
+        }
       }
+    },
+    "condition": {
+      "description": "One deterministic trigger condition. All conditions in a trigger must hold (AND) for the question to be open.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "predicate"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-claim"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-relationship"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "incoming",
+                "outgoing",
+                "any"
+              ]
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "isolated"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-state-defined"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "exists-linkage"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-constraint"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject is an endpoint of at least one flow relationship that has no yarramate/flow/content claim.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-flow-content"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "predicate",
+            "direction"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-reference"
+            },
+            "predicate": {
+              "$ref": "#/$defs/claimPredicate"
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
+            "topic"
+          ],
+          "properties": {
+            "condition": {
+              "const": "missing-attestation"
+            },
+            "topic": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject resembles another subject of the same kind closely enough to be the same thing under two names, and no yarramate/identity/distinct-from claim dismisses the pair. Deterministic and lexical; the algorithm and thresholds are stated in ADR 0077. Questions using it may interpolate {counterparts}.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "near-duplicate"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject's kind is never tested by anything the compiler can check: it participates in no relationship whose kind pins the aspect at the subject's end, so reclassifying it to any other kind of any other aspect would still compile. The kind is a label rather than a constraint (ADR 0083).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unconstrained-kind"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The subject supersedes a predecessor that is still current, and does not say in what respect. A succession that replaced its predecessor outright says so by the predecessor being gone; one where both remain is usually partial, and the respect is the part a reader needs (ADR 0109).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unscoped-succession"
+            }
+          }
+        }
+      ]
+    },
+    "claimPredicate": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/@.#-]*$"
+    },
+    "qualifiedKind": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9/-]*@[0-9][0-9A-Za-z.-]*#[A-Za-z][A-Za-z0-9-]*$"
     }
   }
 }

--- a/skills/yarramate-architecture/SKILL.md
+++ b/skills/yarramate-architecture/SKILL.md
@@ -137,7 +137,11 @@ yarramate design .yarramate/workspace.yaml
 
    Each invocation serves exactly the top open question with its subject
    slice, materiality, and progress — the catalogue is internal; never pass
-   or read catalogue files. Answer one question at a time: questions the
+   or read catalogue files. The step carries the question's `trigger`
+   (its machine-readable answer shape), and the human output includes a
+   prefilled operations skeleton when the trigger maps onto one
+   operation — start from that skeleton instead of authoring the batch
+   from memory. Answer one question at a time: questions the
    model or evidence can answer, answer from your authority; questions
    marked `human`, relay verbatim with their materiality. Land each answer
    as subjects and relationships in one atomic batch (`yarramate apply

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -16,6 +16,7 @@ import {
   evaluateCatalogue,
   loadQuestionCatalogue,
   renderQuestion,
+  type CatalogueCondition,
   type InterrogationReport,
 } from './interrogate-command.js'
 import { evaluateProjection } from './projection.js'
@@ -42,6 +43,8 @@ interface DesignStep {
   readonly askPlain?: string
   readonly materiality: string
   readonly resolution: string
+  /** The catalogue trigger, verbatim: the question's answer shape (#289). */
+  readonly trigger: readonly CatalogueCondition[]
   readonly subject?: { readonly id: string; readonly name?: string }
   readonly remainingSubjects?: number
   readonly openSubjects?: readonly string[]
@@ -88,6 +91,7 @@ const selectStep = (
             : { askPlain: askPlainTemplate.trim() }),
           materiality: question.materiality,
           resolution: question.resolution,
+          trigger: question.trigger,
           ...(question.since === undefined ? {} : { since: question.since }),
         }
       }
@@ -108,6 +112,7 @@ const selectStep = (
           : { askPlain: renderQuestion(askPlainTemplate, first.id, first.name) }),
         materiality: question.materiality,
         resolution: question.resolution,
+        trigger: question.trigger,
         ...(question.since === undefined ? {} : { since: question.since }),
         subject: {
           id: first.id,
@@ -124,6 +129,71 @@ const selectStep = (
     }
   }
   return null
+}
+
+const localKind = (qualified: string): string => {
+  const hash = qualified.lastIndexOf('#')
+  return hash === -1 ? qualified : qualified.slice(hash + 1)
+}
+
+const skeletonHeader = (
+  documentAddress: string,
+  op: string,
+): readonly string[] => [
+  '',
+  'Prefilled skeleton (edit the <placeholders>, save as operations.yaml):',
+  '  format: yarramate/operations/v1',
+  '  operations:',
+  `    - op: ${op}`,
+  `      document: ${documentAddress}`,
+]
+
+// The skeleton is a rendering of the step's trigger (#289), printed only
+// when a single condition maps unambiguously onto one operation, so a
+// wrong skeleton is never offered; every other trigger leaves the output
+// exactly as before. Kinds print as local names: that is the form a
+// native document declares.
+const renderSkeleton = (
+  step: DesignStep,
+  documentAddress: string | undefined,
+): readonly string[] => {
+  if (documentAddress === undefined || step.trigger.length !== 1) return []
+  const condition = step.trigger[0]!
+  if (condition.condition === 'no-subject-of-kind') {
+    const kinds = condition.kinds.map(localKind)
+    const alternatives =
+      kinds.length > 1 ? `  # or: ${kinds.slice(1).join(', ')}` : ''
+    return [
+      ...skeletonHeader(documentAddress, 'add-concept'),
+      '      concept:',
+      '        id: <kebab-case-id>',
+      `        kind: ${kinds[0]}${alternatives}`,
+      '        name: <one line>',
+    ]
+  }
+  if (
+    condition.condition === 'missing-relationship' &&
+    step.subject !== undefined
+  ) {
+    const kinds = condition.kinds.map(localKind)
+    const alternatives =
+      kinds.length > 1 ? `  # or: ${kinds.slice(1).join(', ')}` : ''
+    const swap =
+      condition.direction === 'any' ? '  # or swap the endpoints' : ''
+    const from =
+      condition.direction === 'incoming' ? '<counterpart-id>' : step.subject.id
+    const to =
+      condition.direction === 'incoming' ? step.subject.id : '<counterpart-id>'
+    return [
+      ...skeletonHeader(documentAddress, 'add-relationship'),
+      '      relationship:',
+      '        id: <kebab-case-id>',
+      `        kind: ${kinds[0]}${alternatives}`,
+      `        from: ${from}${swap}`,
+      `        to: ${to}`,
+    ]
+  }
+  return []
 }
 
 export function runDesignCommand(
@@ -333,10 +403,26 @@ export function runDesignCommand(
       if (slice !== undefined) {
         lines.push('', 'Subject slice:', '', slice.trimEnd())
       }
+      // The skeleton's document address is the manifest-relative form
+      // when the first document sits under the manifest directory - the
+      // address an author naturally writes and apply accepts (#216) -
+      // falling back to the workspace path, which apply also accepts.
+      const manifestDirectory = workspacePath.includes('/')
+        ? workspacePath.slice(0, workspacePath.lastIndexOf('/'))
+        : ''
+      const firstDocument = workspace.documents[0]
+      const documentAddress =
+        firstDocument === undefined
+          ? undefined
+          : manifestDirectory !== '' &&
+              firstDocument.startsWith(`${manifestDirectory}/`)
+            ? firstDocument.slice(manifestDirectory.length + 1)
+            : firstDocument
       lines.push(
         '',
         'Answer by updating the model (one atomic batch):',
         `  yarramate apply <operations.yaml> ${workspacePath}`,
+        ...renderSkeleton(step, documentAddress),
         `Then re-run: yarramate design ${workspacePath}`,
       )
     }

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -159,6 +159,14 @@ export interface ReportQuestion {
   readonly question: string
   readonly materiality: string
   readonly resolution: string
+  /**
+   * The catalogue trigger, verbatim (#289). The conditions that opened a
+   * question are its machine-readable answer shape: a host builds the
+   * matching affordance (a prefilled form, an operations skeleton) from
+   * them instead of re-deriving the shape from its own catalogue copy and
+   * drifting from engine semantics.
+   */
+  readonly trigger: readonly CatalogueCondition[]
   readonly since?: string
   readonly subjects?: readonly OpenSubject[]
 }
@@ -766,6 +774,7 @@ export function evaluateCatalogue(
           question: question.question.trim(),
           materiality: question.materiality.trim(),
           resolution: question.resolution.trim(),
+          trigger: question.trigger,
           ...(question.since === undefined ? {} : { since: question.since }),
         }
         if (question.scope === 'workspace') {

--- a/test/design-command.test.ts
+++ b/test/design-command.test.ts
@@ -93,6 +93,56 @@ describe('design command', () => {
     expect(result.stderr).toContain('Unknown subject identity: nope')
   })
 
+  it('prints a prefilled add-concept skeleton for a mapped workspace trigger', () => {
+    const result = runCli(['design', 'workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(
+      'Prefilled skeleton (edit the <placeholders>, save as operations.yaml):',
+    )
+    expect(result.stdout).toContain('- op: add-concept')
+    expect(result.stdout).toContain('document: architecture/main.yaml')
+    expect(result.stdout).toContain('kind: goal  # or: outcome')
+  })
+
+  it('prefills the subject endpoint in an add-relationship skeleton', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      [
+        'format: yarramate/v1',
+        'id: main',
+        'profile: yarramate/core@0.1',
+        'concepts:',
+        '  - id: north-star',
+        '    kind: goal',
+        '    name: North star',
+        'relationships: []',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+    const result = runCli(
+      ['design', 'workspace.yaml', '--subject', 'north-star'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Q [motivation · goal-unrealized]')
+    expect(result.stdout).toContain('- op: add-relationship')
+    expect(result.stdout).toContain('kind: realization')
+    // goal-unrealized wants an incoming realization: the goal is the
+    // fixed endpoint, the missing realizer is the placeholder.
+    expect(result.stdout).toContain('from: <counterpart-id>')
+    expect(result.stdout).toContain('to: north-star')
+  })
+
+  it('offers no skeleton when the trigger does not map onto one operation', () => {
+    const result = runCli(
+      ['design', 'workspace.yaml', '--subject', 'todo-service'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).not.toContain('Prefilled skeleton')
+  })
+
   it('emits a deterministic, schema-valid machine step', () => {
     const first = runCli(['design', 'workspace.yaml', '--json'], workspace)
     const second = runCli(['design', 'workspace.yaml', '--json'], workspace)

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -262,6 +262,12 @@ describe('ask --open interrogation', () => {
     // The delta annotation (ADR 0063) rides the report so consumers can
     // tell 'the catalogue deepened' from 'the model regressed'.
     expect((owners as { since?: string }).since).toBe('1.1')
+    // The verbatim catalogue trigger rides every question (#289): the
+    // machine-readable answer shape a host builds its affordance from,
+    // instead of re-deriving it from its own catalogue copy.
+    expect((owners as { trigger?: unknown }).trigger).toEqual([
+      { condition: 'missing-claim', predicate: 'yarramate/ownership/owner' },
+    ])
     const validate = new Ajv2020({ allErrors: true }).compile(reportSchema)
     expect(validate(payload), JSON.stringify(validate.errors)).toBe(true)
   })


### PR DESCRIPTION
Closes #289.

Every interrogation-report question and design step now carries `trigger`, the catalogue conditions that opened it, verbatim — the question's machine-readable answer shape. A consumer (ApertureX prefilled answer forms; any harness) builds its answering affordance from the report instead of re-deriving the shape from its own catalogue copy and drifting from engine semantics.

The CLI renders the first such affordance itself: human `yarramate design` output prints a prefilled `yarramate/operations/v1` skeleton when the top question's trigger has exactly one condition mapping unambiguously onto one operation:
- `no-subject-of-kind` → `add-concept` (kind preselected, alternatives in a comment, manifest-relative document address);
- `missing-relationship` → `add-relationship` (the direction-fixed endpoint prefilled with the subject).

Every other trigger leaves the output exactly as before, so a wrong skeleton is never offered. Extending coverage is one new mapping case.

Design record: [ADR 0110](docs/adr/0110-an-open-question-carries-its-answer-shape.md) (excluded: normalized remedy DSL, `proposedOperations` in the engine, semantics bump, optional schema field).

Compatibility: `trigger` is required and both schemas use `additionalProperties: false`, so pinned pre-change schemas reject new output (same class of note as 1.1.0's `semantics` field). No semantics bump — no answer changes (ADR 0106's rule); `test/interrogation-semantics.test.ts` passes untouched.

Verified: clean-slate `pnpm verify` exit 0 (94 files, 1572 passed / 1 skipped). Acceptance demo replayed the cold-start dogfood: `init` → `design` prints the skeleton → filled verbatim → `apply` succeeds on the first attempt → interview advances. The exact five-round failure the skeleton exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)