### PR TITLE
feat: a mounted editor can refuse the pen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Added.** A mounted editor can refuse the pen (#298). `mountEditor`
+  gains `readOnly?: boolean` (default `false`) and `mountEditorWith` a
+  trailing `readOnly` parameter, so a host can render a frozen snapshot
+  with the authoring surface's own visual language. Read-only keeps
+  everything that reads — the canvas, selection, the quick filter, view
+  navigation, live query narrowing, open questions, the properties
+  facts (rendered as values where the editable forms stood), Export PNG
+  and the session-local layout Discard — and every affordance that
+  stages or commits is absent, not disabled: no Add subject, no
+  palette or changes sections (stripped from whatever `sections` names;
+  the read-only `mountEditor` default is `['properties', 'questions']`),
+  no Connect/Delete, no Stage view change, no new/rename/duplicate/
+  delete menu items, and a drag still moves a node but writes no
+  layout. A UI posture only: the host's store refuses writes on its own
+  authority, and the two defenses are independent. The session shell
+  and the `EditorHost` seam are unchanged.
+  [ADR 0117](docs/adr/0117-a-mounted-editor-can-refuse-the-pen.md).
+
 - **Added.** A kind palette the canvas accepts by drag (#295). A `palette`
   section leads the right column, listing the profile's concept kinds —
   the same `vocabulary.conceptKinds` the Add-subject dialog compiles its

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -298,6 +298,17 @@ const editor = mountEditor(document.querySelector('#editor')!, {
 editor.unmount()
 ```
 
+Pass `readOnly: true` to mount a viewer over the same surface — for a frozen
+published snapshot, say ([ADR 0117](adr/0117-a-mounted-editor-can-refuse-the-pen.md)).
+The reviewer still selects, filters, navigates views and reads questions and
+properties (as values, not forms), but every affordance that stages or commits
+is absent rather than disabled: no Add subject, no palette or changes
+sections, no Connect/Delete, no view create/rename/delete, and drags move
+nodes without writing layouts. With no `sections` named, a read-only mount
+defaults to `['properties', 'questions']`. This is a UI posture only — pair it
+with a store that refuses writes; the two defenses are independent.
+`mountEditorWith` takes the same flag as its trailing parameter.
+
 `store` is the caller's synchronous `SourceStore`; `workspace` is the caller's
 pre-resolved `ResolvedWorkspace`. The local host compiles, projects, filters,
 commits and saves layouts over that store. A changeset's model and view writes

--- a/docs/adr/0117-a-mounted-editor-can-refuse-the-pen.md
+++ b/docs/adr/0117-a-mounted-editor-can-refuse-the-pen.md
@@ -1,0 +1,86 @@
+# A mounted editor can refuse the pen
+
+Status: accepted
+
+ApertureX, embedding the editor over its own store (#252), keeps
+immutable published snapshots beside its working workspace. Working mode
+mounts the editor as the authoring surface; published views still go
+through their own renderer, because there was no documented way to mount
+the editor over a store that refuses writes without the UI still
+offering to stage and commit (#298). Their store's refusal is real —
+`writeAll` fails — but the surface kept the pen: Add subject, the
+palette, Connect and Delete, editable forms, the changes tray, "Stage
+view change", drag-to-save layouts, and every staging item on the
+context menus. A viewer built on that mount learns the snapshot is
+frozen one error at a time, which is why they built a second renderer —
+and a second renderer is exactly the drift the mountable editor exists
+to end.
+
+## Decision
+
+`mountEditor` gains `readOnly?: boolean` (default `false`),
+`mountEditorWith` a trailing `readOnly` parameter, and `App` one prop —
+one flag, threaded once. Read-only keeps everything that reads: the
+canvas, selection, the quick filter, view navigation, the query fields
+(a live filter narrows the canvas and writes nothing), the open
+questions, the properties facts, Export PNG, and the saved-layout pill
+with its session-local Discard. Every affordance that stages or commits
+is **absent, not disabled**, each cut at the seam it already had:
+
+- **Sections.** Read-only strips `palette` and `changes` from whatever
+  list the host names, beside the existing questions gate: a palette
+  that cannot create and a tray that cannot commit are not "sections
+  the host wants shown", whatever the list says. `mountEditor` with no
+  `sections` defaults to `['properties', 'questions']` — the local host
+  has no agent, so a read-only default that drew chat would draw a
+  composer with nobody behind it.
+- **Menus.** `contextMenuFor` filters by intent, once, at its tail: a
+  closed reading set (inspect, open view, show all, copy path, export
+  PNG) survives, and a group the filter empties — every destructive
+  group among them — is dropped whole.
+- **The inspector.** The facts render as values (`ConceptFacts`,
+  `RelationshipFacts`) where the editable forms stood; Connect and
+  Delete leave, Clear stays, the description still reads.
+- **The canvas.** A drag still moves a node — arranging what is on
+  screen is reading — but the debounced layout save goes nowhere, and
+  the kind-drop handler is withdrawn so the canvas itself refuses the
+  drag.
+
+The `EditorHost` seam needs nothing. Read-only is a UI posture, and the
+host refuses writes on its own authority — ApertureX's store already
+does. The two are independent defenses: the posture keeps the surface
+honest, the store keeps the data safe, and neither substitutes for the
+other.
+
+## Excluded options
+
+- **Disabled-but-visible controls**: a greyed pen says the surface is
+  broken, not that the snapshot is frozen. This shell already draws
+  controls only where they can act — the session button leaves with the
+  chat section (#252), a splitter is never drawn against a hidden
+  column (#294) — and absence is the same rule here.
+- **A second permission system** (per-affordance capabilities, roles):
+  one boolean names the only posture anyone has asked for. A capability
+  vocabulary would need its own versioning and its own tests for
+  combinations nobody holds.
+- **Server-session read-only**: `yarramate-visual` sessions stay
+  authoring surfaces. Threading the same prop through the session page
+  is cheap if a frozen session is ever wanted, and deferred until it is.
+- **Emptying `sections` as the whole answer**: the sections vocabulary
+  cannot reach the pen's other homes — the Add-subject opener, the
+  inspector's buttons, the menus, the drag save — and bending it to try
+  would conflate what exists with what may act.
+
+## Consequences
+
+`MountOptions` grows one optional flag and `mountEditorWith` one
+trailing parameter with a default, so every existing call stands
+unchanged; the session shell passes nothing and is untouched. A host
+naming its own `sections` alongside `readOnly: true` keeps its list
+minus the two staging sections. The read-only menu rule is a set of
+intent types, so a future menu item declares its side of the line by
+the intent it carries and the filter needs no edit. The staged-state
+plumbing (`pendingChangeset`, the tray, the rail's staged chips) still
+exists under a read-only mount and simply never receives anything —
+which is the honest shape: nothing was forked, one surface was told to
+put the pen down.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -6,7 +6,12 @@ import { ViewTree } from "./view-tree.js";
 import { SaveViewDialog } from "./save-view.js";
 import { describeQuery } from "./describe-query.js";
 import { ChangesetTray } from "./changeset-tray.js";
-import { ConceptForm, RelationshipForm } from "./subject-form.js";
+import {
+  ConceptFacts,
+  ConceptForm,
+  RelationshipFacts,
+  RelationshipForm,
+} from "./subject-form.js";
 import { OpenQuestions } from "./open-questions.js";
 import {
   useEffect,
@@ -251,6 +256,7 @@ const DiagramWorkspace = ({
   onSelectBottomTab,
   onApplyFilter,
   onStageView,
+  readOnly,
 }: {
   readonly state: VisualAppState;
   readonly selectedId: string | null;
@@ -310,6 +316,13 @@ const DiagramWorkspace = ({
   readonly onSelectBottomTab: (tab: BottomPanelTabId) => void;
   readonly onApplyFilter: (query: ProjectionQuery) => void;
   readonly onStageView: (operation: VisualViewOperation) => void;
+  /**
+   * A viewer, not an author (#298, ADR 0117). The canvas still selects,
+   * filters and navigates; everything that stages - the Add-subject opener,
+   * the palette drop, the stage-view-change affordance - is absent, and a
+   * drag still moves a node transiently but writes no layout.
+   */
+  readonly readOnly: boolean;
 }) => {
   // An edge names its endpoints by node id; the reviewer reads titles. The
   // rendering model the renderer itself draws answers that, so nothing here
@@ -357,13 +370,15 @@ const DiagramWorkspace = ({
               value={state.quickFilterText}
               onChange={onQuickFilterChange}
             />
-            <button
-              type="button"
-              className="subject-draft-open"
-              onClick={onDraftSubject}
-            >
-              Add subject
-            </button>
+            {readOnly ? null : (
+              <button
+                type="button"
+                className="subject-draft-open"
+                onClick={onDraftSubject}
+              >
+                Add subject
+              </button>
+            )}
           </div>
         )}
         {!draftingSubject || state.model === null ? null : (
@@ -457,8 +472,14 @@ const DiagramWorkspace = ({
             openQuestionCounts={openQuestionCounts}
             activeViewId={state.activeView}
             savedPositions={state.model.layouts[state.activeView]}
-            onSaveLayout={onSaveLayout}
-            onKindDrop={onKindDrop}
+            // A read-only drag still moves the node - arranging what is on
+            // screen is reading - but the debounced save it would queue goes
+            // nowhere: nothing a viewer does may write. The saved-layout pill
+            // keeps working either way; Discard is session-local.
+            onSaveLayout={readOnly ? () => undefined : onSaveLayout}
+            // No palette in a read-only mount, so nothing honest could drop:
+            // an undefined handler makes the canvas refuse the drag itself.
+            onKindDrop={readOnly ? undefined : onKindDrop}
             onCanvasReady={onCanvasReady}
           />
         )}
@@ -489,6 +510,7 @@ const DiagramWorkspace = ({
         onSelectTab={onSelectBottomTab}
         onApply={onApplyFilter}
         onStage={onStageView}
+        readOnly={readOnly}
       />
     </section>
   );
@@ -556,6 +578,7 @@ const SelectedSubjectInspector = ({
   onConnect,
   onDelete,
   onStageChange,
+  readOnly,
 }: {
   readonly subject: SelectedDiagramSubject;
   readonly model: VisualRenderedModel;
@@ -566,6 +589,12 @@ const SelectedSubjectInspector = ({
   readonly onConnect: (from: string) => void;
   readonly onDelete: (id: string) => void;
   readonly onStageChange: (operation: YarramateOperation) => void;
+  /**
+   * A viewer, not an author (#298): Connect and Delete are absent and the
+   * facts render as values rather than as the editable forms. Clear stays -
+   * putting a selection down is reading.
+   */
+  readonly readOnly: boolean;
 }) => {
   const node =
     subject.type === "element"
@@ -591,7 +620,7 @@ const SelectedSubjectInspector = ({
               : `${subject.sourceTitle} → ${subject.targetTitle}`}
           </h2>
         </div>
-        {subject.type === "element" ? (
+        {subject.type === "element" && !readOnly ? (
           <button
             type="button"
             className="subject-connect"
@@ -600,33 +629,43 @@ const SelectedSubjectInspector = ({
             Connect
           </button>
         ) : null}
-        <button
-          type="button"
-          className="subject-delete"
-          onClick={() => onDelete(subject.id)}
-        >
-          Delete
-        </button>
+        {readOnly ? null : (
+          <button
+            type="button"
+            className="subject-delete"
+            onClick={() => onDelete(subject.id)}
+          >
+            Delete
+          </button>
+        )}
         <button type="button" className="subject-clear" onClick={onClear}>
           Clear
         </button>
       </div>
 
       {node !== undefined ? (
-        <ConceptForm
-          node={node}
-          model={model}
-          operations={operations}
-          onStageChange={onStageChange}
-        />
+        readOnly ? (
+          <ConceptFacts node={node} model={model} />
+        ) : (
+          <ConceptForm
+            node={node}
+            model={model}
+            operations={operations}
+            onStageChange={onStageChange}
+          />
+        )
       ) : null}
       {edge !== undefined ? (
-        <RelationshipForm
-          edge={edge}
-          model={model}
-          operations={operations}
-          onStageChange={onStageChange}
-        />
+        readOnly ? (
+          <RelationshipFacts edge={edge} model={model} />
+        ) : (
+          <RelationshipForm
+            edge={edge}
+            model={model}
+            operations={operations}
+            onStageChange={onStageChange}
+          />
+        )
       ) : null}
 
       <ExpandableDescription
@@ -882,13 +921,21 @@ const ConversationSeparator = ({
  * embedder's own store with no server at all. `sections` is what the host
  * wants shown - a product with no agent behind it leaves `chat` out, and the
  * section and the session button go with it.
+ *
+ * `readOnly` is one flag, threaded once (#298, ADR 0117): a viewer keeps
+ * everything that reads - the canvas, the tree, the query fields, the facts,
+ * the questions - and every affordance that stages or commits is absent
+ * rather than disabled. A UI posture only: whatever this shell draws, the
+ * host still answers for its own store.
  */
 export const App = ({
   host,
   sections = RIGHT_SECTIONS,
+  readOnly = false,
 }: {
   readonly host: EditorHost;
   readonly sections?: readonly RightSectionId[];
+  readonly readOnly?: boolean;
 }) => {
   const {
     state,
@@ -1060,10 +1107,20 @@ export const App = ({
       ),
     [interrogation],
   );
+  // Read-only strips the sections that exist only to stage (#298, ADR 0117):
+  // a palette that cannot create and a changes tray that cannot commit are
+  // not "sections the host wants shown", whatever the list says. The filter
+  // sits beside the questions gate because both answer the same question -
+  // which sections have anything true to draw.
+  const offeredSections = readOnly
+    ? sections.filter(
+        (section) => section !== "palette" && section !== "changes",
+      )
+    : sections;
   const visibleSections =
     interrogation === undefined
-      ? sections.filter((section) => section !== "questions")
-      : sections;
+      ? offeredSections.filter((section) => section !== "questions")
+      : offeredSections;
   const selectedElementId =
     workspace.selectedSubject?.type === "element"
       ? workspace.selectedSubject.id
@@ -1135,6 +1192,7 @@ export const App = ({
           activeViewId: state.activeView,
           filtered: state.activeFilter !== null,
           membership: activeViewMembership(state),
+          readOnly,
         });
 
   /**
@@ -1368,6 +1426,7 @@ export const App = ({
               position,
             )
           }
+          readOnly={readOnly}
         />
         <DiagramWorkspace
           state={state}
@@ -1456,6 +1515,7 @@ export const App = ({
           // filtered as `editor` and the tree goes on naming what is drawn.
           onApplyFilter={(query) => filter(query, "editor")}
           onStageView={stageViewChange}
+          readOnly={readOnly}
         />
         {conversationHidden ? (
           // The way back stands where the column stood: a thin strip, not a
@@ -1570,6 +1630,7 @@ export const App = ({
                             dispatchWorkspace({ type: "deletion.asked", id })
                           }
                           onStageChange={stageChange}
+                          readOnly={readOnly}
                         />
                       )}
                     </Section>

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -117,7 +117,29 @@ export interface ContextMenuContext {
    * than offering one that would do nothing (#255).
    */
   readonly membership: readonly string[] | null;
+  /**
+   * A viewer, not an author (#298, ADR 0117). A read-only menu keeps the items
+   * that read or navigate and drops every item whose intent stages a change -
+   * absent, never disabled.
+   */
+  readonly readOnly?: boolean;
 }
+
+/**
+ * The intents that only read or navigate. Everything outside this set stages
+ * a change - directly, or by opening a dialog whose whole purpose is to stage
+ * one - and a read-only menu (#298) is the menu filtered to this set.
+ * `subject.connect` is here in spirit only: it stages nothing itself, but the
+ * panel it opens exists to stage a relationship, so it is out.
+ */
+const READING_INTENTS: ReadonlySet<ContextMenuIntent["type"]> = new Set([
+  "subject.inspect",
+  "relationship.inspect",
+  "view.open",
+  "view.clear",
+  "view.copy-path",
+  "canvas.export-png",
+]);
 
 /**
  * Putting a subject into the active view, or taking it out — whichever the
@@ -427,18 +449,32 @@ export const contextMenuFor = (
   target: ContextMenuTarget,
   context: ContextMenuContext,
 ): readonly ContextMenuGroup[] => {
-  switch (target.kind) {
-    case "subject":
-      return subjectMenu(target.id, context);
-    case "relationship":
-      return relationshipMenu(target.id, context);
-    case "canvas":
-      return canvasMenu(context);
-    case "view-row":
-      return viewRowMenu(target.id, context);
-    case "model-row":
-      return modelRowMenu(target.id, context);
-  }
+  const groups = ((): readonly ContextMenuGroup[] => {
+    switch (target.kind) {
+      case "subject":
+        return subjectMenu(target.id, context);
+      case "relationship":
+        return relationshipMenu(target.id, context);
+      case "canvas":
+        return canvasMenu(context);
+      case "view-row":
+        return viewRowMenu(target.id, context);
+      case "model-row":
+        return modelRowMenu(target.id, context);
+    }
+  })();
+  if (context.readOnly !== true) return groups;
+  // One filter, by intent, rather than a read-only branch in every builder:
+  // the intents are the discriminated union built to be read, so "which items
+  // stage" is a question the menu can be asked once, at the end. A group
+  // emptied by the filter is dropped whole - including every destructive
+  // group, which by the rule above holds nothing but staging items.
+  return groups.flatMap((group) => {
+    const items = group.items.filter((item) =>
+      READING_INTENTS.has(item.intent.type),
+    );
+    return items.length === 0 ? [] : [{ ...group, items }];
+  });
 };
 
 export interface MenuPlacement {

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -29,6 +29,9 @@ import './styles.css'
  * `sections` is what the host wants shown. Chat is the one a product usually
  * leaves out: with no agent behind it there is nobody to talk to and nothing to
  * hand control back to, so the section and the session button go together.
+ *
+ * `readOnly: true` mounts a viewer (#298): the same canvas, tree, questions
+ * and properties, with every staging and committing affordance absent.
  */
 export interface MountOptions extends LocalHostOptions {
   /**
@@ -38,6 +41,14 @@ export interface MountOptions extends LocalHostOptions {
    * name the two it wants.
    */
   readonly sections?: readonly RightSectionId[]
+  /**
+   * A viewer, not an author (#298, ADR 0117). Every affordance that stages or
+   * commits a change is absent - not disabled - so a frozen snapshot renders
+   * with the authoring surface's visual language and none of its pen. A UI
+   * posture only: a host whose store also refuses writes has two independent
+   * defenses, and this option is not the one that guards the data.
+   */
+  readonly readOnly?: boolean
 }
 
 export interface MountedEditor {
@@ -45,10 +56,25 @@ export interface MountedEditor {
   readonly unmount: () => void
 }
 
+/**
+ * The sections a read-only mount defaults to: the reading surfaces. No palette
+ * and no changes tray - those exist only to stage - and no chat, because the
+ * local host has no agent behind it. A host that wants a different reading set
+ * still names its own `sections`.
+ */
+const READ_SECTIONS: readonly RightSectionId[] = ['properties', 'questions']
+
 export const mountEditor = (
   element: Element,
   options: MountOptions,
-): MountedEditor => mountEditorWith(element, createLocalHost(options), options.sections)
+): MountedEditor =>
+  mountEditorWith(
+    element,
+    createLocalHost(options),
+    options.sections ??
+      (options.readOnly === true ? READ_SECTIONS : RIGHT_SECTIONS),
+    options.readOnly,
+  )
 
 /**
  * The same editor over a host the caller built.
@@ -56,17 +82,20 @@ export const mountEditor = (
  * Exported for the case `mountEditor` does not cover: a product that already
  * speaks the visual protocol - to its own server, over its own transport - and
  * wants the editor in front of it. The protocol is the contract (ADR 0081), so
- * anything that answers it is a host.
+ * anything that answers it is a host. `readOnly` composes: a custom host gets
+ * the same viewer posture `mountEditor` offers, and stays free to refuse
+ * writes on its own side of the seam as well.
  */
 export const mountEditorWith = (
   element: Element,
   host: EditorHost,
   sections: readonly RightSectionId[] = RIGHT_SECTIONS,
+  readOnly = false,
 ): MountedEditor => {
   // No StrictMode: its double mount would open the host twice, and a host with
   // a socket behind it would open two.
   const root = createRoot(element)
-  root.render(<App host={host} sections={sections} />)
+  root.render(<App host={host} sections={sections} readOnly={readOnly} />)
   return {
     unmount: () => root.unmount(),
   }

--- a/src/visual-app/query-panel.tsx
+++ b/src/visual-app/query-panel.tsx
@@ -307,6 +307,12 @@ export interface QueryPanelProps {
    * write: what is on screen is what the reviewer is composing. */
   readonly onApply: (query: ProjectionQuery) => void;
   readonly onStage: (operation: VisualViewOperation) => void;
+  /**
+   * A viewer, not an author (#298): the fields still narrow the canvas - a
+   * live filter writes nothing - but the affordance that stages the edit as a
+   * view change is absent. The document still shows, because it is a fact.
+   */
+  readonly readOnly?: boolean;
 }
 
 export function QueryPanel({
@@ -324,6 +330,7 @@ export function QueryPanel({
   onSelectTab,
   onApply,
   onStage,
+  readOnly = false,
 }: QueryPanelProps) {
   const debounceHandle = useRef<number | null>(null);
   // The VIEW's own query first, and the standing filter only when no view is
@@ -510,31 +517,34 @@ export function QueryPanel({
               <h3>Document</h3>
               {documentInput === null ? (
                 <p className="query-outcome-note">
-                  No view is active, so this query has no document yet. Pick one
-                  in the tree, or save this query as a new view.
+                  {readOnly
+                    ? "No view is active, so this query has no document. Pick one in the tree."
+                    : "No view is active, so this query has no document yet. Pick one in the tree, or save this query as a new view."}
                 </p>
               ) : (
                 <>
                   <pre className="query-document">
                     {stringify(viewDocument(documentInput))}
                   </pre>
-                  <div className="query-tab-actions">
-                    <button
-                      type="button"
-                      disabled={!documentChanged(documentInput)}
-                      onClick={() => {
-                        onStage(stagedViewEdit(documentInput));
-                        setStaged(true);
-                      }}
-                    >
-                      Stage view change
-                    </button>
-                    <span role="status" className="query-stage-status">
-                      {staged
-                        ? "Staged. It lands when the changeset is committed."
-                        : ""}
-                    </span>
-                  </div>
+                  {readOnly ? null : (
+                    <div className="query-tab-actions">
+                      <button
+                        type="button"
+                        disabled={!documentChanged(documentInput)}
+                        onClick={() => {
+                          onStage(stagedViewEdit(documentInput));
+                          setStaged(true);
+                        }}
+                      >
+                        Stage view change
+                      </button>
+                      <span role="status" className="query-stage-status">
+                        {staged
+                          ? "Staged. It lands when the changeset is committed."
+                          : ""}
+                      </span>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -2208,6 +2208,15 @@ body {
   color: var(--ink);
 }
 
+/* A fact said as a value (#298): the read-only inspector's answer to a form
+   control - same label treatment above it, plain text where the input was. */
+.subject-fact-value {
+  font-family: var(--body);
+  font-size: 13px;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
 .subject-form-list {
   border-top: 1px solid var(--rule);
   padding-top: calc(var(--step) * 0.75);

--- a/src/visual-app/subject-form.tsx
+++ b/src/visual-app/subject-form.tsx
@@ -773,6 +773,97 @@ export const ConceptForm = ({ node, model, operations, onStageChange }: ConceptF
   )
 }
 
+// ---------------------------------------------------------------------------
+// The read-only twins (#298, ADR 0117). The same fields the forms edit, said
+// as values: a read-only mount renders these instead of the forms, so the
+// facts still read where nothing may be staged. Fields the model does not
+// declare are skipped rather than shown empty - a viewer reads what is there,
+// and a wall of blank labels says less than their absence.
+
+const FactRow = ({
+  label,
+  value,
+}: {
+  readonly label: string
+  readonly value: string
+}) =>
+  value === '' ? null : (
+    <div className="subject-form-field">
+      <span className="subject-form-label">{label}</span>
+      <span className="subject-fact-value">{value}</span>
+    </div>
+  )
+
+export const ConceptFacts = ({
+  node,
+  model,
+}: {
+  readonly node: CanvasNode
+  readonly model: VisualRenderedModel
+}) => (
+  <div className="subject-form subject-facts">
+    <div className="subject-form-field">
+      <span className="subject-form-label">Identity</span>
+      <code>{node.id}</code>
+    </div>
+    <FactRow label="Kind" value={kindLabelFor(node.kind, model.vocabulary.conceptKinds)} />
+    <FactRow label="Name" value={node.name} />
+    <FactRow label="Status" value={node.status ?? ''} />
+    <FactRow label="Owner" value={node.owner ?? ''} />
+    <FactRow label="Aka" value={node.aka.join(', ')} />
+    <FactRow label="Distinct from" value={node.distinctFrom.join(', ')} />
+    <FactRow label="Supersedes" value={node.supersedes.join(', ')} />
+    <FactRow label="Present in" value={node.presentIn.join(', ')} />
+    <FactRow
+      label="References"
+      value={node.references.map((row) => `${row.id}: ${row.ref}`).join('; ')}
+    />
+    <FactRow
+      label="Constraints"
+      value={node.constraints.map((row) => `${row.id}: ${row.ref}`).join('; ')}
+    />
+    <FactRow
+      label="Attestations"
+      value={node.attestations
+        .map((row) => `${row.topic} by ${row.by} on ${row.on}`)
+        .join('; ')}
+    />
+  </div>
+)
+
+export const RelationshipFacts = ({
+  edge,
+  model,
+}: {
+  readonly edge: CanvasEdge
+  readonly model: VisualRenderedModel
+}) => {
+  // Endpoints are node ids; the reviewer reads titles, the same answer the
+  // editable form's endpoint selects give.
+  const titleOf = (ref: string): string =>
+    model.graph.nodes.find((candidate) => candidate.id === ref)?.name ?? ref
+  return (
+    <div className="subject-form subject-facts">
+      <div className="subject-form-field">
+        <span className="subject-form-label">Identity</span>
+        <code>{edge.id}</code>
+      </div>
+      <FactRow label="Kind" value={kindLabelFor(edge.kind, model.vocabulary.relationshipKinds)} />
+      <FactRow label="From" value={titleOf(edge.from)} />
+      <FactRow label="To" value={titleOf(edge.to)} />
+      <FactRow label="Name" value={edge.name ?? ''} />
+      <FactRow label="Mode" value={edge.mode ?? ''} />
+      <FactRow label="Content" value={edge.content ?? ''} />
+      <FactRow label="Status" value={edge.status ?? ''} />
+      <FactRow
+        label="References"
+        value={edge.references.map((row) => `${row.id}: ${row.ref}`).join('; ')}
+      />
+      <FactRow label="Present in" value={edge.presentIn.join(', ')} />
+    </div>
+  )
+}
+
 export interface RelationshipFormProps {
   readonly edge: CanvasEdge
   readonly model: VisualRenderedModel

--- a/src/visual-app/view-tree.tsx
+++ b/src/visual-app/view-tree.tsx
@@ -191,6 +191,8 @@ export interface ViewTreeProps {
   readonly onNewView: () => void;
   readonly onSelectSubject: (id: string) => void;
   readonly onRowMenu: TreeRowMenu;
+  /** A viewer, not an author (#298): the new-view affordance is absent. */
+  readonly readOnly?: boolean;
 }
 
 export function ViewTree({
@@ -208,6 +210,7 @@ export function ViewTree({
   onNewView,
   onSelectSubject,
   onRowMenu,
+  readOnly = false,
 }: ViewTreeProps) {
   const tree = buildViewTree({
     views,
@@ -247,22 +250,24 @@ export function ViewTree({
           value={filterText}
           onChange={(event) => onFilterChange(event.currentTarget.value)}
         />
-        <button
-          type="button"
-          className="view-tree-new"
-          title="New view"
-          aria-label="New view"
-          onClick={onNewView}
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-            <path
-              d="M7 3v8M3 7h8"
-              stroke="currentColor"
-              strokeWidth="1.3"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
+        {readOnly ? null : (
+          <button
+            type="button"
+            className="view-tree-new"
+            title="New view"
+            aria-label="New view"
+            onClick={onNewView}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <path
+                d="M7 3v8M3 7h8"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
       </div>
 
       <div className="view-tree-body">

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -5,7 +5,10 @@ import type { VisualAppState } from '../src/visual-app/state.js'
 import type { CanvasNode } from '../src/graph-projection.js'
 import type { VisualRenderedModel } from '../src/adapters/visual/wire.js'
 import type { EditorHost } from '../src/visual-app/editor-host.js'
-import type { RightSectionId } from '../src/visual-app/workspace-state.js'
+import type {
+  RightSectionId,
+  SelectedDiagramSubject,
+} from '../src/visual-app/workspace-state.js'
 
 const session = vi.hoisted(() => {
   const baseState: VisualAppState = {
@@ -67,8 +70,15 @@ vi.mock('../src/visual-app/session-client.js', () => ({
 // Static markup cannot click, so the workspace the shell opens with is the
 // seam: everything real is re-exported, and only the initial state is bent -
 // which is exactly what a session that had hidden the column looks like on
-// the next render (#294).
-const workspace = vi.hoisted(() => ({ hidden: false, unread: 0 }))
+// the next render (#294). `selectedSubject` and `panelOpen` bend the same
+// seam for the inspector and the query panel (#298), which otherwise only a
+// click could reach.
+const workspace = vi.hoisted(() => ({
+  hidden: false,
+  unread: 0,
+  selectedSubject: null as SelectedDiagramSubject | null,
+  panelOpen: false,
+}))
 
 vi.mock('../src/visual-app/workspace-state.js', async (importOriginal) => {
   const actual =
@@ -79,6 +89,10 @@ vi.mock('../src/visual-app/workspace-state.js', async (importOriginal) => {
       const state = actual.createVisualWorkspaceState(width, height)
       return {
         ...state,
+        selectedSubject: workspace.selectedSubject,
+        bottomPanel: workspace.panelOpen
+          ? { ...state.bottomPanel, open: true }
+          : state.bottomPanel,
         conversation: {
           ...state.conversation,
           hidden: workspace.hidden,
@@ -124,11 +138,16 @@ const idleHost: EditorHost = {
 beforeEach(() => {
   workspace.hidden = false
   workspace.unread = 0
+  workspace.selectedSubject = null
+  workspace.panelOpen = false
 })
 
 const renderSession = (
   overrides: Partial<VisualAppState> = {},
-  props: { readonly sections?: readonly RightSectionId[] } = {},
+  props: {
+    readonly sections?: readonly RightSectionId[]
+    readonly readOnly?: boolean
+  } = {},
 ): string => {
   session.state = { ...session.baseState, ...overrides }
   return renderToStaticMarkup(createElement(App, { host: idleHost, ...props }))
@@ -849,5 +868,145 @@ describe('a hidden right column (#294)', () => {
 
     expect(markup).not.toContain('--conversation-width:0px')
     expect(markup).toContain('--conversation-width:')
+  })
+})
+
+/**
+ * A read-only mount (#298, ADR 0117): the same visual language with the pen
+ * absent. Everything that reads still renders - the tree, the canvas, the
+ * facts, the questions - and every affordance that stages or commits is not
+ * drawn at all, never drawn disabled.
+ */
+describe('a read-only mount (#298)', () => {
+  const selected: SelectedDiagramSubject = {
+    type: 'element',
+    id: 'app.checkout',
+    title: 'Checkout',
+    kind: 'applicationComponent',
+    description: null,
+  }
+
+  const activeViewState: Partial<VisualAppState> = {
+    model: renderedModel,
+    activeView: 'v1',
+    views: [
+      {
+        id: 'v1',
+        title: 'View One',
+        description: '',
+        query: {},
+        presentation: {},
+        path: '.yarramate/projections/v1.yaml',
+        subjectCount: 2,
+      },
+    ],
+  }
+
+  /** The inspector's own markup: heading row and fields, before the
+   * description block that closes it. */
+  const inspectorOf = (markup: string): string =>
+    markup.slice(
+      markup.indexOf('subject-inspector'),
+      markup.indexOf('subject-description'),
+    )
+
+  it('offers no Add subject button, while the quick filter stays', () => {
+    const markup = renderSession({ model: renderedModel }, { readOnly: true })
+
+    expect(markup).not.toContain('>Add subject</button>')
+    expect(markup).toContain('class="quick-filter"')
+  })
+
+  it('strips the palette and changes sections from whatever the host names', () => {
+    const markup = renderSession(
+      { model: renderedModel },
+      { sections: ['palette', 'properties', 'changes'], readOnly: true },
+    )
+
+    expect(markup).not.toContain('stack-section-palette')
+    expect(markup).not.toContain('stack-section-changes')
+    expect(markup).toContain('stack-section-properties')
+  })
+
+  it('renders the facts of a selected subject with nothing editable', () => {
+    workspace.selectedSubject = selected
+    const markup = renderSession({ model: renderedModel }, { readOnly: true })
+    const inspector = inspectorOf(markup)
+
+    expect(markup).toContain('subject-facts')
+    expect(markup).toContain('class="subject-fact-value">Checkout</span>')
+    expect(inspector).toContain('app.checkout')
+    expect(inspector).not.toContain('<input')
+    expect(inspector).not.toContain('<select')
+  })
+
+  it('keeps Clear on the inspector and drops Connect and Delete', () => {
+    workspace.selectedSubject = selected
+    const markup = renderSession({ model: renderedModel }, { readOnly: true })
+    const inspector = inspectorOf(markup)
+
+    expect(inspector).toContain('>Clear</button>')
+    expect(inspector).not.toContain('>Connect</button>')
+    expect(inspector).not.toContain('>Delete</button>')
+  })
+
+  it('offers no New view affordance in a rail that still reads the views', () => {
+    const markup = renderSession(activeViewState, { readOnly: true })
+
+    expect(markup).toContain('aria-label="Views and model"')
+    expect(markup).toContain('View One')
+    expect(markup).toContain('Checkout')
+    expect(markup).toContain('Ledger')
+    expect(markup).not.toContain('aria-label="New view"')
+  })
+
+  it('shows the view document without the affordance to stage it', () => {
+    workspace.panelOpen = true
+    const markup = renderSession(activeViewState, { readOnly: true })
+
+    expect(markup).toContain('class="query-document"')
+    expect(markup).not.toContain('>Stage view change</button>')
+  })
+
+  it('still reads the open questions the model carries', () => {
+    const markup = renderSession(
+      {
+        model: {
+          ...renderedModel,
+          interrogation: {
+            catalogue: 'core-enrichment@1.1',
+            semantics: '1',
+            workspace: [
+              {
+                questionId: 'outcome-missing',
+                question: 'What outcome justifies this system?',
+                authority: 'human' as const,
+              },
+            ],
+            subjects: {},
+          },
+        },
+      },
+      { readOnly: true },
+    )
+
+    expect(markup).toContain('Open questions')
+    expect(markup).toContain('What outcome justifies this system?')
+  })
+
+  it('leaves the default mount the authoring surface it was', () => {
+    workspace.selectedSubject = selected
+    workspace.panelOpen = true
+    const markup = renderSession(activeViewState)
+    const inspector = inspectorOf(markup)
+
+    expect(markup).toContain('>Add subject</button>')
+    expect(markup).toContain('stack-section-palette')
+    expect(markup).toContain('stack-section-changes')
+    expect(markup).toContain('aria-label="New view"')
+    expect(markup).toContain('>Stage view change</button>')
+    expect(inspector).toContain('>Connect</button>')
+    expect(inspector).toContain('>Delete</button>')
+    expect(inspector).toContain('<select')
   })
 })

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -474,3 +474,63 @@ describe("putting a subject into a view, and taking it out", () => {
     expect(groups[groups.length - 1]?.destructive).toBe(true);
   });
 });
+
+/**
+ * A read-only menu (#298, ADR 0117): the items that read or navigate survive,
+ * every item whose intent stages a change is absent - not disabled - and a
+ * group the filter empties is dropped whole, destructive groups first among
+ * them.
+ */
+describe("a read-only menu offers no way to stage", () => {
+  const readOnly = context({ readOnly: true, membership: ["api"] });
+
+  it("leaves a subject its Properties and nothing that stages", () => {
+    expect(
+      labels(contextMenuFor({ kind: "subject", id: "api" }, readOnly)),
+    ).toEqual(["Properties"]);
+  });
+
+  it("leaves a relationship its Properties: no retype, no delete", () => {
+    expect(
+      labels(
+        contextMenuFor({ kind: "relationship", id: "api-serving-ui" }, readOnly),
+      ),
+    ).toEqual(["Properties"]);
+  });
+
+  it("leaves the canvas its reads: export, and the way back to everything", () => {
+    expect(
+      labels(
+        contextMenuFor(
+          { kind: "canvas" },
+          context({ readOnly: true, filtered: true }),
+        ),
+      ),
+    ).toEqual(["Show all subjects", "Export PNG"]);
+  });
+
+  it("leaves a view row navigation and its path, nothing that writes one", () => {
+    expect(
+      labels(contextMenuFor({ kind: "view-row", id: "current" }, readOnly)),
+    ).toEqual(["Open view", "Copy projection path"]);
+  });
+
+  it("leaves a model row its Properties, with no membership edit", () => {
+    expect(
+      labels(contextMenuFor({ kind: "model-row", id: "api" }, readOnly)),
+    ).toEqual(["Properties"]);
+  });
+
+  it("drops every destructive group rather than emptying it in place", () => {
+    for (const target of [
+      { kind: "subject", id: "api" },
+      { kind: "relationship", id: "api-serving-ui" },
+      { kind: "view-row", id: "current" },
+      { kind: "model-row", id: "api" },
+    ] as const) {
+      const groups = contextMenuFor(target, readOnly);
+      expect(groups.some((group) => group.destructive)).toBe(false);
+      expect(groups.every((group) => group.items.length > 0)).toBe(true);
+    }
+  });
+});

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -37,4 +37,15 @@ describe('mountEditorWith', () => {
 
     expect(root.unmount).toHaveBeenCalledOnce()
   })
+
+  it('mounts an author unless told otherwise, and threads the read-only posture (#298)', () => {
+    mountEditorWith({} as Element, host, sections)
+    mountEditorWith({} as Element, host, sections, true)
+
+    const [authoring, reading] = root.render.mock.calls.map(
+      ([element]) => (element as { props: { readOnly: boolean } }).props,
+    )
+    expect(authoring?.readOnly).toBe(false)
+    expect(reading?.readOnly).toBe(true)
+  })
 })


### PR DESCRIPTION
Closes #298. ADR: [0117 — a mounted editor can refuse the pen](docs/adr/0117-a-mounted-editor-can-refuse-the-pen.md).

From ApertureX (embedding `mountEditor` over a `SourceStore`, #252): immutable published snapshots need the editor's visual language without the UI offering to stage or commit. This lands `mountEditor(element, { store, workspace, readOnly: true })` as supported API surface; `mountEditorWith` composes via a trailing `readOnly` parameter, so a custom host gets the same posture.

**Gating mechanism: one flag, threaded once — cut at the seams that already exist.**

- **`readOnly` on `App`** is the whole mechanism; no second permission system. Read-only keeps everything that reads (canvas, tree, selection, quick filter, live query narrowing, open questions, properties facts, Export PNG, session-local layout Discard) and makes every staging/committing affordance **absent, never disabled**.
- **Sections**: read-only strips `palette` and `changes` from whatever `sections` names, beside the existing `questions` gate; `mountEditor` with no `sections` defaults to `['properties', 'questions']` (the local host has no agent, so no chat).
- **Context menus**: one filter by intent at `contextMenuFor`'s tail — a closed reading set (inspect, open view, show all, copy path, export PNG) survives; emptied groups (all destructive groups among them) drop whole.
- **Inspector**: `ConceptFacts`/`RelationshipFacts` render the same fields as values where the editable forms stood; Connect/Delete leave, Clear stays.
- **Canvas**: drags still move nodes transiently, but the debounced layout save is a no-op and the palette's kind-drop handler is withdrawn.
- **The `EditorHost` seam is untouched**: read-only is a UI posture, and the host's store refuses writes on its own authority — two independent defenses (stated in the ADR). Session-server read-only (`yarramate-visual` pages) stays deferred; the prop is cheap to thread there later if a frozen session is ever wanted.

**Docs**: `docs/CONSUMING-YARRAMATE.md` mount section documents `readOnly`; CHANGELOG entry under Unreleased.

**Tests** (extends existing visual test files, so no tsconfig changes): read-only renders no Add subject, no palette/changes sections (even when named), no Connect/Delete, no editable inputs in the inspector, no New view, no Stage view change; the model tree, questions and properties facts still read; menu-model tests pin the reading-intent set per target; a mount test pins the posture threading; a contrast test pins the default mount unchanged.

**Verify**: `pnpm verify` exit 0 — 96 test files, 1657 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)