### PR TITLE
chore: prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.2.0
 
 - **Added.** An open question carries its machine-readable answer shape
   (#289). Every interrogation-report question and design step now carries

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -268,6 +268,17 @@ answer is about the model and belongs in front of a user, different means the
 engine moved and the right response is to re-baseline silently rather than
 reopen someone's queue.
 
+Every question also carries `trigger`, the catalogue conditions that opened
+it, verbatim ([ADR 0110](adr/0110-an-open-question-carries-its-answer-shape.md)).
+That is the question's machine-readable answer shape: a host building an
+answering affordance — a concept form with the kind preselected from
+`no-subject-of-kind`, a relationship editor with one endpoint fixed by
+`missing-relationship`'s `direction`, an attestation form on
+`missing-attestation`'s `topic` — maps the conditions directly instead of
+re-deriving the shape from its own catalogue copy. The field is required and
+the published report schema uses `additionalProperties: false`, so upgrade a
+separately pinned schema together with the package.
+
 ### Mount the visual editor
 
 Mount the packaged editor when the consuming product owns the sources and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release preparation per docs/RELEASING.md.

- `package.json` → 1.2.0; changelog Unreleased section renamed to 1.2.0.
- Consumer guide: `trigger` documented beside the `semantics` persistence caution, with the pinned-schema upgrade note.
- Validation run on this branch: `pnpm install --frozen-lockfile` clean, `pnpm run verify` exit 0 (94 files, 1572 passed / 1 skipped), `pnpm changelog:check` green (every user-visible commit since v1.1.0 has an entry), `npm pack --dry-run` clean at 238 files (runtime, schemas, consumer guide, skill, README, licence; no source, tests, fixtures, or generated output).

After merge: annotated tag `v1.2.0`, GitHub release, then npm publish from the tagged checkout (maintainer step, gitHead rule per the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)