### PR TITLE
feat: a saved layout is visible, view-scoped, and discardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Changed.** A saved layout is visible, view-scoped, and discardable
+  (#273). A per-view layout sidecar silently re-pinned every relayout — an
+  experimental relayout moved 0 of 16 nodes with no hint why — and a stale
+  sidecar could scatter a 20-subject view across coordinates saved for all
+  37. Now a sidecar entry for a subject the active view does not draw is
+  inert (`applySavedPositions` pins only drawn nodes), and whenever a saved
+  layout is actually in force the canvas shows a standing "Saved layout in
+  force" pill with a **Discard** affordance. Discard is session-local: the
+  canvas stops honouring that view's sidecar and runs a fresh layout; the
+  sidecar stays on disk (deleting it is a staged write), and the reviewer's
+  next drag-save re-arms the pin with their own fresh layout. Pruning stale
+  sidecar entries on view save is deferred.
+  [ADR 0113](docs/adr/0113-a-saved-layout-is-visible-and-view-scoped.md).
+
 - **Added.** `yarramate init` names the workspace after its directory
   (#275). The seed document and workspace manifest ids derive from the
   target directory's basename, slugified to the id grammar both schemas

--- a/docs/adr/0113-a-saved-layout-is-visible-and-view-scoped.md
+++ b/docs/adr/0113-a-saved-layout-is-visible-and-view-scoped.md
@@ -1,0 +1,82 @@
+# A saved layout is visible and view-scoped
+
+Status: accepted
+
+A reviewer's dragged positions persist in a per-view sidecar
+(`yarramate/visual-layout/v1`), and the canvas honours them by re-pinning
+every node the sidecar names after every layout run — `layoutstop` is the
+only per-node "leave this one alone" hook ELK offers. Correct for
+preserving drags; silent for everything else, and measured to be so twice
+on the same fixture (#273). An experimental relayout moved 0 of 16 leaf
+nodes until the pin was suspended, with no error and no hint. And a
+sidecar can be stale relative to its view: `contact-update-solution`'s
+held positions for 37 subjects spanning y 86–2914 while the view drew 20,
+so the view was scattered across coordinates sized for the whole model
+(fit zoom 0.28) with nothing on screen saying a saved layout was in
+force. The staleness compounds: every drag-save snapshots the whole
+canvas, hidden nodes included, so a stale entry once pinned is written
+straight back.
+
+## Decision
+
+Two changes, separable and both view-scoped:
+
+1. **A sidecar entry for a subject the active view does not draw is
+   inert.** `applySavedPositions` pins only visible nodes. A hidden node
+   keeps whatever coordinates the last layout left it, instead of being
+   planted at a sidecar position from a canvas sized for the whole model —
+   stale coordinates the next whole-canvas drag-save would have
+   immortalised. `visible()` is the same judgement `relayoutVisible`
+   already scopes by.
+
+2. **A saved layout in force is announced, with the way out beside it.**
+   Whenever the active view's sidecar names at least one subject the view
+   draws, the canvas shows a standing pill — "Saved layout in force", with
+   a **Discard** affordance. It is state, not an event: derived at render
+   time from the sidecar and the view's match set (`savedLayoutInForce`),
+   never a flag some effect has to remember to clear, and distinct from
+   the transient `layoutNotice` save receipt. Discard is session-local:
+   the canvas records the view as discarded, stops honouring its sidecar,
+   and runs a fresh layout over what is drawn. The sidecar document stays
+   on disk — deleting it is a staged, committed write (the discipline every
+   other file change already obeys, ADR 0103), and inventing an unstaged
+   delete path for one convenience is not worth it. A later drag-save
+   re-arms the view: the reviewer's own fresh sidecar supersedes the
+   discard that cleared the old one.
+
+## Excluded options
+
+- **Pruning sidecar entries on view save** (the issue's third candidate):
+  deferred, not rejected. Duplicate-view already drops the sidecar
+  outright, so precedent exists for layouts being view-scoped state, but
+  pruning belongs to the view-save write path and stages a document
+  change — a separate change with its own blast radius.
+- **A real sidecar delete behind Discard**: it would be the only write in
+  the editor that bypasses the staged changeset, or it would stage a
+  deletion of a document kind the changeset machinery does not yet carry.
+  The session-local unpin gives the reviewer the relayout they asked for
+  now; the disk story stays with the staged-write discipline.
+- **Deriving the pill from cytoscape's live visibility**: exact (a
+  quick-filter keystroke that hides every pinned node would drop the
+  pill), but only computable after effects run against a mounted canvas.
+  The match-set derivation is a pure function of rendered state — testable
+  with no canvas, honest under server rendering — at the price of the
+  pill standing through a transient quick-filter that momentarily hides
+  every pinned node.
+- **One session-wide discard flag**: discarding view A's pin says nothing
+  about view B's, and returning to A must not resurrect what was
+  discarded — so the record is a set of view ids, not a boolean.
+
+## Consequences
+
+An experimental relayout still appears to do nothing while a saved layout
+is in force — that behaviour is the feature protecting a reviewer's
+drags — but the pill now says why, and Discard makes the relayout land.
+When `presentation.direction` becomes editable per view, the trap this
+was measured on (flip the direction, see nothing happen, no way to
+discover why) is already answered. Stale sidecar entries stop being
+copied forward by drag-saves of views that no longer draw them, though
+the entries themselves remain until something prunes them (deferred
+above). The pill claims "in force" from the match set rather than pixels,
+so the one dishonest corner is a quick-filter that temporarily hides
+every pinned node while the pill stands.

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import cytoscape from 'cytoscape'
 import type { Core, CollectionReturnValue, ElementDefinition, NodeCollection, NodeSingular } from 'cytoscape'
 import elk from 'cytoscape-elk'
@@ -835,17 +835,57 @@ export function buildPositionMap(nodes: NodeCollection): VisualLayoutPositions {
   return positions
 }
 
-// Pins every node the sidecar names to its saved position; a node the
+// Pins every drawn node the sidecar names to its saved position; a node the
 // sidecar doesn't mention keeps wherever the layout run that just finished
 // placed it. Runs after layout completes - there is no per-node "leave this
 // one alone" hook in `nodeLayoutOptions`, so overriding the finished result
 // is the only way to keep a subset fixed while ELK freely places the rest.
+//
+// Only drawn nodes: a sidecar entry for a subject the active view does not
+// currently draw is inert (#273). A hidden node keeps coordinates from
+// whatever full-graph layout last placed it, so re-pinning it to a sidecar
+// written against a canvas sized for the whole model plants stale positions
+// that the next whole-canvas drag-save would immortalise. `visible()` is the
+// same judgement `relayoutVisible` scopes by (and returns true wholesale on a
+// style-disabled instance, where nothing is ever hidden).
 export function applySavedPositions(cy: Core, saved: VisualLayoutPositions | undefined): void {
   if (saved === undefined) return
   cy.nodes().forEach((node) => {
+    if (!node.visible()) return
     const position = saved[node.id()]
     if (position !== undefined) node.position(position)
   })
+}
+
+// The sidecar the canvas actually honours: a view the reviewer discarded this
+// session yields nothing to pin, every other view passes its sidecar through
+// untouched. Session-local by design - the sidecar document stays on disk
+// (deleting it is a staged, committed write this canvas does not own), so the
+// discard lives beside the canvas instead of pretending to be a file change.
+export function effectiveSavedPositions(
+  saved: VisualLayoutPositions | undefined,
+  viewId: string,
+  discardedViews: ReadonlySet<string>,
+): VisualLayoutPositions | undefined {
+  return discardedViews.has(viewId) ? undefined : saved
+}
+
+// Whether a saved layout is actually in force for what is on screen: the
+// sidecar names at least one subject the active view draws. Derived from the
+// view's own match set (`matchedIds ?? every node` - the same base
+// `applyFilter` starts from) rather than from cytoscape's live visibility, so
+// the indicator is a pure function of rendered state: computable with no
+// canvas mounted, and never a stale flag some effect forgot to clear. The
+// match set may also name relationships; the sidecar only ever names
+// subjects, so those entries simply never intersect.
+export function savedLayoutInForce(
+  saved: VisualLayoutPositions | undefined,
+  graphNodeIds: readonly string[],
+  matchedIds: readonly string[] | null,
+): boolean {
+  if (saved === undefined) return false
+  const drawn = matchedIds ?? graphNodeIds
+  return drawn.some((id) => saved[id] !== undefined)
 }
 
 export interface DragSaveHandle {
@@ -962,6 +1002,19 @@ export function GraphCanvas({
 }: GraphCanvasProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<Core | null>(null)
+  // Views whose saved layout the reviewer discarded this session. Per view id,
+  // not one flag: discarding view A's pin says nothing about view B's, and
+  // returning to A later must not resurrect what was discarded. A drag-save
+  // re-arms its view (see `registerDragSave` below): the reviewer's own fresh
+  // sidecar supersedes the discard that cleared the old one.
+  const [discardedViews, setDiscardedViews] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  )
+  const effectiveSaved = effectiveSavedPositions(
+    savedPositions,
+    activeViewId,
+    discardedViews,
+  )
   const onSelectRef = useRef(onSelect)
   const onCanvasReadyRef = useRef(onCanvasReady)
   onCanvasReadyRef.current = onCanvasReady
@@ -973,7 +1026,7 @@ export function GraphCanvas({
   const matchedIdsRef = useRef(matchedIds)
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
   const onSaveLayoutRef = useRef(onSaveLayout)
-  const savedPositionsRef = useRef(savedPositions)
+  const savedPositionsRef = useRef(effectiveSaved)
   const dragSaveHandleRef = useRef<DragSaveHandle | null>(null)
   // The force backend's in-flight layout (see `runLayout`), shared by the
   // graph-change effect and the view-switch relayout so either can supersede
@@ -999,10 +1052,12 @@ export function GraphCanvas({
     onSaveLayoutRef.current = onSaveLayout
   }, [onSaveLayout])
 
-  // Keep savedPositionsRef up-to-date for the layoutstop handler
+  // Keep savedPositionsRef up-to-date for the layoutstop handler. The ref
+  // holds the *effective* sidecar - a discarded view's pin is already gone
+  // here, so the layoutstop handler never has to know discards exist.
   useEffect(() => {
-    savedPositionsRef.current = savedPositions
-  }, [savedPositions])
+    savedPositionsRef.current = effectiveSaved
+  }, [effectiveSaved])
 
   // Cancel pending drag-save when the active view changes, so a queued save
   // never lands against a different view's sidecar. Also cleared on unmount.
@@ -1096,7 +1151,18 @@ export function GraphCanvas({
     dragSaveHandleRef.current = registerDragSave(
       cy,
       () => activeViewIdRef.current,
-      (payload) => onSaveLayoutRef.current(payload),
+      (payload) => {
+        // A drag-save writes a fresh sidecar for this view, superseding
+        // whatever the reviewer discarded - the new pin is their own work,
+        // so it re-arms (#273). Untouched views keep their discards.
+        setDiscardedViews((prev) => {
+          if (!prev.has(payload.projectionId)) return prev
+          const next = new Set(prev)
+          next.delete(payload.projectionId)
+          return next
+        })
+        onSaveLayoutRef.current(payload)
+      },
     )
 
     const rememberFraming = (): void => {
@@ -1265,14 +1331,51 @@ export function GraphCanvas({
     }
   }, [matchedIds, quickFilterText, graph])
 
+  // Session-local discard of the active view's saved layout: record the
+  // discard, drop the pin the layoutstop handler would re-apply, and run a
+  // fresh layout over what is drawn. The ref is cleared synchronously rather
+  // than left to the sync effect above, because `relayoutVisible`'s
+  // `layoutstop` can land before React commits the state change - and a
+  // discard whose own relayout re-pins the sidecar has discarded nothing.
+  // A queued drag-save is cancelled too: it would snapshot the very
+  // positions the reviewer just asked to be rid of.
+  const discardSavedLayout = (): void => {
+    setDiscardedViews((prev) => new Set(prev).add(activeViewId))
+    savedPositionsRef.current = undefined
+    dragSaveHandleRef.current?.cancelPending()
+    if (cyRef.current !== null) relayoutVisible(cyRef.current)
+  }
+
+  // The standing indicator (#273): a saved layout silently overrides every
+  // relayout, so whenever one is actually in force for this view the canvas
+  // says so, with the way out beside it. Distinct from the transient
+  // `layoutNotice` pill (a save receipt that happens to appear top-right):
+  // this one is state, not an event, and lives bottom-left for as long as
+  // the pin does.
+  const savedLayoutShown = savedLayoutInForce(
+    effectiveSaved,
+    graph.nodes.map((node) => node.id),
+    matchedIds,
+  )
+
   // The browser's own menu is suppressed here rather than on `window`: every
   // other surface in this application should keep the one the platform gives
   // it, and only the canvas has a menu of its own to put in its place.
   return (
-    <div
-      ref={containerRef}
-      style={{ width: '100%', height: '100%' }}
-      onContextMenu={(event) => event.preventDefault()}
-    />
+    <>
+      <div
+        ref={containerRef}
+        style={{ width: '100%', height: '100%' }}
+        onContextMenu={(event) => event.preventDefault()}
+      />
+      {savedLayoutShown ? (
+        <div className="saved-layout-pill" role="status">
+          <span>Saved layout in force</span>
+          <button type="button" onClick={discardSavedLayout}>
+            Discard
+          </button>
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -2317,3 +2317,49 @@ body {
   font-size: 0.72rem;
   color: var(--quiet);
 }
+
+/* A saved layout in force is invisible by nature - every relayout ends with
+   the sidecar re-pinning what it names (#273) - so the fact gets a standing
+   pill while the pin stands. Bottom-left: the top-right corner already holds
+   the canvas controls and the transient save notice, and the two pills would
+   otherwise co-occur on every save. Same anatomy as .filter-pill, with the
+   one-click way out beside the statement, and the discard is session-local -
+   the sidecar document stays on disk. */
+.saved-layout-pill {
+  position: absolute;
+  inset: auto auto var(--step) var(--step);
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: var(--step);
+  max-width: calc(100% - var(--step) * 2);
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--rule-firm);
+  border-radius: 999px;
+  background: var(--sheet);
+  font-family: var(--utility);
+  font-size: 12px;
+  color: var(--ink);
+}
+
+.saved-layout-pill span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.saved-layout-pill button {
+  flex: none;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--cobalt);
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.saved-layout-pill button:hover {
+  color: var(--ink);
+}

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -6,8 +6,10 @@ import {
   buildPositionMap,
   buildStylesheet,
   DRAG_SAVE_DEBOUNCE_MS,
+  effectiveSavedPositions,
   registerDragSave,
   relayoutVisible,
+  savedLayoutInForce,
 } from '../src/visual-app/graph-canvas.js'
 import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.js'
 import type {
@@ -59,6 +61,38 @@ describe('layout drag-save and position pinning', () => {
     applySavedPositions(cy, undefined)
 
     expect(cy.getElementById('node1').position()).toEqual({ x: 1, y: 1 })
+  })
+
+  it('leaves a hidden node alone: a sidecar entry for an undrawn subject is inert (#273)', () => {
+    const cy = canvasWith([
+      ['drawn', 1, 1],
+      ['hidden', 2, 2],
+    ])
+    // What `applyFilter` does to a node the active view does not draw.
+    cy.getElementById('hidden').style('display', 'none')
+    const saved: VisualLayoutPositions = {
+      drawn: { x: 100, y: 100 },
+      hidden: { x: 900, y: 2900 },
+    }
+
+    applySavedPositions(cy, saved)
+
+    expect(cy.getElementById('drawn').position()).toEqual({ x: 100, y: 100 })
+    // Not planted at the sidecar's whole-model coordinate.
+    expect(cy.getElementById('hidden').position()).toEqual({ x: 2, y: 2 })
+  })
+
+  it('discard unpins: a discarded view yields nothing to pin, so a fresh layout stands (#273)', () => {
+    const cy = canvasWith([['node1', 1, 1]])
+    const saved: VisualLayoutPositions = { node1: { x: 100, y: 100 } }
+    const discarded = new Set(['view1'])
+
+    applySavedPositions(cy, effectiveSavedPositions(saved, 'view1', discarded))
+    expect(cy.getElementById('node1').position()).toEqual({ x: 1, y: 1 })
+
+    // Another view's discard does not reach this one.
+    applySavedPositions(cy, effectiveSavedPositions(saved, 'view2', discarded))
+    expect(cy.getElementById('node1').position()).toEqual({ x: 100, y: 100 })
   })
 
   it('coalesces a burst of drags into one save carrying every node position', () => {
@@ -142,6 +176,38 @@ describe('layout drag-save and position pinning', () => {
     expect(onSaveLayout).not.toHaveBeenCalled()
 
     vi.useRealTimers()
+  })
+})
+
+// The standing indicator's one question (#273): does the active view's
+// sidecar pin anything the view draws? Derived from the view's match set,
+// the same base `applyFilter` starts from, so it is answerable with no
+// canvas mounted.
+describe('savedLayoutInForce', () => {
+  const graphNodeIds = ['a', 'b', 'c']
+
+  it('is false when the view has no sidecar', () => {
+    expect(savedLayoutInForce(undefined, graphNodeIds, ['a'])).toBe(false)
+  })
+
+  it('is true when the sidecar names a subject the view draws', () => {
+    expect(
+      savedLayoutInForce({ a: { x: 0, y: 0 } }, graphNodeIds, ['a', 'b']),
+    ).toBe(true)
+  })
+
+  it('is false when the sidecar names only subjects the view does not draw', () => {
+    // The stale-sidecar case: positions survive for subjects the view no
+    // longer selects, and every one of them is inert - nothing is in force.
+    expect(
+      savedLayoutInForce({ c: { x: 0, y: 0 } }, graphNodeIds, ['a', 'b']),
+    ).toBe(false)
+  })
+
+  it('measures against the whole graph when no structural filter stands', () => {
+    expect(
+      savedLayoutInForce({ c: { x: 0, y: 0 } }, graphNodeIds, null),
+    ).toBe(true)
   })
 })
 

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -497,6 +497,63 @@ describe('a host that asks for some of the sections', () => {
   })
 })
 
+/**
+ * A saved layout silently re-pins every relayout, so when one is actually in
+ * force for the active view the canvas says so and offers the way out (#273).
+ * "In force" means the view's sidecar names at least one subject the view
+ * draws - a stale sidecar naming only undrawn subjects is inert and earns no
+ * pill.
+ */
+describe('saved layout indicator (#273)', () => {
+  const viewFilter = {
+    query: {},
+    matchedIds: ['app.checkout'],
+    excluded: [],
+    source: 'view' as const,
+  }
+
+  it('shows the pill, with a discard affordance, when the sidecar pins a drawn subject', () => {
+    const markup = renderSession({
+      model: {
+        ...renderedModel,
+        layouts: { v1: { 'app.checkout': { x: 10, y: 20 } } },
+      },
+      activeView: 'v1',
+      activeFilter: viewFilter,
+    })
+
+    expect(markup).toContain('class="saved-layout-pill" role="status"')
+    expect(markup).toContain('Saved layout in force')
+    expect(markup).toContain('>Discard</button>')
+  })
+
+  it('shows nothing when the view has no sidecar', () => {
+    const markup = renderSession({
+      model: renderedModel,
+      activeView: 'v1',
+      activeFilter: viewFilter,
+    })
+
+    expect(markup).not.toContain('saved-layout-pill')
+    expect(markup).not.toContain('Saved layout in force')
+  })
+
+  it('shows nothing when the sidecar names only subjects the view does not draw', () => {
+    // The stale-sidecar case: `app.ledger` has a position but the view draws
+    // only `app.checkout`, so the entry is inert and no layout is in force.
+    const markup = renderSession({
+      model: {
+        ...renderedModel,
+        layouts: { v1: { 'app.ledger': { x: 10, y: 20 } } },
+      },
+      activeView: 'v1',
+      activeFilter: viewFilter,
+    })
+
+    expect(markup).not.toContain('saved-layout-pill')
+  })
+})
+
 describe('open questions section (#292)', () => {
   const overlay = {
     catalogue: 'core-enrichment@1.1',


### PR DESCRIPTION
Closes #273.

A per-view layout sidecar silently re-pinned every relayout (an experimental relayout moved 0 of 16 nodes with no hint why), and a sidecar stale relative to its view scattered 20 drawn subjects across coordinates saved for all 37, with nothing on screen saying a saved layout was in force.

## What this builds (the issue's first two candidates)

**1. A sidecar entry for a subject the active view does not draw is inert.**
`applySavedPositions` now pins only visible nodes. A hidden node keeps whatever the last layout gave it instead of being planted at a stale whole-model coordinate, which the next whole-canvas drag-save would have written straight back into the sidecar. `visible()` is the same judgement `relayoutVisible` already scopes by, and it degrades safely (returns true wholesale) on a style-disabled instance.

**2. A visible "saved layout" indicator with a discard affordance.**
When the active view's sidecar names at least one subject the view draws, the canvas shows a standing pill: "Saved layout in force", with a Discard button. It reuses the notice-pill anatomy (`role="status"`, pill styling, bottom-left so it never collides with the transient top-right save receipt) but is deliberately distinct from `state.layoutNotice`, which stays the transient save receipt: the indicator is state derived at render time (`savedLayoutInForce`: sidecar ∩ the view's match set), never a flag an effect must remember to clear.

**Discard is session-local**, as the issue anticipated: actually deleting the sidecar from disk is a staged/committed write this canvas does not own, so wiring a real delete would either bypass the staged-changeset discipline or grow the changeset machinery for one convenience. Instead the canvas records the view as discarded (per view id, in `GraphCanvas` component state), stops honouring its sidecar, and reruns a fresh layout over what is drawn. A later drag-save re-arms that view: the reviewer's own fresh sidecar supersedes the discard.

## Deferred

The issue's third candidate, pruning sidecar entries the view no longer selects on view save, is out of scope here. It belongs to the view-save write path and stages a document change of its own; noted as deferred in [ADR 0113](docs/adr/0113-a-saved-layout-is-visible-and-view-scoped.md).

## Tests

- `test/graph-canvas-layout.test.ts` (headless cytoscape): an undrawn subject's sidecar entry is not applied; discard yields nothing to pin (and another view's discard does not leak); `savedLayoutInForce` truth table including the stale-sidecar case.
- `test/visual-app-render.test.ts` (renderToStaticMarkup): the pill renders with its Discard affordance when the sidecar pins a drawn subject, and not when there is no sidecar or the sidecar names only undrawn subjects.

Both files were already routed in `tsconfig.json` exclude / `tsconfig.visual.json` include; no new test files.

`pnpm verify` exit 0 on a fresh worktree: 96 test files, 1601 passed, 1 skipped.

Files: `src/visual-app/graph-canvas.tsx`, `src/visual-app/styles.css` (append only), `CHANGELOG.md`, `docs/adr/0113-a-saved-layout-is-visible-and-view-scoped.md`, plus the two test files. `App.tsx`, `state.ts`, and `workspace-state.ts` are untouched: the pill renders inside `GraphCanvas` (a sibling of the container div, anchored by `.canvas`), so no sibling-owned file moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)