### PR TITLE
fix: disconnected subjects pack readably, and the canvas grows zoom and fit controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- **Fixed.** Disconnected subjects pack into a readable grid, and the
+  canvas grows zoom and fit controls (#308). Layout: with 54 subjects
+  and no relationships — the natural order when transcribing a client
+  register — every subject is its own ELK component, and the packing
+  was driven by `aspectRatio: cy.width() / cy.height()`, a default
+  cytoscape-elk injects into the option bag it forwards to ELK
+  verbatim: the viewport's momentary shape, NaN on a headless
+  instance, and small enough at mount to break one component per
+  packing row — a single 172x6942 column auto-fitted to zoom ~0.10,
+  every node an unreadable sliver. `buildLayoutConfig` now pins the
+  bare `aspectRatio` key (the same spelling, so the injection is
+  replaced at cytoscape-elk's own merge rather than raced as a second
+  key) at 2.5, measured to land drawn ratios of 1.6–2.2 across
+  9/20/54/120 disconnected subjects — nine make a 3x3 grid — while a
+  connected graph's layout is untouched, since component packing never
+  reaches a single-component graph. Direction stays DOWN; #274 is
+  deliberately held. Controls: the canvas's only zoom affordance was
+  wheel zoom at a tenth sensitivity, undiscoverable and near-immobile
+  without a wheel, so it now carries a zoom in / zoom out / fit
+  cluster bottom-right — the free corner. A press steps the viewport a
+  quarter about its own centre, clamped against runaway presses and
+  left standing as the reviewer's own framing; Fit is #307's
+  `fitVisible` by hand — frame the visible set without moving a node —
+  and records as automatic framing, so a later panel resize may
+  re-frame it the way a layout's own fit is re-framed.
+
 - **Fixed.** A filter that matches nothing no longer blanks the canvas
   silently, and the survivors of one that matches come into view
   (#307). Three mechanisms, one field report. Refit: a quick-filter

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -110,6 +110,25 @@ const CONTAINER_LABEL_GAP = 22
 // on the same framing the layout would have produced at the new canvas size.
 const FIT_PADDING = 20
 
+// One press of the on-canvas zoom buttons (#308). Wheel zoom stands at
+// `wheelSensitivity: 0.1` - roughly ten notches per usual step, and the only
+// zoom the canvas offered at all, so a mouse-only reviewer over a
+// register-scale fit (zoom ~0.10) had no discoverable way in. A button press
+// is a deliberate act, so it takes a full step. The clamp only stops runaway
+// repeat-presses: 0.02 still frames a graph far larger than any field model,
+// and 10 is past any label-reading close-up.
+const BUTTON_ZOOM_STEP = 1.25
+const MIN_BUTTON_ZOOM = 0.02
+const MAX_BUTTON_ZOOM = 10
+
+// The zoom one button press lands on. Exported so the step and its clamp are
+// facts a test can state without a viewport to press against.
+export function steppedZoom(current: number, direction: 1 | -1): number {
+  const level =
+    direction === 1 ? current * BUTTON_ZOOM_STEP : current / BUTTON_ZOOM_STEP
+  return Math.min(MAX_BUTTON_ZOOM, Math.max(MIN_BUTTON_ZOOM, level))
+}
+
 // Spacing, shared by the root graph and every compound container.
 //
 // ELK's defaults are ~20px throughout, which is too tight for 170x50 nodes
@@ -145,6 +164,27 @@ const ELK_SPACING: Record<string, unknown> = {
   'elk.padding': `[top=${CONTAINER_PADDING + CONTAINER_LABEL_GAP},left=${CONTAINER_PADDING},bottom=${CONTAINER_PADDING},right=${CONTAINER_PADDING}]`,
 }
 
+// The proportion disconnected components pack toward (#308). `layered`
+// separates components by default; what failed at register scale was the
+// packing. cytoscape-elk hands the whole `elk` bag to ELK verbatim as the
+// root graph's `layoutOptions` (`graph['layoutOptions'] = options.elk` in
+// its `Layout.run`), but first injects `aspectRatio: cy.width() /
+// cy.height()` as a default - the viewport's momentary shape, which is NaN
+// on a headless instance and, at mount time on a canvas taller than wide,
+// small enough that ELK's row-breaking (`sqrt(total component area) x
+// aspectRatio`) fits one component per row: 54 subjects with no
+// relationships drew as one 172x6942 column fitted to zoom ~0.10. The bare
+// `aspectRatio` spelling below is load-bearing: it replaces the injected
+// key at cytoscape-elk's own `assign`, so exactly one value ever reaches
+// ELK, the same headless and mounted. The value is not the drawn
+// proportion: the packer breaks rows in the pre-rotation frame, so under
+// `DOWN` the requested ratio lands roughly inverted and quantised.
+// Measured on disconnected 170x50 subjects at 2.5: 9 -> 672x312 (a 3x3
+// grid), 20 -> 922x572, 54 -> 1672x962, 120 -> 2422x1482 - drawn ratios
+// 1.6-2.2, no overlaps - while a connected cycle's layout is untouched
+// (component packing never reaches a single-component graph).
+const COMPONENT_ASPECT_RATIO = 2.5
+
 // Shared by the full-graph layout effect and the visible-subgraph relayout
 // that runs on view switch, so both always agree on algorithm and direction.
 //
@@ -169,6 +209,9 @@ export function buildLayoutConfig(): cytoscape.LayoutOptions {
   const elk: ElkLayoutOptions['elk'] = {
     algorithm: 'layered',
     'elk.direction': 'DOWN',
+    // Bare key on purpose - replaces cytoscape-elk's injected viewport
+    // ratio; see COMPONENT_ASPECT_RATIO.
+    aspectRatio: COMPONENT_ASPECT_RATIO,
     ...ELK_SPACING,
   }
   const config: ElkLayoutOptions = {
@@ -1493,6 +1536,33 @@ export function GraphCanvas({
     if (cyRef.current !== null) relayoutVisible(cyRef.current)
   }
 
+  // The on-canvas zoom cluster (#308). A press zooms about the viewport's own
+  // centre - the wheel zooms about the pointer, but a button press carries no
+  // meaningful position. The reviewer's resulting viewport is theirs: it is
+  // deliberately not recorded as automatic framing, so a later panel resize
+  // leaves it standing, exactly as a wheel zoom is left standing.
+  const zoomStep = (direction: 1 | -1): void => {
+    const cy = cyRef.current
+    if (cy === null) return
+    cy.zoom({
+      level: steppedZoom(cy.zoom(), direction),
+      renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 },
+    })
+  }
+
+  // Fit is the same operation a quick-filter keystroke performs (#307), asked
+  // for by hand: frame what is visible without moving a node. A framing this
+  // produced is recorded as automatic - like a layout's own fit, a later
+  // panel resize may re-frame it; a fit that did not happen (nothing
+  // visible) records nothing.
+  const fitToVisible = (): void => {
+    const cy = cyRef.current
+    if (cy === null) return
+    if (fitVisible(cy)) {
+      autoViewportRef.current = { zoom: cy.zoom(), pan: { ...cy.pan() } }
+    }
+  }
+
   // The standing indicator (#273): a saved layout silently overrides every
   // relayout, so whenever one is actually in force for this view the canvas
   // says so, with the way out beside it. Distinct from the transient
@@ -1551,6 +1621,25 @@ export function GraphCanvas({
           </button>
         </div>
       ) : null}
+      {/* Zoom and fit, on the canvas they act on (#308). Bottom-right is the
+          free corner: the quick filter and the save notice hold the
+          top-right, the standing filter pill the top-left, the saved-layout
+          pill the bottom-left, and the empty-state pill the centre. */}
+      <div className="zoom-controls" role="group" aria-label="Zoom controls">
+        <button type="button" aria-label="Zoom in" onClick={() => zoomStep(1)}>
+          +
+        </button>
+        <button
+          type="button"
+          aria-label="Zoom out"
+          onClick={() => zoomStep(-1)}
+        >
+          −
+        </button>
+        <button type="button" aria-label="Fit diagram" onClick={fitToVisible}>
+          Fit
+        </button>
+      </div>
     </>
   )
 }

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -2560,6 +2560,43 @@ body {
 
 .saved-layout-pill button:hover {
   color: var(--ink);
+}
+
+/* Zoom and fit, on the canvas they act on (#308). Bottom-right is the free
+   corner: the quick filter and the save notice hold the top-right, the
+   standing filter pill the top-left, the saved-layout pill the bottom-left,
+   and the empty-state pill the centre. One bordered cluster rather than
+   three floating buttons, so the group reads as a single instrument. */
+.zoom-controls {
+  position: absolute;
+  inset: auto var(--step) var(--step) auto;
+  z-index: 4;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--rule-firm);
+  border-radius: calc(var(--step) * 0.75);
+  background: var(--sheet);
+}
+
+.zoom-controls button {
+  padding: 0.3rem 0.6rem;
+  border: none;
+  background: none;
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.zoom-controls button + button {
+  border-left: 1px solid var(--rule);
+}
+
+.zoom-controls button:hover {
+  background: var(--paper);
+}
 
 /* A staged row is the reviewer's own uncommitted intent beside landed truth
    (ADR 0114): the title leans and a small chip says so. Quiet on purpose —

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -10,6 +10,7 @@ import {
   registerDragSave,
   relayoutVisible,
   savedLayoutInForce,
+  steppedZoom,
 } from '../src/visual-app/graph-canvas.js'
 import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.js'
 import type {
@@ -266,6 +267,20 @@ const buildHubFixture = () =>
     ],
   })
 
+// Subjects with no relationships at all - the register-transcription shape
+// (#308): every node is its own ELK component, so what this exercises is the
+// component packing, not the layering.
+const buildDisconnectedFixture = (count: number) =>
+  cytoscape({
+    styleEnabled: true,
+    style: LAYOUT_FIXTURE_STYLE,
+    layout: { name: 'null' },
+    elements: Array.from({ length: count }, (_, i) => ({
+      data: { id: `subject${i}` },
+      group: 'nodes' as const,
+    })),
+  })
+
 // elk-backed layouts (layered, force) resolve asynchronously; the built-in
 // concentric layout (radial) resolves synchronously but still fires
 // `layoutstop`, so one helper covers all three.
@@ -305,6 +320,35 @@ describe('buildLayoutConfig', () => {
     expect(buildLayoutConfig.length).toBe(0)
   })
 
+  // Nine subjects, no relationships (#308). Before the packing ratio was
+  // pinned, cytoscape-elk's injected `aspectRatio` (the viewport's momentary
+  // shape - NaN headless) let ELK's component packing emit one 172x1092
+  // column: w/h 0.16, every node in the same 250px-wide lane. A grid has
+  // several lanes in both axes and bounded elongation either way.
+  it('packs disconnected subjects into a grid, never one column (#308)', async () => {
+    const cy = buildDisconnectedFixture(9)
+    await runLayout(cy, buildLayoutConfig())
+    const bb = cy.nodes().boundingBox()
+    expect(bb.w / bb.h).toBeGreaterThan(0.5)
+    expect(bb.w / bb.h).toBeLessThan(4)
+    // Grid-ish, stated structurally as well as proportionally: more than one
+    // distinct column of node centres, and more than one distinct row.
+    const xs = new Set(cy.nodes().map((node) => Math.round(node.position().x)))
+    const ys = new Set(cy.nodes().map((node) => Math.round(node.position().y)))
+    expect(xs.size).toBeGreaterThan(1)
+    expect(ys.size).toBeGreaterThan(1)
+    expect(countOverlappingPairs(cy)).toBe(0)
+  })
+
+  // The packing ratio is this config's own, stated on the bare `aspectRatio`
+  // key on purpose: cytoscape-elk injects `aspectRatio: cy.width() /
+  // cy.height()` into the very bag it forwards to ELK, and only the same
+  // spelling replaces that injection instead of racing it as a second key.
+  it('pins the component packing ratio, replacing the injected viewport shape (#308)', () => {
+    const config = buildLayoutConfig() as unknown as { elk: Record<string, unknown> }
+    expect(config.elk['aspectRatio']).toBe(2.5)
+  })
+
   // `layered` is the only backend, so a layout run is one synchronous elk
   // pass. Nothing can still be in flight when the next request arrives, which
   // is what retired the busy notice, the two-pass chain and the in-flight
@@ -317,6 +361,21 @@ describe('buildLayoutConfig', () => {
   })
 })
 
+
+// One press of the on-canvas zoom buttons (#308): a full quarter step, where
+// a wheel notch at `wheelSensitivity: 0.1` barely moves, clamped only
+// against runaway repeat-presses.
+describe('steppedZoom', () => {
+  it('steps a quarter up or down from where the viewport stands', () => {
+    expect(steppedZoom(0.4, 1)).toBeCloseTo(0.5)
+    expect(steppedZoom(0.5, -1)).toBeCloseTo(0.4)
+  })
+
+  it('clamps runaway presses at both ends', () => {
+    expect(steppedZoom(0.02, -1)).toBe(0.02)
+    expect(steppedZoom(10, 1)).toBe(10)
+  })
+})
 
 describe('buildStylesheet ArchiMate notation', () => {
   const edgeRule = (

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -784,6 +784,37 @@ describe('an empty filter result says so on the canvas (#307)', () => {
   })
 })
 
+/**
+ * On-canvas zoom and fit (#308): the canvas's only zoom affordance was wheel
+ * zoom at a tenth sensitivity, so a mouse-only reviewer over a register-scale
+ * fit had no discoverable way in. The cluster sits bottom-right - the free
+ * corner - and travels with the canvas: any mount that draws the diagram
+ * draws it, read-only included, because looking is exactly the work there.
+ */
+describe('zoom and fit controls (#308)', () => {
+  it('draws the cluster, each control named for assistive tech', () => {
+    const markup = renderSession({ model: renderedModel })
+
+    expect(markup).toContain('class="zoom-controls"')
+    expect(markup).toContain('aria-label="Zoom in"')
+    expect(markup).toContain('aria-label="Zoom out"')
+    expect(markup).toContain('aria-label="Fit diagram"')
+  })
+
+  it('keeps the cluster in a read-only mount', () => {
+    const markup = renderSession({ model: renderedModel }, { readOnly: true })
+
+    expect(markup).toContain('class="zoom-controls"')
+    expect(markup).toContain('aria-label="Fit diagram"')
+  })
+
+  it('draws no cluster while there is no canvas to zoom', () => {
+    const markup = renderSession()
+
+    expect(markup).not.toContain('zoom-controls')
+  })
+})
+
 describe('open questions section (#292)', () => {
   const overlay = {
     catalogue: 'core-enrichment@1.1',


### PR DESCRIPTION
Two halves, from the ApertureX Phase A field soak.

## Disconnected-subjects layout

**The verified pass-through mechanism.** The installed `cytoscape-elk@2.3.0` (running its own pnpm-resolved `elkjs@0.9.3`, not the app's top-level 0.12.0) forwards the entire `elk` option bag verbatim as the root graph's `layoutOptions` — `graph['layoutOptions'] = options.elk` in `src/layout.js` — so any ELK option key in `buildLayoutConfig`'s bag reaches ELK. But its `Layout` constructor first injects `aspectRatio: cy.width() / cy.height()` as a default into that same bag. That injected value is the viewport's momentary shape: NaN on a headless instance, and small enough at mount on a tall canvas that ELK's component row-breaking (`sqrt(total component area) × aspectRatio`) fits one component per row. Reproduced headlessly: 54 disconnected 170×50 subjects draw as exactly the field's 172×6942 single column whenever that ratio is ≤ 0.5.

`elk.separateConnectedComponents` is already true by default for `layered` (setting it explicitly changes nothing, measured); the failure was purely the packing ratio. The fix pins the **bare `aspectRatio` key** at 2.5 in `buildLayoutConfig` — the bare spelling is load-bearing, because it replaces the injected key at cytoscape-elk's own `assign` merge instead of racing it as a second key ELK would have to disambiguate. Measured across 9/20/54/120 disconnected subjects the drawn ratios land at 1.6–2.2 (9 subjects become a 3×3 grid; 54 draw 1672×962 instead of 172×6942), with zero overlapping boxes, while a connected cycle's layout is byte-identical — component packing never reaches a single-component graph. The requested value is not the drawn proportion: the packer breaks rows in the pre-rotation frame, so under `DOWN` it lands roughly inverted and quantised, which is why 2.5 was chosen by sweep rather than set to the viewport-ish 1.6.

Layered direction stays `DOWN` — #274 is deliberately held, untouched.

## Zoom and fit controls

The canvas's only zoom affordance was wheel zoom at `wheelSensitivity: 0.1`. It now carries a plain-DOM zoom in / zoom out / Fit cluster bottom-right — the free corner (quick filter and save notice top-right, standing filter pill top-left, saved-layout pill bottom-left, empty-state pill centred). A press steps the viewport ×1.25 about its own centre via the exported `steppedZoom` (clamped 0.02–10 against runaway presses) and is left standing as the reviewer's own framing; Fit reuses #307's `fitVisible` — frame the visible set without moving a node — and records as automatic framing so a later panel resize may re-frame it, the same as a layout's own fit. Buttons are aria-labelled and styled with the existing tokens.

Incidental: inserting the `.zoom-controls` rules revealed the `.saved-layout-pill button:hover` block was missing its closing brace (it was silently swallowing the `.tree-row-staged` italic rule); closed as a prerequisite for the new rules to parse.

## Tests

- `test/graph-canvas-layout.test.ts`: headless cytoscape through the real cytoscape-elk/elkjs pipeline — a 9-subject no-relationship fixture asserts the bounding box is grid-ish (w/h in (0.5, 4), multiple distinct columns *and* rows of node centres, zero overlaps), plus a config-level assertion that the bare `aspectRatio` key is pinned; `steppedZoom` step and clamp units.
- `test/visual-app-render.test.ts`: the cluster renders with a model (all three aria-labels), stays in a read-only mount, and is absent with no model.

Both files were already wired in `tsconfig.json` exclude / `tsconfig.visual.json` include, so no tsconfig changes.

`pnpm verify`: real exit 0 (captured `VERIFY_EXIT=0`), 96 files, 1704 passed, 1 skipped.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
