### PR TITLE
feat: the host can point at the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- **Added.** The host can point at the canvas (#297). The handle
+  `mountEditor` and `mountEditorWith` return grows three methods beside
+  `unmount` — `select(subjectId)`, `openDraft({ kind? })` and
+  `startConnection(fromSubjectId)` — each the programmatic twin of a
+  gesture the surface already has: a canvas tap (the same action and
+  normalization, which also scopes Open questions to the subject), a
+  palette pick (the kind seeds the same Add-subject dialog, #295), and
+  the inspector's Connect (the relationship-with-one-endpoint-fixed
+  affordance a question card's trigger describes, ADR 0110). Every
+  method returns whether it acted: false, never a throw, for an id the
+  model does not name, a model that has not arrived — the handle before
+  the shell's first render or after disposal included — and, for the
+  two that reach for the pen, a read-only mount (#298); selecting stays
+  allowed in a viewer, because selecting is reading. Never a second
+  write path: anything the opened affordances stage still lands through
+  the changeset, and the `EditorHost` seam is untouched — selection is
+  client state, so the bridge is an `onReady` prop on `App`, not a
+  protocol input. The released `{ unmount }` shape is extended
+  additively, so existing embedders stand unchanged.
+  [ADR 0118](docs/adr/0118-the-host-can-point-at-the-canvas.md).
+
 - **Added.** A mounted editor can refuse the pen (#298). `mountEditor`
   gains `readOnly?: boolean` (default `false`) and `mountEditorWith` a
   trailing `readOnly` parameter, so a host can render a frozen snapshot

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -309,6 +309,21 @@ defaults to `['properties', 'questions']`. This is a UI posture only — pair it
 with a store that refuses writes; the two defenses are independent.
 `mountEditorWith` takes the same flag as its trailing parameter.
 
+The returned handle can also point at the canvas
+([ADR 0118](adr/0118-the-host-can-point-at-the-canvas.md)):
+`select(subjectId)` selects a concept or relationship exactly as a canvas tap
+would, which also scopes the Open questions section to it;
+`openDraft({ kind })` opens the Add-subject dialog with the kind preselected
+the way a palette pick seeds it (omit `kind` for the plain no-default form);
+and `startConnection(fromSubjectId)` arms the Connect flow from that subject —
+the relationship-with-one-endpoint-fixed affordance an interrogation trigger
+describes. Each returns `false`, rather than throwing, when it moved nothing:
+an id the current model does not name, a model that has not arrived yet, or —
+for `openDraft` and `startConnection` — a read-only mount. These are the
+programmatic twins of tap, palette and Connect, never a second write path:
+anything they lead to still stages through the changeset and commits through
+the same validated batch.
+
 `store` is the caller's synchronous `SourceStore`; `workspace` is the caller's
 pre-resolved `ResolvedWorkspace`. The local host compiles, projects, filters,
 commits and saves layouts over that store. A changeset's model and view writes

--- a/docs/adr/0118-the-host-can-point-at-the-canvas.md
+++ b/docs/adr/0118-the-host-can-point-at-the-canvas.md
@@ -1,0 +1,87 @@
+# The host can point at the canvas
+
+Status: accepted
+
+ApertureX, embedding the editor over its own store (#252), derives open
+questions from the model through `yarramate/interrogation`, and each
+question card knows exactly what would answer it: the report-carried
+trigger ([ADR 0110](0110-an-open-question-carries-its-answer-shape.md))
+says add a concept of kind K, or add a relationship of kind R with one
+endpoint fixed. The editor already has those affordances — the
+Add-subject dialog a palette pick seeds (#295,
+[ADR 0116](0116-a-kind-is-picked-up-not-remembered.md)), the Connect
+flow, tap-to-select — and a card could hand its intent to none of them:
+`createLocalHost`/`mountEditor` exposed no way to select a subject or
+open creation with defaults, so their cards applied answers through the
+operations path beside the editor instead of driving the surface that
+was mounted to be driven (#297). ADR 0110's excluded options parked a
+`proposedOperations` helper for want of a concrete consumer; this is the
+follow-up, with one.
+
+## Decision
+
+The mount's return value grows. `MountedEditor` keeps `unmount` and
+gains three methods, each the programmatic twin of a gesture the surface
+already has, and nothing the surface does not have:
+
+- **`select(subjectId)`** selects the concept or relationship exactly as
+  a canvas tap would — the same `subject.selected` action, the same
+  graph lookup and normalization the tap handlers run — which also
+  scopes the Open questions section to the subject, the point for a
+  question card.
+- **`openDraft({ kind? })`** opens the Add-subject dialog, the kind
+  riding the same seed a palette pick rides (#295): into the form's own
+  state, cleared by a plain call, the no-default rule intact.
+- **`startConnection(fromSubjectId)`** arms the connection tool from the
+  named subject, exactly as the inspector's Connect does. The Connect
+  flow *is* the relationship-with-one-endpoint-fixed affordance the
+  trigger describes, so no new UI is invented for it.
+
+Every method answers with whether it acted. False — never a throw —
+covers an id the current model does not name, a model that has not
+arrived yet, a handle before the shell's first render or after disposal,
+and, for the two that reach for the pen, a read-only mount (#298,
+[ADR 0117](0117-a-mounted-editor-can-refuse-the-pen.md)). Selecting
+stays allowed in a viewer, because selecting is reading.
+
+The seam is a prop, not the protocol. `App` gains an optional `onReady`
+through which the shell hands up a pointer built by `editorPointerFor` —
+three closures over the shell's own dispatchers, reading the graph and
+the posture at call time so a handle held across commits answers for the
+model on screen. The mount layer keeps that pointer in a private bridge
+the handle's methods delegate through. Nothing about `EditorHost` moves.
+
+## Excluded options
+
+- **Synthetic `VisualBrowserInput`s through the `EditorHost` seam**:
+  selection and dialog state are client state, not host state — the
+  protocol carries documents, filters and staged operations, not
+  gestures. A `select` input would push the reducer's client concerns
+  onto a versioned wire that has never carried them, and every host
+  (the session server included) would have to learn to speak an input
+  whose only speaker is an embedder standing beside the editor.
+- **A full command bus** (a generic `dispatch(action)` on the handle):
+  it would export the workspace reducer's entire action vocabulary as
+  public API and freeze internals no consumer asked to hold. Three
+  named methods are the asks with a consumer behind them; a fourth
+  gesture, if one is ever asked for, is a fourth method delegating to
+  an action that already exists.
+- **Host-driven commit**: the handle points, it never writes. Everything
+  the opened affordances stage still accumulates in the changeset and
+  lands through the same validated `apply` batch (ADR 0102), so what a
+  host can cause is exactly what a reviewer can cause — a second write
+  path would put an unreviewed motion behind a reviewed surface.
+
+## Consequences
+
+The released return shape — an object carrying `unmount` — is extended
+additively, so every existing embedder stands unchanged and the
+documented `editor.unmount()` still holds. `App` gains one optional
+prop; the session shell passes nothing and is untouched, as is the
+`EditorHost` contract. The pointer reads live context rather than
+capturing it, so ready-ness is a window the handle answers false in
+rather than an error state, and a method called after a commit acts on
+the graph that replaced it. `editorPointerFor` is a pure function over
+the reducer's own actions, which is what keeps the programmatic twins
+and the on-screen gestures from ever disagreeing about what a motion
+does.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -44,6 +44,7 @@ import type { VisualAppRecord, VisualAppState } from "./state.js";
 import {
   conversationWidthBounds,
   createVisualWorkspaceState,
+  editorPointerFor,
   formatContextualQuestion,
   normalizeSelectedElement,
   normalizeSelectedRelationship,
@@ -51,6 +52,8 @@ import {
   viewNeedingApplication,
   visualWorkspaceReducer,
   type ConnectionDraft,
+  type EditorPointer,
+  type EditorPointerContext,
   RIGHT_SECTIONS,
   type RightSectionId,
   type SelectedDiagramSubject,
@@ -932,10 +935,20 @@ export const App = ({
   host,
   sections = RIGHT_SECTIONS,
   readOnly = false,
+  onReady,
 }: {
   readonly host: EditorHost;
   readonly sections?: readonly RightSectionId[];
   readonly readOnly?: boolean;
+  /**
+   * How the mount layer's handle reaches this shell's reducer (#297,
+   * ADR 0118). Called once, after the first render, with the pointer the
+   * handle delegates to - which is what makes the handle's pre-ready
+   * false-return window real. Selection and dialog state are client state,
+   * so this rides a prop rather than the `EditorHost` seam: the protocol
+   * carries documents, not gestures.
+   */
+  readonly onReady?: (pointer: EditorPointer) => void;
 }) => {
   const {
     state,
@@ -991,6 +1004,27 @@ export const App = ({
   // exists. A ref rather than state: nothing renders differently because of
   // it, and a menu item reads it at the moment it is chosen.
   const canvasPngRef = useRef<(() => string) | null>(null);
+
+  // What the host's pointer reads at call time (#297, ADR 0118). Refreshed
+  // every render rather than captured when the pointer was handed up, so a
+  // method called after a commit answers for the graph that is on screen.
+  const pointerContext = useRef<EditorPointerContext>({
+    graph: null,
+    readOnly,
+  });
+  pointerContext.current = {
+    graph: state.model?.graph ?? null,
+    readOnly,
+  };
+  useEffect(() => {
+    onReady?.(
+      editorPointerFor(
+        () => pointerContext.current,
+        dispatchWorkspace,
+        setDraftKind,
+      ),
+    );
+  }, [onReady]);
 
   useEffect(() => {
     const resized = () =>

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -2,7 +2,11 @@ import { createRoot } from 'react-dom/client'
 import { App } from './App.js'
 import { createLocalHost, type LocalHostOptions } from './local-host.js'
 import type { EditorHost } from './editor-host.js'
-import { RIGHT_SECTIONS, type RightSectionId } from './workspace-state.js'
+import {
+  RIGHT_SECTIONS,
+  type EditorPointer,
+  type RightSectionId,
+} from './workspace-state.js'
 import './styles.css'
 
 /**
@@ -22,6 +26,8 @@ import './styles.css'
  *   workspace,                          // a resolved manifest
  *   sections: ['properties', 'changes'],
  * })
+ * editor.select('app.checkout')       // as a canvas tap would (#297)
+ * editor.openDraft({ kind: 'goal' })  // as a palette pick would
  * // later
  * editor.unmount()
  * ```
@@ -51,9 +57,39 @@ export interface MountOptions extends LocalHostOptions {
   readonly readOnly?: boolean
 }
 
+/**
+ * The handle a mount returns (#297, ADR 0118): the disposal it always had,
+ * and three ways for the host to point at the canvas. Each method is the
+ * programmatic twin of a gesture the surface already has - never a second
+ * write path: nothing here commits, and anything the opened affordances stage
+ * still goes through the changeset like every reviewer gesture.
+ *
+ * Every method answers with whether it acted. False means nothing moved: the
+ * id named nothing in the current model, the model has not arrived yet - the
+ * editor renders before its host's first frame lands - or the mount is a
+ * viewer (`readOnly`, #298) and the gesture would have reached for the pen.
+ */
 export interface MountedEditor {
   /** Releases the host and takes the editor out of the element. */
   readonly unmount: () => void
+  /**
+   * Selects the subject - concept or relationship - on the canvas and in the
+   * inspector, exactly as a tap on it would, which also scopes the Open
+   * questions section to it.
+   */
+  readonly select: (subjectId: string) => boolean
+  /**
+   * Opens the Add-subject dialog, with the kind preselected when one is
+   * given - the same seed a palette pick rides (#295). Without a kind, the
+   * plain no-default form.
+   */
+  readonly openDraft: (options?: { readonly kind?: string }) => boolean
+  /**
+   * Arms the connection tool from the named subject, exactly as the
+   * inspector's Connect does: the next selection becomes the target and the
+   * kinds on offer are derived from the two endpoints.
+   */
+  readonly startConnection: (fromSubjectId: string) => boolean
 }
 
 /**
@@ -95,9 +131,31 @@ export const mountEditorWith = (
   // No StrictMode: its double mount would open the host twice, and a host with
   // a socket behind it would open two.
   const root = createRoot(element)
-  root.render(<App host={host} sections={sections} readOnly={readOnly} />)
+  // The bridge the imperative methods delegate through (#297, ADR 0118). The
+  // shell hands its pointer up after its first render; until then - and after
+  // disposal - every method answers false rather than throwing, because "not
+  // ready" and "that id names nothing" are the same fact to a caller: nothing
+  // moved.
+  const bridge: { current: EditorPointer | null } = { current: null }
+  root.render(
+    <App
+      host={host}
+      sections={sections}
+      readOnly={readOnly}
+      onReady={(pointer) => {
+        bridge.current = pointer
+      }}
+    />,
+  )
   return {
-    unmount: () => root.unmount(),
+    unmount: () => {
+      root.unmount()
+      bridge.current = null
+    },
+    select: (subjectId) => bridge.current?.select(subjectId) ?? false,
+    openDraft: (options) => bridge.current?.openDraft(options) ?? false,
+    startConnection: (fromSubjectId) =>
+      bridge.current?.startConnection(fromSubjectId) ?? false,
   }
 }
 

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -100,6 +100,78 @@ const nextRelationship = (
 };
 
 /**
+ * What the imperative methods read at the moment they are called (#297,
+ * ADR 0118). A getter rather than a captured value, because the pointer is
+ * handed up once and the graph changes under it with every commit - a method
+ * bound to the model that existed at mount time would answer for a model
+ * that is gone.
+ */
+export interface EditorPointerContext {
+  readonly graph: CanvasGraph | null;
+  readonly readOnly: boolean;
+}
+
+/**
+ * The host's way of pointing at the canvas (#297, ADR 0118): three methods,
+ * each the programmatic twin of a gesture the surface already has - a canvas
+ * tap, a palette pick, the inspector's Connect. Every method answers with
+ * whether it acted; false means nothing moved - the id named nothing, the
+ * model has not arrived, or the mount is a viewer (#298) and the gesture
+ * would have reached for the pen.
+ */
+export interface EditorPointer {
+  readonly select: (subjectId: string) => boolean;
+  readonly openDraft: (options?: { readonly kind?: string }) => boolean;
+  readonly startConnection: (fromSubjectId: string) => boolean;
+}
+
+/**
+ * Builds the pointer over the shell's own dispatchers. Nothing here is a
+ * second write path: every method dispatches the same workspace action its
+ * on-screen twin dispatches, so what a host can reach is exactly what a
+ * reviewer can reach, and anything staged still lands through the changeset.
+ */
+export const editorPointerFor = (
+  context: () => EditorPointerContext,
+  dispatch: (action: VisualWorkspaceAction) => void,
+  seedDraftKind: (kind: string | undefined) => void,
+): EditorPointer => ({
+  select: (subjectId) => {
+    const { graph } = context();
+    if (graph === null) return false;
+    // The same lookup and normalization a canvas tap runs: a node becomes a
+    // selected element, an edge a selected relationship with its endpoint
+    // titles resolved, and an id that names neither moves nothing.
+    const subject =
+      nextElement(graph, subjectId) ?? nextRelationship(graph, subjectId);
+    if (subject === null) return false;
+    dispatch({ type: "subject.selected", subject });
+    return true;
+  },
+  openDraft: (options) => {
+    const { graph, readOnly } = context();
+    // A viewer has no pen (#298, ADR 0117), and before the model arrives
+    // there is no vocabulary to compile the Kind select from.
+    if (readOnly || graph === null) return false;
+    // The kind rides the same seed a palette pick rides (#295, ADR 0116):
+    // into the form's own state, cleared by a plain call, so a host opening
+    // the draft with no kind gets the no-default form every plain opener gets.
+    seedDraftKind(options?.kind);
+    dispatch({ type: "subject.draft.opened" });
+    return true;
+  },
+  startConnection: (fromSubjectId) => {
+    const { graph, readOnly } = context();
+    if (readOnly || graph === null) return false;
+    // Only a node can be a source: the connection tool draws from a subject,
+    // and an edge or an unknown id has no endpoint to draw from.
+    if (!graph.nodes.some((node) => node.id === fromSubjectId)) return false;
+    dispatch({ type: "connection.started", from: fromSubjectId });
+    return true;
+  },
+});
+
+/**
  * The right column's sections, in the order they stack (#249, ADR-free: the
  * design settles the order and nothing derives it).
  *

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -12,6 +12,19 @@ import {
   type EditorHost,
   type RightSectionId,
 } from '../src/visual-app/mount.js'
+import {
+  editorPointerFor,
+  normalizeSelectedElement,
+  normalizeSelectedRelationship,
+  type EditorPointer,
+  type EditorPointerContext,
+  type VisualWorkspaceAction,
+} from '../src/visual-app/workspace-state.js'
+import type {
+  CanvasEdge,
+  CanvasGraph,
+  CanvasNode,
+} from '../src/graph-projection.js'
 
 const host: EditorHost = {
   open: () => () => undefined,
@@ -19,6 +32,13 @@ const host: EditorHost = {
 }
 
 const sections: readonly RightSectionId[] = ['properties', 'changes']
+
+/** The `onReady` seam the mounted `App` element carries (#297). */
+const onReadyOf = (
+  call: readonly unknown[],
+): ((pointer: EditorPointer) => void) =>
+  (call[0] as { props: { onReady: (pointer: EditorPointer) => void } }).props
+    .onReady
 
 describe('mountEditorWith', () => {
   beforeEach(() => {
@@ -47,5 +67,234 @@ describe('mountEditorWith', () => {
     )
     expect(authoring?.readOnly).toBe(false)
     expect(reading?.readOnly).toBe(true)
+  })
+
+  it('answers false, without throwing, before the shell hands its pointer up (#297)', () => {
+    // The mocked render never runs `App`, so `onReady` never fires: exactly
+    // the window between mounting and the shell's first render.
+    const editor = mountEditorWith({} as Element, host, sections)
+
+    expect(editor.select('app.checkout')).toBe(false)
+    expect(editor.openDraft({ kind: 'goal' })).toBe(false)
+    expect(editor.startConnection('app.checkout')).toBe(false)
+  })
+
+  it('delegates each method to the pointer the shell hands up (#297)', () => {
+    const editor = mountEditorWith({} as Element, host, sections)
+    const pointer = {
+      select: vi.fn(() => true),
+      openDraft: vi.fn(() => true),
+      startConnection: vi.fn(() => false),
+    }
+    onReadyOf(root.render.mock.calls[0]!)(pointer)
+
+    expect(editor.select('app.checkout')).toBe(true)
+    expect(pointer.select).toHaveBeenCalledWith('app.checkout')
+    expect(editor.openDraft({ kind: 'goal' })).toBe(true)
+    expect(pointer.openDraft).toHaveBeenCalledWith({ kind: 'goal' })
+    // The pointer's own refusal travels back unchanged.
+    expect(editor.startConnection('app.ledger')).toBe(false)
+    expect(pointer.startConnection).toHaveBeenCalledWith('app.ledger')
+  })
+
+  it('still unmounts, and a disposed handle answers false again (#297)', () => {
+    const editor = mountEditorWith({} as Element, host, sections)
+    const pointer = {
+      select: vi.fn(() => true),
+      openDraft: vi.fn(() => true),
+      startConnection: vi.fn(() => true),
+    }
+    onReadyOf(root.render.mock.calls[0]!)(pointer)
+
+    editor.unmount()
+
+    expect(root.unmount).toHaveBeenCalledOnce()
+    expect(editor.select('app.checkout')).toBe(false)
+    expect(pointer.select).not.toHaveBeenCalled()
+  })
+})
+
+const node = (id: string, name: string): CanvasNode => ({
+  id,
+  localId: id.split('.').at(-1) ?? id,
+  document: 'architecture/main.yaml',
+  kind: 'yarramate/core@0.1#applicationComponent',
+  kindLabel: 'applicationComponent',
+  coreKindLabel: 'applicationComponent',
+  layer: 'application',
+  aspect: 'active-structure',
+  name,
+  description: null,
+  aka: [],
+  status: null,
+  owner: null,
+  folder: null,
+  distinctFrom: [],
+  supersedes: [],
+  constraints: [],
+  references: [],
+  presentIn: [],
+  attestations: [],
+})
+
+const edge = (id: string, from: string, to: string): CanvasEdge => ({
+  id,
+  localId: id,
+  document: 'architecture/main.yaml',
+  kind: 'yarramate/core@0.1#serving',
+  kindLabel: 'serving',
+  coreKindLabel: 'serving',
+  from,
+  to,
+  name: null,
+  description: null,
+  mode: null,
+  content: null,
+  status: null,
+  references: [],
+  presentIn: [],
+})
+
+const graph: CanvasGraph = {
+  nodes: [node('app.checkout', 'Checkout'), node('app.ledger', 'Ledger')],
+  edges: [edge('checkout-serves-ledger', 'app.checkout', 'app.ledger')],
+}
+
+/**
+ * The pointer itself (#297, ADR 0118): the pure factory the shell binds to
+ * its reducer. Each method dispatches the same action its on-screen twin
+ * dispatches - asserted against the same normalizers the tap handlers run -
+ * and answers false where nothing moved.
+ */
+describe('editorPointerFor', () => {
+  const pointerOver = (context: EditorPointerContext) => {
+    const dispatched: VisualWorkspaceAction[] = []
+    const seeded: (string | undefined)[] = []
+    const pointer = editorPointerFor(
+      () => context,
+      (action) => dispatched.push(action),
+      (kind) => seeded.push(kind),
+    )
+    return { pointer, dispatched, seeded }
+  }
+
+  it('selects a concept exactly as a canvas tap would', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.select('app.checkout')).toBe(true)
+    expect(dispatched).toEqual([
+      {
+        type: 'subject.selected',
+        subject: normalizeSelectedElement(graph.nodes[0]!),
+      },
+    ])
+  })
+
+  it('selects a relationship with its endpoint titles resolved', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.select('checkout-serves-ledger')).toBe(true)
+    expect(dispatched).toEqual([
+      {
+        type: 'subject.selected',
+        subject: normalizeSelectedRelationship(
+          graph.edges[0]!,
+          new Map([
+            ['app.checkout', 'Checkout'],
+            ['app.ledger', 'Ledger'],
+          ]),
+        ),
+      },
+    ])
+  })
+
+  it('still selects under a read-only mount, because selecting is reading', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: true })
+
+    expect(pointer.select('app.checkout')).toBe(true)
+    expect(dispatched).toHaveLength(1)
+  })
+
+  it('moves nothing for an id the model does not name', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.select('app.gone')).toBe(false)
+    expect(dispatched).toEqual([])
+  })
+
+  it('opens the draft with the kind seeded, the same seed a palette pick rides (#295)', () => {
+    const { pointer, dispatched, seeded } = pointerOver({
+      graph,
+      readOnly: false,
+    })
+
+    expect(pointer.openDraft({ kind: 'goal' })).toBe(true)
+    expect(seeded).toEqual(['goal'])
+    expect(dispatched).toEqual([{ type: 'subject.draft.opened' }])
+  })
+
+  it('opens a plain draft with no kind, clearing any earlier seed (ADR 0116)', () => {
+    const { pointer, seeded } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.openDraft()).toBe(true)
+    expect(seeded).toEqual([undefined])
+  })
+
+  it('refuses the draft in a viewer, where creation is withdrawn (#298)', () => {
+    const { pointer, dispatched, seeded } = pointerOver({
+      graph,
+      readOnly: true,
+    })
+
+    expect(pointer.openDraft({ kind: 'goal' })).toBe(false)
+    expect(seeded).toEqual([])
+    expect(dispatched).toEqual([])
+  })
+
+  it('arms the connection tool from a subject, as Connect does', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.startConnection('app.checkout')).toBe(true)
+    expect(dispatched).toEqual([
+      { type: 'connection.started', from: 'app.checkout' },
+    ])
+  })
+
+  it('refuses a source that is unknown, or not a concept at all', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+
+    expect(pointer.startConnection('app.gone')).toBe(false)
+    // A relationship has no endpoint to draw from.
+    expect(pointer.startConnection('checkout-serves-ledger')).toBe(false)
+    expect(dispatched).toEqual([])
+  })
+
+  it('refuses to arm the connection tool in a viewer (#298)', () => {
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: true })
+
+    expect(pointer.startConnection('app.checkout')).toBe(false)
+    expect(dispatched).toEqual([])
+  })
+
+  it('reads the model at call time, so the methods answer for the graph on screen', () => {
+    // Before the host's first frame there is nothing to point at; the same
+    // pointer starts answering true once the model arrives, with no re-bind.
+    let context: EditorPointerContext = { graph: null, readOnly: false }
+    const dispatched: VisualWorkspaceAction[] = []
+    const pointer = editorPointerFor(
+      () => context,
+      (action) => dispatched.push(action),
+      () => undefined,
+    )
+
+    expect(pointer.select('app.checkout')).toBe(false)
+    expect(pointer.openDraft()).toBe(false)
+    expect(pointer.startConnection('app.checkout')).toBe(false)
+    expect(dispatched).toEqual([])
+
+    context = { graph, readOnly: false }
+    expect(pointer.select('app.checkout')).toBe(true)
+    expect(pointer.openDraft()).toBe(true)
+    expect(pointer.startConnection('app.checkout')).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #297.

ApertureX's question cards know exactly what would answer them — the report-carried `trigger` ([ADR 0110](docs/adr/0110-an-open-question-carries-its-answer-shape.md)) says add a concept of kind K, or add a relationship with one endpoint fixed — and could hand none of it to the mounted editor. This gives them the imperative route: [ADR 0118](docs/adr/0118-the-host-can-point-at-the-canvas.md), *the host can point at the canvas*.

## API shape

`MountedEditor` — the object `mountEditor`/`mountEditorWith` return — keeps `unmount` and gains three methods, each the programmatic twin of a gesture the surface already has, all mapping onto existing reducer actions with no new UI:

- **`select(subjectId): boolean`** — the same `subject.selected` action a canvas tap dispatches, with the same graph lookup and normalization (element or relationship, endpoint titles resolved). Selecting also scopes the Open questions section, which is the point for a question card. Allowed in a viewer: selecting is reading.
- **`openDraft({ kind? }): boolean`** — opens the Add-subject dialog riding the same seed a palette pick rides (#295, ADR 0116); a plain call clears the seed, so the no-default rule stands.
- **`startConnection(fromSubjectId): boolean`** — arms the Connect flow (`connection.started`), which *is* the relationship-with-one-endpoint-fixed affordance the trigger describes.

Every method returns whether it acted: `false`, never a throw, for an id the model does not name, a model that has not arrived (including the handle before the shell's first render and after disposal), and — for the two that reach for the pen — a read-only mount (#298, ADR 0117).

## Backward compatibility

The released shape is a plain object holding `unmount`, and that is exactly what docs/CONSUMING-YARRAMATE.md documents (`editor.unmount()`), so the handle is extended **additively**: `unmount` keeps its name and behaviour, three methods join it, and every existing embedder stands unchanged. No callable-function compatibility was needed because no released version ever returned a bare function.

## Seam

Selection and dialog state are client state, not host state, so the bridge is a prop, not the protocol: `App` gains an optional `onReady` through which it hands up a pointer built by `editorPointerFor` (a pure factory in `workspace-state.ts`) over call-time context — a handle held across commits answers for the graph on screen. `EditorHost` is untouched; ADR 0118's excluded options record the synthetic-inputs route, a command bus, and host-driven commit.

## Tests

`test/visual-mount.test.ts` (existing file, so no tsconfig changes): 16 tests — the pure pointer (tap-identical selection for concept and relationship, unknown-id false, palette-identical kind seeding, read-only refusals, connect arming, call-time context) and the handle (pre-ready false without throwing, delegation, disposal, false-after-unmount).

`pnpm verify` exit 0: 96 test files, 1671 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)