### PR TITLE
fix: a second relationship between the same pair stays visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Fixed.** A second relationship between the same pair stays visible
+  (#306). Two defects, one report. Drafting: `proposeRelationshipId`
+  built its `taken` set from the landed graph alone, so with the first
+  draft still staged the second proposed the identical id and the
+  editor's replace-by-target staging swallowed it — no row, no error,
+  no toast. `proposeRelationshipId` and `draftRelationship` now take
+  the ids a pending changeset already claims (`stagedSubjectIds`
+  collects them), so the second parallel edge stages as `…-2`, which
+  the schema — no uniqueness on the (from, kind, to) triple — lands and
+  compiles cleanly. Rendering: taxi routing is deterministic from the
+  endpoints alone, so parallel edges, once landed, drew exactly on top
+  of each other and read as one line. Members of a parallel pair (in
+  either direction) now carry a `parallel` class whose `bezier` curve
+  style cytoscape separates automatically; single edges keep
+  `round-taxi` untouched, and an edge consumed into nesting never
+  counts toward a pair.
+
 - **Added.** The host can point at the canvas (#297). The handle
   `mountEditor` and `mountEditorWith` return grows three methods beside
   `unmount` — `select(subjectId)`, `openDraft({ kind? })` and

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ export {
   connectableKinds,
   draftRelationship,
   proposeRelationshipId,
+  stagedSubjectIds,
 } from './relationship-drafting.js'
 export { draftConcept, proposeConceptId } from './concept-drafting.js'
 export {

--- a/src/relationship-drafting.ts
+++ b/src/relationship-drafting.ts
@@ -59,16 +59,26 @@ export const connectableKinds = (
  * relationship kind is a single lowercase word. A collision takes a numeric
  * suffix rather than a hash, because the id is authored text a human will read
  * in a diff.
+ *
+ * `reserved` carries ids the graph does not know yet: a staged-but-uncommitted
+ * draft never enters the rendered graph, so without it a second relationship
+ * between the same pair re-proposed the identical id and the editor's
+ * replace-by-target staging silently swallowed the first (#306). The schema
+ * places no uniqueness on the (from, kind, to) triple - parallel relationships
+ * with distinct ids compile cleanly - so the id proposal is the only place the
+ * collision can be stepped past.
  */
 export const proposeRelationshipId = (
   graph: CanvasGraph,
   fromId: string,
   kind: RelationshipKind,
   toId: string,
+  reserved: Iterable<string> = [],
 ): string => {
   const taken = new Set([
     ...graph.nodes.map((node) => node.id),
     ...graph.edges.map((edge) => edge.id),
+    ...reserved,
   ])
   const base = `${fromId}-${kind}-${toId}`
   if (!taken.has(base)) return base
@@ -90,12 +100,17 @@ export const proposeRelationshipId = (
  * relationship has to live somewhere, both endpoints are equally defensible,
  * and the source is where a reader looking for what this thing does would go
  * first.
+ *
+ * A caller holding drafts the graph has not landed yet - an editor with a
+ * pending changeset - passes their ids as `reserved`, so a second parallel
+ * relationship steps to `-2` instead of colliding with the first (#306).
  */
 export const draftRelationship = (
   graph: CanvasGraph,
   fromId: string,
   kind: RelationshipKind,
   toId: string,
+  reserved: Iterable<string> = [],
 ): YarramateOperation | null => {
   if (!connectableKinds(graph, fromId, toId).includes(kind)) return null
   const from = graph.nodes.find((node) => node.id === fromId)
@@ -104,10 +119,30 @@ export const draftRelationship = (
     op: 'add-relationship',
     document: from.document,
     relationship: {
-      id: proposeRelationshipId(graph, fromId, kind, toId),
+      id: proposeRelationshipId(graph, fromId, kind, toId, reserved),
       kind,
       from: fromId,
       to: toId,
     },
   }
 }
+
+/**
+ * The ids a pending changeset already claims, for `proposeRelationshipId`'s
+ * `reserved` parameter. Every operation that names a subject id reserves it -
+ * an update's id is already in the graph and reserving it twice is harmless,
+ * while an add's id is exactly the one the graph cannot know yet.
+ */
+export const stagedSubjectIds = (
+  operations: readonly YarramateOperation[],
+): readonly string[] =>
+  operations.flatMap((op) => {
+    // A staged rename claims the id it moves to as well as the one it leaves.
+    const renamedTo =
+      op.op === 'rename-concept' || op.op === 'rename-relationship'
+        ? [op.to]
+        : []
+    if ('relationship' in op) return [op.relationship.id, ...renamedTo]
+    if ('concept' in op) return [op.concept.id, ...renamedTo]
+    return renamedTo
+  })

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -77,6 +77,7 @@ import {
 } from "./context-menu-model.js";
 import { stageRelationshipScalarChange } from "./subject-form.js";
 import { describeDeletion, draftDeletion } from "../deletion-drafting.js";
+import { stagedSubjectIds } from "../relationship-drafting.js";
 
 /**
  * A drawing board, not a document: the diagram holds the workspace, one compact
@@ -436,6 +437,10 @@ const DiagramWorkspace = ({
           <ConnectionPanel
             draft={connection}
             graph={state.model.graph}
+            // What is staged but not landed: the graph cannot know these ids,
+            // and without them a second relationship between the same pair
+            // collides with the first and is silently swallowed (#306).
+            reservedIds={stagedSubjectIds(state.pendingChangeset.operations)}
             onStage={onConnectStage}
             onCancel={onConnectCancel}
           />

--- a/src/visual-app/connection-panel.tsx
+++ b/src/visual-app/connection-panel.tsx
@@ -24,11 +24,20 @@ import type { ConnectionDraft } from './workspace-state.js'
 export const ConnectionPanel = ({
   draft,
   graph,
+  reservedIds,
   onStage,
   onCancel,
 }: {
   readonly draft: ConnectionDraft
   readonly graph: CanvasGraph
+  /**
+   * Ids the pending changeset already claims. The graph only knows what has
+   * landed, so without these a second relationship between the same pair
+   * proposed the identical id and replace-by-target staging swallowed it
+   * silently (#306). Required rather than defaulted: a caller has to say
+   * what is staged, even when the answer is nothing.
+   */
+  readonly reservedIds: readonly string[]
   readonly onStage: (operation: YarramateOperation) => void
   readonly onCancel: () => void
 }): React.ReactElement => {
@@ -75,6 +84,7 @@ export const ConnectionPanel = ({
                     draft.from,
                     kind,
                     target,
+                    reservedIds,
                   )
                   // Null here would mean this panel offered a kind the table
                   // does not permit, which `connectableKinds` cannot produce.

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -447,6 +447,20 @@ export function buildStylesheet(
       },
     },
     {
+      // Two or more relationships between the same pair of endpoints. Taxi
+      // routing is deterministic from the endpoints alone, so parallel edges
+      // route identically and draw as one line - the second relationship
+      // exists but cannot be seen or tapped (#306). Bezier is the one curve
+      // family cytoscape separates automatically for multi-edges:
+      // `control-point-step-size` fans them out, so each stays visible and
+      // individually selectable. Single edges keep `round-taxi` untouched.
+      selector: 'edge.parallel',
+      style: {
+        'curve-style': 'bezier',
+        'control-point-step-size': 40,
+      },
+    },
+    {
       selector: 'edge.selected',
       style: {
         'line-color': '#FF6B6B',
@@ -635,8 +649,10 @@ export function resolveNestingParents(
   return { parentOf, consumedEdgeIds }
 }
 
-// Convert CanvasGraph nodes and edges to cytoscape ElementDefinition format
-function graphToElements(
+// Convert CanvasGraph nodes and edges to cytoscape ElementDefinition format.
+// Exported for the headless tests: the parallel-edge class assignment below is
+// a rendering guarantee (#306) that has to be assertable without a DOM.
+export function graphToElements(
   graph: CanvasGraph,
   nesting: readonly NestingKind[],
   openQuestionCounts: ReadonlyMap<string, number>
@@ -681,21 +697,43 @@ function graphToElements(
     }
   })
 
-  const edgeElements = graph.edges
-    .filter((edge) => !consumedEdgeIds.has(edge.id))
-    .map(
-      (edge): ElementDefinition => ({
-        data: {
-          id: edge.id,
-          source: edge.from,
-          target: edge.to,
-          label: edge.name ?? edge.kindLabel,
-          wrapLabel: withWrapPoints(edge.name ?? edge.kindLabel),
-          coreKindLabel: edge.coreKindLabel,
-        },
-        group: 'edges',
-      })
-    )
+  const drawnEdges = graph.edges.filter(
+    (edge) => !consumedEdgeIds.has(edge.id)
+  )
+
+  // How many drawn edges share each unordered endpoint pair. Members of a
+  // multiple get the `parallel` class, which swaps their curve style to one
+  // cytoscape separates automatically - under the default taxi routing they
+  // draw exactly on top of each other and read as one relationship (#306).
+  // Unordered, because an A->B over a B->A occludes just the same. Counted
+  // over drawn edges only: an edge consumed into nesting is not on screen to
+  // collide with.
+  const drawnPerPair = new Map<string, number>()
+  const pairKey = (edge: CanvasEdge): string =>
+    edge.from < edge.to
+      ? `${edge.from} ${edge.to}`
+      : `${edge.to} ${edge.from}`
+  for (const edge of drawnEdges) {
+    const key = pairKey(edge)
+    drawnPerPair.set(key, (drawnPerPair.get(key) ?? 0) + 1)
+  }
+
+  const edgeElements = drawnEdges.map(
+    (edge): ElementDefinition => ({
+      data: {
+        id: edge.id,
+        source: edge.from,
+        target: edge.to,
+        label: edge.name ?? edge.kindLabel,
+        wrapLabel: withWrapPoints(edge.name ?? edge.kindLabel),
+        coreKindLabel: edge.coreKindLabel,
+      },
+      group: 'edges',
+      ...(drawnPerPair.get(pairKey(edge))! > 1
+        ? { classes: 'parallel' }
+        : {}),
+    })
+  )
 
   return [...nodeElements, ...edgeElements]
 }

--- a/test/connection-panel.test.ts
+++ b/test/connection-panel.test.ts
@@ -6,6 +6,7 @@ import { projectGraphForCanvas } from '../src/graph-projection.js'
 import { connectableKinds } from '../src/relationship-drafting.js'
 import { ConnectionPanel } from '../src/visual-app/connection-panel.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
+import type { YarramateOperation } from '../src/operations.js'
 
 /**
  * What the panel puts on screen, which is the safety-critical half: a kind
@@ -40,6 +41,7 @@ const render = (draft: { from: string; to: string | null }) =>
     createElement(ConnectionPanel, {
       draft,
       graph,
+      reservedIds: [],
       onStage: () => undefined,
       onCancel: () => undefined,
     }),
@@ -104,6 +106,7 @@ describe('ConnectionPanel', () => {
       createElement(ConnectionPanel, {
         draft: { from: 'orders', to: 'settle' },
         graph: outside,
+        reservedIds: [],
         onStage: () => undefined,
         onCancel: () => undefined,
       }),
@@ -116,5 +119,51 @@ describe('ConnectionPanel', () => {
   it('can always be backed out of', () => {
     expect(render({ from: 'orders', to: null })).toContain('Cancel')
     expect(render({ from: 'orders', to: 'settle' })).toContain('Cancel')
+  })
+
+  it('threads reserved ids into the draft it stages (#306)', () => {
+    // The panel is hook-free, so it can be invoked as a plain function and
+    // its element tree walked for the kind button - no DOM needed. The
+    // reserved id plays a first relationship that is staged but not landed:
+    // clicking the same kind again must draft `-2`, not silently collide.
+    const staged: YarramateOperation[] = []
+    const buttonsOf = (
+      node: unknown,
+      found: Array<{ children?: unknown; onClick?: () => void }> = [],
+    ): Array<{ children?: unknown; onClick?: () => void }> => {
+      if (Array.isArray(node)) {
+        for (const child of node) buttonsOf(child, found)
+        return found
+      }
+      if (node === null || typeof node !== 'object') return found
+      const element = node as {
+        type?: unknown
+        props?: { children?: unknown; onClick?: () => void }
+      }
+      if (element.type === 'button' && element.props !== undefined) {
+        found.push(element.props)
+      }
+      buttonsOf(element.props?.children, found)
+      return found
+    }
+
+    const tree = ConnectionPanel({
+      draft: { from: 'orders', to: 'settle' },
+      graph,
+      reservedIds: ['orders-assignment-settle'],
+      onStage: (operation) => staged.push(operation),
+      onCancel: () => undefined,
+    })
+    const assignment = buttonsOf(tree).find(
+      (button) => button.children === 'assignment',
+    )
+    expect(assignment).toBeDefined()
+    assignment!.onClick!()
+
+    expect(staged).toHaveLength(1)
+    expect(staged[0]).toMatchObject({
+      op: 'add-relationship',
+      relationship: { id: 'orders-assignment-settle-2' },
+    })
   })
 })

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -2,9 +2,16 @@ import cytoscape from 'cytoscape'
 import { describe, expect, it } from 'vitest'
 import {
   applyFilter,
+  buildStylesheet,
+  graphToElements,
   modelPositionOf,
   relayoutVisible,
 } from '../src/visual-app/graph-canvas.js'
+import type {
+  CanvasEdge,
+  CanvasGraph,
+  CanvasNode,
+} from '../src/graph-projection.js'
 
 // A small headless cytoscape instance (no container/DOM needed for hide/show
 // and data queries) - mirrors the shape graphToElements produces, without
@@ -254,5 +261,131 @@ describe('modelPositionOf', () => {
       x: 35,
       y: 50,
     })
+  })
+})
+
+/**
+ * Two relationships between the same endpoints (#306). The projection delivers
+ * both and cytoscape keeps both as elements, but taxi routing is deterministic
+ * from the endpoints alone: parallel edges drew exactly on top of each other
+ * and read as one line, with only the topmost tappable. Members of a parallel
+ * pair now carry the `parallel` class, whose bezier curve style cytoscape
+ * separates automatically - so both are visible and individually selectable.
+ */
+describe('parallel relationships between the same pair', () => {
+  const node = (id: string): CanvasNode =>
+    ({
+      id,
+      localId: id,
+      document: 'main.yaml',
+      kind: 'yarramate/core@0.1#applicationComponent',
+      kindLabel: 'applicationComponent',
+      coreKindLabel: 'applicationComponent',
+      layer: 'application',
+      aspect: 'active-structure',
+      name: id,
+      description: null,
+      aka: [],
+      status: null,
+      owner: null,
+      folder: null,
+      distinctFrom: [],
+      supersedes: [],
+      constraints: [],
+      references: [],
+      presentIn: [],
+      attestations: [],
+    }) as unknown as CanvasNode
+
+  const edge = (
+    id: string,
+    kind: string,
+    from: string,
+    to: string,
+  ): CanvasEdge =>
+    ({
+      id,
+      localId: id,
+      document: 'main.yaml',
+      kind: `yarramate/core@0.1#${kind}`,
+      kindLabel: kind,
+      coreKindLabel: kind,
+      from,
+      to,
+      name: null,
+      description: null,
+      mode: null,
+      content: null,
+      status: null,
+      references: [],
+      presentIn: [],
+    }) as unknown as CanvasEdge
+
+  const graph: CanvasGraph = {
+    nodes: [node('a'), node('b'), node('c')],
+    edges: [
+      // Same direction, different kinds - the ICWA register case.
+      edge('e1', 'flow', 'a', 'b'),
+      edge('e2', 'association', 'a', 'b'),
+      // Opposite directions: an a->b over a b->a occludes just the same.
+      edge('e3', 'flow', 'b', 'c'),
+      edge('e4', 'access', 'c', 'b'),
+      // A single edge stays exactly as it was.
+      edge('e5', 'flow', 'a', 'c'),
+    ],
+  }
+
+  const elements = graphToElements(graph, [], new Map())
+  const elementById = new Map(
+    elements.map((element) => [element.data.id, element]),
+  )
+
+  it('keeps every parallel edge as its own element', () => {
+    for (const id of ['e1', 'e2', 'e3', 'e4', 'e5']) {
+      expect(elementById.get(id), id).toBeDefined()
+    }
+  })
+
+  it('marks members of a parallel pair, in either direction, and no single edge', () => {
+    expect(elementById.get('e1')?.classes).toBe('parallel')
+    expect(elementById.get('e2')?.classes).toBe('parallel')
+    expect(elementById.get('e3')?.classes).toBe('parallel')
+    expect(elementById.get('e4')?.classes).toBe('parallel')
+    expect(elementById.get('e5')?.classes).toBeUndefined()
+  })
+
+  it('resolves parallel edges to a curve style cytoscape separates', () => {
+    // The real stylesheet against the real elements, headless: parallel
+    // members leave `round-taxi` for `bezier` with a nonzero step, which is
+    // the mechanism that fans them apart; a single edge keeps `round-taxi`.
+    const cy = cytoscape({
+      styleEnabled: true,
+      elements,
+      style: buildStylesheet(false, false, false, false),
+    })
+    expect(cy.edges().length).toBe(5)
+    expect(cy.$id('e1').style('curve-style')).toBe('bezier')
+    expect(cy.$id('e2').style('curve-style')).toBe('bezier')
+    expect(cy.$id('e4').style('curve-style')).toBe('bezier')
+    expect(cy.$id('e1').style('control-point-step-size')).toBe('40px')
+    expect(cy.$id('e5').style('curve-style')).toBe('round-taxi')
+  })
+
+  it('does not count an edge consumed into nesting as a parallel member', () => {
+    const nested: CanvasGraph = {
+      nodes: [node('a'), node('b')],
+      edges: [
+        edge('c1', 'composition', 'a', 'b'),
+        edge('e1', 'flow', 'a', 'b'),
+      ],
+    }
+    const drawn = graphToElements(nested, ['composition'], new Map())
+    const ids = drawn.map((element) => element.data.id)
+    // The composition is consumed into the compound box, so the flow is the
+    // only line between the pair and keeps its ordinary routing.
+    expect(ids).not.toContain('c1')
+    expect(
+      drawn.find((element) => element.data.id === 'e1')?.classes,
+    ).toBeUndefined()
   })
 })

--- a/test/relationship-drafting.test.ts
+++ b/test/relationship-drafting.test.ts
@@ -5,6 +5,7 @@ import {
   connectableKinds,
   draftRelationship,
   proposeRelationshipId,
+  stagedSubjectIds,
 } from '../src/relationship-drafting.js'
 import { applyOperations } from '../src/apply-command.js'
 import { stringify } from 'yaml'
@@ -125,6 +126,24 @@ describe('proposeRelationshipId', () => {
       ).toMatch(pattern)
     }
   })
+
+  it('steps past a reserved id the graph does not know yet (#306)', () => {
+    // A staged-but-uncommitted draft is not in the rendered graph, so its id
+    // arrives as `reserved` rather than as an edge. Without this the second
+    // parallel relationship re-proposed the identical id and staging
+    // swallowed it.
+    expect(
+      proposeRelationshipId(graph, 'orders', 'flow', 'billing', [
+        'orders-flow-billing',
+      ]),
+    ).toBe('orders-flow-billing-2')
+    expect(
+      proposeRelationshipId(graph, 'orders', 'flow', 'billing', [
+        'orders-flow-billing',
+        'orders-flow-billing-2',
+      ]),
+    ).toBe('orders-flow-billing-3')
+  })
 })
 
 describe('draftRelationship', () => {
@@ -199,5 +218,103 @@ describe('draftRelationship', () => {
     // Not passing by drafting nothing. A floor rather than the exact count,
     // which is a property of the ArchiMate table and not of this test.
     expect(drafted).toBeGreaterThan(12)
+  })
+
+  /**
+   * The ICWA register case from #306: two parallel `flow`s between the same
+   * pair, the second drafted while the first is still only staged. The schema
+   * has no uniqueness on the (from, kind, to) triple, so both must land -
+   * distinct ids, applied together, compiled cleanly.
+   */
+  it('drafts a second parallel relationship that lands beside the first (#306)', () => {
+    const first = draftRelationship(graph, 'orders', 'flow', 'billing')
+    expect(first?.op).toBe('add-relationship')
+    if (first?.op !== 'add-relationship') return
+
+    // The first is staged, not landed: the graph is unchanged, and only
+    // `stagedSubjectIds` can tell the proposal about it.
+    const second = draftRelationship(
+      graph,
+      'orders',
+      'flow',
+      'billing',
+      stagedSubjectIds([first]),
+    )
+    expect(second?.op).toBe('add-relationship')
+    if (second?.op !== 'add-relationship') return
+
+    expect(first.relationship.id).toBe('orders-flow-billing')
+    expect(second.relationship.id).toBe('orders-flow-billing-2')
+
+    const outcome = applyOperations({
+      workspace: {
+        id: 'drafting',
+        documents: ['architecture/main.yaml'],
+        profiles: [],
+        projections: [],
+        adapterMappings: [],
+        evidence: [],
+        contracts: [],
+      },
+      sources: [{ path: 'architecture/main.yaml', source: DOCUMENT }],
+      operations: {
+        path: 'changeset.yaml',
+        source: stringify({
+          format: 'yarramate/operations/v1',
+          operations: [first, second],
+        }),
+      },
+      manifestDirectory: '.yarramate',
+    })
+    expect(
+      outcome.ok ? [] : outcome.diagnostics.map((d) => d.code),
+    ).toEqual([])
+    if (!outcome.ok) return
+
+    const landed = graphOf(
+      outcome.sources.find(
+        (document) => document.path === 'architecture/main.yaml',
+      )!.source,
+    )
+    const parallel = landed.edges.filter(
+      (edge) =>
+        edge.from === 'orders' &&
+        edge.to === 'billing' &&
+        edge.coreKindLabel === 'flow',
+    )
+    expect(parallel.map((edge) => edge.localId).sort()).toEqual([
+      'orders-flow-billing',
+      'orders-flow-billing-2',
+    ])
+  })
+})
+
+describe('stagedSubjectIds', () => {
+  it('collects every id a pending changeset claims, renames included', () => {
+    expect(
+      stagedSubjectIds([
+        {
+          op: 'add-relationship',
+          document: 'architecture/main.yaml',
+          relationship: {
+            id: 'orders-flow-billing',
+            kind: 'flow',
+            from: 'orders',
+            to: 'billing',
+          },
+        },
+        {
+          op: 'add-concept',
+          document: 'architecture/main.yaml',
+          concept: { id: 'payments', kind: 'applicationComponent' },
+        },
+        {
+          op: 'rename-concept',
+          document: 'architecture/main.yaml',
+          concept: { id: 'billing' },
+          to: 'invoicing',
+        },
+      ]),
+    ).toEqual(['orders-flow-billing', 'payments', 'billing', 'invoicing'])
   })
 })

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -480,6 +480,39 @@ describe("visualAppReducer changeset management", () => {
     expect(staged2.pendingChangeset.operations[0]).toBe(op2);
   });
 
+  it("queues a second parallel relationship rather than replacing the first (#306)", () => {
+    // Same (from, kind, to) triple, distinct ids - which is what
+    // `draftRelationship` now produces when the first is still staged. The
+    // replace-by-target rule keys on the id, so the pair queues; only a
+    // restage of the *same* id replaces.
+    const first = {
+      op: "add-relationship",
+      document: "model.yaml",
+      relationship: {
+        id: "orders-flow-billing",
+        kind: "flow",
+        from: "orders",
+        to: "billing",
+      },
+    } as const;
+    const second = {
+      op: "add-relationship",
+      document: "model.yaml",
+      relationship: {
+        id: "orders-flow-billing-2",
+        kind: "flow",
+        from: "orders",
+        to: "billing",
+      },
+    } as const;
+    const staged = [first, second].reduce(
+      (state, operation) =>
+        visualAppReducer(state, { type: "changeset.staged", operation }),
+      activeState,
+    );
+    expect(staged.pendingChangeset.operations).toEqual([first, second]);
+  });
+
   it("keeps the changeset intact when apply fails, and sets diagnostics", () => {
     const op = {
       op: "update-concept",


### PR DESCRIPTION
Closes #306

## Diagnosed mechanism

Reproduced headless before fixing (two `draftRelationship` calls against the landed graph, staged through `visualAppReducer`; two parallel edges in a headless cytoscape instance). The report's mechanism is confirmed, and there are two layers to it:

1. **Drafting/staging (the "silently swallowed" click).** `proposeRelationshipId` built its `taken` set from the **landed** `CanvasGraph` alone (`src/relationship-drafting.ts`). A staged-but-uncommitted relationship never enters that graph, so a second draft of the same (from, kind, to) re-proposed the identical base id. The reducer's `changeset.staged` case then computed an identical `changesetTargetKey` (keyed on the id), filtered the first op out and appended the second - net row count unchanged, no diagnostic. The projection (`projectGraphForCanvas`) is **not** at fault: it delivers every relationship subject 1:1, and the compiler accepts parallel relationships with distinct ids (no uniqueness on the triple), so the id proposal was the only place the collision could be stepped past.

2. **Rendering (parallel edges, once landed, read as one).** `graphToElements` maps both edges to cytoscape elements and cytoscape keeps both - nothing is dropped - but `round-taxi` routing is deterministic from the endpoints alone, so parallel edges drew exactly coincident: one visible line, only the topmost tappable.

## Fix

- `proposeRelationshipId` / `draftRelationship` gain an optional trailing `reserved` id collection; new `stagedSubjectIds` collects every id a pending changeset claims (adds, updates, deletes, renames incl. the rename target). `App` feeds `state.pendingChangeset.operations` through `ConnectionPanel`'s new **required** `reservedIds` prop, so the second parallel edge stages as `…-2` and both rows land and compile. The prop is required rather than defaulted so a future caller cannot silently reintroduce the collision.
- `graphToElements` marks members of a parallel pair (unordered endpoints, so opposite directions count; edges consumed into nesting do not) with a `parallel` class, styled `curve-style: bezier` + `control-point-step-size: 40` - the one curve family cytoscape separates automatically, so both edges are visible and individually selectable. Single edges keep `round-taxi` untouched. The published `CanvasNode`/`CanvasEdge` schema shape is untouched.

## Tests

- `test/relationship-drafting.test.ts`: reserved ids step to `-2`/`-3`; the ICWA case end-to-end - second parallel `flow` drafted while the first is only staged, both applied and compiled, both edges in the re-projected graph; `stagedSubjectIds` coverage.
- `test/visual-app-state.test.ts`: two add-relationship ops, same triple, distinct ids - both stay staged (replace-by-target still replaces a restage of the *same* id).
- `test/connection-panel.test.ts`: the panel threads `reservedIds` into the draft it stages (hook-free component invoked directly, kind button clicked).
- `test/graph-canvas.test.ts`: headless cytoscape with the real `buildStylesheet` - every parallel edge is its own element, pair members (either direction) resolve to `bezier` with a nonzero step while a single edge resolves `round-taxi`, and a nesting-consumed composition never counts toward a pair.

`pnpm verify`: real exit 0 (96 test files, 1680 passed, 1 skipped).

Noted, not fixed here: `proposeConceptId` in concept drafting has the same landed-graph-only blind spot for staged concepts; out of scope for #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
