### PR TITLE
fix: a staged concept reserves its id the way a staged relationship now does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Fixed.** A second staged subject survives beside the first when
+  their names slug to the same id (#315). `proposeConceptId` built its
+  taken set from the landed graph alone, so with the first draft still
+  staged the second proposed the identical id and the editor's
+  replace-by-target staging swallowed it: no row, no error, no toast.
+  The same blind spot #313 closed for `proposeRelationshipId`, noted
+  there as out of scope; this completes that fix for the concept path
+  with the same shape. `proposeConceptId` and `draftConcept` now take
+  the ids a pending changeset already claims (`stagedSubjectIds`
+  collects them), the Add-subject form threads them through a required
+  `reservedIds` prop the way the connection panel does, and the second
+  subject stages as `…-2`, which lands and compiles cleanly.
+
 - **Fixed.** Disconnected subjects pack into a readable grid, and the
   canvas grows zoom and fit controls (#308). Layout: with 54 subjects
   and no relationships — the natural order when transcribing a client

--- a/src/concept-drafting.ts
+++ b/src/concept-drafting.ts
@@ -22,10 +22,17 @@ const ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
  * about a name produces worse ids than a transliteration of the name does.
  * Returning null rather than a placeholder keeps a subject called `"???"` from
  * landing as `subject-1`, which nothing could later be traced back from.
+ *
+ * `reserved` carries ids the graph does not know yet: a staged-but-uncommitted
+ * draft never enters the rendered graph, so without it a second subject whose
+ * name slugs to the same id re-proposed it and the editor's replace-by-target
+ * staging silently swallowed the first (#315) - the identical blind spot
+ * `proposeRelationshipId` had before #306's fix, and the identical way out.
  */
 export const proposeConceptId = (
   graph: CanvasGraph,
   name: string,
+  reserved: Iterable<string> = [],
 ): string | null => {
   const base = name
     .normalize('NFKD')
@@ -46,6 +53,7 @@ export const proposeConceptId = (
   const taken = new Set([
     ...graph.nodes.map((node) => node.id),
     ...graph.edges.map((edge) => edge.id),
+    ...reserved,
   ])
   if (!taken.has(base)) return base
   for (let suffix = 2; ; suffix += 1) {
@@ -62,6 +70,11 @@ export const proposeConceptId = (
  * a kind outside it here, rather than trusting the caller's palette, is the
  * same posture `draftRelationship` takes: the guarantee has to hold for any
  * caller, not only one that filtered first.
+ *
+ * A caller holding drafts the graph has not landed yet - an editor with a
+ * pending changeset - passes their ids as `reserved`, so a second subject
+ * slugging to a taken id steps to `-2` instead of colliding with the first
+ * (#315).
  */
 export const draftConcept = (
   graph: CanvasGraph,
@@ -71,12 +84,13 @@ export const draftConcept = (
     readonly document: string
   },
   kinds: readonly string[],
+  reserved: Iterable<string> = [],
 ): YarramateOperation | null => {
   if (input.document === '') return null
   if (!kinds.includes(input.kind)) return null
   const name = input.name.trim()
   if (name === '') return null
-  const id = proposeConceptId(graph, name)
+  const id = proposeConceptId(graph, name, reserved)
   if (id === null) return null
   return {
     op: 'add-concept',

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -417,6 +417,10 @@ const DiagramWorkspace = ({
             graph={state.model.graph}
             kinds={state.model.vocabulary.conceptKinds}
             documents={state.model.documents}
+            // What is staged but not landed: the graph cannot know these ids,
+            // and without them a second subject slugging to the same id
+            // collides with the first and is silently swallowed (#315).
+            reservedIds={stagedSubjectIds(state.pendingChangeset.operations)}
             defaultDocument={
               // Near what the reviewer is looking at: the selected subject's
               // document, or the first the workspace declares.

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -21,6 +21,7 @@ export const SubjectDraftPanel = ({
   documents,
   defaultDocument,
   initialKind,
+  reservedIds,
   onStage,
   onCancel,
 }: {
@@ -32,6 +33,14 @@ export const SubjectDraftPanel = ({
    * or clicked there (#295). Their own choice arriving with the gesture, not
    * a default this form chose for them, so the no-default rule below stands. */
   readonly initialKind?: string
+  /**
+   * Ids the pending changeset already claims. The graph only knows what has
+   * landed, so without these a second subject slugging to the same id
+   * proposed it again and replace-by-target staging swallowed the first
+   * silently (#315). Required rather than defaulted: a caller has to say
+   * what is staged, even when the answer is nothing.
+   */
+  readonly reservedIds: readonly string[]
   readonly onStage: (operation: YarramateOperation) => void
   readonly onCancel: () => void
 }): React.ReactElement => {
@@ -42,7 +51,8 @@ export const SubjectDraftPanel = ({
   const [kind, setKind] = useState(initialKind ?? '')
   const [document, setDocument] = useState(defaultDocument)
 
-  const proposed = name.trim() === '' ? null : proposeConceptId(graph, name)
+  const proposed =
+    name.trim() === '' ? null : proposeConceptId(graph, name, reservedIds)
   const operation =
     proposed === null
       ? null
@@ -50,6 +60,7 @@ export const SubjectDraftPanel = ({
           graph,
           { name, kind, document },
           kinds.map((option) => option.label),
+          reservedIds,
         )
 
   return (

--- a/test/concept-drafting.test.ts
+++ b/test/concept-drafting.test.ts
@@ -3,6 +3,7 @@ import { stringify } from 'yaml'
 import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
 import { projectGraphForCanvas } from '../src/graph-projection.js'
 import { draftConcept, proposeConceptId } from '../src/concept-drafting.js'
+import { stagedSubjectIds } from '../src/relationship-drafting.js'
 import { applyOperations } from '../src/apply-command.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
 
@@ -80,6 +81,23 @@ describe('proposeConceptId', () => {
     // made of, and the caller is told rather than handed a mangled one.
     expect(proposeConceptId(graph, '2FA Gateway')).toBeNull()
     expect(proposeConceptId(graph, '123')).toBeNull()
+  })
+
+  it('steps past a reserved id the graph does not know yet (#315)', () => {
+    // A staged-but-uncommitted subject is not in the rendered graph, so its
+    // id arrives as `reserved` rather than as a node. Without this a second
+    // subject slugging to the same id re-proposed it and the editor's
+    // replace-by-target staging swallowed the first - the same blind spot
+    // `proposeRelationshipId` had before #306's fix.
+    expect(
+      proposeConceptId(graph, 'Payment Service', ['payment-service']),
+    ).toBe('payment-service-2')
+    expect(
+      proposeConceptId(graph, 'Payment Service', [
+        'payment-service',
+        'payment-service-2',
+      ]),
+    ).toBe('payment-service-3')
   })
 
   it('always produces something the document schema accepts', () => {
@@ -196,6 +214,63 @@ describe('draftConcept', () => {
       ).toEqual([])
     }
     expect(drafted).toBe(KINDS.length)
+  })
+
+  /**
+   * The repro from #315: stage 'Payment Service', rename nothing, stage
+   * another subject that slugs to `payment-service` before committing. The
+   * first is staged, not landed, so the graph alone cannot warn the second
+   * off its id - only `stagedSubjectIds` can. Both must survive: distinct
+   * ids, applied together, compiled cleanly.
+   */
+  it('drafts a second subject that lands beside the first when their names slug identically (#315)', () => {
+    const first = draftConcept(
+      graph,
+      {
+        name: 'Payment Service',
+        kind: 'applicationComponent',
+        document: 'architecture/main.yaml',
+      },
+      KINDS,
+    )
+    expect(first?.op).toBe('add-concept')
+    if (first?.op !== 'add-concept') return
+
+    const second = draftConcept(
+      graph,
+      {
+        // A different name that slugs to the same id, which is exactly how
+        // the collision arrives in practice - nobody types the same name
+        // twice on purpose.
+        name: 'Payment (Service)',
+        kind: 'businessActor',
+        document: 'architecture/main.yaml',
+      },
+      KINDS,
+      stagedSubjectIds([first]),
+    )
+    expect(second?.op).toBe('add-concept')
+    if (second?.op !== 'add-concept') return
+
+    expect(first.concept.id).toBe('payment-service')
+    expect(second.concept.id).toBe('payment-service-2')
+
+    const outcome = apply([first, second])
+    expect(
+      outcome.ok ? [] : outcome.diagnostics.map((d) => d.code),
+    ).toEqual([])
+    if (!outcome.ok) return
+
+    const landed = graphOf(
+      outcome.sources.find(
+        (document) => document.path === 'architecture/main.yaml',
+      )!.source,
+    )
+    expect(landed.nodes.map((node) => node.id).sort()).toEqual([
+      'orders',
+      'payment-service',
+      'payment-service-2',
+    ])
   })
 
   it('lands a subject the connection tool can then reach', () => {

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -1,10 +1,11 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
 import { projectGraphForCanvas } from '../src/graph-projection.js'
 import { SubjectDraftPanel } from '../src/visual-app/subject-draft-panel.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
+import type { YarramateOperation } from '../src/operations.js'
 
 /**
  * What the form puts on screen. What it produces when submitted is
@@ -29,27 +30,30 @@ concepts:
 relationships: []
 `)
 
+const KINDS = [
+  // id is the full identity the wire carries; label is the short name a
+  // document names. The two differ, which is the whole point.
+  {
+    id: 'yarramate/core@0.1#applicationComponent',
+    label: 'applicationComponent',
+    coreLabel: 'applicationComponent',
+  },
+  {
+    id: 'yarramate/core@0.1#businessActor',
+    label: 'businessActor',
+    coreLabel: 'businessActor',
+  },
+]
+
 const render = (overrides: { readonly initialKind?: string } = {}) =>
   renderToStaticMarkup(
     createElement(SubjectDraftPanel, {
       ...overrides,
       graph,
-      kinds: [
-        // id is the full identity the wire carries; label is the short name a
-        // document names. The two differ, which is the whole point.
-        {
-          id: 'yarramate/core@0.1#applicationComponent',
-          label: 'applicationComponent',
-          coreLabel: 'applicationComponent',
-        },
-        {
-          id: 'yarramate/core@0.1#businessActor',
-          label: 'businessActor',
-          coreLabel: 'businessActor',
-        },
-      ],
+      kinds: KINDS,
       documents: ['architecture/main.yaml', 'architecture/other.yaml'],
       defaultDocument: 'architecture/main.yaml',
+      reservedIds: [],
       onStage: () => undefined,
       onCancel: () => undefined,
     }),
@@ -135,6 +139,83 @@ describe('SubjectDraftPanel', () => {
 
   it('can always be backed out of', () => {
     expect(render()).toContain('Cancel')
+  })
+
+  /**
+   * The concept half of #315, threaded through the form: the reserved id
+   * plays a first subject that is staged but not landed, so submitting a
+   * name that slugs to the same id must stage `-2`, not silently collide.
+   *
+   * The form holds its fields in `useState`, which `renderToStaticMarkup`
+   * cannot be typed into, so `useState` is answered with a filled form and
+   * the panel runs as a plain function - the ConnectionPanel threading
+   * test's shape (#306), adapted for a panel with hooks.
+   */
+  it('threads reserved ids into the draft it stages (#315)', async () => {
+    vi.resetModules()
+    vi.doMock('react', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('react')>()
+      // The panel's three fields, in declaration order: name, kind, document.
+      const answers: unknown[] = [
+        'Payment Service',
+        'applicationComponent',
+        'architecture/main.yaml',
+      ]
+      return {
+        ...actual,
+        useState: (initial: unknown) => [
+          answers.shift() ?? initial,
+          () => undefined,
+        ],
+      }
+    })
+    try {
+      const { SubjectDraftPanel: Panel } = await import(
+        '../src/visual-app/subject-draft-panel.js'
+      )
+      const staged: YarramateOperation[] = []
+      const buttonsOf = (
+        node: unknown,
+        found: Array<{ children?: unknown; onClick?: () => void }> = [],
+      ): Array<{ children?: unknown; onClick?: () => void }> => {
+        if (Array.isArray(node)) {
+          for (const child of node) buttonsOf(child, found)
+          return found
+        }
+        if (node === null || typeof node !== 'object') return found
+        const element = node as {
+          type?: unknown
+          props?: { children?: unknown; onClick?: () => void }
+        }
+        if (element.type === 'button' && element.props !== undefined) {
+          found.push(element.props)
+        }
+        buttonsOf(element.props?.children, found)
+        return found
+      }
+
+      const tree = Panel({
+        graph,
+        kinds: KINDS,
+        documents: ['architecture/main.yaml'],
+        defaultDocument: 'architecture/main.yaml',
+        reservedIds: ['payment-service'],
+        onStage: (operation) => staged.push(operation),
+        onCancel: () => undefined,
+      })
+      const add = buttonsOf(tree).find((button) => button.children === 'Add')
+      expect(add).toBeDefined()
+      add!.onClick!()
+
+      expect(staged).toHaveLength(1)
+      expect(staged[0]).toMatchObject({
+        op: 'add-concept',
+        concept: { id: 'payment-service-2', name: 'Payment Service' },
+      })
+    } finally {
+      vi.doUnmock('react')
+      vi.resetModules()
+    }
   })
 
   /**

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -513,6 +513,37 @@ describe("visualAppReducer changeset management", () => {
     expect(staged.pendingChangeset.operations).toEqual([first, second]);
   });
 
+  it("queues a second staged subject rather than replacing the first (#315)", () => {
+    // Two names slugging to the same base, distinct ids - which is what
+    // `draftConcept` now produces when the first is still staged. The
+    // replace-by-target rule keys on the id, so the pair queues; only a
+    // restage of the *same* id replaces.
+    const first = {
+      op: "add-concept",
+      document: "model.yaml",
+      concept: {
+        id: "payment-service",
+        kind: "applicationComponent",
+        name: "Payment Service",
+      },
+    } as const;
+    const second = {
+      op: "add-concept",
+      document: "model.yaml",
+      concept: {
+        id: "payment-service-2",
+        kind: "businessActor",
+        name: "Payment (Service)",
+      },
+    } as const;
+    const staged = [first, second].reduce(
+      (state, operation) =>
+        visualAppReducer(state, { type: "changeset.staged", operation }),
+      activeState,
+    );
+    expect(staged.pendingChangeset.operations).toEqual([first, second]);
+  });
+
   it("keeps the changeset intact when apply fails, and sets diagnostics", () => {
     const op = {
       op: "update-concept",


### PR DESCRIPTION
Closes #315

## What broke

`proposeConceptId` built its taken-id set from the landed graph alone. A staged-but-uncommitted subject never enters the rendered graph, so a second subject whose name slugs to the same id re-proposed it, and the editor's replace-by-target staging silently swallowed the first: no row, no error, no toast. The repro from the issue: stage 'Payment Service', then stage another subject that slugs to `payment-service` before committing, and the second op replaces the first in the changeset.

This is the identical blind spot PR #313 closed for `proposeRelationshipId` (#306), noted there as out of scope for the concept path. This PR completes that fix with the same shape.

## The fix

- `proposeConceptId` and `draftConcept` take `reserved: Iterable<string>` (defaulted on the pure functions, as `proposeRelationshipId`/`draftRelationship` do) and fold it into the taken set.
- `SubjectDraftPanel` grows a **required** `reservedIds` prop, mirroring `ConnectionPanel`'s: a caller has to say what is staged, even when the answer is nothing. It threads the ids into both the shown proposal and the staged draft. The palette flow reuses this dialog, so it is covered by the same prop.
- `App.tsx` wires `reservedIds={stagedSubjectIds(state.pendingChangeset.operations)}`, the same expression the connection panel already receives.

## Tests

Written first and watched fail against the old code:

- `test/concept-drafting.test.ts`: `proposeConceptId` steps past reserved ids (`-2`, `-3`); the full #315 repro through `draftConcept` + `stagedSubjectIds`, applied and compiled, both subjects landing (`payment-service`, `payment-service-2`).
- `test/subject-draft-panel.test.ts`: the form threads `reservedIds` into the draft it stages, run as a plain function with `useState` answered by a filled form (the ConnectionPanel threading test's shape, adapted for a panel with hooks).
- `test/visual-app-state.test.ts`: two staged adds with distinct ids queue rather than replace, the #306 reducer test's concept counterpart.

`pnpm verify`: exit 0, 96 test files, 1708 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)