### PR TITLE
fix: an empty filter result says so, and survivors come into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **Fixed.** A filter that matches nothing no longer blanks the canvas
+  silently, and the survivors of one that matches come into view
+  (#307). Three mechanisms, one field report. Refit: a quick-filter
+  keystroke changed visibility without re-framing, so a surviving node
+  kept its register-scale coordinate and drew a few pixels tall,
+  indistinguishable from an empty canvas; the canvas now fits the
+  viewport to the visible set on every quick-filter change (a fit,
+  never a re-layout: nodes keep their positions, dragged ones
+  included). Honesty: an empty result now says so where the subjects
+  would be, as a centred status pill naming the narrowing that caused
+  it, with the way out beside it: Show all for a standing query whose
+  match set draws no subject (a view-sourced one included, which the
+  top-left pill deliberately stays silent about), Clear filter for
+  quick-filter text that zeroed an otherwise drawn set. Fallback: the
+  local host answered `filter.query` with `matchedIds: []` whenever
+  the workspace did not compile, a claim that every subject failed the
+  query; it now refuses with `YMVS318` and leaves the last good model
+  standing, the same posture its own `recompile` takes.
+
 - **Fixed.** A second relationship between the same pair stays visible
   (#306). Two defects, one report. Drafting: `proposeRelationshipId`
   built its `taken` set from the landed graph alone, so with the first

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1,4 +1,4 @@
-import { GraphCanvas } from "./graph-canvas.js";
+import { filteredSubjectCount, GraphCanvas } from "./graph-canvas.js";
 import type { PresentationFlag } from "./query-fields.js";
 import { QueryPanel, type BottomPanelTabId } from "./query-panel.js";
 import { QuickFilterBox } from "./quick-filter.js";
@@ -341,6 +341,28 @@ const DiagramWorkspace = ({
     [state.model],
   );
 
+  // A filter that leaves nothing visible blanks the canvas, and a blank
+  // canvas does not say why (#307): at register scale the very same blank is
+  // what an off-viewport survivor looks like, so absence has to be stated,
+  // never inferred. Counted with the exact narrowing the canvas applies
+  // (`filteredSubjectCount` restates `applyFilter`), and attributed to what
+  // caused it: the standing query when its own match set draws no subject,
+  // the quick filter's text when subjects would otherwise be drawn. A model
+  // with no subjects earns no pill, because nothing was hidden.
+  const graphNodes = state.model?.graph.nodes ?? [];
+  const structuralMatchedIds = state.activeFilter?.matchedIds ?? null;
+  const filterEmptiedCanvas =
+    graphNodes.length > 0 &&
+    (state.activeFilter !== null || state.quickFilterText.trim() !== "") &&
+    filteredSubjectCount(
+      graphNodes,
+      structuralMatchedIds,
+      state.quickFilterText,
+    ) === 0;
+  const structuralFilterEmptied =
+    state.activeFilter !== null &&
+    filteredSubjectCount(graphNodes, structuralMatchedIds, "") === 0;
+
   return (
     <section className="diagram-workspace" aria-label="Architecture diagram">
       {/*
@@ -490,6 +512,38 @@ const DiagramWorkspace = ({
             onKindDrop={readOnly ? undefined : onKindDrop}
             onCanvasReady={onCanvasReady}
           />
+        )}
+        {/*
+         * The canvas is blank because of a filter, not because the model is
+         * empty (#307): say so where the subjects would be, and hand back the
+         * way out. Attribution decides the escape offered: a standing query
+         * that itself matches no subject gets the pill's own Show all, while
+         * a quick filter that zeroed an otherwise drawn set gets its text
+         * named and cleared, leaving the standing filter standing.
+         */}
+        {!filterEmptiedCanvas ? null : (
+          <div className="filter-empty-pill" role="status">
+            {structuralFilterEmptied && state.activeFilter !== null ? (
+              <>
+                <span>
+                  Nothing matches this filter:{" "}
+                  <code>{describeQuery(state.activeFilter.query)}</code>
+                </span>
+                <button type="button" onClick={onClearFilter}>
+                  Show all
+                </button>
+              </>
+            ) : (
+              <>
+                <span>
+                  Nothing matches “{state.quickFilterText.trim()}”
+                </span>
+                <button type="button" onClick={() => onQuickFilterChange("")}>
+                  Clear filter
+                </button>
+              </>
+            )}
+          </div>
         )}
         {state.layoutNotice === null ? null : (
           <div className="layout-notice-pill" role="status">

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -738,6 +738,50 @@ export function graphToElements(
   return [...nodeElements, ...edgeElements]
 }
 
+// The one substring judgement the canvas pass and the shell's empty-state
+// honesty share, so what hides and what is reported can never drift (#307):
+// case-insensitive, against a subject's id, name, and kind label. `name` and
+// `kindLabel` are `unknown` because the canvas reads them out of cytoscape
+// data, which types nothing.
+export function subjectMatchesQuickFilter(
+  trimmedLowerFilter: string,
+  id: string,
+  name: unknown,
+  kindLabel: unknown,
+): boolean {
+  if (trimmedLowerFilter === '') return true
+  if (id.toLowerCase().includes(trimmedLowerFilter)) return true
+  if (typeof name === 'string' && name.toLowerCase().includes(trimmedLowerFilter)) {
+    return true
+  }
+  return (
+    typeof kindLabel === 'string' &&
+    kindLabel.toLowerCase().includes(trimmedLowerFilter)
+  )
+}
+
+// How many of the graph's subjects the standing filter and the quick-filter
+// text leave drawn: the same narrowing `applyFilter` performs, restated as a
+// pure function of render data so the shell can say "nothing matches" with no
+// canvas mounted (#307). Container ancestors pulled in for nesting are not
+// counted, and need not be: they are only ever added alongside at least one
+// matching subject, so zero here is exactly the blank canvas. A `matchedIds`
+// entry naming a relationship (a view's match set may) draws no subject and
+// counts none.
+export function filteredSubjectCount(
+  nodes: readonly Pick<CanvasNode, 'id' | 'name' | 'kindLabel'>[],
+  matchedIds: readonly string[] | null,
+  quickFilterText: string,
+): number {
+  const trimmed = quickFilterText.trim().toLowerCase()
+  const matched = matchedIds === null ? null : new Set(matchedIds)
+  return nodes.filter(
+    (node) =>
+      (matched === null || matched.has(node.id)) &&
+      subjectMatchesQuickFilter(trimmed, node.id, node.name, node.kindLabel),
+  ).length
+}
+
 // Recompute which elements cytoscape shows from the structural (server-matched)
 // `matchedIds` filter and the client-side `quickFilterText` narrowing, then
 // hide/show elements in one pass. `matchedIds === null` means "no structural
@@ -760,12 +804,13 @@ export function applyFilter(
   const baseNodeIds = matchedIds === null ? cy.nodes().map((node) => node.id()) : matchedIds
 
   const nodeMatchesQuickFilter = (id: string): boolean => {
-    if (id.toLowerCase().includes(trimmedQuickFilter)) return true
     const node = cy.getElementById(id)
-    const label = node.data('label')
-    if (typeof label === 'string' && label.toLowerCase().includes(trimmedQuickFilter)) return true
-    const kindLabel = node.data('kindLabel')
-    return typeof kindLabel === 'string' && kindLabel.toLowerCase().includes(trimmedQuickFilter)
+    return subjectMatchesQuickFilter(
+      trimmedQuickFilter,
+      id,
+      node.data('label'),
+      node.data('kindLabel'),
+    )
   }
 
   const visibleNodeIds = new Set(
@@ -853,6 +898,24 @@ function runLayout(eles: Core | CollectionReturnValue): void {
 // never need to guard against "the new view matched nothing".
 export function relayoutVisible(cy: Core): void {
   runLayout(cy.elements(':visible'))
+}
+
+// Re-frames the viewport around what is visible without moving a single node.
+// A quick-filter keystroke changes visibility only: the survivors keep the
+// positions the last layout (or the reviewer's own drag) gave them, but at
+// register scale those positions can sit anywhere in the old framing, off the
+// viewport or a few pixels tall, indistinguishable from an empty canvas
+// (#307). A FIT is the least destructive operation that brings them into
+// view: deliberately not `relayoutVisible`, which would repack the graph and
+// discard dragged positions on every keystroke. Returns whether it fitted, so
+// the caller records only a framing this function actually produced; nothing
+// visible means nothing to frame, and the shell's empty-state pill is what
+// explains a blank canvas.
+export function fitVisible(cy: Core): boolean {
+  const visible = cy.elements(':visible')
+  if (visible.empty()) return false
+  cy.fit(visible, FIT_PADDING)
+  return true
 }
 
 // `dragfree` fires once per drag (unlike `position`, which fires on every
@@ -1089,6 +1152,9 @@ export function GraphCanvas({
   const activeViewIdRef = useRef(activeViewId)
   const pendingViewFitRef = useRef(false)
   const matchedIdsRef = useRef(matchedIds)
+  // Seeded with the prop so the mount render never reads as "the quick filter
+  // just changed" - the mount effect's own layout frames the first paint.
+  const quickFilterTextRef = useRef(quickFilterText)
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
   const onSaveLayoutRef = useRef(onSaveLayout)
   const savedPositionsRef = useRef(effectiveSaved)
@@ -1390,9 +1456,25 @@ export function GraphCanvas({
     // `filter-result` frame.
     const matchedChanged = matchedIds !== matchedIdsRef.current
     matchedIdsRef.current = matchedIds
+    const quickFilterChanged = quickFilterText !== quickFilterTextRef.current
+    quickFilterTextRef.current = quickFilterText
     if (pendingViewFitRef.current || matchedChanged) {
       pendingViewFitRef.current = false
       relayoutVisible(cyRef.current)
+    } else if (quickFilterChanged && fitVisible(cyRef.current)) {
+      // A quick-filter keystroke never relayouts - the survivors keep their
+      // positions (a reviewer's drags included) and the viewport re-frames
+      // around them (#307). Without this, a filter typed over a register-scale
+      // fit left the survivor pinned at its stack coordinate, ~17x5px at zoom
+      // 0.10: a blank-looking canvas over a filter that matched. The fitted
+      // framing is recorded as automatic, the same as a layout's own fit, so
+      // a later panel resize still knows it may reframe; a fit that did not
+      // happen (nothing visible) records nothing, leaving the reviewer's own
+      // viewport theirs.
+      autoViewportRef.current = {
+        zoom: cyRef.current.zoom(),
+        pan: { ...cyRef.current.pan() },
+      }
     }
   }, [matchedIds, quickFilterText, graph])
 

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -316,26 +316,37 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
     send: (input: VisualBrowserInput) => {
       switch (input.type) {
         case 'filter.query':
+          // A workspace that does not compile has no graph to evaluate a
+          // query against. This used to answer `matchedIds: []`, which the
+          // canvas reads as "every subject failed the query" and hides the
+          // whole model - a claim about the subjects, when the truth is the
+          // question could not be asked at all (#307). Refuse with the
+          // reason instead, the way every other unanswerable input is
+          // refused, leaving whatever filter and model were standing - the
+          // same keep-the-last-good-model posture `recompile` itself takes.
+          if (compiled === undefined) {
+            refuse(input, [
+              serverDiagnostic(
+                'YMVS318',
+                'The workspace does not compile, so a filter cannot be evaluated; the last good model stays as it is',
+              ),
+            ])
+            return
+          }
           deliver?.frame({
             kind: 'filter-result',
             result: {
               query: input.payload.query,
-              matchedIds:
-                compiled === undefined
-                  ? []
-                  : matchedIdsOf(
-                      compiled.graph,
-                      input.payload.query,
-                      compiled.profileContext,
-                    ),
-              excluded:
-                compiled === undefined
-                  ? []
-                  : exclusionsOf(
-                      compiled.graph,
-                      input.payload.query,
-                      compiled.profileContext,
-                    ),
+              matchedIds: matchedIdsOf(
+                compiled.graph,
+                input.payload.query,
+                compiled.profileContext,
+              ),
+              excluded: exclusionsOf(
+                compiled.graph,
+                input.payload.query,
+                compiled.profileContext,
+              ),
             },
           })
           return

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -615,6 +615,57 @@ body {
   color: var(--ink);
 }
 
+/* A filter that leaves nothing on the canvas (#307): the same pill anatomy as
+   .filter-pill, centred where the subjects would be. A corner badge is easy
+   to miss on a canvas whose whole story is that it is blank, and the centre
+   of an empty canvas collides with nothing: the standing .filter-pill keeps
+   the top-left, the saved-layout pill the bottom-left, the layout notice the
+   top-right. */
+.canvas > .filter-empty-pill {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: var(--step);
+  max-width: min(52ch, calc(100% - var(--step) * 2));
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--rule-firm);
+  border-radius: 999px;
+  background: var(--sheet);
+  font-family: var(--utility);
+  font-size: 12px;
+  color: var(--ink);
+}
+
+.filter-empty-pill span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-empty-pill code {
+  font-weight: 700;
+}
+
+.filter-empty-pill button {
+  flex: none;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--cobalt);
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.filter-empty-pill button:hover {
+  color: var(--ink);
+}
+
 .conversation-separator {
   position: relative;
   z-index: 3;

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   applyFilter,
   buildStylesheet,
+  filteredSubjectCount,
+  fitVisible,
   graphToElements,
   modelPositionOf,
   relayoutVisible,
@@ -155,25 +157,25 @@ describe('applyFilter', () => {
   })
 })
 
-describe('relayoutVisible', () => {
-  // Explicit positions and a `preset` initial layout (cytoscape otherwise
-  // auto-runs a `grid` layout on init, discarding them) so moved-vs-untouched
-  // is observable, not masked by every node already starting at (0, 0).
-  const buildPositionedCy = () =>
-    cytoscape({
-      styleEnabled: true,
-      layout: { name: 'preset' },
-      elements: [
-        { data: { id: 'node1' }, position: { x: 500, y: 500 }, group: 'nodes' },
-        { data: { id: 'node2' }, position: { x: 600, y: 500 }, group: 'nodes' },
-        { data: { id: 'node3' }, position: { x: 9999, y: 9999 }, group: 'nodes' },
-        {
-          data: { id: 'edge1', source: 'node1', target: 'node2', label: 'calls' },
-          group: 'edges',
-        },
-      ],
-    })
+// Explicit positions and a `preset` initial layout (cytoscape otherwise
+// auto-runs a `grid` layout on init, discarding them) so moved-vs-untouched
+// is observable, not masked by every node already starting at (0, 0).
+const buildPositionedCy = () =>
+  cytoscape({
+    styleEnabled: true,
+    layout: { name: 'preset' },
+    elements: [
+      { data: { id: 'node1' }, position: { x: 500, y: 500 }, group: 'nodes' },
+      { data: { id: 'node2' }, position: { x: 600, y: 500 }, group: 'nodes' },
+      { data: { id: 'node3' }, position: { x: 9999, y: 9999 }, group: 'nodes' },
+      {
+        data: { id: 'edge1', source: 'node1', target: 'node2', label: 'calls' },
+        group: 'edges',
+      },
+    ],
+  })
 
+describe('relayoutVisible', () => {
   it('repositions only the currently visible elements, leaving hidden ones untouched', async () => {
     const cy = buildPositionedCy()
     applyFilter(cy, ['node1', 'node2'], '')
@@ -192,6 +194,110 @@ describe('relayoutVisible', () => {
     const cy = buildPositionedCy()
     applyFilter(cy, [], '')
     expect(() => relayoutVisible(cy)).not.toThrow()
+  })
+})
+
+/**
+ * The refit a quick-filter keystroke earns (#307). A keystroke changes
+ * visibility only, so the survivors keep their layout (and dragged) positions
+ * but can sit anywhere in the old framing: off-viewport, or a few pixels tall
+ * under a register-scale fit, either way indistinguishable from an empty
+ * canvas. `fitVisible` re-frames the viewport around them without moving a
+ * single node, which is what makes it safe to run on every keystroke where
+ * `relayoutVisible` is not.
+ */
+describe('fitVisible', () => {
+  it('re-frames the viewport around the visible set without moving any node', () => {
+    const cy = buildPositionedCy()
+    applyFilter(cy, ['node1', 'node2'], '')
+    // A viewport the reviewer (or a stale fit) left standing.
+    cy.zoom(0.5)
+    cy.pan({ x: 100, y: 100 })
+    const before = cy.nodes().map((node) => ({ ...node.position() }))
+
+    expect(fitVisible(cy)).toBe(true)
+
+    const untouched =
+      cy.zoom() === 0.5 && cy.pan().x === 100 && cy.pan().y === 100
+    expect(untouched, 'the viewport was re-framed').toBe(false)
+    cy.nodes().forEach((node, at) => {
+      expect(node.position(), node.id()).toEqual(before[at])
+    })
+  })
+
+  it('declines to frame nothing, and leaves the viewport alone saying so', () => {
+    const cy = buildPositionedCy()
+    applyFilter(cy, [], '')
+    cy.zoom(0.5)
+    cy.pan({ x: 100, y: 100 })
+
+    expect(fitVisible(cy)).toBe(false)
+    expect(cy.zoom()).toBe(0.5)
+    expect(cy.pan()).toEqual({ x: 100, y: 100 })
+  })
+})
+
+/**
+ * The shell's empty-state honesty (#307): the same narrowing `applyFilter`
+ * performs, restated over render data so "nothing matches" is computable with
+ * no canvas mounted. Zero here must be exactly a blank canvas there, so the
+ * two are asserted against each other on the shared fixture.
+ */
+describe('filteredSubjectCount', () => {
+  const subjects = [
+    { id: 'node1', name: 'Checkout Service', kindLabel: 'applicationComponent' },
+    { id: 'node2', name: 'Payments Gateway', kindLabel: 'applicationComponent' },
+    { id: 'node3', name: 'Order Fulfillment', kindLabel: 'businessProcess' },
+  ]
+
+  it('counts every subject with no narrowing standing', () => {
+    expect(filteredSubjectCount(subjects, null, '')).toBe(3)
+  })
+
+  it('narrows by name, id and kind label, case-insensitively', () => {
+    expect(filteredSubjectCount(subjects, null, 'CHECKOUT')).toBe(1)
+    expect(filteredSubjectCount(subjects, null, 'node2')).toBe(1)
+    expect(filteredSubjectCount(subjects, null, 'applicationComponent')).toBe(2)
+  })
+
+  it('intersects the structural match set with the quick filter', () => {
+    expect(filteredSubjectCount(subjects, ['node1', 'node2'], 'gateway')).toBe(1)
+  })
+
+  it('counts no subject for a match set naming only relationships', () => {
+    // A view's match set may name relationships; none of them draws a node.
+    expect(filteredSubjectCount(subjects, ['checkout-serves-teller'], '')).toBe(0)
+  })
+
+  it('finds the field report subject by id, whatever the case typed', () => {
+    // The ApertureX soak typed CEP and cep over "cep-salesforce"; the
+    // predicate matched all along - the blanking came from elsewhere - and
+    // this pins that it stays true.
+    const register = [
+      { id: 'cep-salesforce', name: 'CEP (Salesforce)', kindLabel: 'applicationComponent' },
+    ]
+    expect(filteredSubjectCount(register, null, 'CEP')).toBe(1)
+    expect(filteredSubjectCount(register, null, 'cep')).toBe(1)
+  })
+
+  it('agrees with applyFilter about emptiness in every direction', () => {
+    const narrowings: readonly (readonly [readonly string[] | null, string])[] = [
+      [null, 'cep'],
+      [null, 'checkout'],
+      [['node1', 'node2'], 'fulfil'],
+      [['node1', 'node2'], 'gateway'],
+      [[], ''],
+    ]
+    for (const [matched, text] of narrowings) {
+      const cy = buildCy()
+      applyFilter(cy, matched, text)
+      const canvasBlank =
+        cy.nodes().filter((node) => node.visible()).length === 0
+      expect(
+        filteredSubjectCount(subjects, matched, text) === 0,
+        `matched=${JSON.stringify(matched)} text=${JSON.stringify(text)}`,
+      ).toBe(canvasBlank)
+    }
   })
 })
 

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -668,6 +668,122 @@ describe('saved layout indicator (#273)', () => {
   })
 })
 
+/**
+ * A filter that matches nothing used to leave the canvas silently blank, with
+ * every control still describing the whole model (#307). The canvas now says
+ * so where the subjects would be, names the narrowing that caused it, and
+ * offers the way out: the standing query's Show all when its own match set
+ * draws no subject, clearing the quick filter when its text zeroed an
+ * otherwise drawn set.
+ */
+describe('an empty filter result says so on the canvas (#307)', () => {
+  it('names the quick-filter text that matched nothing, with the way out', () => {
+    const markup = renderSession({
+      model: renderedModel,
+      quickFilterText: 'zzz',
+    })
+
+    expect(markup).toContain('class="filter-empty-pill" role="status"')
+    expect(markup).toContain('Nothing matches “zzz”')
+    expect(markup).toContain('>Clear filter</button>')
+  })
+
+  it('renders no pill while the quick filter still matches subjects', () => {
+    const markup = renderSession({
+      model: renderedModel,
+      quickFilterText: 'checkout',
+    })
+
+    expect(markup).not.toContain('filter-empty-pill')
+    expect(markup).not.toContain('Nothing matches')
+  })
+
+  it('names the standing query when its own match set draws no subject', () => {
+    const markup = renderSession({
+      model: renderedModel,
+      activeFilter: {
+        query: { layers: ['technology'] },
+        matchedIds: [],
+        excluded: [],
+        source: 'panel',
+      },
+    })
+
+    expect(markup).toContain('filter-empty-pill')
+    expect(markup).toContain('Nothing matches this filter:')
+    expect(markup).toContain('layers: technology')
+  })
+
+  it('treats a match set naming only relationships as drawing no subject', () => {
+    // The match set is non-empty, but nothing in it is a node: the canvas is
+    // exactly as blank as with `matchedIds: []`, and as honest about it.
+    const markup = renderSession({
+      model: renderedModel,
+      activeFilter: {
+        query: { layers: ['technology'] },
+        matchedIds: ['checkout-serves-ledger'],
+        excluded: [],
+        source: 'panel',
+      },
+    })
+
+    expect(markup).toContain('filter-empty-pill')
+    expect(markup).toContain('Nothing matches this filter:')
+  })
+
+  it('speaks even for a view-sourced filter the top pill stays silent about', () => {
+    // The tree names a view, so the top-left filter-pill deliberately does
+    // not render for it - which left a view that matches nothing with NO
+    // on-screen explanation at all.
+    const markup = renderSession({
+      model: renderedModel,
+      activeFilter: {
+        query: { layers: ['technology'] },
+        matchedIds: [],
+        excluded: [],
+        source: 'view',
+      },
+    })
+
+    expect(markup).not.toContain('class="filter-pill"')
+    expect(markup).toContain('filter-empty-pill')
+    expect(markup).toContain('>Show all</button>')
+  })
+
+  it('attributes emptiness to the standing query, not the quick filter, when both stand', () => {
+    // Clearing the quick filter would change nothing here: the match set is
+    // already empty, so the pill names the query and offers Show all.
+    const markup = renderSession({
+      model: renderedModel,
+      quickFilterText: 'zzz',
+      activeFilter: {
+        query: { layers: ['technology'] },
+        matchedIds: [],
+        excluded: [],
+        source: 'panel',
+      },
+    })
+
+    expect(markup).toContain('Nothing matches this filter:')
+    expect(markup).not.toContain('Nothing matches “zzz”')
+  })
+
+  it('stays silent over a model with no subjects, where nothing was hidden', () => {
+    const markup = renderSession({
+      model: { ...renderedModel, graph: { nodes: [], edges: [] } },
+      quickFilterText: 'zzz',
+    })
+
+    expect(markup).not.toContain('filter-empty-pill')
+  })
+
+  it('stays silent with no model at all', () => {
+    const markup = renderSession({ quickFilterText: 'zzz' })
+
+    expect(markup).not.toContain('filter-empty-pill')
+  })
+})
+
 describe('open questions section (#292)', () => {
   const overlay = {
     catalogue: 'core-enrichment@1.1',

--- a/test/visual-local-host.test.ts
+++ b/test/visual-local-host.test.ts
@@ -182,6 +182,32 @@ describe('an editor over a store, with no server', () => {
     expect(ready.snapshot.views[0]?.subjectCount).toBe(2)
   })
 
+  it('refuses a filter over a workspace that does not compile, rather than matching nothing', () => {
+    // `matchedIds: []` is a claim about the subjects - every one of them
+    // failed the query - and the canvas honours it by hiding the whole model.
+    // A workspace that does not compile cannot answer the question at all,
+    // so the host says that instead, leaving the last good model standing
+    // the same way `recompile` itself does (#307).
+    const { frames, send } = openHost({
+      'architecture/main.yaml': `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: nope
+    kind: notAKind
+    name: Nope
+`,
+      'projections/apps.yaml': projection,
+    })
+    send(input('filter.query', { query: {} }))
+    const refused = frames.at(-1)
+
+    expect(refused?.kind).toBe('rejected')
+    if (refused?.kind !== 'rejected') return
+    expect(refused.refused).toBe('filter.query')
+    expect(refused.diagnostics[0]?.code).toBe('YMVS318')
+  })
+
   it('answers a filter with what matched and what it dropped', () => {
     const { frames, send } = openHost()
     send(


### PR DESCRIPTION
## The report (#307)

Typing `CEP` into the quick filter over the 54-subject ICWA register hid every node, the pill kept reading "54 subjects", and clearing the box was the only way back. Verified against the code, three mechanisms produce that blank, and each gets its own fix.

## Diagnosed mechanisms

1. **No refit on a quick-filter keystroke.** The filter effect (`graph-canvas.tsx`) relayouts only on a view switch or a `matchedIds` identity change; `quickFilterText` changes re-ran `applyFilter` and nothing else. With 54 nodes fitted at zoom ~0.10, a genuine survivor stayed pinned at its stack coordinate rendering ~17x5 px: indistinguishable from an empty canvas.
2. **A genuinely empty result was silent.** When the narrowing (structural match set, quick filter, or both) left no subject visible, everything hid with no on-screen statement that the *filter*, not the model, was why. A view-sourced filter was the worst case: the top-left `.filter-pill` deliberately does not render for it (the tree names the view), so an empty view had no explanation anywhere.
3. **`matchedIds: []` as a fallback for "cannot answer".** `local-host.ts` answered `filter.query` with `matchedIds: []` whenever `compiled === undefined` (workspace does not compile). The canvas reads that as "every subject failed the query" and hides the whole model on any standing filter, whatever the text.

## The fixes

**Refit is a FIT, not a re-layout.** New `fitVisible(cy)`: `cy.fit` over `:visible` with the standard padding, run when the quick-filter text changes (narrowing *and* clearing) and no relayout is already due. Chosen deliberately over `relayoutVisible`: a layout would repack the graph and blow away dragged positions on every keystroke, while a fit moves no node, only the viewport - the least destructive operation that brings survivors into view. The fitted framing is recorded in `autoViewportRef` the same way a layout's own fit is, so the existing panel-resize refit logic still recognises it as automatic; a fit that could not happen (nothing visible) records nothing. `matchedIds` changes keep the existing `relayoutVisible` path untouched.

**An empty result says so, where the subjects would be.** A centred `role="status"` pill (`.filter-empty-pill`, same anatomy as `.filter-pill`; centre chosen so it cannot collide with the standing filter pill top-left, the saved-layout pill bottom-left from #273, or the layout notice top-right). Attribution decides the escape: a standing query whose own match set draws no subject (including one naming only relationships) gets `Nothing matches this filter: <query>` with **Show all**; quick-filter text that zeroed an otherwise drawn set gets `Nothing matches "<text>"` with **Clear filter**, leaving the standing filter standing. Emptiness is computed by a new pure `filteredSubjectCount`, which restates `applyFilter`'s narrowing over render data; the substring predicate is extracted (`subjectMatchesQuickFilter`) and shared by both so what hides and what is reported cannot drift, and a parity test asserts zero-count = blank-canvas in both directions. A model with no subjects earns no pill: nothing was hidden.

**The local host refuses what it cannot evaluate.** `filter.query` over a non-compiling workspace now returns a `rejected` frame with `YMVS318` ("the workspace does not compile, so a filter cannot be evaluated"), the same shape as its other unanswerable inputs, leaving whatever filter and model were standing - the keep-the-last-good-model posture `recompile` itself already takes. This is the issue's "surface why matching is unavailable" arm: the protocol's `filter-result.matchedIds` is a required `string[]`, so "no filter" cannot be said in-band without a wire change.

## Out of scope (noted in the issue, not fixable here)

- The rail filter's missing `id` field (`view-tree-model.ts`) - that file is outside this defect fix's allowed surface; worth its own small follow-up.
- Making the tree's subject counts reflect the quick filter - same file.

## Tests

- `test/graph-canvas.test.ts` (headless cytoscape): `fitVisible` re-frames the viewport without moving any node, and declines (returning `false`, viewport untouched) when nothing is visible; `filteredSubjectCount` narrowing, relationship-only match sets, the `CEP`/`cep` field-report predicate, and the emptiness-parity sweep against `applyFilter`.
- `test/visual-app-render.test.ts` (renderToStaticMarkup): pill present with the right text and escape for quick-filter, structural, relationship-only, and view-sourced emptiness; absent while subjects still draw, over an empty model, and with no model.
- `test/visual-local-host.test.ts`: a non-compiling workspace refuses `filter.query` with `YMVS318` instead of matching nothing.

`pnpm verify`: exit 0, 96 files, 1697 passed, 1 skipped.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)