### PR TITLE
feat: the rail shows staged intent beside landed truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Fixed.** A staged view is visible in the rail, marked (#299). The view
+  tree now merges the pending changeset's view operations over the landed
+  views: a staged new view — and the folder it declares, which is how "New
+  folder…" becomes visible at all — renders at once with a quiet `staged`
+  chip; a staged overwrite marks the existing row and shows what will land;
+  a staged delete marks its row rather than hiding it. Nothing is stored:
+  the tree derives from `pendingChangeset`, so discarding the operation is
+  the revert and committing converts staged rows to ordinary ones. In the
+  same flow, a save dialog opened with a folder preset ("New folder…", "New
+  view in this folder…") disables plain Save — the overwrite carries the
+  active view's own folder by design, so it was the one button that could
+  silently drop the folder just named; Save As New, which adopts it, is the
+  action left standing.
+  [ADR 0114](docs/adr/0114-the-rail-shows-staged-intent-beside-landed-truth.md).
+
 - **Changed.** A saved layout is visible, view-scoped, and discardable
   (#273). A per-view layout sidecar silently re-pinned every relayout — an
   experimental relayout moved 0 of 16 nodes with no hint why — and a stale

--- a/docs/adr/0114-the-rail-shows-staged-intent-beside-landed-truth.md
+++ b/docs/adr/0114-the-rail-shows-staged-intent-beside-landed-truth.md
@@ -1,0 +1,82 @@
+# The rail shows staged intent beside landed truth
+
+Status: accepted
+
+The view tree rendered `state.views`, the landed list: it learned about a
+view when a commit landed it, and not before. A staged `write-view` sat in
+`pendingChangeset.viewOperations`, appeared as "1 staged" in the Changes
+tray, and was invisible in the rail until Commit. The pipeline underneath
+is sound — a committed view carrying `presentation.folder` flows through
+and renders — so what a reviewer hit was pure visibility timing: "New
+folder…" names a folder, the save dialog stages the first view into it,
+and the rail shows nothing. The folder looks swallowed (#299).
+
+The rule producing this was deliberate — the rail shows what the
+workspace holds — but it collided with an inconsistency the editor
+already carries: a staged subject edit appears on the canvas immediately
+through the draft model, while a staged view appeared nowhere. One
+changeset, two visibility rules.
+
+The same flow held a second trap. Plain **Save** (overwrite) carries the
+active view's own declared folder by design — the carry rule, which keeps
+an ordinary overwrite from moving a view because of whatever the folder
+control happened to be holding. Opened by "New folder…", that same rule
+means the one button nearest the reviewer's finger silently drops the
+folder they just named, and no commit will ever show it.
+
+## Decision
+
+The tree's input merges `pendingChangeset.viewOperations` over
+`state.views`, in the pure model (`buildViewTree`) where a test can hold
+it. A staged `write-view` at a path nothing landed renders as a row —
+title and folder read from its own projection document — so the folder
+just named is visible the moment its first view is staged. A staged
+`write-view` at a landed path marks that row rather than duplicating it,
+and the row shows what WILL land: the staged title, the staged folder. A
+staged `delete-view` marks its row rather than hiding it. Every staged
+row is visibly distinguished — an italic title and a quiet `staged` chip,
+never the failure palette, because staging is ordinary work. The rail
+becomes landed truth plus the reviewer's own uncommitted intent, visibly
+told apart.
+
+Nothing is stored. The merge derives from the changeset on every render,
+so discarding the operation IS the revert and committing converts staged
+rows to ordinary ones by the paths that already existed. A staged NEW row
+is not navigable: opening a view resolves its id in the landed list,
+where a staged one does not exist yet, so the row takes no click and no
+menu — acting on staged intent belongs to the tray.
+
+In the save dialog, a folder preset (the "New folder…" and "New view in
+this folder…" openers) disables plain Save. The carry rule stands
+untouched — an ordinary overwrite still carries the view's own folder —
+but under a preset the overwrite is the one action that would silently
+drop the named folder, so Save As New, which adopts it, is the action
+left standing, and the disabled button says why.
+
+## Excluded options
+
+- **Keep the rail landed-only and say so** — a dialog notice reading
+  "staged — appears in the rail when committed". Cheaper, and it keeps
+  the rail's landed-truth semantics pure; but the folder still cannot be
+  found until commit, and the canvas already shows staged subject edits,
+  so the notice would be documenting the inconsistency rather than
+  removing it.
+- **Save adopts the preset folder on overwrite**: it closes the trap by
+  breaking the rule that prevents a worse one — an overwrite that moves
+  the active view into a folder as a side effect of how the dialog was
+  opened is exactly what the carry rule exists to refuse.
+- **Staged rows held in workspace state**: a marker the state remembers
+  is a marker that can disagree with the changeset it describes. Deriving
+  from `pendingChangeset` makes discard-reverts-the-tree a property of
+  construction rather than a behaviour to maintain.
+
+## Consequences
+
+`ViewTreeRow` says how a row relates to the changeset (`staged`), and its
+`subjectCount` admits `null`: a staged new view has no landed document to
+measure and resolving its query needs the semantic graph the browser does
+not hold, so the row shows its chip where a count would go rather than a
+made-up zero. A staged overwrite keeps the landed count, the same
+staleness story the summary already tells. The filter matches staged rows
+by the words they display — the staged title and folder — and `matched`
+counts them like any other row.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1260,6 +1260,11 @@ export const App = ({
       <div className="workspace">
         <ViewTree
           views={state.views}
+          // Landed truth plus the reviewer's own staged intent (#299): the
+          // tree merges these over `state.views`, so a staged view — and the
+          // folder it declares — is visible, marked, before commit. Read off
+          // the changeset, never stored: discarding the row is the revert.
+          stagedViewOperations={state.pendingChangeset.viewOperations}
           activeViewId={state.activeView}
           nodes={state.model?.graph.nodes ?? []}
           // What the canvas is drawing, which is the graph narrowed by the

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -125,6 +125,16 @@ export const buildPayload = ({
 
 interface SaveViewFormProps {
   readonly activeView: VisualViewSummary | null;
+  /**
+   * The folder the OPENER named — "New folder…" or "New view in this
+   * folder…" — or undefined for every other way in. Only Save As New adopts
+   * it; plain Save carries the active view's own folder, so while a folder is
+   * preset the overwrite is disabled rather than offered (#299): pressing it
+   * would silently drop the folder the reviewer just named, and adopting the
+   * folder instead would silently MOVE the active view, which is the very
+   * thing the carry rule exists to prevent.
+   */
+  readonly presetFolder: string | undefined;
   readonly onSubmit: (
     id: string | undefined,
     title: string,
@@ -142,7 +152,12 @@ interface SaveViewFormProps {
  * an overwrite of the active view with nothing retyped, and closing it
  * discard a half-typed name that was never workspace state.
  */
-function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
+function SaveViewForm({
+  activeView,
+  presetFolder,
+  onSubmit,
+  onCancel,
+}: SaveViewFormProps) {
   const [title, setTitle] = useState(activeView?.title ?? "");
   const [description, setDescription] = useState(activeView?.description ?? "");
 
@@ -150,6 +165,9 @@ function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
   // `viewSavePayload`, so the form refuses exactly what the server would
   // reject rather than sending a save that can only come back as a fault.
   const incomplete = title.trim() === "" || description.trim() === "";
+  // A folder preset means the opener asked for a NEW view in that folder, and
+  // an overwrite is the one action that would ignore it (see the prop).
+  const overwriteDropsFolder = presetFolder !== undefined;
 
   return (
     <div className="save-view-panel">
@@ -159,7 +177,14 @@ function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
           onSubmit={(event) => {
             event.preventDefault();
             if (incomplete) return;
-            onSubmit(activeView?.id, title, description);
+            // Submission follows the one action a folder preset leaves
+            // enabled: while the overwrite is disabled below, nothing this
+            // form does may reach it.
+            onSubmit(
+              overwriteDropsFolder ? undefined : activeView?.id,
+              title,
+              description,
+            );
           }}
         >
           <div>
@@ -184,7 +209,14 @@ function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
           <div className="save-view-actions">
             <button
               type="submit"
-              disabled={activeView === null || incomplete}
+              disabled={activeView === null || incomplete || overwriteDropsFolder}
+              // The reason, where the disabled button is: a control that
+              // refuses without saying why reads as broken.
+              title={
+                overwriteDropsFolder
+                  ? `Save overwrites the active view and keeps its own folder — Save As New puts the first view in "${presetFolder}".`
+                  : undefined
+              }
             >
               Save
             </button>
@@ -219,6 +251,11 @@ function SaveViewForm({ activeView, onSubmit, onCancel }: SaveViewFormProps) {
  * an overwrite was immediate and unundoable; a staged overwrite is a row the
  * reviewer can read, discard and undo before it lands, which is a better
  * answer than a dialog.
+ *
+ * Opened with a folder preset — "New folder…", "New view in this folder…" —
+ * the overwrite is disabled (#299): it carries the active view's own folder
+ * by design, so it is the one button that would silently drop the folder the
+ * reviewer just named.
  */
 export function SaveViewDialog({
   views,
@@ -278,6 +315,7 @@ export function SaveViewDialog({
         // fields describe the view the Save button would overwrite.
         key={activeViewId}
         activeView={activeView}
+        presetFolder={folder}
         onSubmit={(id, title, description) => {
           submit(id, title, description);
           onClose();

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -2362,4 +2362,32 @@ body {
 
 .saved-layout-pill button:hover {
   color: var(--ink);
+
+/* A staged row is the reviewer's own uncommitted intent beside landed truth
+   (ADR 0114): the title leans and a small chip says so. Quiet on purpose —
+   staging is ordinary work, so nothing here borrows the failure palette. */
+.tree-row-staged .tree-label {
+  font-style: italic;
+}
+
+.tree-row-staged-delete .tree-label {
+  text-decoration: line-through;
+}
+
+.tree-staged {
+  flex: none;
+  padding: 0 0.3em;
+  font-family: var(--utility);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--quiet);
+  border: 1px solid var(--rule-firm);
+  border-radius: 2px;
+}
+
+.tree-row-active .tree-staged {
+  color: inherit;
+  border-color: currentColor;
+  opacity: 0.75;
 }

--- a/src/visual-app/view-tree-model.ts
+++ b/src/visual-app/view-tree-model.ts
@@ -2,7 +2,8 @@
  * What the left rail shows, as data.
  *
  * The rail is two trees over things the session already has — the saved views
- * and the subjects the model declares — so everything it decides is a pure
+ * with the reviewer's staged view operations merged over them (ADR 0114), and
+ * the subjects the model declares — so everything it decides is a pure
  * function of those plus what the reviewer typed. It lives outside the
  * component for the reason `filterToReresolve` does: this repo renders React
  * with `renderToStaticMarkup` and has no DOM test environment, so logic that
@@ -14,7 +15,10 @@
 import type { CanvasNode } from "../graph-projection.js";
 import type { Layer } from "../profile.js";
 import { layers } from "../profile.js";
-import type { VisualViewSummary } from "../adapters/visual/protocol-contract.js";
+import type {
+  VisualViewOperation,
+  VisualViewSummary,
+} from "../adapters/visual/protocol-contract.js";
 
 export const VIEWS_ROOT_KEY = "views";
 export const MODEL_ROOT_KEY = "model";
@@ -30,12 +34,28 @@ export const modelFolderKey = (folder: string): string =>
 /** Where a subject with no resolved layer is grouped, last. */
 export const UNLAYERED = "unlayered";
 
+/**
+ * How a row relates to the pending changeset (ADR 0114). `"new"` is a staged
+ * `write-view` at a path nothing has landed; `"overwrite"` is one at a path a
+ * landed view occupies; `"delete"` is a staged `delete-view`. A landed row
+ * nothing pending touches carries `null`.
+ */
+export type ViewRowStaging = "new" | "overwrite" | "delete";
+
 export interface ViewTreeRow {
   readonly id: string;
   readonly title: string;
   readonly path: string;
-  readonly subjectCount: number;
+  /**
+   * `null` when nothing has measured it: a staged NEW view has no landed
+   * document, and resolving its query needs the semantic graph the browser
+   * does not hold. A number here is always the server's measure of what
+   * LANDED — a staged overwrite keeps the landed count, the same staleness
+   * story `VisualViewSummary.subjectCount` already tells.
+   */
+  readonly subjectCount: number | null;
   readonly active: boolean;
+  readonly staged: ViewRowStaging | null;
 }
 
 export interface ViewTreeFolder {
@@ -119,6 +139,15 @@ export const folderOf = (view: VisualViewSummary): string =>
 
 export interface ViewTreeInput {
   readonly views: readonly VisualViewSummary[];
+  /**
+   * The pending changeset's view operations, merged over `views` so the rail
+   * shows the reviewer's own staged intent beside landed truth (ADR 0114).
+   * A staged `write-view` at a new path becomes a row; one at a landed path
+   * marks that row and shows what WILL land; a staged `delete-view` marks the
+   * row rather than hiding it. Discarding an operation removes it from this
+   * list, which is the whole revert — the tree derives, it never remembers.
+   */
+  readonly stagedOperations: readonly VisualViewOperation[];
   readonly activeViewId: string;
   /**
    * How many subjects the active view is drawing right now, from the standing
@@ -132,6 +161,7 @@ export interface ViewTreeInput {
 
 export const buildViewTree = ({
   views,
+  stagedOperations,
   activeViewId,
   activeSubjectCount,
   filterText,
@@ -139,26 +169,79 @@ export const buildViewTree = ({
   const needle = normalize(filterText);
   const rowsByFolder = new Map<string, ViewTreeRow[]>();
 
+  const place = (folder: string, row: ViewTreeRow): void => {
+    const existing = rowsByFolder.get(folder);
+    if (existing === undefined) rowsByFolder.set(folder, [row]);
+    else existing.push(row);
+  };
+
+  // The reducer keeps one operation per path; read last-wins anyway, so a
+  // changeset that somehow says a document twice still renders what the
+  // reviewer last meant rather than a duplicate row.
+  const stagedByPath = new Map<string, VisualViewOperation>();
+  for (const operation of stagedOperations) {
+    stagedByPath.set(operation.path, operation);
+  }
+
   for (const view of views) {
+    const operation = stagedByPath.get(view.path);
+    stagedByPath.delete(view.path);
+    // A staged write over a landed path MARKS the landed row rather than
+    // duplicating it, and the row says what will land — the staged title, the
+    // staged folder — because a rail showing the state a discard would return
+    // to, unmarked, is a rail claiming the save did not happen (#299). The id
+    // stays the landed one: it is what navigation resolves.
+    const projection =
+      operation?.op === "write-view" ? operation.projection : null;
+    const staged: ViewRowStaging | null =
+      operation === undefined
+        ? null
+        : projection === null
+          ? "delete"
+          : "overwrite";
+    const title =
+      projection === null
+        ? view.title
+        : (projection.presentation?.title ?? projection.id);
+    const folder =
+      projection === null ? folderOf(view) : (projection.presentation?.folder ?? "");
     const active = view.id === activeViewId;
-    const folder = folderOf(view);
     // A folder that matches shows everything it holds: the reviewer typing
     // `target` is asking for that folder, not for views whose titles happen
     // to say so.
-    if (!matches(view.title, needle) && !matches(folder, needle)) continue;
-    const row: ViewTreeRow = {
+    if (!matches(title, needle) && !matches(folder, needle)) continue;
+    place(folder, {
       id: view.id,
-      title: view.title,
+      title,
       path: view.path,
       subjectCount:
         active && activeSubjectCount !== null
           ? activeSubjectCount
           : view.subjectCount,
       active,
-    };
-    const existing = rowsByFolder.get(folder);
-    if (existing === undefined) rowsByFolder.set(folder, [row]);
-    else existing.push(row);
+      staged,
+    });
+  }
+
+  // What remains is staged against paths nothing landed: each `write-view` is
+  // a NEW view, drawn from its own projection document — which is what makes
+  // "New folder…" visible the moment its first view is staged. It cannot be
+  // the active view (navigation resolves landed ids only), and a `delete-view`
+  // of a path that never landed has nothing to show.
+  for (const operation of stagedByPath.values()) {
+    if (operation.op !== "write-view") continue;
+    const { projection } = operation;
+    const title = projection.presentation?.title ?? projection.id;
+    const folder = projection.presentation?.folder ?? "";
+    if (!matches(title, needle) && !matches(folder, needle)) continue;
+    place(folder, {
+      id: projection.id,
+      title,
+      path: operation.path,
+      subjectCount: null,
+      active: false,
+      staged: "new",
+    });
   }
 
   const byTitle = (a: ViewTreeRow, b: ViewTreeRow): number =>

--- a/src/visual-app/view-tree.tsx
+++ b/src/visual-app/view-tree.tsx
@@ -1,5 +1,8 @@
 import { LAYER_COLORS } from "../notation/archimate.js";
-import type { VisualViewSummary } from "../adapters/visual/protocol-contract.js";
+import type {
+  VisualViewOperation,
+  VisualViewSummary,
+} from "../adapters/visual/protocol-contract.js";
 import type { CanvasNode } from "../graph-projection.js";
 import {
   MODEL_ROOT_KEY,
@@ -99,23 +102,44 @@ interface ViewRowProps {
 }
 
 function ViewRow({ row, depth, onSelect, onMenu }: ViewRowProps) {
+  // A staged NEW view is not navigable: opening a view resolves its id in the
+  // landed list, where a staged one does not exist yet. The row is the
+  // reviewer's intent made visible (ADR 0114); acting on it — discard, undo,
+  // commit — belongs to the tray, so the row takes no click and no menu.
+  const navigable = row.staged !== "new";
   return (
     <li>
       <button
         type="button"
         className={`tree-row tree-view tree-depth-${depth}${
           row.active ? " tree-row-active" : ""
+        }${row.staged === null ? "" : " tree-row-staged"}${
+          row.staged === "delete" ? " tree-row-staged-delete" : ""
         }`}
         // The title is width-capped and elided, exactly as the picker it
         // replaces was, so hover still recovers the authored title.
         title={row.title}
         aria-current={row.active ? "true" : undefined}
-        onClick={() => onSelect(row.id)}
-        onContextMenu={menuHandler({ kind: "view", id: row.id }, onMenu)}
+        onClick={navigable ? () => onSelect(row.id) : undefined}
+        onContextMenu={
+          navigable
+            ? menuHandler({ kind: "view", id: row.id }, onMenu)
+            : undefined
+        }
       >
         <ViewGlyph />
         <span className="tree-label">{row.title}</span>
-        <span className="tree-count">{row.subjectCount}</span>
+        {row.staged === null ? null : (
+          <span className="tree-staged">
+            {row.staged === "delete" ? "staged delete" : "staged"}
+          </span>
+        )}
+        {/* No count for a row nothing has measured: a staged new view's query
+            needs the semantic graph, and a made-up zero would read as an
+            empty view. */}
+        {row.subjectCount === null ? null : (
+          <span className="tree-count">{row.subjectCount}</span>
+        )}
       </button>
     </li>
   );
@@ -146,6 +170,13 @@ function Branch({ label, open, count, depth, onToggle }: BranchProps) {
 
 export interface ViewTreeProps {
   readonly views: readonly VisualViewSummary[];
+  /**
+   * The pending changeset's view operations, merged over `views` by
+   * `buildViewTree` so staged intent is visible beside landed truth
+   * (ADR 0114). Derived from the changeset at the call site, never stored:
+   * discarding the operation is the revert.
+   */
+  readonly stagedViewOperations: readonly VisualViewOperation[];
   readonly activeViewId: string;
   /** Every subject the workspace declares, filtered or not. */
   readonly nodes: readonly CanvasNode[];
@@ -164,6 +195,7 @@ export interface ViewTreeProps {
 
 export function ViewTree({
   views,
+  stagedViewOperations,
   activeViewId,
   nodes,
   inViewIds,
@@ -179,6 +211,7 @@ export function ViewTree({
 }: ViewTreeProps) {
   const tree = buildViewTree({
     views,
+    stagedOperations: stagedViewOperations,
     activeViewId,
     // Nodes drawn, not entries in the match set: a match set holds the
     // relationships a view matched as well as its concepts, and the number

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -1,5 +1,11 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { buildPayload } from '../src/visual-app/save-view.js'
+import {
+  buildPayload,
+  SaveViewDialog,
+  type SaveViewDialogProps,
+} from '../src/visual-app/save-view.js'
 import type {
   ProjectionDefinition,
   ProjectionQuery,
@@ -309,5 +315,72 @@ describe('view membership', () => {
     // so by other means.
     expect(membershipDelta(listed.query, listed.query)).toEqual([])
     expect(membershipDelta(described.query, described.query)).toEqual([])
+  })
+})
+
+/**
+ * The folder-preset rule (#299, ADR 0114). Plain Save carries the active
+ * view's own folder by design; opened by "New folder…" or "New view in this
+ * folder…", it is therefore the one button that would silently drop the
+ * folder the reviewer just named — so it is disabled, and Save As New (which
+ * adopts the preset) is the action left standing.
+ */
+describe('the save dialog, opened with a folder preset', () => {
+  const activeView = {
+    id: 'existing-view',
+    title: 'Existing view',
+    description: 'What it shows',
+    query: {},
+    presentation: { folder: 'Elsewhere' },
+    path: '.yarramate/projections/existing-view.yaml',
+    subjectCount: 3,
+  }
+
+  const renderDialog = (overrides: Partial<SaveViewDialogProps> = {}) =>
+    renderToStaticMarkup(
+      createElement(SaveViewDialog, {
+        views: [activeView],
+        activeViewId: 'existing-view',
+        query: null,
+        layout: 'layered',
+        showLifecycle: true,
+        showEvidence: true,
+        showOwnership: false,
+        open: true,
+        folder: undefined,
+        onClose: () => {},
+        onStage: () => {},
+        ...overrides,
+      }),
+    )
+
+  /** The overwrite button's own markup, so `disabled` cannot be read off a
+   * neighbour. */
+  const saveButton = (markup: string): string => {
+    const at = markup.indexOf('<button type="submit"')
+    if (at === -1) throw new Error('expected a Save button')
+    return markup.slice(at, markup.indexOf('</button>', at))
+  }
+
+  it('offers the overwrite as usual when no folder was preset', () => {
+    // The ordinary flows are untouched: an overwrite still carries the
+    // active view's own folder, and nothing here disables it.
+    expect(saveButton(renderDialog())).not.toContain('disabled')
+  })
+
+  it('disables the overwrite, which is the one button that would drop the folder', () => {
+    const markup = renderDialog({ folder: 'Roadmap' })
+
+    expect(saveButton(markup)).toContain('disabled')
+    // Save As New stays available: it is the action the opener asked for,
+    // and the one that adopts the folder.
+    expect(markup).toContain('<button type="button">Save As New</button>')
+  })
+
+  it('says why, on the disabled button itself', () => {
+    // A control that refuses without saying why reads as broken.
+    expect(saveButton(renderDialog({ folder: 'Roadmap' }))).toContain(
+      'Save As New puts the first view in &quot;Roadmap&quot;',
+    )
   })
 })

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -288,6 +288,70 @@ describe('visual conversation rendering', () => {
     expect(markup).not.toContain('<option value="v1">')
   })
 
+  it('shows a staged view, and the folder it declares, before any commit lands it', () => {
+    // The #299 repro: "New folder…" stages the first view of a folder no
+    // landed document declares, and the rail used to show nothing at all.
+    const markup = renderSession({
+      pendingChangeset: {
+        operations: [],
+        viewOperations: [
+          {
+            op: 'write-view',
+            path: '.yarramate/projections/roadmap-first.yaml',
+            projection: {
+              format: 'yarramate/projection/v1',
+              id: 'roadmap-first',
+              version: '1.0',
+              query: {},
+              presentation: {
+                title: 'Roadmap first',
+                description: 'staged',
+                folder: 'Roadmap',
+              },
+            },
+          },
+        ],
+        sourceDigests: {},
+      },
+    })
+
+    // The folder branch and its first view, at once, visibly staged — and no
+    // count, because nothing has measured a query that has not landed.
+    expect(markup).toContain('<span class="tree-label">Roadmap</span>')
+    expect(markup).toContain('tree-row-staged')
+    expect(markup).toContain(
+      '<span class="tree-label">Roadmap first</span><span class="tree-staged">staged</span>',
+    )
+  })
+
+  it('marks a staged delete in the tree rather than dropping the row', () => {
+    const markup = renderSession({
+      views: [
+        {
+          id: 'v1',
+          title: 'View One',
+          description: '',
+          query: {},
+          presentation: {},
+          path: '.yarramate/projections/v1.yaml',
+          subjectCount: 4,
+        },
+      ],
+      pendingChangeset: {
+        operations: [],
+        viewOperations: [
+          { op: 'delete-view', path: '.yarramate/projections/v1.yaml' },
+        ],
+        sourceDigests: {},
+      },
+    })
+
+    expect(markup).toContain('tree-row-staged-delete')
+    expect(markup).toContain(
+      '<span class="tree-label">View One</span><span class="tree-staged">staged delete</span>',
+    )
+  })
+
   it('lists every declared subject under Model, marking the ones the view leaves out', () => {
     const markup = renderSession({
       model: renderedModel,

--- a/test/visual-view-tree.test.ts
+++ b/test/visual-view-tree.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { CanvasNode } from "../src/graph-projection.js";
-import type { VisualViewSummary } from "../src/adapters/visual/protocol-contract.js";
+import type {
+  VisualViewOperation,
+  VisualViewSummary,
+} from "../src/adapters/visual/protocol-contract.js";
 import {
   buildModelTree,
   buildViewTree,
@@ -51,6 +54,7 @@ describe("view folders, which the author declares", () => {
     ];
     const tree = buildViewTree({
       views,
+      stagedOperations: [],
       activeViewId: "",
       activeSubjectCount: null,
       filterText: "",
@@ -67,6 +71,7 @@ describe("view folders, which the author declares", () => {
     ];
     const tree = buildViewTree({
       views,
+      stagedOperations: [],
       activeViewId: "",
       activeSubjectCount: null,
       filterText: "",
@@ -93,6 +98,7 @@ describe("view folders, which the author declares", () => {
     // author declares, not a consequence of where a file happens to sit.
     const tree = buildViewTree({
       views: [view({ path: "deeply/nested/only.yaml" })],
+      stagedOperations: [],
       activeViewId: "",
       activeSubjectCount: null,
       filterText: "",
@@ -109,6 +115,7 @@ describe("view rows", () => {
         view({ id: "a", title: "A", subjectCount: 7 }),
         view({ id: "b", title: "B", subjectCount: 9, path: ".yarramate/projections/b.yaml" }),
       ],
+      stagedOperations: [],
       activeViewId: "a",
       // A commit landed and this view now draws six, whatever the frame that
       // carried its summary said.
@@ -127,6 +134,7 @@ describe("view rows", () => {
     ];
     const byTitle = buildViewTree({
       views,
+      stagedOperations: [],
       activeViewId: "",
       activeSubjectCount: null,
       filterText: "the",
@@ -135,6 +143,7 @@ describe("view rows", () => {
 
     const byFolder = buildViewTree({
       views,
+      stagedOperations: [],
       activeViewId: "",
       activeSubjectCount: null,
       filterText: "target",
@@ -312,5 +321,232 @@ describe("the model root, once subjects declare folders", () => {
       ["business", "layer"],
       ["application", "layer"],
     ]);
+  });
+});
+
+/**
+ * Staged intent beside landed truth (ADR 0114, #299). The tree merges the
+ * pending changeset's view operations over the landed views, so a staged
+ * view — and the folder it declares — is visible before commit, marked.
+ */
+describe("staged view operations, merged over the landed views", () => {
+  const writeOp = (
+    id: string,
+    overrides: {
+      readonly title?: string;
+      readonly folder?: string;
+      readonly path?: string;
+    } = {},
+  ): VisualViewOperation => ({
+    op: "write-view",
+    path: overrides.path ?? `.yarramate/projections/${id}.yaml`,
+    projection: {
+      format: "yarramate/projection/v1",
+      id,
+      version: "1.0",
+      query: {},
+      presentation: {
+        title: overrides.title ?? id,
+        description: "staged",
+        ...(overrides.folder === undefined ? {} : { folder: overrides.folder }),
+      },
+    },
+  });
+
+  it("renders a staged NEW view as a row, in the folder it declares", () => {
+    // The #299 repro: "New folder…" stages the first view of a folder no
+    // landed document declares, and the rail used to show nothing at all.
+    const tree = buildViewTree({
+      views: [view()],
+      stagedOperations: [
+        writeOp("roadmap-first", { title: "Roadmap first", folder: "Roadmap" }),
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    expect(tree.folders.map((folder) => folder.name)).toEqual(["Roadmap"]);
+    expect(tree.folders[0]?.views).toEqual([
+      {
+        id: "roadmap-first",
+        title: "Roadmap first",
+        path: ".yarramate/projections/roadmap-first.yaml",
+        // Nothing has measured a staged view: its query needs the semantic
+        // graph, which the browser does not hold.
+        subjectCount: null,
+        // Navigation resolves landed ids, so a staged new view can never be
+        // the active one.
+        active: false,
+        staged: "new",
+      },
+    ]);
+  });
+
+  it("marks the landed row a staged write overwrites, showing what WILL land", () => {
+    const tree = buildViewTree({
+      views: [view({ id: "current-engine", title: "Current engine" })],
+      stagedOperations: [
+        writeOp("current-engine", {
+          title: "Engine, renamed",
+          folder: "Current",
+          path: ".yarramate/projections/current-engine.yaml",
+        }),
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    // Marked, not duplicated: one document, one row.
+    expect(tree.matched).toBe(1);
+    expect(tree.loose).toEqual([]);
+    expect(tree.folders[0]?.name).toBe("Current");
+    expect(tree.folders[0]?.views[0]).toMatchObject({
+      id: "current-engine",
+      title: "Engine, renamed",
+      staged: "overwrite",
+      // The landed measure stays: the staged query has not landed, and the
+      // summary's own staleness story already covers it.
+      subjectCount: 7,
+    });
+  });
+
+  it("marks a staged delete rather than hiding the row", () => {
+    const tree = buildViewTree({
+      views: [view()],
+      stagedOperations: [
+        { op: "delete-view", path: ".yarramate/projections/current-engine.yaml" },
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    expect(tree.loose[0]).toMatchObject({
+      id: "current-engine",
+      title: "Current engine",
+      staged: "delete",
+    });
+    expect(tree.matched).toBe(1);
+  });
+
+  it("reverts to the plain tree when the operations are discarded", () => {
+    // Discarding a staged row leaves the changeset without it, and the tree
+    // derives rather than remembers — so absence of operations IS the revert.
+    const views = [view()];
+    const staged = buildViewTree({
+      views,
+      stagedOperations: [writeOp("brand-new", { folder: "Roadmap" })],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+    const discarded = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    expect(staged.matched).toBe(2);
+    expect(discarded.matched).toBe(1);
+    expect(discarded.folders).toEqual([]);
+    expect(discarded.loose[0]).toMatchObject({
+      id: "current-engine",
+      staged: null,
+    });
+  });
+
+  it("counts staged rows in matched, and filters them by their staged words", () => {
+    const input = {
+      views: [view({ id: "loose-view", title: "Loose view", path: "a.yaml" })],
+      stagedOperations: [
+        writeOp("target-next", { title: "Target next", folder: "Target" }),
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+    };
+
+    // The staged folder is searchable the way a landed one is: typing it is
+    // asking for the folder, wherever its rows come from.
+    expect(buildViewTree({ ...input, filterText: "target" }).matched).toBe(1);
+    expect(buildViewTree({ ...input, filterText: "" }).matched).toBe(2);
+    expect(
+      buildViewTree({ ...input, filterText: "nothing-says-this" }).matched,
+    ).toBe(0);
+  });
+
+  it("filters an overwritten row by what will land, not by what did", () => {
+    const input = {
+      views: [view({ id: "current-engine", title: "Current engine" })],
+      stagedOperations: [
+        writeOp("current-engine", {
+          title: "Renamed entirely",
+          path: ".yarramate/projections/current-engine.yaml",
+        }),
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+    };
+
+    // The row SHOWS the staged title, so the filter has to match it — a row
+    // found by a word it no longer displays would look like a false hit.
+    expect(buildViewTree({ ...input, filterText: "renamed" }).matched).toBe(1);
+    expect(
+      buildViewTree({ ...input, filterText: "current engine" }).matched,
+    ).toBe(0);
+  });
+
+  it("keeps the drawn count on an overwritten row that is active", () => {
+    const tree = buildViewTree({
+      views: [view({ id: "current-engine" })],
+      stagedOperations: [
+        writeOp("current-engine", {
+          path: ".yarramate/projections/current-engine.yaml",
+        }),
+      ],
+      activeViewId: "current-engine",
+      activeSubjectCount: 3,
+      filterText: "",
+    });
+
+    expect(tree.loose[0]).toMatchObject({
+      active: true,
+      staged: "overwrite",
+      subjectCount: 3,
+    });
+  });
+
+  it("shows nothing for a staged delete of a path nothing landed", () => {
+    const tree = buildViewTree({
+      views: [],
+      stagedOperations: [{ op: "delete-view", path: "never-landed.yaml" }],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    expect(tree.matched).toBe(0);
+  });
+
+  it("renders the last operation staged for a path, never two rows for one document", () => {
+    // The reducer already keeps one row per document; the tree reads
+    // last-wins anyway, so a malformed changeset degrades to what the
+    // reviewer last meant rather than to a duplicate.
+    const tree = buildViewTree({
+      views: [],
+      stagedOperations: [
+        writeOp("draft", { title: "First words", path: "draft.yaml" }),
+        writeOp("draft", { title: "Second thoughts", path: "draft.yaml" }),
+      ],
+      activeViewId: "",
+      activeSubjectCount: null,
+      filterText: "",
+    });
+
+    expect(tree.matched).toBe(1);
+    expect(tree.loose[0]?.title).toBe("Second thoughts");
   });
 });


### PR DESCRIPTION
Closes #299. ADR: [0114-the-rail-shows-staged-intent-beside-landed-truth](docs/adr/0114-the-rail-shows-staged-intent-beside-landed-truth.md).

## What this builds (options 1 + 3 from the issue)

**Staged views join the tree, marked.** `buildViewTree` now takes the pending changeset's `viewOperations` and merges them over `state.views`, in the pure model where tests can hold it:

- A staged `write-view` at a path nothing landed renders as a row, title and folder read from its own projection document, so "New folder…" is visible the moment its first view is staged. No count is shown for it: nothing has measured a query that has not landed, and a made-up zero would read as an empty view.
- A staged `write-view` at a landed path marks the existing row (no duplicate) and shows what WILL land: the staged title, the staged folder. The landed subject count stays, the same staleness story the summary already tells.
- A staged `delete-view` marks its row (strikethrough plus chip) rather than hiding it.
- Nothing is stored. The tree derives from `pendingChangeset` on every render, so discarding the operation IS the revert, and committing converts staged rows to ordinary ones.
- The marker is quiet by design: italic title and a small `staged` / `staged delete` chip, never the failure palette. Staging is ordinary work.
- The filter matches staged rows by the words they display (staged title, staged folder), and `matched` counts them like any other row.

**The "New folder…" flow cannot silently drop the folder.** In the save dialog, a folder preset (set by "New folder…" and "New view in this folder…", and by nothing else) disables plain Save, with the reason on the button itself; Save As New stays enabled and adopts the folder.

## The two design choices, as asked

1. **A staged NEW row is non-navigable.** Opening a view resolves its id in the landed list, where a staged one does not exist yet. Navigating and letting the standing filter apply the staged query would make the row *behave* landed while the canvas state (`activeView`) pointed at an id no landed view has, which every downstream lookup (`state.views.find`) treats as absent. So the row takes no click and no context menu: it is the reviewer's intent made visible, and acting on that intent (discard, undo, commit) belongs to the Changes tray. Staged overwrite and delete rows keep their landed identity and stay fully navigable.

2. **Under a folder preset, plain Save is disabled rather than adopting the folder.** The carry-rule comments exist to stop an overwrite from moving a view because of whatever the folder control happens to be holding; making Save adopt the preset would close the #299 trap by committing exactly that sin (an overwrite that silently MOVES the active view as a side effect of how the dialog was opened). Disabling it preserves the carry rule untouched for every ordinary overwrite, and both preset openers ask for a NEW view anyway, so Save As New is the action the flow meant. The disabled button carries a title saying why, and the form's submit path follows the one action the preset leaves enabled, so no path through the form can reach the drop.

## Tests

- `test/visual-view-tree.test.ts`: nine new pure cases for the merge (new-path staged row with its folder, overwrite marking showing what will land, delete marking, discard reversion as absence of operations, matched counts including staged rows, filtering by staged words, active-count interplay, delete of a never-landed path, last-op-wins per path). Existing call sites gain the explicit empty `stagedOperations`.
- `test/visual-app-render.test.ts`: the staged folder and its first view render with the chip; a staged delete row stays, marked. `renderToStaticMarkup`, no jsdom, per house convention.
- `test/save-view.test.ts`: overwrite enabled with no preset, disabled with one (read off the button's own markup), Save As New still offered, and the reason present on the disabled button.

No new test files, so no tsconfig routing changes. `App.tsx` is touched only at the `<ViewTree` call site. `package.json` untouched.

## Verification

`pnpm verify` exit code 0 (captured directly, not off a wrapper): 96 test files, 1606 passed, 1 skipped; typecheck clean on both tsconfigs; self:check and LikeC4 validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)