### PR TITLE
feat: a kind palette the canvas accepts by drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Added.** A kind palette the canvas accepts by drag (#295). A `palette`
+  section leads the right column, listing the profile's concept kinds —
+  the same `vocabulary.conceptKinds` the Add-subject dialog compiles its
+  Kind select from — grouped into layer bands by core lineage, each row
+  carrying the glyph the canvas draws for that kind. Dragging a row onto
+  the canvas (a custom `application/x-yarramate-kind` payload, so stray
+  text drops stay inert) opens the existing Add-subject dialog with the
+  kind preselected; clicking a row does the same without the drag. The
+  palette holds no armed mode and the plain openers still start with no
+  kind chosen; the drop position is converted to model coordinates and
+  handed up but deliberately not carried into the staged result —
+  placement belongs to the layout system. Hosts opt in or out through
+  the `sections` vocabulary, like every other section.
+  [ADR 0116](docs/adr/0116-a-kind-is-picked-up-not-remembered.md).
+
 - **Added.** The right column can leave (#294). A hide control on a slim
   rim above the section stack collapses the entire column — sections,
   splitters and separator — and gives the canvas the full width; the

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -114,11 +114,16 @@ sentence about what the session *is* belongs beside the name.
 **The right column is a stack of collapsible sections**, split by handles a
 pointer or the arrow keys can drag:
 
-1. **Element properties** — the subject form. Its header names the selected
+1. **Kind palette** — the profile's concept kinds, grouped by layer, dragged
+   onto the canvas or clicked: either way the Add-subject dialog opens with
+   the kind preselected (#295).
+2. **Element properties** — the subject form. Its header names the selected
    subject; selecting one opens the section, because that is what selecting was
    for.
-2. **Changes** — the staged rows, and how many are staged.
-3. **Chat** — pinned at the foot, owning the session's own control.
+3. **Open questions** — what the interrogation overlay asks, beside what is
+   declared; drawn only when the host ships the overlay (#292).
+4. **Changes** — the staged rows, and how many are staged.
+5. **Chat** — pinned at the foot, owning the session's own control.
 
 There is no open/closed mode for the column. The sections collapse one at a
 time, and a shut header still says what is behind it — the selected subject,

--- a/docs/adr/0116-a-kind-is-picked-up-not-remembered.md
+++ b/docs/adr/0116-a-kind-is-picked-up-not-remembered.md
@@ -1,0 +1,77 @@
+# A kind is picked up, not remembered
+
+Status: accepted
+
+Making a subject has one route: the Add-subject popover, reached from a
+button or the canvas menu, with a Kind select compiled from the model
+frame's `vocabulary.conceptKinds`. Every subject costs click → three
+fields → Add, and the vocabulary itself — the first thing a consultant
+new to a profile needs to see — is buried behind that select. ApertureX,
+embedding the editor over its own store (#252), asked after real
+consultant use for the gesture diagramming tools taught everyone:
+a palette of kinds, dragged onto the canvas (#295).
+
+## Decision
+
+A `palette` section joins `RIGHT_SECTIONS`, first — it is the tool that
+makes subjects, and tools read above inspection — so a host opts in or
+out through the `sections` vocabulary it already speaks, exactly like
+`properties` or `changes`. The rows are `vocabulary.conceptKinds`, the
+same list the Add-subject dialog compiles its select from, grouped into
+layer bands by each kind's core lineage in the profile's own layer
+order: the organisation the model tree already reads in, so the palette
+and the rail tell one story. Each row carries the glyph the canvas draws
+on a node of that kind.
+
+A row is picked up, not armed. Dragging it carries the kind's label —
+the value a document names and `apply` accepts — under a custom type,
+`application/x-yarramate-kind`, so a stray text drop stays inert; the
+canvas container accepts the drop and the existing Add-subject dialog
+opens with the kind preselected. Clicking a row opens the same dialog
+the same way, which is the whole gesture without a pointer drag. Either
+way the palette holds nothing afterwards: the kind travels with the
+gesture into the form's own state (`initialKind`), the plain openers
+still start with no kind chosen, and a second pick while the form is
+open re-seeds a fresh draft rather than silently changing nothing.
+
+The drop's position is converted to model coordinates and handed up,
+and deliberately goes no further. Placement belongs to the layout
+system: elk lays out what the graph declares, and pinning one node is a
+saved-layout sidecar write (ADR 0113) against a subject that does not
+exist until the changeset commits — a write the unfiltered pseudo-view
+refuses outright. A dropped subject lands where the layout puts it,
+like every subject before it.
+
+## Excluded options
+
+- **Creating the subject on drop, no dialog**: the id is derived from
+  the name, so there is no name to derive it from — the drop would have
+  to invent one, and a derived address the author never saw is one
+  nobody agreed to. The dialog stays the details editor.
+- **An armed mode** (click a kind, then stamp the canvas): a mode the
+  reviewer must remember to leave, and the palette would hold a
+  selection the next click honours long after the intent behind it has
+  gone. The title is the rule: picked up, not remembered.
+- **A flat list**: sixty rows with no bands is a wall, and the model
+  tree already taught this shell that layers are how a vocabulary is
+  read. Grouping is derived per render from the core lineage the wire
+  carries; nothing new travels.
+- **Threading the drop position into the staged result**: the
+  disproportion above — a sidecar write for an uncommitted subject
+  against a view that may refuse it — for a position the next relayout
+  would move anyway.
+- **Holding the picked kind in workspace state**: it is the gesture's
+  payload on its way to the form, not a fact about the workspace — the
+  same rule that keeps a half-typed name out of the reducer. The shell
+  holds it beside `saveViewFolder`, which is the same kind of seed.
+
+## Consequences
+
+`RIGHT_SECTIONS` grows to five and the palette leads, so hosts that
+pass an explicit section list see nothing new until they ask, and the
+session shell — which passes none — gets the palette by default. The
+form gains an optional `initialKind` that seeds its state once; its
+no-default rule stands, because a palette pick is the reviewer's own
+choice arriving with the gesture. `GraphCanvas` gains an optional
+`onKindDrop` and accepts only the palette's own MIME type, so nothing
+changes for a host that never renders a palette.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -52,6 +52,7 @@ import {
 } from "./workspace-state.js";
 import { ConnectionPanel } from "./connection-panel.js";
 import { faultedSubjects } from "./faults.js";
+import { KindPalette } from "./kind-palette.js";
 import { SubjectDraftPanel } from "./subject-draft-panel.js";
 import { ConfirmDialog } from "./confirm-dialog.js";
 import { PromptDialog } from "./prompt-dialog.js";
@@ -231,6 +232,8 @@ const DiagramWorkspace = ({
   onConnectStage,
   onDraftStage,
   draftingSubject,
+  draftInitialKind,
+  onKindDrop,
   onDraftSubject,
   onDraftSubjectClose,
   pendingDeletion,
@@ -270,6 +273,14 @@ const DiagramWorkspace = ({
    */
   readonly onDraftStage: (operation: YarramateOperation) => void;
   readonly draftingSubject: boolean;
+  /** The kind the open draft was seeded with - a palette pick (#295) - or
+   * undefined for a draft opened plain. */
+  readonly draftInitialKind: string | undefined;
+  /** A kind dropped from the palette onto the canvas (#295). */
+  readonly onKindDrop: (
+    kindLabel: string,
+    position: { readonly x: number; readonly y: number },
+  ) => void;
   readonly onDraftSubject: () => void;
   readonly onDraftSubjectClose: () => void;
   readonly pendingDeletion: string | null;
@@ -357,6 +368,11 @@ const DiagramWorkspace = ({
         )}
         {!draftingSubject || state.model === null ? null : (
           <SubjectDraftPanel
+            // Keyed on the seed: a kind picked up while the form is already
+            // open is a fresh draft, re-seeded, rather than a pick that
+            // silently changes nothing (ADR 0116).
+            key={draftInitialKind ?? ""}
+            initialKind={draftInitialKind}
             graph={state.model.graph}
             kinds={state.model.vocabulary.conceptKinds}
             documents={state.model.documents}
@@ -442,6 +458,7 @@ const DiagramWorkspace = ({
             activeViewId={state.activeView}
             savedPositions={state.model.layouts[state.activeView]}
             onSaveLayout={onSaveLayout}
+            onKindDrop={onKindDrop}
             onCanvasReady={onCanvasReady}
           />
         )}
@@ -917,6 +934,12 @@ export const App = ({
   const [saveViewFolder, setSaveViewFolder] = useState<
     string | undefined
   >(undefined);
+  // The kind a palette gesture picked up, seeding the Add-subject dialog it
+  // opens (#295). Shell state like `saveViewFolder`, not workspace state: it
+  // is the gesture's payload on its way to the form, not a fact about the
+  // workspace - the reducer keeps only that the draft is open. A plain opener
+  // clears it, so "Add subject" still starts with no kind chosen (ADR 0116).
+  const [draftKind, setDraftKind] = useState<string | undefined>(undefined);
   // A way to photograph the canvas, handed up by `GraphCanvas` while one
   // exists. A ref rather than state: nothing renders differently because of
   // it, and a menu item reads it at the moment it is chosen.
@@ -1051,6 +1074,10 @@ export const App = ({
       : selectedElementId === null
         ? interrogation.workspace.length
         : (openQuestionCounts.get(selectedElementId) ?? 0);
+  // The palette's rows are the model frame's own vocabulary (#295) - the same
+  // list the Add-subject dialog compiles its Kind select from, so the two can
+  // never disagree about what a workspace may contain.
+  const paletteKinds = state.model?.vocabulary.conceptKinds ?? [];
   const treeCollapsed = useMemo(
     () => new Set(workspace.tree.collapsed),
     [workspace.tree.collapsed],
@@ -1072,6 +1099,18 @@ export const App = ({
       ? `${workspace.conversation.chatHeight}px`
       : "auto",
   } as CSSProperties;
+
+  // Every palette gesture ends here (#295): the kind rides along to seed the
+  // form, and the same Add-subject dialog opens - a drop is not a shortcut
+  // past the name and the document, it is a shortcut past the Kind select.
+  // The drop's position is deliberately NOT taken further: placement belongs
+  // to the layout system, so a dropped kind lands where elk puts it, and the
+  // canvas hands the position up only so a future layout integration has the
+  // seam already cut (ADR 0116).
+  const draftWithKind = (kindLabel: string) => {
+    setDraftKind(kindLabel);
+    dispatchWorkspace({ type: "subject.draft.opened" });
+  };
 
   const openMenu = (
     target: ContextMenuTarget,
@@ -1158,6 +1197,9 @@ export const App = ({
         return;
       }
       case "canvas.draft-subject":
+        // A plain opener: no kind arrives with the gesture, so none is left
+        // over from an earlier palette pick.
+        setDraftKind(undefined);
         dispatchWorkspace({ type: "subject.draft.opened" });
         return;
       case "view.add-subject":
@@ -1357,9 +1399,14 @@ export const App = ({
             }
           }}
           draftingSubject={workspace.draftingSubject}
-          onDraftSubject={() =>
-            dispatchWorkspace({ type: "subject.draft.opened" })
-          }
+          draftInitialKind={draftKind}
+          onKindDrop={(kindLabel) => draftWithKind(kindLabel)}
+          onDraftSubject={() => {
+            // The plain opener starts with no kind chosen, whatever a palette
+            // gesture seeded last time (ADR 0116).
+            setDraftKind(undefined);
+            dispatchWorkspace({ type: "subject.draft.opened" });
+          }}
           onDraftSubjectClose={() =>
             dispatchWorkspace({ type: "subject.draft.closed" })
           }
@@ -1467,6 +1514,31 @@ export const App = ({
               {stackRows(
                 visibleSections,
                 {
+                  palette: (
+                    <Section
+                      id="palette"
+                      label="Kind palette"
+                      meta={
+                        paletteKinds.length === 0
+                          ? undefined
+                          : paletteKinds.length === 1
+                            ? "1 kind"
+                            : `${paletteKinds.length} kinds`
+                      }
+                      open={sectionOpen("palette")}
+                      onToggle={() =>
+                        dispatchWorkspace({ type: "section.toggled", section: "palette" })
+                      }
+                    >
+                      {paletteKinds.length === 0 ? (
+                        <p className="section-empty">
+                          No model yet. The kinds arrive with it.
+                        </p>
+                      ) : (
+                        <KindPalette kinds={paletteKinds} onPick={draftWithKind} />
+                      )}
+                    </Section>
+                  ),
                   properties: (
                     <Section
                       id="properties"

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -22,6 +22,7 @@ import {
   ownerInitialsOf,
 } from './badges.js'
 import { ICON_SIZE, kindIconUriOf } from './kind-icons.js'
+import { KIND_MIME } from './kind-palette.js'
 import { ASPECT_SHAPES, LAYER_COLORS, RELATIONSHIP_NOTATION } from '../notation/archimate.js'
 
 // Register elk extension once at module load, guarded against re-registration
@@ -888,6 +889,18 @@ export function savedLayoutInForce(
   return drawn.some((id) => saved[id] !== undefined)
 }
 
+// A drop lands in the container's own coordinates; the graph lives in model
+// coordinates under whatever pan and zoom are standing. One conversion,
+// cytoscape's own rendered-to-model arithmetic, exported so the sum is a fact
+// a test can state without a canvas to drop on.
+export function modelPositionOf(
+  rendered: { readonly x: number; readonly y: number },
+  pan: { readonly x: number; readonly y: number },
+  zoom: number,
+): { readonly x: number; readonly y: number } {
+  return { x: (rendered.x - pan.x) / zoom, y: (rendered.y - pan.y) / zoom }
+}
+
 export interface DragSaveHandle {
   /** Cancels a queued save without unbinding the drag listener. */
   readonly cancelPending: () => void
@@ -964,6 +977,17 @@ interface GraphCanvasProps {
   readonly savedPositions: VisualLayoutPositions | undefined
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
   /**
+   * A kind dropped from the palette (#295): the kind's label and the model
+   * position under the pointer. Optional because only a shell with a palette
+   * has anything to drop; a host without one never sees a drop at all - the
+   * `dragover` acceptance is gated on the callback too, so a stray drag is
+   * left to the browser's default refusal.
+   */
+  readonly onKindDrop?: (
+    kindLabel: string,
+    position: { readonly x: number; readonly y: number },
+  ) => void
+  /**
    * A way to take a picture of what is drawn, handed up once the instance
    * exists and withdrawn when it goes. The shell holds it so a menu item can
    * export a PNG without reaching into cytoscape itself; `null` means there is
@@ -993,6 +1017,7 @@ export function GraphCanvas({
   activeViewId,
   savedPositions,
   onSaveLayout,
+  onKindDrop,
   onCanvasReady,
   showLifecycle,
   showEvidence,
@@ -1018,6 +1043,8 @@ export function GraphCanvas({
   const onSelectRef = useRef(onSelect)
   const onCanvasReadyRef = useRef(onCanvasReady)
   onCanvasReadyRef.current = onCanvasReady
+  const onKindDropRef = useRef(onKindDrop)
+  onKindDropRef.current = onKindDrop
   const onContextMenuRef = useRef(onContextMenu)
   const isInitialSyncRef = useRef(true)
   const isInitialPresentationSyncRef = useRef(true)
@@ -1367,6 +1394,34 @@ export function GraphCanvas({
         ref={containerRef}
         style={{ width: '100%', height: '100%' }}
         onContextMenu={(event) => event.preventDefault()}
+        // A kind dragged from the palette (#295). Accepted on the container
+        // rather than on any cytoscape element: a new subject belongs to no
+        // node yet, and the container is the one element that is always under
+        // the pointer. Only the palette's own type is accepted - the payload
+        // itself is unreadable until the drop, but the type list is not.
+        onDragOver={(event) => {
+          if (
+            onKindDropRef.current !== undefined &&
+            event.dataTransfer.types.includes(KIND_MIME)
+          ) {
+            event.preventDefault()
+          }
+        }}
+        onDrop={(event) => {
+          const kindLabel = event.dataTransfer.getData(KIND_MIME)
+          if (kindLabel === '' || onKindDropRef.current === undefined) return
+          event.preventDefault()
+          const box = event.currentTarget.getBoundingClientRect()
+          const cy = cyRef.current
+          onKindDropRef.current(
+            kindLabel,
+            modelPositionOf(
+              { x: event.clientX - box.left, y: event.clientY - box.top },
+              cy?.pan() ?? { x: 0, y: 0 },
+              cy?.zoom() ?? 1,
+            ),
+          )
+        }}
       />
       {savedLayoutShown ? (
         <div className="saved-layout-pill" role="status">

--- a/src/visual-app/kind-palette.tsx
+++ b/src/visual-app/kind-palette.tsx
@@ -1,0 +1,118 @@
+import type React from 'react'
+import type { VisualKindOption } from '../adapters/visual/protocol-contract.js'
+import { conceptKinds, layers } from '../profile.js'
+import { ICON_SIZE, kindIconUriOf } from './kind-icons.js'
+
+/**
+ * The kind palette (#295): the profile's concept kinds, listed to be picked up.
+ *
+ * The kinds are the same vocabulary the Add-subject dialog's Kind select
+ * compiles from - `vocabulary.conceptKinds`, sent with every model frame - so
+ * nothing here decides what a workspace may contain. A row is a thing to drag
+ * onto the canvas, and a thing to click for the same result without a pointer
+ * gesture: either way the details dialog opens with the kind already chosen,
+ * and the palette itself holds nothing afterwards (ADR 0116).
+ */
+
+/**
+ * The drag payload's type. Custom rather than `text/plain`, so the canvas
+ * accepts exactly what the palette offers and a stray text drop onto the
+ * diagram stays inert. The payload is the kind's LABEL, not its full identity:
+ * a document names a kind the short way, and `apply` refuses the identity as
+ * an unknown kind (`YM401`) - the same rule the dialog's own select follows.
+ */
+export const KIND_MIME = 'application/x-yarramate-kind'
+
+/** Where a kind whose lineage resolves outside the core profile is grouped,
+ * last - the same word the model tree uses for a subject with no layer. */
+const UNLAYERED = 'unlayered'
+
+// A kind's layer, off its CORE label: the wire carries no layer, but every
+// option names the nearest core kind it descends from, and the core profile
+// declares a layer for each of those. An extension kind therefore files under
+// its parent's layer, which is where a reader fluent in the bands would look.
+const LAYER_OF_CORE_KIND: ReadonlyMap<string, string> = new Map(
+  conceptKinds.map((kind) => [kind.id, kind.layer] as const),
+)
+
+export interface PaletteGroup {
+  readonly layer: string
+  readonly kinds: readonly VisualKindOption[]
+}
+
+/**
+ * Rows grouped by layer, in the profile's own layer order - the same bands the
+ * model tree groups subjects by, so the palette and the rail read as one
+ * organisation. Within a group the wire's order is kept: the vocabulary
+ * arrives sorted and re-sorting it here would be a second opinion.
+ */
+export const paletteGroups = (
+  kinds: readonly VisualKindOption[],
+): readonly PaletteGroup[] => {
+  const byLayer = new Map<string, VisualKindOption[]>()
+  for (const option of kinds) {
+    const layer = LAYER_OF_CORE_KIND.get(option.coreLabel) ?? UNLAYERED
+    const group = byLayer.get(layer)
+    if (group === undefined) {
+      byLayer.set(layer, [option])
+    } else {
+      group.push(option)
+    }
+  }
+  return [...layers, UNLAYERED].flatMap((layer) => {
+    const grouped = byLayer.get(layer)
+    return grouped === undefined ? [] : [{ layer, kinds: grouped }]
+  })
+}
+
+export const KindPalette = ({
+  kinds,
+  onPick,
+}: {
+  readonly kinds: readonly VisualKindOption[]
+  /** A kind chosen without the drag - a click, a keyboard - which opens the
+   * same dialog a drop does. */
+  readonly onPick: (kindLabel: string) => void
+}): React.ReactElement => (
+  <div className="kind-palette">
+    {paletteGroups(kinds).map((group) => (
+      <div className="kind-palette-layer" key={group.layer}>
+        <p className="kind-palette-layer-name">{group.layer}</p>
+        <ul className="kind-palette-rows">
+          {group.kinds.map((option) => {
+            // The glyph the canvas already draws on a node of this kind; an
+            // extension kind borrows its core parent's. No glyph, no image -
+            // the label alone still names the kind.
+            const icon =
+              kindIconUriOf(option.label) ?? kindIconUriOf(option.coreLabel)
+            return (
+              <li key={option.id}>
+                <button
+                  type="button"
+                  className="kind-palette-row"
+                  draggable
+                  data-kind={option.label}
+                  onDragStart={(event) => {
+                    event.dataTransfer.setData(KIND_MIME, option.label)
+                    event.dataTransfer.effectAllowed = 'copy'
+                  }}
+                  onClick={() => onPick(option.label)}
+                >
+                  {icon === null ? null : (
+                    <img
+                      src={icon}
+                      alt=""
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                    />
+                  )}
+                  <span>{option.label}</span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    ))}
+  </div>
+)

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -750,11 +750,77 @@ body {
   flex: 0 0 var(--chat-height, 300px);
 }
 
-/* With properties absent there is no slack-taker, so the section above the
-   foot takes it instead - otherwise a two-section stack leaves a gap under
-   the last one. */
-.section-stack > .stack-section:first-child {
+/* With properties absent there is no slack-taker, so the first section that
+   is not the palette takes it instead - otherwise a short stack leaves a gap
+   under the last one. Never the palette: it lists a fixed vocabulary, not
+   the reviewer's work, so the room passes it by (#295). */
+.section-stack:not(:has(> .stack-section-properties))
+  > .stack-section:nth-child(1 of .stack-section:not(.stack-section-palette)) {
   flex: 1 1 auto;
+}
+
+/* Unless the palette stands alone - there is nobody else to give the room
+   to, and a lone section with a gap under it reads as a broken stack. */
+.section-stack > .stack-section-palette:only-child {
+  flex: 1 1 auto;
+  max-height: none;
+}
+
+/* The palette keeps to its content and scrolls past 45% of the column - a
+   vocabulary of sixty kinds must not push the properties, the changes and
+   the chat off the foot of the stack (#295). */
+.stack-section-palette {
+  flex: 0 1 auto;
+  max-height: 45%;
+}
+
+.kind-palette {
+  padding: calc(var(--step) * 0.5) 0 calc(var(--step) * 0.75);
+}
+
+/* The layer bands, in the profile's order - the same grouping the model tree
+   reads in, so the palette and the rail are one organisation. */
+.kind-palette-layer-name {
+  margin: 0;
+  padding: calc(var(--step) * 0.75) calc(var(--step) * 1.5)
+    calc(var(--step) * 0.25);
+  font-family: var(--utility);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--quiet);
+}
+
+.kind-palette-rows {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* A row is a thing to pick up, and a button a keyboard can press for the same
+   dialog - so it reads like a tree row and grabs like a handle. */
+.kind-palette-row {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--step) * 0.75);
+  width: 100%;
+  padding: 0.3rem calc(var(--step) * 1.5);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  color: var(--ink);
+  background: none;
+  border: 0;
+  border-radius: 0;
+  cursor: grab;
+}
+
+.kind-palette-row:hover,
+.kind-palette-row:focus-visible {
+  background: color-mix(in oklab, var(--cobalt) 10%, transparent);
+}
+
+.kind-palette-row img {
+  flex: 0 0 auto;
 }
 
 .section-head {

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -20,6 +20,7 @@ export const SubjectDraftPanel = ({
   kinds,
   documents,
   defaultDocument,
+  initialKind,
   onStage,
   onCancel,
 }: {
@@ -27,6 +28,10 @@ export const SubjectDraftPanel = ({
   readonly kinds: readonly VisualKindOption[]
   readonly documents: readonly string[]
   readonly defaultDocument: string
+  /** A kind the reviewer picked up on the way in - dragged from the palette
+   * or clicked there (#295). Their own choice arriving with the gesture, not
+   * a default this form chose for them, so the no-default rule below stands. */
+  readonly initialKind?: string
   readonly onStage: (operation: YarramateOperation) => void
   readonly onCancel: () => void
 }): React.ReactElement => {
@@ -34,7 +39,7 @@ export const SubjectDraftPanel = ({
   // No default. The first kind alphabetically is `andJunction`, a plumbing
   // construct nobody means to create, and a form that quietly picks one is a
   // form that makes that subject by accident.
-  const [kind, setKind] = useState('')
+  const [kind, setKind] = useState(initialKind ?? '')
   const [document, setDocument] = useState(defaultDocument)
 
   const proposed = name.trim() === '' ? null : proposeConceptId(graph, name)

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -103,11 +103,14 @@ const nextRelationship = (
  * The right column's sections, in the order they stack (#249, ADR-free: the
  * design settles the order and nothing derives it).
  *
- * Chat is last because it is pinned at the foot and owns the session's own
- * control - the reviewer ends the conversation beside the conversation, not
- * from a strip that carries identity and nothing else.
+ * The palette leads (#295): it is the tool that makes subjects, and tools
+ * read above inspection - a reviewer reaches for what to add before what is
+ * selected. Chat is last because it is pinned at the foot and owns the
+ * session's own control - the reviewer ends the conversation beside the
+ * conversation, not from a strip that carries identity and nothing else.
  */
 export const RIGHT_SECTIONS = [
+  "palette",
   "properties",
   "questions",
   "changes",

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -1,6 +1,10 @@
 import cytoscape from 'cytoscape'
 import { describe, expect, it } from 'vitest'
-import { applyFilter, relayoutVisible } from '../src/visual-app/graph-canvas.js'
+import {
+  applyFilter,
+  modelPositionOf,
+  relayoutVisible,
+} from '../src/visual-app/graph-canvas.js'
 
 // A small headless cytoscape instance (no container/DOM needed for hide/show
 // and data queries) - mirrors the shape graphToElements produces, without
@@ -227,5 +231,28 @@ describe('a subject the model has just gained', () => {
     applyFilter(cy, null, '')
 
     expect(cy.getElementById('payment-gateway').visible()).toBe(true)
+  })
+})
+
+/**
+ * Where a palette drop lands (#295): the container's own coordinates, undone
+ * through whatever pan and zoom are standing, give the model position under
+ * the pointer. Pure arithmetic, so it is stated without a canvas to drop on.
+ */
+describe('modelPositionOf', () => {
+  it('is the identity under no pan and unit zoom', () => {
+    expect(modelPositionOf({ x: 120, y: 80 }, { x: 0, y: 0 }, 1)).toEqual({
+      x: 120,
+      y: 80,
+    })
+  })
+
+  it('undoes the standing pan and zoom', () => {
+    // A canvas panned to (50, -20) and zoomed to 2 draws model (35, 50) at
+    // rendered (120, 80): the drop must give back the model point.
+    expect(modelPositionOf({ x: 120, y: 80 }, { x: 50, y: -20 }, 2)).toEqual({
+      x: 35,
+      y: 50,
+    })
   })
 })

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -29,9 +29,10 @@ concepts:
 relationships: []
 `)
 
-const render = () =>
+const render = (overrides: { readonly initialKind?: string } = {}) =>
   renderToStaticMarkup(
     createElement(SubjectDraftPanel, {
+      ...overrides,
       graph,
       kinds: [
         // id is the full identity the wire carries; label is the short name a
@@ -88,6 +89,28 @@ describe('SubjectDraftPanel', () => {
 
     expect(values).toContain('applicationComponent')
     expect(values.some((value) => value.includes('#'))).toBe(false)
+  })
+
+  /**
+   * The palette's half of #295: a kind dragged or clicked there arrives as
+   * `initialKind` and the select opens on it. Not a default - the reviewer's
+   * own pick riding the gesture in - so the untouched form's no-default rule
+   * (below) stands, and the guidance moves on to the name the id still needs.
+   */
+  it('seeds the kind a palette gesture picked up', () => {
+    const markup = render({ initialKind: 'businessActor' })
+
+    // Only the Kind select: Document legitimately opens on its default too.
+    const kindSelect =
+      /<select id="subject-draft-kind"[^>]*>([\s\S]*?)<\/select>/.exec(
+        markup,
+      )?.[1] ?? ''
+    const seeded = [...kindSelect.matchAll(/<option ([^>]*)>/g)]
+      .filter((match) => match[1]!.includes('selected'))
+      .map((match) => /value="([^"]*)"/.exec(match[1]!)?.[1])
+    expect(seeded).toEqual(['businessActor'])
+    expect(markup).toContain('Give it a name.')
+    expect(markup).not.toContain('Choose a kind.')
   })
 
   it('picks no kind for the reviewer', () => {

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -90,6 +90,7 @@ vi.mock('../src/visual-app/workspace-state.js', async (importOriginal) => {
 })
 
 import { App } from '../src/visual-app/App.js'
+import { KIND_MIME } from '../src/visual-app/kind-palette.js'
 
 const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
 
@@ -488,11 +489,11 @@ describe('command strip', () => {
  * in the right column, and the session's own control beside the conversation.
  */
 describe('the right column, as a stack of sections', () => {
-  it('draws all three sections, chat last', () => {
+  it('draws the sections in the stack order, palette first and chat last', () => {
     const markup = renderSession()
 
     expect(markup).toContain('class="section-stack"')
-    const order = ['properties', 'changes', 'chat'].map((id) =>
+    const order = ['palette', 'properties', 'changes', 'chat'].map((id) =>
       markup.indexOf(`stack-section-${id}`),
     )
     expect(order.every((at) => at !== -1)).toBe(true)
@@ -582,10 +583,10 @@ describe('a host that asks for some of the sections', () => {
     expect(markup).not.toContain('class="section-splitter"')
   })
 
-  it('draws all three when the host says nothing', () => {
+  it('draws every section when the host says nothing', () => {
     const markup = renderSession()
 
-    for (const id of ['properties', 'changes', 'chat']) {
+    for (const id of ['palette', 'properties', 'changes', 'chat']) {
       expect(markup).toContain(`stack-section-${id}`)
     }
   })
@@ -684,6 +685,99 @@ describe('open questions section (#292)', () => {
     // overlay must see the canvas it always saw, not a section of zeros.
     const markup = renderSession({ model: renderedModel })
     expect(markup).not.toContain('Open questions')
+  })
+})
+
+/**
+ * The kind palette (#295): the profile's concept kinds as a section, each row
+ * a thing to drag onto the canvas or click, either way opening the Add-subject
+ * dialog with the kind preselected. The rows come from the model frame's own
+ * `vocabulary.conceptKinds` - the list the dialog's Kind select compiles from -
+ * so the palette and the select can never disagree.
+ */
+describe('kind palette (#295)', () => {
+  const kindsModel: VisualRenderedModel = {
+    ...renderedModel,
+    vocabulary: {
+      conceptKinds: [
+        {
+          id: 'yarramate/core@0.1#applicationComponent',
+          label: 'applicationComponent',
+          coreLabel: 'applicationComponent',
+        },
+        {
+          id: 'yarramate/core@0.1#businessActor',
+          label: 'businessActor',
+          coreLabel: 'businessActor',
+        },
+        {
+          id: 'yarramate/core@0.1#goal',
+          label: 'goal',
+          coreLabel: 'goal',
+        },
+      ],
+      relationshipKinds: [],
+    },
+  }
+
+  it('lists the vocabulary the model frame carries, and counts it in the header', () => {
+    const markup = renderSession({ model: kindsModel })
+
+    expect(markup).toContain('stack-section-palette')
+    expect(markup).toContain('>Kind palette</span>')
+    expect(markup).toContain('class="section-meta">3 kinds</span>')
+    expect(markup).toContain('data-kind="applicationComponent"')
+    expect(markup).toContain('data-kind="businessActor"')
+    expect(markup).toContain('data-kind="goal"')
+  })
+
+  it('makes every row draggable and clickable, never a plain span', () => {
+    const markup = renderSession({ model: kindsModel })
+
+    const rows = [...markup.matchAll(/class="kind-palette-row"/g)]
+    expect(rows).toHaveLength(3)
+    expect(
+      [...markup.matchAll(/<button[^>]*class="kind-palette-row"[^>]*>/g)].every(
+        (row) => row[0].includes('draggable="true"'),
+      ),
+    ).toBe(true)
+  })
+
+  it('groups the rows into layer bands, in the profile layer order', () => {
+    // The same organisation the model tree reads in: motivation before
+    // business before application, whatever order the wire listed the kinds.
+    const markup = renderSession({ model: kindsModel })
+
+    const bands = ['motivation', 'business', 'application'].map((layer) =>
+      markup.indexOf(`class="kind-palette-layer-name">${layer}<`),
+    )
+    expect(bands.every((at) => at !== -1)).toBe(true)
+    expect(bands).toEqual([...bands].sort((a, b) => a - b))
+  })
+
+  it('says the kinds arrive with the model while there is none', () => {
+    const markup = renderSession()
+
+    expect(markup).toContain('stack-section-palette')
+    expect(markup).toContain('No model yet. The kinds arrive with it.')
+  })
+
+  it('renders no palette for a host that did not ask for one', () => {
+    // The section vocabulary is the host's opt-in, like every other section.
+    const markup = renderSession(
+      { model: kindsModel },
+      { sections: ['properties', 'changes'] },
+    )
+
+    expect(markup).not.toContain('stack-section-palette')
+    expect(markup).not.toContain('kind-palette-row')
+  })
+
+  it('names the drag payload type hosts and tests can rely on', () => {
+    // The wire format of the gesture: a canvas accepts exactly this type, so
+    // a stray text drop stays inert. Static markup cannot carry the
+    // `dataTransfer` call; the constant is the contract.
+    expect(KIND_MIME).toBe('application/x-yarramate-kind')
   })
 })
 

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -836,12 +836,14 @@ describe("the right column's sections", () => {
   ): VisualWorkspaceState =>
     visualWorkspaceReducer(from, { type: "section.toggled", section });
 
-  it("stacks properties, questions, changes and chat, with chat last", () => {
-    // Chat is pinned at the foot because it owns the session's own control -
-    // the reviewer ends the conversation beside the conversation. Questions
-    // sit under properties: what is asked about a subject reads beside what
-    // is declared about it (#292).
+  it("stacks palette, properties, questions, changes and chat, in that order", () => {
+    // The palette leads: it is the tool that makes subjects, and tools read
+    // above inspection (#295). Chat is pinned at the foot because it owns the
+    // session's own control - the reviewer ends the conversation beside the
+    // conversation. Questions sit under properties: what is asked about a
+    // subject reads beside what is declared about it (#292).
     expect(RIGHT_SECTIONS).toEqual([
+      "palette",
       "properties",
       "questions",
       "changes",
@@ -1035,6 +1037,7 @@ describe("the right column can leave (#294)", () => {
  */
 describe("stackRows", () => {
   const bodies = {
+    palette: "palette-body",
     properties: "properties-body",
     questions: "questions-body",
     changes: "changes-body",
@@ -1051,6 +1054,7 @@ describe("stackRows", () => {
 
   it("draws every section and the handles between them by default", () => {
     expect(rows(RIGHT_SECTIONS)).toEqual([
+      "palette",
       "properties",
       "questions",
       "splitter-changes",
@@ -1079,9 +1083,9 @@ describe("stackRows", () => {
     // The sequence means something - properties above changes above chat, which
     // is pinned at the foot - so a host cannot reorder the shell by writing its
     // array differently.
-    expect(rows(["chat", "questions", "properties", "changes"])).toEqual(
-      rows(RIGHT_SECTIONS),
-    );
+    expect(
+      rows(["chat", "questions", "palette", "properties", "changes"]),
+    ).toEqual(rows(RIGHT_SECTIONS));
   });
 
   it("draws nothing for a host that asked for nothing", () => {


### PR DESCRIPTION
Closes #295.

A `palette` section joins the right column, listing the profile's concept kinds — the same `vocabulary.conceptKinds` the Add-subject dialog compiles its Kind select from, so the palette and the select can never disagree. A row is dragged onto the canvas under a custom `application/x-yarramate-kind` payload (a stray text drop stays inert), or clicked for the keyboard/no-drag path; either way the existing Add-subject dialog opens with the kind preselected (`initialKind`), and the change stages like any other. Hosts opt in or out through the `sections` vocabulary, exactly like `properties` or `changes`.

[ADR 0116 — A kind is picked up, not remembered](docs/adr/0116-a-kind-is-picked-up-not-remembered.md).

**Recorded choices**

- **Palette position: first.** It is the tool that makes subjects, and tools read above inspection. Hosts passing an explicit section list see nothing new until they ask; the session shell (which passes none) gets the palette by default.
- **Grouped by layer, not flat.** The bands come from each kind's core lineage in the profile's own layer order — the same organisation the model tree reads in. A flat list of sixty kinds is a wall.
- **The dialog stays the details editor.** Creating the subject on drop with no dialog is excluded: the id derives from the name, and a drop has no name to derive it from.
- **No armed mode.** Clicking a row opens the dialog directly rather than arming a kind the next canvas click would stamp — a mode the reviewer must remember to leave.
- **Scope cut: the drop position is not threaded into the staged result.** It is converted to model coordinates and handed up (`onKindDrop`), and deliberately goes no further — placement belongs to elk and the layout system, and pinning one node would be a saved-layout sidecar write against a subject that does not exist until the changeset commits. A dropped subject lands where the layout puts it. The seam is cut for a future integration; nothing is built on it.
- **The picked kind is shell state, not workspace state** — the gesture's payload on its way to the form, beside `saveViewFolder`, not a fact the reducer holds.

**Verification**: `pnpm verify` exit 0 — 96 test files passed, 1642 tests passed, 1 skipped (a pre-existing platform-conditional skip).

This completes a salvaged partial build: an earlier agent's uncommitted work for #295 was recovered, audited against the design constraints, and finished — the recovered work was kept essentially whole; the one correction is the section-stack slack rule, which now actually passes the column's spare room past the palette when `properties` is absent, as its comment promised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)