### PR TITLE
fix: the rail filters the way the canvas does, and counts what survives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- **Fixed.** The rail's filter judges a subject the way the canvas
+  quick filter does, and its counts say what survives (#317,
+  completing the two asks #307 deferred out of #316). Parity: the
+  tree's own matching restated the predicate with `id` missing, so
+  id-shaped input — `cep` for `cep-salesforce` — emptied the tree
+  while the canvas kept drawing; the predicate #316 extracted
+  (`subjectMatchesQuickFilter`) now lives in a small pure module,
+  `subject-filter.ts`, imported by the canvas and the tree model
+  alike, because `view-tree-model.ts` keeps its no-React/no-cytoscape
+  discipline and merely loading `graph-canvas.tsx` registers
+  cytoscape-elk. The rail keeps its one extra: a folder or layer
+  label that matches still shows everything it holds, which the
+  canvas has no counterpart for. Counts: while the tree filter
+  narrows, the active view's row counts the drawn subjects that
+  survive the text (an honest zero included), the "All subjects" row
+  counts the survivors across the model, and a landed view whose
+  subjects live only in the server's semantic graph shows no number
+  at all rather than a full count the narrowing has made wrong — the
+  same honesty as a staged new row's missing count. Group rows
+  already list only survivors, so their counts follow. With no filter
+  text every count is exactly what it was.
+
 - **Fixed.** A second staged subject survives beside the first when
   their names slug to the same id (#315). `proposeConceptId` built its
   taken set from the landed graph alone, so with the first draft still

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -23,6 +23,10 @@ import {
 } from './badges.js'
 import { ICON_SIZE, kindIconUriOf } from './kind-icons.js'
 import { KIND_MIME } from './kind-palette.js'
+// The one substring judgement the canvas pass, the shell's empty-state
+// honesty, and the rail's tree filter share, so what hides and what is
+// reported can never drift (#307, #317).
+import { subjectMatchesQuickFilter } from './subject-filter.js'
 import { ASPECT_SHAPES, LAYER_COLORS, RELATIONSHIP_NOTATION } from '../notation/archimate.js'
 
 // Register elk extension once at module load, guarded against re-registration
@@ -779,28 +783,6 @@ export function graphToElements(
   )
 
   return [...nodeElements, ...edgeElements]
-}
-
-// The one substring judgement the canvas pass and the shell's empty-state
-// honesty share, so what hides and what is reported can never drift (#307):
-// case-insensitive, against a subject's id, name, and kind label. `name` and
-// `kindLabel` are `unknown` because the canvas reads them out of cytoscape
-// data, which types nothing.
-export function subjectMatchesQuickFilter(
-  trimmedLowerFilter: string,
-  id: string,
-  name: unknown,
-  kindLabel: unknown,
-): boolean {
-  if (trimmedLowerFilter === '') return true
-  if (id.toLowerCase().includes(trimmedLowerFilter)) return true
-  if (typeof name === 'string' && name.toLowerCase().includes(trimmedLowerFilter)) {
-    return true
-  }
-  return (
-    typeof kindLabel === 'string' &&
-    kindLabel.toLowerCase().includes(trimmedLowerFilter)
-  )
 }
 
 // How many of the graph's subjects the standing filter and the quick-filter

--- a/src/visual-app/subject-filter.ts
+++ b/src/visual-app/subject-filter.ts
@@ -1,0 +1,71 @@
+/**
+ * The one substring judgement every surface that filters subjects by typed
+ * text shares.
+ *
+ * #307 extracted the predicate inside `graph-canvas.tsx` so the canvas pass
+ * and the shell's empty-state honesty could not drift; #317 lifts it here so
+ * the rail's tree filter can share it too. It cannot simply be imported from
+ * `graph-canvas.tsx`: the rail's tree model (`view-tree-model.ts`) keeps a
+ * zero-dependency discipline — no React, no cytoscape — and merely loading
+ * the canvas module registers cytoscape-elk. So the predicate lives in this
+ * small pure module and both surfaces import it from here.
+ */
+import type { CanvasNode } from "../graph-projection.js";
+
+/**
+ * The slice of a subject the predicate reads — the render data both the
+ * canvas and the rail already hold.
+ */
+export type FilterableSubject = Pick<CanvasNode, "id" | "name" | "kindLabel">;
+
+/**
+ * Typed filter text made comparable: trimmed and lowercased, once, so every
+ * surface trims the same way before matching.
+ */
+export const normalizeFilterText = (text: string): string =>
+  text.trim().toLowerCase();
+
+/**
+ * Whether a subject survives the typed text: case-insensitive, against its
+ * id, name, and kind label. `name` and `kindLabel` are `unknown` because the
+ * canvas reads them out of cytoscape data, which types nothing.
+ */
+export function subjectMatchesQuickFilter(
+  trimmedLowerFilter: string,
+  id: string,
+  name: unknown,
+  kindLabel: unknown,
+): boolean {
+  if (trimmedLowerFilter === "") return true;
+  if (id.toLowerCase().includes(trimmedLowerFilter)) return true;
+  if (
+    typeof name === "string" &&
+    name.toLowerCase().includes(trimmedLowerFilter)
+  ) {
+    return true;
+  }
+  return (
+    typeof kindLabel === "string" &&
+    kindLabel.toLowerCase().includes(trimmedLowerFilter)
+  );
+}
+
+/**
+ * How many of these subjects survive the typed text — the number a tree row
+ * shows while the filter narrows (#317). With no text every subject
+ * survives, so this is also the plain length.
+ */
+export const countMatchingSubjects = (
+  subjects: readonly FilterableSubject[],
+  filterText: string,
+): number => {
+  const needle = normalizeFilterText(filterText);
+  return subjects.filter((subject) =>
+    subjectMatchesQuickFilter(
+      needle,
+      subject.id,
+      subject.name,
+      subject.kindLabel,
+    ),
+  ).length;
+};

--- a/src/visual-app/view-tree-model.ts
+++ b/src/visual-app/view-tree-model.ts
@@ -19,6 +19,12 @@ import type {
   VisualViewOperation,
   VisualViewSummary,
 } from "../adapters/visual/protocol-contract.js";
+import {
+  countMatchingSubjects,
+  normalizeFilterText,
+  subjectMatchesQuickFilter,
+  type FilterableSubject,
+} from "./subject-filter.js";
 
 export const VIEWS_ROOT_KEY = "views";
 export const MODEL_ROOT_KEY = "model";
@@ -49,9 +55,12 @@ export interface ViewTreeRow {
   /**
    * `null` when nothing has measured it: a staged NEW view has no landed
    * document, and resolving its query needs the semantic graph the browser
-   * does not hold. A number here is always the server's measure of what
-   * LANDED — a staged overwrite keeps the landed count, the same staleness
-   * story `VisualViewSummary.subjectCount` already tells.
+   * does not hold — and, while the tree filter narrows, every landed view
+   * but the active one, whose subjects live only in that same graph (#317).
+   * A number is either the server's measure of what LANDED (a staged
+   * overwrite keeps the landed count, the same staleness story
+   * `VisualViewSummary.subjectCount` already tells) or, on the active row,
+   * a count of the drawn subjects that survive the typed filter.
    */
   readonly subjectCount: number | null;
   readonly active: boolean;
@@ -102,8 +111,13 @@ export interface ModelTreeGroup {
   readonly subjects: readonly ModelSubjectRow[];
 }
 
-const normalize = (text: string): string => text.trim().toLowerCase();
-
+/**
+ * Whether a LABEL — a view title, a folder name, a group heading — survives
+ * the typed text. Subjects go through `subjectMatchesQuickFilter` instead,
+ * the very predicate the canvas quick filter applies (#317), so the two
+ * boxes cannot disagree about a subject; labels are a rail-only concept the
+ * canvas has no counterpart for, matched here with the same normalization.
+ */
 const matches = (haystack: string, needle: string): boolean =>
   needle === "" || haystack.toLowerCase().includes(needle);
 
@@ -116,7 +130,7 @@ const matches = (haystack: string, needle: string): boolean =>
  * leaves a view row standing above the line saying nothing matched.
  */
 export const matchesFilter = (label: string, filterText: string): boolean =>
-  matches(label, normalize(filterText));
+  matches(label, normalizeFilterText(filterText));
 
 /**
  * The folder a view files itself under, or `""` for none.
@@ -150,12 +164,16 @@ export interface ViewTreeInput {
   readonly stagedOperations: readonly VisualViewOperation[];
   readonly activeViewId: string;
   /**
-   * How many subjects the active view is drawing right now, from the standing
-   * filter's match set. The server's `subjectCount` was true when the frame
-   * carrying it was sent; this one is true of the canvas beside it, which is
-   * the number the reviewer can check by looking.
+   * The subjects the active view is drawing right now, from the standing
+   * filter's match set, or `null` when nothing is filtering the canvas. The
+   * subjects themselves rather than their count (#317): the active row's
+   * number is how many of them survive the typed filter, which a
+   * pre-computed count could not answer. Unfiltered it is their plain
+   * length — the number the reviewer can check by looking, where the
+   * server's `subjectCount` was only true when the frame carrying it was
+   * sent.
    */
-  readonly activeSubjectCount: number | null;
+  readonly activeSubjects: readonly FilterableSubject[] | null;
   readonly filterText: string;
 }
 
@@ -163,10 +181,21 @@ export const buildViewTree = ({
   views,
   stagedOperations,
   activeViewId,
-  activeSubjectCount,
+  activeSubjects,
   filterText,
 }: ViewTreeInput): ViewTree => {
-  const needle = normalize(filterText);
+  const needle = normalizeFilterText(filterText);
+  // While the filter narrows, a shown count has to count SURVIVORS (#317):
+  // the active view's drawn subjects are here to count, and every other
+  // landed view's subjects live only in the server's semantic graph, so its
+  // row shows no number rather than a full count the narrowing has made
+  // wrong — the same honesty as the staged new row's null. With no filter
+  // text every drawn subject survives, and every count is what it was.
+  const filtering = needle !== "";
+  const activeCount =
+    activeSubjects === null
+      ? null
+      : countMatchingSubjects(activeSubjects, filterText);
   const rowsByFolder = new Map<string, ViewTreeRow[]>();
 
   const place = (folder: string, row: ViewTreeRow): void => {
@@ -215,9 +244,11 @@ export const buildViewTree = ({
       title,
       path: view.path,
       subjectCount:
-        active && activeSubjectCount !== null
-          ? activeSubjectCount
-          : view.subjectCount,
+        active && activeCount !== null
+          ? activeCount
+          : filtering
+            ? null
+            : view.subjectCount,
       active,
       staged,
     });
@@ -280,7 +311,7 @@ export const buildModelTree = ({
   inViewIds,
   filterText,
 }: ModelTreeInput): readonly ModelTreeGroup[] => {
-  const needle = normalize(filterText);
+  const needle = normalizeFilterText(filterText);
   const byFolder = new Map<string, ModelSubjectRow[]>();
   const byLayer = new Map<string, ModelSubjectRow[]>();
 
@@ -292,11 +323,16 @@ export const buildModelTree = ({
     // every model today - is grouped exactly as it was.
     const folder = node.folder;
     const group = folder ?? layer ?? UNLAYERED;
-    // Kind is searchable because it is how an architect names a set of
-    // subjects — "every applicationComponent" — and the row already shows it.
+    // A subject survives by the canvas quick filter's own predicate — id,
+    // name, kind label — imported, never restated, so the two boxes cannot
+    // drift (#317; the rail used to omit `id`, and id-shaped input emptied
+    // the tree while the canvas kept drawing, #307). Kind is in the
+    // predicate because it is how an architect names a set of subjects —
+    // "every applicationComponent" — and the row already shows it. The
+    // group label is the rail's own extra: a folder or layer that matches
+    // shows everything it holds.
     if (
-      !matches(node.name, needle) &&
-      !matches(node.kindLabel, needle) &&
+      !subjectMatchesQuickFilter(needle, node.id, node.name, node.kindLabel) &&
       !matches(group, needle)
     ) {
       continue;

--- a/src/visual-app/view-tree.tsx
+++ b/src/visual-app/view-tree.tsx
@@ -13,6 +13,7 @@ import {
   type ModelTreeGroup,
   type ViewTreeRow,
 } from "./view-tree-model.js";
+import { countMatchingSubjects } from "./subject-filter.js";
 
 /**
  * The rail: the saved views and the whole model, as one tree.
@@ -219,10 +220,12 @@ export function ViewTree({
     // Nodes drawn, not entries in the match set: a match set holds the
     // relationships a view matched as well as its concepts, and the number
     // beside a view has to be the one the reviewer can count on the canvas.
-    activeSubjectCount:
+    // The subjects themselves rather than their count, so the tree can say
+    // how many survive the typed filter (#317).
+    activeSubjects:
       inViewIds === null
         ? null
-        : nodes.filter((node) => inViewIds.has(node.id)).length,
+        : nodes.filter((node) => inViewIds.has(node.id)),
     filterText,
   });
   const model: readonly ModelTreeGroup[] = buildModelTree({
@@ -296,7 +299,11 @@ export function ViewTree({
                 >
                   <ViewGlyph />
                   <span className="tree-label">{ALL_SUBJECTS_LABEL}</span>
-                  <span className="tree-count">{nodes.length}</span>
+                  {/* Survivors of the typed filter, which with no text is
+                      every subject the model declares (#317). */}
+                  <span className="tree-count">
+                    {countMatchingSubjects(nodes, filterText)}
+                  </span>
                 </button>
               </li>
             )}

--- a/test/visual-view-tree.test.ts
+++ b/test/visual-view-tree.test.ts
@@ -10,6 +10,11 @@ import {
   folderOf,
   matchesFilter,
 } from "../src/visual-app/view-tree-model.js";
+import {
+  countMatchingSubjects,
+  normalizeFilterText,
+  subjectMatchesQuickFilter,
+} from "../src/visual-app/subject-filter.js";
 
 const view = (overrides: Partial<VisualViewSummary> = {}): VisualViewSummary => ({
   id: "current-engine",
@@ -56,7 +61,7 @@ describe("view folders, which the author declares", () => {
       views,
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
     expect(tree.folders).toEqual([]);
@@ -73,7 +78,7 @@ describe("view folders, which the author declares", () => {
       views,
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
     expect(tree.folders.map((folder) => folder.name)).toEqual([
@@ -100,7 +105,7 @@ describe("view folders, which the author declares", () => {
       views: [view({ path: "deeply/nested/only.yaml" })],
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
     expect(tree.folders).toEqual([]);
@@ -118,8 +123,11 @@ describe("view rows", () => {
       stagedOperations: [],
       activeViewId: "a",
       // A commit landed and this view now draws six, whatever the frame that
-      // carried its summary said.
-      activeSubjectCount: 6,
+      // carried its summary said. The tree gets the drawn subjects, and with
+      // no filter text the count is their plain length.
+      activeSubjects: Array.from({ length: 6 }, (_, index) =>
+        node({ id: `drawn.${index}`, name: `Drawn ${index}` }),
+      ),
       filterText: "",
     });
     expect(tree.loose[0]).toMatchObject({ id: "a", active: true, subjectCount: 6 });
@@ -136,7 +144,7 @@ describe("view rows", () => {
       views,
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "the",
     });
     expect(byTitle.matched).toBe(2);
@@ -145,7 +153,7 @@ describe("view rows", () => {
       views,
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "target",
     });
     expect(byFolder.matched).toBe(2);
@@ -362,7 +370,7 @@ describe("staged view operations, merged over the landed views", () => {
         writeOp("roadmap-first", { title: "Roadmap first", folder: "Roadmap" }),
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
@@ -394,7 +402,7 @@ describe("staged view operations, merged over the landed views", () => {
         }),
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
@@ -419,7 +427,7 @@ describe("staged view operations, merged over the landed views", () => {
         { op: "delete-view", path: ".yarramate/projections/current-engine.yaml" },
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
@@ -439,14 +447,14 @@ describe("staged view operations, merged over the landed views", () => {
       views,
       stagedOperations: [writeOp("brand-new", { folder: "Roadmap" })],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
     const discarded = buildViewTree({
       views,
       stagedOperations: [],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
@@ -466,7 +474,7 @@ describe("staged view operations, merged over the landed views", () => {
         writeOp("target-next", { title: "Target next", folder: "Target" }),
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
     };
 
     // The staged folder is searchable the way a landed one is: typing it is
@@ -488,7 +496,7 @@ describe("staged view operations, merged over the landed views", () => {
         }),
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
     };
 
     // The row SHOWS the staged title, so the filter has to match it — a row
@@ -508,7 +516,11 @@ describe("staged view operations, merged over the landed views", () => {
         }),
       ],
       activeViewId: "current-engine",
-      activeSubjectCount: 3,
+      activeSubjects: [
+        node({ id: "a.one", name: "One" }),
+        node({ id: "a.two", name: "Two" }),
+        node({ id: "a.three", name: "Three" }),
+      ],
       filterText: "",
     });
 
@@ -524,7 +536,7 @@ describe("staged view operations, merged over the landed views", () => {
       views: [],
       stagedOperations: [{ op: "delete-view", path: "never-landed.yaml" }],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
@@ -542,11 +554,242 @@ describe("staged view operations, merged over the landed views", () => {
         writeOp("draft", { title: "Second thoughts", path: "draft.yaml" }),
       ],
       activeViewId: "",
-      activeSubjectCount: null,
+      activeSubjects: null,
       filterText: "",
     });
 
     expect(tree.matched).toBe(1);
     expect(tree.loose[0]?.title).toBe("Second thoughts");
+  });
+});
+
+/**
+ * The shared subject predicate (#317). #307 extracted it inside
+ * `graph-canvas.tsx` so the canvas pass and the shell's empty-state honesty
+ * could not drift; it now lives in `subject-filter.ts` so the rail's tree
+ * filter imports the same judgement — one predicate, three surfaces.
+ */
+describe("the shared subject predicate, which both filter boxes import", () => {
+  it("matches id, name, and kind label, case-insensitively", () => {
+    // The #307 field report: `CEP` and `cep` must both find
+    // `cep-salesforce` ("CEP (Salesforce)") — by id as well as by name.
+    expect(
+      subjectMatchesQuickFilter(
+        "cep",
+        "cep-salesforce",
+        "CEP (Salesforce)",
+        "applicationComponent",
+      ),
+    ).toBe(true);
+    expect(
+      subjectMatchesQuickFilter(
+        normalizeFilterText("  CEP "),
+        "cep-salesforce",
+        "CEP (Salesforce)",
+        "applicationComponent",
+      ),
+    ).toBe(true);
+    expect(
+      subjectMatchesQuickFilter(
+        "businessprocess",
+        "biz.pay",
+        "Pay a supplier",
+        "businessProcess",
+      ),
+    ).toBe(true);
+    expect(
+      subjectMatchesQuickFilter(
+        "ledger",
+        "cep-salesforce",
+        "CEP (Salesforce)",
+        "applicationComponent",
+      ),
+    ).toBe(false);
+  });
+
+  it("lets every subject through when the text is empty", () => {
+    expect(subjectMatchesQuickFilter("", "anything", undefined, undefined)).toBe(
+      true,
+    );
+  });
+
+  it("tolerates untyped cytoscape data without matching it", () => {
+    // The canvas reads name/kindLabel out of cytoscape data, which types
+    // nothing: a non-string is simply not a match, never a throw.
+    expect(subjectMatchesQuickFilter("x", "id", 42, null)).toBe(false);
+  });
+
+  it("counts survivors, and counts everything when nothing narrows", () => {
+    const subjects = [
+      node({ id: "cep-salesforce", name: "CEP (Salesforce)" }),
+      node({ id: "app.ledger", name: "Ledger" }),
+    ];
+    expect(countMatchingSubjects(subjects, "")).toBe(2);
+    expect(countMatchingSubjects(subjects, "  CEP ")).toBe(1);
+    expect(countMatchingSubjects(subjects, "nothing-says-this")).toBe(0);
+  });
+});
+
+/**
+ * Rail parity (#317): the rail keeps a subject by the very predicate the
+ * canvas quick filter applies, plus the rail's own group labels. #307's
+ * repro was id-shaped input — the rail matched only name/kind/group, so
+ * `cep` emptied the tree while the canvas kept drawing `cep-salesforce`.
+ */
+describe("the rail filter, which judges subjects the way the canvas does", () => {
+  const nodes = [
+    node({
+      id: "cep-salesforce",
+      name: "CEP (Salesforce)",
+      layer: "application",
+    }),
+    node({ id: "app.ledger", name: "Ledger", layer: "application" }),
+  ];
+
+  it("finds a subject by id, which the rail used to omit", () => {
+    const groups = buildModelTree({
+      nodes,
+      inViewIds: null,
+      filterText: "cep-sales",
+    });
+    expect(groups.flatMap((group) => group.subjects.map((s) => s.id))).toEqual([
+      "cep-salesforce",
+    ]);
+  });
+
+  it("keeps exactly the subjects the shared predicate keeps, group hits aside", () => {
+    // The no-drift sweep: for text naming no group, the rail's survivors are
+    // the predicate's survivors, verbatim.
+    for (const text of ["", "cep", "CEP", "ledger", "app.", "no-such-thing"]) {
+      const survivors = buildModelTree({ nodes, inViewIds: null, filterText: text })
+        .flatMap((group) => group.subjects.map((s) => s.id))
+        .sort();
+      const needle = normalizeFilterText(text);
+      const expected = nodes
+        .filter((n) => subjectMatchesQuickFilter(needle, n.id, n.name, n.kindLabel))
+        .map((n) => n.id)
+        .sort();
+      expect(survivors).toEqual(expected);
+    }
+  });
+
+  it("still shows a whole group the reviewer named", () => {
+    // The rail's own extra stands: a folder (or layer) that matches shows
+    // everything it holds, which the canvas has no counterpart for. The
+    // subject itself says "payments" nowhere, so only the group hit keeps it.
+    const groups = buildModelTree({
+      nodes: [
+        ...nodes,
+        node({
+          id: "app.gateway",
+          name: "Gateway",
+          layer: "application",
+          folder: "Payments",
+        }),
+      ],
+      inViewIds: null,
+      filterText: "payments",
+    });
+    expect(groups.flatMap((group) => group.subjects.map((s) => s.id))).toEqual([
+      "app.gateway",
+    ]);
+  });
+});
+
+/**
+ * Counts under the filter (#317): while the tree filter narrows, a number
+ * beside a view row counts SURVIVORS. The active view's drawn subjects are
+ * in the browser to count; every other landed view's subjects live only in
+ * the server's semantic graph, so those rows show no number rather than a
+ * full count the narrowing has made wrong — the same honesty as the staged
+ * new row's null. Clearing the text restores every count untouched.
+ */
+describe("view-row counts while the filter narrows", () => {
+  const drawn = [
+    node({ id: "cep-salesforce", name: "CEP (Salesforce)" }),
+    node({ id: "app.ledger", name: "Ledger" }),
+    node({ id: "app.checkout", name: "Checkout" }),
+  ];
+  const views = [
+    view({ id: "cep-map", title: "CEP landscape", subjectCount: 54 }),
+    view({
+      id: "cep-target",
+      title: "CEP target",
+      subjectCount: 9,
+      path: ".yarramate/projections/cep-target.yaml",
+    }),
+  ];
+
+  it("counts the active view's surviving subjects, not what it draws unfiltered", () => {
+    const tree = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "cep-map",
+      activeSubjects: drawn,
+      filterText: "cep",
+    });
+    // Three drawn, one survives `cep` — by id, the field the rail used to
+    // omit (#307).
+    expect(tree.loose[0]).toMatchObject({
+      id: "cep-map",
+      active: true,
+      subjectCount: 1,
+    });
+  });
+
+  it("says zero when the text matched the title but no drawn subject", () => {
+    const tree = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "cep-map",
+      activeSubjects: drawn,
+      filterText: "landscape",
+    });
+    // An honest zero, not the full count: nothing on the canvas says
+    // "landscape".
+    expect(tree.loose[0]?.subjectCount).toBe(0);
+  });
+
+  it("withholds the count of a view whose subjects the browser cannot see", () => {
+    const tree = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "cep-map",
+      activeSubjects: drawn,
+      filterText: "cep",
+    });
+    // The non-active row still shows (its title matches) but carries no
+    // number: its 9 subjects live in the semantic graph, and how many of
+    // them say `cep` is not knowable here.
+    expect(tree.loose[1]).toMatchObject({
+      id: "cep-target",
+      active: false,
+      subjectCount: null,
+    });
+  });
+
+  it("restores every count, untouched, when the text clears", () => {
+    const tree = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "cep-map",
+      activeSubjects: drawn,
+      filterText: "",
+    });
+    expect(tree.loose.map((row) => row.subjectCount)).toEqual([3, 9]);
+  });
+
+  it("withholds even the active count when nothing says what is drawn", () => {
+    // Active view, no standing match set to read subjects from: under a
+    // narrowing filter the landed count would be the wrong number, so the
+    // row shows none.
+    const tree = buildViewTree({
+      views,
+      stagedOperations: [],
+      activeViewId: "cep-map",
+      activeSubjects: null,
+      filterText: "cep",
+    });
+    expect(tree.loose[0]?.subjectCount).toBe(null);
   });
 });


### PR DESCRIPTION
## The deferred pair (#317)

Both asks #307 deferred out of #316, now that `view-tree-model.ts` is free to change.

## Predicate parity: one judgement, imported, never restated

The rail's tree filter restated the canvas predicate by hand, with `id` missing, so id-shaped input (`cep` for `cep-salesforce`) emptied the tree while the canvas kept drawing. The predicate #316 extracted, `subjectMatchesQuickFilter`, now lives in a new small pure module, `src/visual-app/subject-filter.ts`, and both surfaces import it from there.

Lifted rather than imported from the canvas, deliberately: `view-tree-model.ts` keeps a zero-dependency discipline (no React, no cytoscape), it is type-checked under the main `tsconfig` through its test, and merely loading `graph-canvas.tsx` registers cytoscape-elk at module scope. `graph-canvas.tsx` changes only by re-pointing its predicate import; `applyFilter` and `filteredSubjectCount` route through the shared module unchanged.

The rail keeps its one extra, unchanged: a folder or layer label that matches still shows everything it holds, which the canvas has no counterpart for. Its normalization (`trim().toLowerCase()`) is also shared (`normalizeFilterText`), so the two boxes cannot even trim differently.

## Counts under the filter: survivors, honestly

While the tree filter narrows:

- the **active view's row** counts the drawn subjects that survive the text, an honest zero included. `buildViewTree` now takes the drawn subjects themselves (`activeSubjects`) instead of the pre-computed `activeSubjectCount`, because a count cannot answer how many of itself survive; unfiltered, its plain length is exactly the number the row showed before.
- the **All subjects row** counts the survivors across the model (`countMatchingSubjects`).
- a **landed, non-active view's row shows no number at all**: its subjects live only in the server's semantic graph, so how many survive is not knowable in the browser, and the full count would be the one number the narrowing has made wrong. This is the same honesty the tree already applies to a staged new view's unmeasured count, and it is the judgment call in this PR: withheld beats wrong, and nothing here invents protocol traffic to ask the server per view.
- **group rows** already list only survivors, so their counts (and the folders' collapsed counts, wherever shown) follow by construction.

With no filter text, every count is exactly what it was.

## Tests

`test/visual-view-tree.test.ts`, extended (the shared module is pure `.ts`, so no tsconfig routing changes): the predicate's own describe (the `CEP`/`cep` field-report match by id, case-insensitivity, empty text, untyped cytoscape data, survivor counting); rail parity (find-by-id, a no-drift sweep asserting the rail keeps exactly what the shared predicate keeps for non-group text, and the group-hit extra proven with a folder the subject itself never names); and the count semantics (active survivors, honest zero, withheld non-active count, withheld active count with no match set, and full restoration on clear). Existing suites covering the canvas side run against the lifted predicate unchanged.

`pnpm verify`: real exit 0 (captured from `$?`), 96 files, 1720 passed, 1 skipped.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)