### PR TITLE
fix: the Add-subject popover clears the toolbar, and dialog labels reach their controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   the overlay carries the catalogue `id@version` and the engine `semantics`
   stamp (ADR 0106).
 
+- **Fixed.** The Add-subject popover clears the canvas toolbar, and its
+  labels reach their controls (#296). The popover opened at the toolbar's own
+  corner one stacking layer below it, so the filter bar painted over the Name
+  field's label; it now opens below the toolbar's row and stacks above it.
+  And the dialog's Name/Kind/Document labels carry explicit `for`/`id`
+  associations, so `getByLabel`-style queries and screen readers resolve
+  them; the other dialogs (save-view, prompt, confirm) already had theirs.
+
 ## 1.2.0
 
 - **Added.** An open question carries its machine-readable answer shape

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -976,10 +976,17 @@ body {
   color: var(--quiet);
 }
 
+/* Opens below the canvas toolbar rather than under it: `.canvas-controls`
+   sits at `top: var(--step)` with 28px-high controls and z-index 5, and this
+   panel used to open at nearly the same corner one layer down, so the toolbar
+   painted over the Name field's label (#296). The offset clears the toolbar's
+   row (step + 28px + step of breathing room), and the z-index puts an open
+   dialog above the controls that opened it should the two ever meet again —
+   still under the command strip (10) and the modal layers. */
 .subject-draft-panel {
   position: absolute;
-  z-index: 3;
-  top: calc(var(--step) * 1.5);
+  z-index: 6;
+  top: calc(var(--step) * 2 + 28px);
   right: calc(var(--step) * 1.5);
   width: min(340px, calc(100% - var(--step) * 4));
   padding: calc(var(--step) * 1.5) calc(var(--step) * 2);

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -49,18 +49,27 @@ export const SubjectDraftPanel = ({
 
   return (
     <section className="subject-draft-panel" aria-label="Add a subject">
-      <label className="subject-draft-field">
+      {/* Explicit for/id on top of the wrapping label: the wrap alone is an
+          implicit association some queries and assistive tech do not resolve
+          (#296). The ids are safe as constants because the app mounts at most
+          one of this panel, like `save-view-title` and `prompt-dialog-value`. */}
+      <label className="subject-draft-field" htmlFor="subject-draft-name">
         <span>Name</span>
         <input
+          id="subject-draft-name"
           type="text"
           value={name}
           onChange={(event) => setName(event.target.value)}
         />
       </label>
 
-      <label className="subject-draft-field">
+      <label className="subject-draft-field" htmlFor="subject-draft-kind">
         <span>Kind</span>
-        <select value={kind} onChange={(event) => setKind(event.target.value)}>
+        <select
+          id="subject-draft-kind"
+          value={kind}
+          onChange={(event) => setKind(event.target.value)}
+        >
           <option value="">Choose a kind</option>
           {kinds.map((option) => (
             // The label, not the id: a document names a kind the short way and
@@ -73,9 +82,10 @@ export const SubjectDraftPanel = ({
         </select>
       </label>
 
-      <label className="subject-draft-field">
+      <label className="subject-draft-field" htmlFor="subject-draft-document">
         <span>Document</span>
         <select
+          id="subject-draft-document"
           value={document}
           onChange={(event) => setDocument(event.target.value)}
         >

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -113,4 +113,33 @@ describe('SubjectDraftPanel', () => {
   it('can always be backed out of', () => {
     expect(render()).toContain('Cancel')
   })
+
+  /**
+   * The a11y half of #296: the labels wrapped their controls but named them
+   * for nothing else — no `for`/`id`, so `getByLabel`-style queries and some
+   * assistive tech could not resolve Name, Kind or Document. Every label must
+   * point at a control that exists, and every id must be unique, or two
+   * fields would answer to one name.
+   */
+  it('associates every label with its control', () => {
+    const markup = render()
+
+    const fors = [...markup.matchAll(/<label[^>]*\bfor="([^"]*)"/g)].map(
+      (match) => match[1]!,
+    )
+    const ids = [...markup.matchAll(/\bid="([^"]*)"/g)].map(
+      (match) => match[1]!,
+    )
+
+    // One association per field: Name, Kind, Document.
+    expect(fors).toHaveLength(3)
+    expect(fors.every((target) => target !== '')).toBe(true)
+    // Each names a control that is really there…
+    for (const target of fors) {
+      expect(ids).toContain(target)
+    }
+    // …and no id is claimed twice, in the panel or by two labels.
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(new Set(fors).size).toBe(fors.length)
+  })
 })


### PR DESCRIPTION
Closes #296

## What

Two Add-subject dialog defects observed in real embedding (#252):

1. **Popover overlap.** The mechanism: `.canvas-controls` (the quick filter + Add subject button) and `.subject-draft-panel` are absolutely positioned siblings inside `.canvas`, both anchored to the top-right corner — the toolbar at `top: var(--step)` with `z-index: 5`, the panel at `top: calc(var(--step) * 1.5)` with `z-index: 3`. Same corner, one stacking layer down, so the toolbar painted over the panel's top edge and clipped the Name field's label. The fix is both halves the issue asks for: the panel now opens **below the toolbar's row** (`top: calc(var(--step) * 2 + 28px)` — toolbar offset + its 28px control height + a step of breathing room) and **stacks above it** (`z-index: 6`, above the toolbar's 5 but still under the command strip at 10 and the modal layers), so if the two ever meet again the open dialog wins. No portal needed; the panel stays a sibling in the canvas.

2. **Label association.** The dialog's Name/Kind/Document labels wrapped their controls but carried no `for`/`id`, an implicit association some `getByLabel`-style queries and assistive tech do not resolve. Each label now carries an explicit `htmlFor` paired with an `id` on its control (`subject-draft-name` / `subject-draft-kind` / `subject-draft-document`); the ids are safe as constants because the app mounts at most one of this panel, same as `save-view-title` and `prompt-dialog-value`.

## The other dialogs (checked, unchanged)

- `save-view.tsx`: Title and Description already have `htmlFor`/`id` pairs — **skipped entirely** (a sibling PR is touching this file; nothing to fix here keeps that merge trivial).
- `prompt-dialog.tsx`: already associated (`prompt-dialog-value`).
- `confirm-dialog.tsx`: no labelable controls, only buttons and `aria-labelledby` on the dialog itself.

## Tests

- `test/subject-draft-panel.test.ts` gains one renderToStaticMarkup test: every `<label for>` names an `id` that exists in the markup, there are exactly three (Name, Kind, Document), and no id or `for` target is claimed twice. 8/8 pass in the file; full suite 96 files, 1593 passed, 1 skipped.
- The placement half is CSS and not reachable from renderToStaticMarkup (no layout engine), so it is covered by a manual check instead: launched a real session (`yarramate-visual start` against this repo's own workspace, serving the freshly built bundle), opened it in Chrome, clicked **Add subject**, and measured live: panel top 92px vs toolbar bottom 85.3px (no rect intersection, Name label fully visible — screenshot confirms), computed z-indexes 6 vs 5, and `input.labels.length === 1` for the Name field, so the association resolves in a real browser too.

`pnpm verify` exit code 0 (typecheck, build, tests, self:check, validate). `pnpm changelog:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)