### PR TITLE
feat: the right column can leave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Added.** The right column can leave (#294). A hide control on a slim
+  rim above the section stack collapses the entire column — sections,
+  splitters and separator — and gives the canvas the full width; the
+  canvas refits through the `ResizeObserver` it already reframes with. A
+  thin reopen strip stands where the column stood, and it carries the
+  attention a hidden column would have shown: the chat unread count
+  (`attention.received` now counts arrivals while the column is hidden,
+  not only while the chat section is shut) and a marker while the agent
+  is waiting on a choice, both also spoken in the strip's accessible
+  name. Reopening restores the previous width, sections and splitter
+  heights intact — `hidden` lives in
+  `VisualWorkspaceState.conversation` beside the width, moved by
+  `conversation.toggled` beside `conversation.resized`, and a resize
+  arriving while hidden is ignored. Host-supplied `sections` behaviour
+  is unchanged; a keyboard shortcut is deferred.
+  [ADR 0115](docs/adr/0115-the-right-column-can-leave.md).
+
 - **Fixed.** A staged view is visible in the rail, marked (#299). The view
   tree now merges the pending changeset's view operations over the landed
   views: a staged new view — and the folder it declares, which is how "New

--- a/docs/adr/0115-the-right-column-can-leave.md
+++ b/docs/adr/0115-the-right-column-can-leave.md
@@ -1,0 +1,82 @@
+# The right column can leave
+
+Status: accepted
+
+The right column could shrink but never leave. Its sections collapse one
+by one (#249), and the splitter narrows the column to
+`CONVERSATION_MIN_WIDTH` (320px), but the `section-stack` aside and its
+separator rendered unconditionally in the shell, so 320px plus the
+separator was the floor. #249 was deliberate about this: the column lost
+its open/closed mode because three shut headers say what is behind them
+where a shut strip button said nothing. That reasoning holds for working —
+and it is silent about presenting. Walking a diagram on a shared screen,
+a projector, or a laptop's wide layered band are exactly the moments the
+whole canvas is wanted, and every one of them paid a 320px tax for
+panels nobody was reading (#294). A host can pass `sections: []`, but
+that is the host's decision made before the session; the person at the
+canvas had no control at all.
+
+## Decision
+
+`VisualWorkspaceState.conversation` gains `hidden: boolean`, a mode
+beside the width rather than a zero width, moved by a
+`conversation.toggled` action beside `conversation.resized`. The width —
+and the section list, and the splitter heights — stay exactly what they
+were, so reopening restores the layout the reviewer left: hiding is
+presentation, and presentation must not cost anyone their staged work or
+their dragged sizes. A `conversation.resized` arriving while hidden is
+ignored: no separator is on screen to have produced it, and honouring a
+stray would make reopening restore a width nobody dragged to.
+
+The shell renders the separator and the aside only while the column is
+on screen — a resize handle is never drawn against a column that is not
+there — with a slim rim above the sections carrying the hide control.
+Hidden, a thin reopen strip stands in the boundary's own place, full
+height, one click to bring everything back. The strip is not a memory
+test: it carries the attention the hidden column would have shown — the
+unread count the chat header would have counted (`attention.received`
+now counts arrivals while the column is hidden, not only while the chat
+section is shut), and a marker while the agent is waiting on a choice.
+Reopening clears the count the way opening the chat section does, unless
+the reviewer had shut that section before hiding, where the count moves
+to the chat header it always lived on.
+
+The canvas refits by the mechanism it already has: its `ResizeObserver`
+reframes on any container resize — a panel toggle, a drag, a window
+change — and collapsing the column's grid track (`--conversation-width`
+goes to `0px`) is just the largest such resize. Nothing in the canvas
+knows the column exists.
+
+Host-supplied `sections` behaviour is unchanged: the host still declares
+which sections exist; the reviewer decides whether the column holding
+them is on screen. A keyboard shortcut is deferred — the canvas and the
+composer both listen for keys, and a binding chosen casually here is a
+conflict discovered by whoever relies on it.
+
+## Excluded options
+
+- **A zero-width state on the width model**: one field instead of two,
+  but every clamp rule, the separator's aria bounds, and the "restore
+  the previous width" behaviour would need a special case for zero — the
+  width would stop being the memory the reopen depends on.
+- **Emptying `sections` as the collapse**: it conflates the host's
+  contract (which sections exist) with the reviewer's presentation
+  (whether the column is on screen), and an empty stack still draws the
+  column chrome.
+- **Auto-reopening on attention**: a reply yanking the column back
+  mid-presentation is the interruption hiding exists to prevent. The
+  strip signals; the reviewer decides.
+- **A floating overlay toggle on the canvas**: the control belongs to
+  the thing it acts on — the #249 rule that moved every strip control to
+  its subject — so the hide control sits on the column and the reopen
+  strip stands where the column stood.
+
+## Consequences
+
+`createVisualWorkspaceState` gains `hidden: false` — hiding is a gesture
+a reviewer makes, never a resting state a session opens into — and the
+persisted shape of `conversation` grows one boolean beside the width.
+The reopen strip's accessible name states the unread count and a waiting
+choice, so what the badges show a screen reader hears. The narrow-window
+layout, where the stack lies across the foot, gets a horizontal strip by
+the same rule that lies the stack down.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1055,8 +1055,13 @@ export const App = ({
     () => new Set(workspace.tree.collapsed),
     [workspace.tree.collapsed],
   );
+  const conversationHidden = workspace.conversation.hidden;
   const shellStyle = {
-    "--conversation-width": `${workspace.conversation.width}px`,
+    // A hidden column gives its grid track back to the canvas; the dragged
+    // width stays in state, waiting for the reopen (#294).
+    "--conversation-width": conversationHidden
+      ? "0px"
+      : `${workspace.conversation.width}px`,
     // The two sections that have a height of their own; properties takes what
     // is left. A shut section is its header and nothing more, so the height it
     // was dragged to waits for it to open again.
@@ -1254,6 +1259,16 @@ export const App = ({
       : (state.views.find((view) => view.id === workspace.pendingViewRename) ??
         null);
 
+  // The reopen strip's accessible name says what the hidden column is
+  // holding back: a reader who cannot see the badges gets the same facts.
+  const reopenLabel = [
+    "Show the session panel",
+    ...(workspace.conversation.unread === 0
+      ? []
+      : [`${workspace.conversation.unread} unread`]),
+    ...(state.choices === null ? [] : ["the agent is waiting on a choice"]),
+  ].join(", ");
+
   return (
     <main className="visual-shell" style={shellStyle}>
       <CommandStrip state={state} connection={connectionOf(state, connected)} />
@@ -1395,162 +1410,210 @@ export const App = ({
           onApplyFilter={(query) => filter(query, "editor")}
           onStageView={stageViewChange}
         />
-        <ConversationSeparator
-          width={workspace.conversation.width}
-          viewportWidth={workspace.viewportWidth}
-          onResize={(width) =>
-            dispatchWorkspace({ type: "conversation.resized", width })
-          }
-        />
-        <aside className="section-stack" aria-label="Session">
-          {stackRows(
-            visibleSections,
-            {
-              properties: (
-                <Section
-                  id="properties"
-                  label="Element properties"
-                  meta={workspace.selectedSubject?.id}
-                  open={sectionOpen("properties")}
-                  onToggle={() =>
-                    dispatchWorkspace({ type: "section.toggled", section: "properties" })
+        {conversationHidden ? (
+          // The way back stands where the column stood: a thin strip, not a
+          // memory test, and it carries what the hidden column would have
+          // shown - the unread count and a waiting choice - so presenting
+          // never means missing the agent (#294).
+          <button
+            type="button"
+            className="conversation-reopen"
+            title="Show the session panel"
+            aria-label={reopenLabel}
+            onClick={() => dispatchWorkspace({ type: "conversation.toggled" })}
+          >
+            <span className="reopen-chevron" aria-hidden="true">
+              «
+            </span>
+            {workspace.conversation.unread === 0 ? null : (
+              <span className="attention-count">
+                {workspace.conversation.unread}
+              </span>
+            )}
+            {state.choices === null ? null : (
+              <span
+                className="attention-choice"
+                title="The agent is waiting on a choice"
+              >
+                ?
+              </span>
+            )}
+          </button>
+        ) : (
+          <>
+            {/* Never against a hidden column: the separator resizes what is
+                on screen, and the reopen strip is not a thing to drag. */}
+            <ConversationSeparator
+              width={workspace.conversation.width}
+              viewportWidth={workspace.viewportWidth}
+              onResize={(width) =>
+                dispatchWorkspace({ type: "conversation.resized", width })
+              }
+            />
+            <aside className="section-stack" aria-label="Session">
+              <div className="stack-rim">
+                <button
+                  type="button"
+                  className="conversation-hide"
+                  title="Hide the session panel"
+                  aria-label="Hide the session panel"
+                  onClick={() =>
+                    dispatchWorkspace({ type: "conversation.toggled" })
                   }
                 >
-                  {workspace.selectedSubject === null || state.model === null ? (
-                    <p className="section-empty">
-                      Nothing selected. Pick a subject on the canvas or in the rail.
-                    </p>
-                  ) : (
-                    <SelectedSubjectInspector
-                      subject={workspace.selectedSubject}
-                      model={state.model}
-                      operations={state.pendingChangeset.operations}
-                      expanded={workspace.descriptionExpanded}
-                      onToggleDescription={() =>
-                        dispatchWorkspace({ type: "description.toggled" })
+                  »
+                </button>
+              </div>
+              {stackRows(
+                visibleSections,
+                {
+                  properties: (
+                    <Section
+                      id="properties"
+                      label="Element properties"
+                      meta={workspace.selectedSubject?.id}
+                      open={sectionOpen("properties")}
+                      onToggle={() =>
+                        dispatchWorkspace({ type: "section.toggled", section: "properties" })
                       }
-                      onClear={() => dispatchWorkspace({ type: "subject.cleared" })}
-                      onConnect={(from) =>
-                        dispatchWorkspace({ type: "connection.started", from })
+                    >
+                      {workspace.selectedSubject === null || state.model === null ? (
+                        <p className="section-empty">
+                          Nothing selected. Pick a subject on the canvas or in the rail.
+                        </p>
+                      ) : (
+                        <SelectedSubjectInspector
+                          subject={workspace.selectedSubject}
+                          model={state.model}
+                          operations={state.pendingChangeset.operations}
+                          expanded={workspace.descriptionExpanded}
+                          onToggleDescription={() =>
+                            dispatchWorkspace({ type: "description.toggled" })
+                          }
+                          onClear={() => dispatchWorkspace({ type: "subject.cleared" })}
+                          onConnect={(from) =>
+                            dispatchWorkspace({ type: "connection.started", from })
+                          }
+                          onDelete={(id) =>
+                            dispatchWorkspace({ type: "deletion.asked", id })
+                          }
+                          onStageChange={stageChange}
+                        />
+                      )}
+                    </Section>
+                  ),
+                  questions: (
+                    <Section
+                      id="questions"
+                      label="Open questions"
+                      meta={
+                        openQuestionMeta === undefined
+                          ? undefined
+                          : openQuestionMeta === 0
+                            ? "nothing open"
+                            : `${openQuestionMeta} open`
                       }
-                      onDelete={(id) =>
-                        dispatchWorkspace({ type: "deletion.asked", id })
+                      open={sectionOpen("questions")}
+                      onToggle={() =>
+                        dispatchWorkspace({ type: "section.toggled", section: "questions" })
                       }
-                      onStageChange={stageChange}
+                    >
+                      {interrogation === undefined ? null : (
+                        <OpenQuestions
+                          overlay={interrogation}
+                          selectedId={selectedElementId}
+                        />
+                      )}
+                    </Section>
+                  ),
+                  changes: (
+                    <Section
+                      id="changes"
+                      label="Changes"
+                      meta={stagedCount === 0 ? "nothing staged" : `${stagedCount} staged`}
+                      open={sectionOpen("changes")}
+                      onToggle={() =>
+                        dispatchWorkspace({ type: "section.toggled", section: "changes" })
+                      }
+                    >
+                      <ChangesetTray
+                        state={state}
+                        onDiscardChange={discardChange}
+                        onClearChangeset={clearChangeset}
+                        onUndoChangeset={undoChangeset}
+                        onRedoChangeset={redoChangeset}
+                        onCommitChangeset={commitChangeset}
+                      />
+                    </Section>
+                  ),
+                  chat: (
+                    <Section
+                      id="chat"
+                      label="Chat"
+                      meta={
+                        workspace.conversation.unread === 0 ? (
+                          chatMeta(state)
+                        ) : (
+                          <span className="attention-count">
+                            {workspace.conversation.unread}
+                          </span>
+                        )
+                      }
+                      open={sectionOpen("chat")}
+                      onToggle={() =>
+                        dispatchWorkspace({ type: "section.toggled", section: "chat" })
+                      }
+                    >
+                      <ChatSection
+                        state={state}
+                        disabled={!state.composerEnabled}
+                        selectedSubject={workspace.selectedSubject}
+                        onSend={(text) =>
+                          ask(formatContextualQuestion(text, workspace.selectedSubject))
+                        }
+                        onChoice={choose}
+                        onClearSubject={() =>
+                          dispatchWorkspace({ type: "subject.cleared" })
+                        }
+                        onEnd={end}
+                      />
+                    </Section>
+                  ),
+                },
+                {
+                  changes: (
+                    <SectionSplitter
+                      label="Resize the changes section"
+                      height={workspace.conversation.changesHeight}
+                      viewportHeight={workspace.viewportHeight}
+                      onResize={(height) =>
+                        dispatchWorkspace({
+                          type: "section.resized",
+                          section: "changes",
+                          height,
+                        })
+                      }
                     />
-                  )}
-                </Section>
-              ),
-              questions: (
-                <Section
-                  id="questions"
-                  label="Open questions"
-                  meta={
-                    openQuestionMeta === undefined
-                      ? undefined
-                      : openQuestionMeta === 0
-                        ? "nothing open"
-                        : `${openQuestionMeta} open`
-                  }
-                  open={sectionOpen("questions")}
-                  onToggle={() =>
-                    dispatchWorkspace({ type: "section.toggled", section: "questions" })
-                  }
-                >
-                  {interrogation === undefined ? null : (
-                    <OpenQuestions
-                      overlay={interrogation}
-                      selectedId={selectedElementId}
+                  ),
+                  chat: (
+                    <SectionSplitter
+                      label="Resize the chat section"
+                      height={workspace.conversation.chatHeight}
+                      viewportHeight={workspace.viewportHeight}
+                      onResize={(height) =>
+                        dispatchWorkspace({
+                          type: "section.resized",
+                          section: "chat",
+                          height,
+                        })
+                      }
                     />
-                  )}
-                </Section>
-              ),
-              changes: (
-                <Section
-                  id="changes"
-                  label="Changes"
-                  meta={stagedCount === 0 ? "nothing staged" : `${stagedCount} staged`}
-                  open={sectionOpen("changes")}
-                  onToggle={() =>
-                    dispatchWorkspace({ type: "section.toggled", section: "changes" })
-                  }
-                >
-                  <ChangesetTray
-                    state={state}
-                    onDiscardChange={discardChange}
-                    onClearChangeset={clearChangeset}
-                    onUndoChangeset={undoChangeset}
-                    onRedoChangeset={redoChangeset}
-                    onCommitChangeset={commitChangeset}
-                  />
-                </Section>
-              ),
-              chat: (
-                <Section
-                  id="chat"
-                  label="Chat"
-                  meta={
-                    workspace.conversation.unread === 0 ? (
-                      chatMeta(state)
-                    ) : (
-                      <span className="attention-count">
-                        {workspace.conversation.unread}
-                      </span>
-                    )
-                  }
-                  open={sectionOpen("chat")}
-                  onToggle={() =>
-                    dispatchWorkspace({ type: "section.toggled", section: "chat" })
-                  }
-                >
-                  <ChatSection
-                    state={state}
-                    disabled={!state.composerEnabled}
-                    selectedSubject={workspace.selectedSubject}
-                    onSend={(text) =>
-                      ask(formatContextualQuestion(text, workspace.selectedSubject))
-                    }
-                    onChoice={choose}
-                    onClearSubject={() =>
-                      dispatchWorkspace({ type: "subject.cleared" })
-                    }
-                    onEnd={end}
-                  />
-                </Section>
-              ),
-            },
-            {
-              changes: (
-                <SectionSplitter
-                  label="Resize the changes section"
-                  height={workspace.conversation.changesHeight}
-                  viewportHeight={workspace.viewportHeight}
-                  onResize={(height) =>
-                    dispatchWorkspace({
-                      type: "section.resized",
-                      section: "changes",
-                      height,
-                    })
-                  }
-                />
-              ),
-              chat: (
-                <SectionSplitter
-                  label="Resize the chat section"
-                  height={workspace.conversation.chatHeight}
-                  viewportHeight={workspace.viewportHeight}
-                  onResize={(height) =>
-                    dispatchWorkspace({
-                      type: "section.resized",
-                      section: "chat",
-                      height,
-                    })
-                  }
-                />
-              ),
-            },
-          )}
-        </aside>
+                  ),
+                },
+              )}
+            </aside>
+          </>
+        )}
       </div>
       {/* At the shell, not inside the canvas or the rail: a menu opened on the
           last row of the rail has to be able to hang past the rail's edge. */}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -669,6 +669,66 @@ body {
   background: var(--sheet);
 }
 
+/* The column's own rim: one slim row above the sections, holding the control
+   that puts the whole column away (#294). The sections' headers stay about
+   their sections; the rim is about the column. */
+.stack-rim {
+  display: flex;
+  flex: none;
+  justify-content: flex-end;
+  border-bottom: 1px solid var(--rule);
+}
+
+.conversation-hide {
+  min-height: 22px;
+  padding: 0 calc(var(--step) * 1.5);
+  border: none;
+  background: transparent;
+  color: var(--quiet);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.conversation-hide:hover,
+.conversation-hide:focus-visible {
+  color: var(--cobalt);
+}
+
+/* The way back while the column is away: a thin strip the full height of the
+   workspace, in the boundary's own place, carrying the attention the hidden
+   column would have shown - the unread count, and a waiting choice. */
+.conversation-reopen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--step);
+  width: 22px;
+  height: 100%;
+  padding: calc(var(--step) * 1.5) 0;
+  border: none;
+  border-left: 1px solid var(--rule);
+  background: var(--sheet);
+  color: var(--quiet);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.conversation-reopen:hover,
+.conversation-reopen:focus-visible {
+  color: var(--cobalt);
+}
+
+.attention-choice {
+  min-width: 1.25rem;
+  padding: 0 0.35rem;
+  border: 1px solid var(--cobalt);
+  border-radius: 999px;
+  color: var(--cobalt);
+  font-size: 11px;
+  text-align: center;
+}
+
 .stack-section {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -1650,6 +1710,18 @@ body {
     max-height: 56dvh;
     border-top: 1px solid var(--rule);
     border-left: 0;
+  }
+
+  /* The stack lies across the foot here, so its reopen strip does too. */
+  .conversation-reopen {
+    flex-direction: row;
+    justify-content: center;
+    width: auto;
+    height: auto;
+    min-height: 24px;
+    padding: 0;
+    border-left: 0;
+    border-top: 1px solid var(--rule);
   }
 }
 

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -141,16 +141,26 @@ const CONVERSATION_MAX_VIEWPORT_SHARE = 0.45;
 
 export interface VisualWorkspaceState {
   /**
-   * The right column: one width, and the sections stacked inside it.
+   * The right column: one width, whether the reviewer has put the whole
+   * column away, and the sections stacked inside it.
    *
-   * There is no longer an open/closed mode. The column is always drawn,
-   * because the sections are collapsible one by one and a reviewer who wants
-   * the canvas back shuts the sections rather than the column - which leaves
-   * three headers saying what is behind them instead of a strip button
-   * saying nothing (#249).
+   * The sections are collapsible one by one, and a reviewer who wants room
+   * shuts sections rather than the column - shut headers say what is behind
+   * them (#249). `hidden` is the further step for the moments that want the
+   * whole canvas - presenting, a projector, a laptop - and the reopen strip
+   * that stands in for the column carries what a shut header would have
+   * said: the unread count and a waiting choice (#294).
    */
   readonly conversation: {
     readonly width: number;
+    /**
+     * Whether the reviewer has put the whole column away (#294). A mode
+     * beside the width rather than a zero width, so the width stays what it
+     * was and reopening restores it - sections and splitters intact. The
+     * presenting moments are exactly when this is used, and presentation
+     * must not cost the reviewer their layout.
+     */
+    readonly hidden: boolean;
     readonly unread: number;
     /** The sections the reviewer has shut. Held as what is CLOSED so a
      * section added later arrives open rather than hidden behind a default
@@ -257,6 +267,7 @@ export type VisualWorkspaceAction =
       readonly height: number;
     }
   | { readonly type: "conversation.resized"; readonly width: number }
+  | { readonly type: "conversation.toggled" }
   | {
       readonly type: "viewport.resized";
       readonly viewportWidth: number;
@@ -445,6 +456,9 @@ export const createVisualWorkspaceState = (
 ): VisualWorkspaceState => ({
   conversation: {
     width: clampInitialConversationWidth(viewportWidth * 0.28, viewportWidth),
+    // On screen: hiding the column is a presenting gesture the reviewer
+    // makes, never a resting state a session opens into.
+    hidden: false,
     unread: 0,
     // Every section open: the reviewer has not shut anything yet, and a stack
     // that opened closed would say nothing about what is in it.
@@ -516,10 +530,32 @@ export const visualWorkspaceReducer = (
           };
     }
     case "conversation.resized": {
+      // No separator is drawn against a hidden column, so a resize arriving
+      // while hidden is a stray - and honouring it would make reopening
+      // restore a width the reviewer never dragged to.
+      if (state.conversation.hidden) return state;
       const width = clampConversationWidth(action.width, state.viewportWidth);
       return width === state.conversation.width
         ? state
         : { ...state, conversation: { ...state.conversation, width } };
+    }
+    case "conversation.toggled": {
+      const hidden = !state.conversation.hidden;
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          hidden,
+          // Reopening puts chat back in front of the reviewer, so the count
+          // goes the way it goes when the section itself is opened - unless
+          // they had shut the section, where the arrival is still out of
+          // sight and the count moves to the chat header instead.
+          unread:
+            !hidden && !state.conversation.collapsed.includes("chat")
+              ? 0
+              : state.conversation.unread,
+        },
+      };
     }
     case "viewport.resized": {
       const width = clampConversationWidth(
@@ -555,9 +591,10 @@ export const visualWorkspaceReducer = (
     }
     case "attention.received":
       // Chat is on screen unless the reviewer shut it, so an arriving reply
-      // needs no count to stand in for it. A shut section is the only case
-      // where something happened out of sight.
-      return state.conversation.collapsed.includes("chat")
+      // needs no count to stand in for it. A shut section - or the whole
+      // column hidden (#294) - is where something happened out of sight.
+      return state.conversation.hidden ||
+        state.conversation.collapsed.includes("chat")
         ? {
             ...state,
             conversation: {

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -64,6 +64,31 @@ vi.mock('../src/visual-app/session-client.js', () => ({
   }),
 }))
 
+// Static markup cannot click, so the workspace the shell opens with is the
+// seam: everything real is re-exported, and only the initial state is bent -
+// which is exactly what a session that had hidden the column looks like on
+// the next render (#294).
+const workspace = vi.hoisted(() => ({ hidden: false, unread: 0 }))
+
+vi.mock('../src/visual-app/workspace-state.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../src/visual-app/workspace-state.js')>()
+  return {
+    ...actual,
+    createVisualWorkspaceState: (width: number, height?: number) => {
+      const state = actual.createVisualWorkspaceState(width, height)
+      return {
+        ...state,
+        conversation: {
+          ...state.conversation,
+          hidden: workspace.hidden,
+          unread: workspace.unread,
+        },
+      }
+    },
+  }
+})
+
 import { App } from '../src/visual-app/App.js'
 
 const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
@@ -94,6 +119,11 @@ const idleHost: EditorHost = {
   open: () => () => {},
   send: () => {},
 }
+
+beforeEach(() => {
+  workspace.hidden = false
+  workspace.unread = 0
+})
 
 const renderSession = (
   overrides: Partial<VisualAppState> = {},
@@ -654,5 +684,76 @@ describe('open questions section (#292)', () => {
     // overlay must see the canvas it always saw, not a section of zeros.
     const markup = renderSession({ model: renderedModel })
     expect(markup).not.toContain('Open questions')
+  })
+})
+
+/**
+ * The right column can leave (#294): a hide control on the column, a thin
+ * reopen strip in its place, and the attention a hidden column would have
+ * shown carried on the strip.
+ */
+describe('a hidden right column (#294)', () => {
+  it('offers the hide control on the column while it is on screen', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('class="conversation-hide"')
+    expect(markup).toContain('aria-label="Hide the session panel"')
+    expect(markup).not.toContain('conversation-reopen')
+  })
+
+  it('takes the column, its separator and its grid track away when hidden', () => {
+    workspace.hidden = true
+    const markup = renderSession()
+
+    expect(markup).not.toContain('section-stack')
+    expect(markup).not.toContain('stack-section-')
+    expect(markup).not.toContain('conversation-separator')
+    expect(markup).toContain('--conversation-width:0px')
+  })
+
+  it('leaves a reopen strip standing where the column stood', () => {
+    workspace.hidden = true
+    const markup = renderSession()
+
+    expect(markup).toContain('class="conversation-reopen"')
+    expect(markup).toContain('aria-label="Show the session panel"')
+  })
+
+  it('carries the unread count on the strip', () => {
+    // The presenting moments are exactly when a reply must not be missed:
+    // what the chat header would have counted, the strip counts.
+    workspace.hidden = true
+    workspace.unread = 3
+    const markup = renderSession()
+
+    expect(markup).toContain('class="attention-count">3</span>')
+    expect(markup).toContain(
+      'aria-label="Show the session panel, 3 unread"',
+    )
+  })
+
+  it('signals a pending agent choice on the strip', () => {
+    workspace.hidden = true
+    const markup = renderSession({
+      choices: {
+        choiceId: 'choice-1',
+        question: 'Which option?',
+        options: [{ id: 'option-a', label: 'Option A' }],
+      },
+    })
+
+    expect(markup).toContain('class="attention-choice"')
+    expect(markup).toContain(
+      'aria-label="Show the session panel, the agent is waiting on a choice"',
+    )
+  })
+
+  it('keeps the dragged width in the shell while shown', () => {
+    // The width the strip restores is the one the state still holds: hiding
+    // is a mode, not a zero width.
+    const markup = renderSession()
+
+    expect(markup).not.toContain('--conversation-width:0px')
+    expect(markup).toContain('--conversation-width:')
   })
 })

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -73,6 +73,7 @@ describe("visual workspace state", () => {
     const state = createVisualWorkspaceState(1568);
     expect(state.conversation).toEqual({
       width: expect.closeTo(439.04, 2),
+      hidden: false,
       unread: 0,
       collapsed: [],
       changesHeight: 200,
@@ -921,6 +922,110 @@ describe("the right column's sections", () => {
         height: state.conversation.chatHeight,
       }),
     ).toBe(state);
+  });
+});
+
+/**
+ * The whole column can leave (#294). Hiding is a mode beside the width, not a
+ * zero width: the width stays what it was, so reopening restores the layout -
+ * sections, splitters and dragged width intact - and the reopen strip carries
+ * the attention the hidden column would have shown.
+ */
+describe("the right column can leave (#294)", () => {
+  const state = createVisualWorkspaceState(1568, 900);
+  const toggled = (from: VisualWorkspaceState): VisualWorkspaceState =>
+    visualWorkspaceReducer(from, { type: "conversation.toggled" });
+
+  it("starts on screen: hiding is a gesture, never a resting state", () => {
+    expect(state.conversation.hidden).toBe(false);
+  });
+
+  it("hides on the toggle, leaving the width and sections untouched", () => {
+    const shutChanges = visualWorkspaceReducer(state, {
+      type: "section.toggled",
+      section: "changes",
+    });
+    const hidden = toggled(shutChanges);
+
+    expect(hidden.conversation.hidden).toBe(true);
+    expect(hidden.conversation.width).toBe(state.conversation.width);
+    expect(hidden.conversation.collapsed).toEqual(["changes"]);
+  });
+
+  it("reopens at the previous dragged width, splitters intact", () => {
+    const dragged = visualWorkspaceReducer(
+      visualWorkspaceReducer(state, {
+        type: "conversation.resized",
+        width: 560,
+      }),
+      { type: "section.resized", section: "chat", height: 360 },
+    );
+    const reopened = toggled(toggled(dragged));
+
+    expect(reopened.conversation.hidden).toBe(false);
+    expect(reopened.conversation.width).toBe(560);
+    expect(reopened.conversation.chatHeight).toBe(360);
+  });
+
+  it("ignores a resize while hidden: no separator is on screen to drag", () => {
+    // Honouring a stray resize would make reopening restore a width the
+    // reviewer never dragged to.
+    const hidden = toggled(state);
+    expect(
+      visualWorkspaceReducer(hidden, {
+        type: "conversation.resized",
+        width: 640,
+      }),
+    ).toBe(hidden);
+  });
+
+  it("survives a viewport resize, and the held width is still re-clamped", () => {
+    // The mode is not the width: a window that narrows while the column is
+    // away must still leave a width the reopen can legally restore.
+    const wide = toggled(
+      visualWorkspaceReducer(state, {
+        type: "conversation.resized",
+        width: 640,
+      }),
+    );
+    const narrowed = visualWorkspaceReducer(wide, {
+      type: "viewport.resized",
+      viewportWidth: 900,
+    });
+
+    expect(narrowed.conversation.hidden).toBe(true);
+    expect(narrowed.conversation.width).toBe(405);
+  });
+
+  it("counts what arrives while hidden, and reopening reads it", () => {
+    // The whole column away is chat out of sight, whatever the section list
+    // says - and reopening puts chat back in front of the reviewer, so the
+    // count goes the way it goes when the section itself is opened.
+    const waiting = visualWorkspaceReducer(toggled(state), {
+      type: "attention.received",
+    });
+    expect(waiting.conversation.unread).toBe(1);
+
+    expect(toggled(waiting).conversation.unread).toBe(0);
+  });
+
+  it("keeps the count for a chat the reviewer had shut before hiding", () => {
+    // Reopening the column does not open the chat section, so the arrival is
+    // still out of sight: the count moves to the chat header instead.
+    const shutChat = visualWorkspaceReducer(state, {
+      type: "section.toggled",
+      section: "chat",
+    });
+    const waiting = visualWorkspaceReducer(toggled(shutChat), {
+      type: "attention.received",
+    });
+    const reopened = toggled(waiting);
+
+    expect(reopened.conversation.hidden).toBe(false);
+    expect(reopened.conversation).toMatchObject({
+      collapsed: ["chat"],
+      unread: 1,
+    });
   });
 });
 


### PR DESCRIPTION
Closes #294. [ADR 0115](docs/adr/0115-the-right-column-can-leave.md).

## What

The right column (the #249 section stack) could shrink to 320px but never leave. Now the reviewer can put the whole column away mid-session and bring it back, without losing anything:

- A **hide control** on a slim rim above the sections collapses the entire column — sections, splitters and the `ConversationSeparator` — and the canvas takes the full width.
- A **thin reopen strip** stands where the column stood: one click restores the previous width, sections and splitter heights intact. Not a memory test.
- **Attention reaches a hidden column**: the strip carries the chat unread count (`attention.received` now counts arrivals while the column is hidden, not only while the chat section is shut) and a marker while the agent is waiting on a choice (`state.choices`). Both are also spoken in the strip's accessible name.
- The **canvas refits by the mechanism it already has**: the `ResizeObserver` on its container reframes on any resize, and collapsing the grid track (`--conversation-width` goes to `0px`) is just the largest one. `graph-canvas.tsx` is untouched.

## Design choices

- `hidden: boolean` on `VisualWorkspaceState.conversation`, moved by `conversation.toggled` beside `conversation.resized` — a mode beside the width rather than a zero width, so the width stays the memory the reopen restores. A `conversation.resized` arriving while hidden is ignored (no separator is on screen to have produced it).
- Reopening clears the unread count the way opening the chat section does — unless the reviewer had shut that section before hiding, where the count moves to the chat header it always lived on.
- Hiding is presentation only: staged work, the pending changeset and the commit button are state, untouched.
- Host-supplied `sections` behaviour is unchanged — the host declares which sections exist; the reviewer decides whether the column holding them is on screen.
- **Deferred**: a keyboard shortcut. The canvas and composer both listen for keys; a binding chosen casually here is a conflict discovered by whoever relies on it. Excluded options (zero-width state, emptying `sections`, auto-reopen on attention, floating canvas toggle) are recorded in the ADR.
- Narrow windows (<900px), where the stack lies across the foot, get a horizontal reopen strip by the same rule.

## Tests

- `test/visual-workspace-state.test.ts`: toggled hides with width/sections untouched; reopen restores dragged width and splitter heights; resize-while-hidden ignored; hidden survives viewport resize with the held width still re-clamped; attention counted while hidden, cleared on reopen, kept for a chat shut before hiding.
- `test/visual-app-render.test.ts` (renderToStaticMarkup, no jsdom): hide control present by default; column, separator and grid track absent when hidden; reopen strip present with unread count and pending-choice marker; dragged width kept in the shell while shown. The initial workspace state is the seam (the real `createVisualWorkspaceState` wrapped in a module mock), since static markup cannot click.

Verify: `pnpm verify` green (real exit code 0) — 96 test files, 1633 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)