### PR TITLE
feat: the viewer accepts the host's marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **Added.** The mounted viewer accepts the host's per-subject marks
+  (#314, ADR 0119). `mountEditor` gains
+  `decorations: Record<subjectId, 'added' | 'removed' | 'changed'>`
+  (concepts and relationships alike) and the returned handle gains
+  `setDecorations(decorations)` on the #297 pointer bridge, so a live
+  comparison replaces the map wholesale — never a merge, `{}` clears.
+  Comparison SEMANTICS stay host-side by design: the viewer renders
+  marks and never diffs, which is what lets a host with its own
+  comparison model (ApertureX's published-snapshot diffs) delete its
+  parallel renderer and use the one viewer for authoring, read-only
+  viewing (#298) and decorated comparison. Rendering is the faults
+  mechanism — `deco-*` classes, stylesheet rules — with added in the
+  eucalyptus token, removed in the quiet ink-grey with a dash, changed
+  in the ochre, and never the failure red, which faults own. Unknown
+  ids are silently inert; decorating is reading, so `setDecorations`
+  works under `readOnly` and before the first model frame. Precedence
+  is declared once: a fault outranks a decoration outranks selection —
+  and ordering the fault rule last makes the failure red real on
+  faulted edges, whose line colour the base edge rule had silently won
+  back (cytoscape resolves style by declaration order alone). The
+  vocabulary is closed at three and the viewer draws no legend — the
+  host owns what a mark means — both recorded as excluded options in
+  the ADR, alongside a session-server equivalent as follow-up.
+
 - **Fixed.** The rail's filter judges a subject the way the canvas
   quick filter does, and its counts say what survives (#317,
   completing the two asks #307 deferred out of #316). Parity: the

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -324,6 +324,20 @@ programmatic twins of tap, palette and Connect, never a second write path:
 anything they lead to still stages through the changeset and commits through
 the same validated batch.
 
+The viewer also accepts per-subject marks
+([ADR 0119](adr/0119-the-viewer-accepts-the-hosts-marks.md)): pass
+`decorations: { [subjectId]: 'added' | 'removed' | 'changed' }` — concepts and
+relationships alike — and the canvas renders them as visual treatments (added
+an eucalyptus border, removed a quiet dashed one, changed ochre; a fault still
+outranks any mark). Comparison semantics stay on your side of the seam: the
+viewer never diffs, it draws the map it is handed, so what a mark means — and
+any legend saying so — is yours. The option is the initial map; the handle's
+`setDecorations(decorations)` replaces it wholesale (never a merge, `{}`
+clears) for a live comparison, works under `readOnly` and before the first
+model frame, and ids the model does not name are silently inert. It shares the
+pointer methods' one false window: before the shell's first render, or after
+unmount.
+
 `store` is the caller's synchronous `SourceStore`; `workspace` is the caller's
 pre-resolved `ResolvedWorkspace`. The local host compiles, projects, filters,
 commits and saves layouts over that store. A changeset's model and view writes

--- a/docs/adr/0119-the-viewer-accepts-the-hosts-marks.md
+++ b/docs/adr/0119-the-viewer-accepts-the-hosts-marks.md
@@ -1,0 +1,99 @@
+# The viewer accepts the host's marks
+
+Status: accepted
+
+ApertureX asked it on #298 and #314 committed to it: their product keeps
+its own comparison model — published-snapshot diffs, register overlays —
+and, for want of a way to show a comparison on the mounted editor, holds
+a parallel cytoscape renderer beside it. A parallel renderer is exactly
+the drift the mountable editor exists to end
+([ADR 0117](0117-a-mounted-editor-can-refuse-the-pen.md) closed the
+read-only half of it), but the remaining half needed a seam: the viewer
+showing a difference it did not compute. The precedents were already
+shipped — faults mark subjects by class over ids someone else named
+(ADR 0102), and the interrogation overlay rides beside the model with
+absence meaning nothing drawn
+([ADR 0111](0111-the-canvas-carries-the-interviews-nudges.md)).
+
+## Decision
+
+The mounted editor accepts **host-supplied per-subject decorations** and
+renders them; it never diffs. `MountOptions` gains
+`decorations?: Readonly<Record<string, 'added' | 'removed' | 'changed'>>`
+— subject id to mark, concepts and relationships alike, the way the
+faults lane already marks both node and edge by id — and the
+`MountedEditor` handle gains `setDecorations(decorations)`, riding the
+same `onReady` pointer bridge as the #297 methods
+([ADR 0118](0118-the-host-can-point-at-the-canvas.md)). The option is
+the initial map; a live comparison hands new maps through the handle.
+
+- **The boundary is marks, not semantics.** What `added` is relative to
+  — another snapshot, a register, a proposal — is the host's knowledge
+  and stays on the host's side of the seam. The viewer renders the map
+  it is handed and computes nothing, which is what lets one viewer serve
+  authoring, read-only viewing (#298) and decorated comparison without
+  learning what comparison is.
+- **Replace, not merge.** The map is the unit of exchange: every
+  `setDecorations` replaces the previous marks wholesale, and `{}`
+  clears them. A merge would make the current picture the sum of every
+  map ever handed over, which no one — host or viewer — could state.
+- **Unknown ids are silently inert.** The host may be describing
+  subjects this model has not gained yet, or has already lost; a mark
+  with nothing to land on marks nothing and raises nothing. Absent means
+  nothing drawn, the overlay discipline of ADR 0111.
+- **Rendering is the faults mechanism.** `deco-added` / `deco-removed`
+  / `deco-changed` classes toggled by an effect keyed on the map and the
+  graph, styled by stylesheet rules: added wears the eucalyptus token as
+  a border, removed the quiet ink-grey with a dash — an outline of an
+  absence, deliberately nothing like a defect — and changed the ochre.
+  Never the failure red: faults own it, and a comparison mark that
+  borrowed it would report a difference as a refusal.
+- **Precedence: a fault outranks a decoration outranks selection.**
+  Cytoscape resolves its stylesheet by declaration order alone — no
+  CSS-style specificity — so the precedence is made by order and stated
+  here once: the marking rules land after the base and notation rules,
+  the fault rule after the marking rules. The reviewer can move the
+  selection, the host can hand a decoration, and a subject a diagnostic
+  named reads as refused through both. Ordering the fault rule last
+  also lands it after the base `edge` rule for the first time, which
+  makes the failure red real on faulted *edges* — previously the base
+  rule, declared later, silently won their line colour back.
+- **`setDecorations` needs no model and no pen.** Unlike its pointer
+  siblings there is no graph gate — the marks are client state, drawn
+  the moment a model is on screen, so a host may hand them before the
+  first frame — and no read-only gate, because decorating is reading:
+  the primary consumer decorates frozen snapshots under `readOnly`.
+  False is only the shared not-there window: before the shell's first
+  render, or after unmount.
+
+## Excluded options
+
+- **A custom-class escape hatch** (`decorations: { id: 'my-class' }`):
+  the three-mark vocabulary is closed in v1. An open class vocabulary is
+  an unversioned styling API onto this canvas's internals; a fourth mark
+  joins the enum when demand names it, styled once here for everyone.
+- **Legend or affordance chrome in the viewer**: the viewer cannot say
+  what `changed` is relative to, so any legend it drew would be a guess
+  at the host's semantics. The host owns meaning and draws its own
+  legend beside the mount.
+- **Comparison semantics in the viewer** (hand it two models, let it
+  diff): the seam exists precisely because comparison models differ per
+  host; one shipped diff would be wrong for every host but its author.
+- **A session-server equivalent**: recorded as follow-up, not built. The
+  wire protocol, the adapters and `yarramate-visual` are untouched;
+  threading a decorations frame through the session host is its own
+  decision for whenever a session consumer asks, the way ADR 0117
+  deferred server-session read-only.
+
+## Consequences
+
+`MountOptions` grows one optional field, `mountEditorWith` one trailing
+parameter, `MountedEditor` and the pointer one method, `App` one
+optional prop — every existing embedder stands unchanged, and the
+session shell passes nothing. ApertureX can delete the parallel renderer
+this gated: working mode mounts the author, published views mount
+`readOnly` with `decorations`, and a live diff view replaces the map as
+its comparison moves. The vocabulary is deliberately small and shared
+with the LikeC4 exporter's compare instinct (`--changed`'s
+new/changed/context), so the two comparison surfaces stay conceptually
+one even though neither reads the other.

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1,4 +1,8 @@
-import { filteredSubjectCount, GraphCanvas } from "./graph-canvas.js";
+import {
+  filteredSubjectCount,
+  GraphCanvas,
+  type DecorationMap,
+} from "./graph-canvas.js";
 import type { PresentationFlag } from "./query-fields.js";
 import { QueryPanel, type BottomPanelTabId } from "./query-panel.js";
 import { QuickFilterBox } from "./quick-filter.js";
@@ -235,6 +239,7 @@ const DiagramWorkspace = ({
   showOwnership,
   showNudges,
   openQuestionCounts,
+  decorations,
   connection,
   onConnectTarget,
   onConnectCancel,
@@ -272,6 +277,8 @@ const DiagramWorkspace = ({
   readonly showOwnership: boolean;
   readonly showNudges: boolean;
   readonly openQuestionCounts: ReadonlyMap<string, number>;
+  /** The host's per-subject marks (#314, ADR 0119), for the canvas. */
+  readonly decorations: DecorationMap;
   readonly connection: ConnectionDraft | null;
   readonly onConnectTarget: (id: string) => void;
   readonly onConnectCancel: () => void;
@@ -499,6 +506,7 @@ const DiagramWorkspace = ({
             quickFilterText={state.quickFilterText}
             nesting={nesting}
             faultedIds={faultedSubjects(state.commitDiagnostics ?? [])}
+            decorations={decorations}
             showLifecycle={showLifecycle}
             showEvidence={showEvidence}
             showOwnership={showOwnership}
@@ -998,11 +1006,20 @@ export const App = ({
   host,
   sections = RIGHT_SECTIONS,
   readOnly = false,
+  decorations: initialDecorations,
   onReady,
 }: {
   readonly host: EditorHost;
   readonly sections?: readonly RightSectionId[];
   readonly readOnly?: boolean;
+  /**
+   * The host's per-subject marks at mount time (#314, ADR 0119) - the
+   * initial value only, the way React means an initial value: later
+   * hand-overs travel through the pointer's `setDecorations`, each one
+   * replacing the map wholesale. Client state like selection, so it rides a
+   * prop rather than the `EditorHost` seam.
+   */
+  readonly decorations?: DecorationMap;
   /**
    * How the mount layer's handle reaches this shell's reducer (#297,
    * ADR 0118). Called once, after the first render, with the pointer the
@@ -1063,6 +1080,13 @@ export const App = ({
   // workspace - the reducer keeps only that the draft is open. A plain opener
   // clears it, so "Add subject" still starts with no kind chosen (ADR 0116).
   const [draftKind, setDraftKind] = useState<string | undefined>(undefined);
+  // The host's marks (#314, ADR 0119). Shell state seeded from the mount
+  // option and thereafter owned by the pointer's `setDecorations`, which
+  // replaces the whole map: rendering is the canvas's job, the comparison
+  // that produced the marks stays on the host's side of the seam.
+  const [decorations, setDecorations] = useState<DecorationMap>(
+    initialDecorations ?? {},
+  );
   // A way to photograph the canvas, handed up by `GraphCanvas` while one
   // exists. A ref rather than state: nothing renders differently because of
   // it, and a menu item reads it at the moment it is chosen.
@@ -1085,6 +1109,7 @@ export const App = ({
         () => pointerContext.current,
         dispatchWorkspace,
         setDraftKind,
+        setDecorations,
       ),
     );
   }, [onReady]);
@@ -1531,6 +1556,7 @@ export const App = ({
           waiting={waiting}
           layout={workspace.layout}
           nesting={workspace.nesting}
+          decorations={decorations}
           connection={workspace.connection}
           onConnectTarget={(id) =>
             dispatchWorkspace({ type: "connection.targeted", to: id })

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -336,6 +336,65 @@ function badgeLayersFor(
 // future toggle effect (Task 7 wires the checkboxes to `GraphCanvasProps`)
 // both call this with whatever is current instead of racing a shared mutable
 // stylesheet.
+/**
+ * The closed mark vocabulary a host may hand the mounted viewer (#314,
+ * ADR 0119). Three marks, because three is what comparison against another
+ * model needs and a fourth waits for the demand that names it. What a mark
+ * MEANS - added relative to what, changed since when - lives entirely on the
+ * host's side of the seam: this canvas renders marks, it never diffs.
+ */
+export type DecorationMark = 'added' | 'removed' | 'changed'
+
+/**
+ * Subject id (concepts and relationships alike) to mark. The whole map is the
+ * unit of exchange: each hand-over REPLACES the previous marks wholesale,
+ * never merges into them, and an id the current model does not name marks
+ * nothing, silently - the host may be describing subjects this model has not
+ * gained (or has already lost).
+ */
+export type DecorationMap = Readonly<Record<string, DecorationMark>>
+
+const DECORATION_MARKS: readonly DecorationMark[] = [
+  'added',
+  'removed',
+  'changed',
+]
+
+const decorationClass = (mark: DecorationMark): string => `deco-${mark}`
+
+const ALL_DECORATION_CLASSES = DECORATION_MARKS.map(decorationClass).join(' ')
+
+// The decoration lane's colours (#314, ADR 0119), restated from styles.css as
+// hex because cytoscape styles are not CSS and cannot read tokens - the same
+// restatement the fault rule makes of the failure red. Never that red: faults
+// own it (ADR 0102), and a comparison mark that borrowed it would report a
+// difference as a defect.
+const DECORATION_COLORS: Readonly<Record<DecorationMark, string>> = {
+  /** `--eucalyptus`: present in this model, not in the host's other one. */
+  added: '#416F65',
+  /** `--quiet` (its oklab color-mix resolved): an outline of an absence. */
+  removed: '#677074',
+  /** `--ochre`: the same subject, not the same content. */
+  changed: '#8C4D18',
+}
+
+/**
+ * Marks every subject the host's decoration map names, the exact class
+ * mechanism faults use: previous `deco-*` classes come off every element
+ * first (replacement is wholesale, the map is the unit), then each id that
+ * names a drawn node or edge gains its mark's class. Unknown ids are
+ * silently inert. The `faulted` class is never touched here, and the
+ * stylesheet orders the fault rule after the decoration rules, so a subject
+ * both decorated and refused reads as refused.
+ */
+export function applyDecorations(cy: Core, decorations: DecorationMap): void {
+  cy.elements().removeClass(ALL_DECORATION_CLASSES)
+  for (const [id, mark] of Object.entries(decorations)) {
+    const element = cy.getElementById(id)
+    if (element.nonempty()) element.addClass(decorationClass(mark))
+  }
+}
+
 export function buildStylesheet(
   showLifecycle: boolean,
   showEvidence: boolean,
@@ -457,19 +516,6 @@ export function buildStylesheet(
       },
     },
     {
-      // A subject a diagnostic named. Declared after selection so a selected
-      // element that is also refused still reads as refused: the reviewer can
-      // move the selection, and the fault is the thing that has to stay
-      // visible (ADR 0102).
-      selector: 'node.faulted, edge.faulted',
-      style: {
-        'border-color': '#A3403A',
-        'border-width': 4,
-        'line-color': '#A3403A',
-        'target-arrow-color': '#A3403A',
-      },
-    },
-    {
       selector: 'edge',
       style: {
         'line-color': '#999999',
@@ -571,7 +617,75 @@ export function buildStylesheet(
     },
   )
 
-  return [...baseStylesheet, ...archimateNodeShapes, ...archimateEdgeStyles]
+  // The marking lanes, last on purpose. Cytoscape resolves its stylesheet by
+  // order alone - no CSS-style specificity, later rules win per property - so
+  // a mark's colour only holds if its rule lands after the base `node`/`edge`
+  // rules AND after the notation's per-kind edge treatments above. Precedence
+  // within the lanes, made by declaration order and stated once (ADR 0119):
+  // a fault outranks a decoration outranks selection - the reviewer can move
+  // the selection, and a mark is the thing that has to stay visible, with a
+  // refusal the loudest fact of all.
+  const markStylesheet: cytoscape.StylesheetJsonBlock[] = [
+    {
+      // The host's marks (#314, ADR 0119): a comparison the HOST computed,
+      // rendered here and never derived here. Cytoscape styles are not CSS,
+      // so the styles.css tokens are restated as hex the way the failure red
+      // is below. Added wears the eucalyptus token: present here, not there.
+      selector: 'node.deco-added, edge.deco-added',
+      style: {
+        'border-color': DECORATION_COLORS.added,
+        'border-width': 3,
+        'line-color': DECORATION_COLORS.added,
+        'target-arrow-color': DECORATION_COLORS.added,
+      },
+    },
+    {
+      // Removed is the quiet ink-grey with a dash: an outline of what is not
+      // in this model, deliberately nothing like the failure red - absence in
+      // a comparison is a fact, not a defect. The dash overrides the
+      // notation's per-kind line style for exactly this mark and no other.
+      selector: 'node.deco-removed, edge.deco-removed',
+      style: {
+        'border-color': DECORATION_COLORS.removed,
+        'border-width': 3,
+        'border-style': 'dashed',
+        'line-color': DECORATION_COLORS.removed,
+        'target-arrow-color': DECORATION_COLORS.removed,
+        'line-style': 'dashed',
+      },
+    },
+    {
+      // Changed wears the ochre: the same subject, not the same content.
+      selector: 'node.deco-changed, edge.deco-changed',
+      style: {
+        'border-color': DECORATION_COLORS.changed,
+        'border-width': 3,
+        'line-color': DECORATION_COLORS.changed,
+        'target-arrow-color': DECORATION_COLORS.changed,
+      },
+    },
+    {
+      // A subject a diagnostic named. Declared after every other mark so an
+      // element that is also refused still reads as refused (ADR 0102): the
+      // reviewer can move the selection, the host can hand a decoration, and
+      // the fault outranks both. Landing after the base `edge` rule is what
+      // makes the line colour real for edges - order is the whole cascade.
+      selector: 'node.faulted, edge.faulted',
+      style: {
+        'border-color': '#A3403A',
+        'border-width': 4,
+        'line-color': '#A3403A',
+        'target-arrow-color': '#A3403A',
+      },
+    },
+  ]
+
+  return [
+    ...baseStylesheet,
+    ...archimateNodeShapes,
+    ...archimateEdgeStyles,
+    ...markStylesheet,
+  ]
 }
 
 // Composition expresses exclusive whole-part structure (ADR 0004: a workspace
@@ -1091,6 +1205,13 @@ interface GraphCanvasProps {
   readonly nesting: readonly NestingKind[]
   /** Subjects a diagnostic named, marked so a failure is visible where it is. */
   readonly faultedIds: ReadonlySet<string>
+  /**
+   * The host's per-subject marks (#314, ADR 0119), rendered as `deco-*`
+   * classes the way faults are rendered. The map replaces wholesale on every
+   * change; an empty map draws nothing, an unknown id marks nothing, and a
+   * subject that is also faulted reads as faulted.
+   */
+  readonly decorations: DecorationMap
   readonly showLifecycle: boolean
   readonly showEvidence: boolean
   readonly showOwnership: boolean
@@ -1140,6 +1261,7 @@ export function GraphCanvas({
   quickFilterText,
   nesting,
   faultedIds,
+  decorations,
   activeViewId,
   savedPositions,
   onSaveLayout,
@@ -1424,6 +1546,16 @@ export function GraphCanvas({
       if (element.nonempty()) element.addClass('faulted')
     }
   }, [faultedIds, graph])
+
+  // Render the host's marks (#314, ADR 0119). Its own effect for the same
+  // reason faults get one: a decoration outlives whatever the reviewer has
+  // selected or filtered, and must be re-marked after a graph replacement
+  // wipes every class. `applyDecorations` clears the old marks first, so a
+  // new map - the empty one included - replaces rather than accumulates.
+  useEffect(() => {
+    if (!cyRef.current) return
+    applyDecorations(cyRef.current, decorations)
+  }, [decorations, graph])
 
   // Update selection highlight when selectedId or graph changes
   useEffect(() => {

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App.js'
 import { createLocalHost, type LocalHostOptions } from './local-host.js'
+import type { DecorationMap } from './graph-canvas.js'
 import type { EditorHost } from './editor-host.js'
 import {
   RIGHT_SECTIONS,
@@ -55,6 +56,17 @@ export interface MountOptions extends LocalHostOptions {
    * defenses, and this option is not the one that guards the data.
    */
   readonly readOnly?: boolean
+  /**
+   * The host's per-subject marks at mount time (#314, ADR 0119): subject id -
+   * concept or relationship - to `'added' | 'removed' | 'changed'`, rendered
+   * as class-based visual treatments the way faults are. This is the seam
+   * that lets a host with its own comparison model use the one viewer for
+   * decorated comparison: the SEMANTICS stay host-side - the viewer never
+   * diffs, it renders the marks it is handed. An id the model does not name
+   * is silently inert. This option is the initial map; a live comparison
+   * replaces it wholesale through the handle's `setDecorations`.
+   */
+  readonly decorations?: DecorationMap
 }
 
 /**
@@ -90,6 +102,17 @@ export interface MountedEditor {
    * kinds on offer are derived from the two endpoints.
    */
   readonly startConnection: (fromSubjectId: string) => boolean
+  /**
+   * Replaces the per-subject marks wholesale (#314, ADR 0119) - never a
+   * merge: the map handed here is the map drawn, and `{}` clears every mark.
+   * The one handle method that is not a gesture's twin, because no gesture
+   * decorates: it is the live half of the `decorations` mount option, for a
+   * comparison that moves under an open viewer. Decorating is reading, so it
+   * works under `readOnly`, and unknown ids are silently inert - false is
+   * only the shared not-there window: before the shell's first render, or
+   * after unmount.
+   */
+  readonly setDecorations: (decorations: DecorationMap) => boolean
 }
 
 /**
@@ -110,6 +133,7 @@ export const mountEditor = (
     options.sections ??
       (options.readOnly === true ? READ_SECTIONS : RIGHT_SECTIONS),
     options.readOnly,
+    options.decorations,
   )
 
 /**
@@ -127,6 +151,7 @@ export const mountEditorWith = (
   host: EditorHost,
   sections: readonly RightSectionId[] = RIGHT_SECTIONS,
   readOnly = false,
+  decorations?: DecorationMap,
 ): MountedEditor => {
   // No StrictMode: its double mount would open the host twice, and a host with
   // a socket behind it would open two.
@@ -142,6 +167,7 @@ export const mountEditorWith = (
       host={host}
       sections={sections}
       readOnly={readOnly}
+      decorations={decorations}
       onReady={(pointer) => {
         bridge.current = pointer
       }}
@@ -156,10 +182,13 @@ export const mountEditorWith = (
     openDraft: (options) => bridge.current?.openDraft(options) ?? false,
     startConnection: (fromSubjectId) =>
       bridge.current?.startConnection(fromSubjectId) ?? false,
+    setDecorations: (decorations) =>
+      bridge.current?.setDecorations(decorations) ?? false,
   }
 }
 
 export type { EditorHost, EditorHostEvents } from './editor-host.js'
+export type { DecorationMap, DecorationMark } from './graph-canvas.js'
 export type { LocalHostOptions } from './local-host.js'
 export { createLocalHost } from './local-host.js'
 export { RIGHT_SECTIONS, type RightSectionId } from './workspace-state.js'

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -4,6 +4,7 @@ import type {
   CanvasNode,
 } from "../graph-projection.js";
 import { DEFAULT_NESTING, type NestingKind } from "../nesting.js";
+import type { DecorationMap } from "./graph-canvas.js";
 import type { ContextMenuTarget } from "./context-menu-model.js";
 import type { BottomPanelTabId } from "./query-panel.js";
 
@@ -123,6 +124,15 @@ export interface EditorPointer {
   readonly select: (subjectId: string) => boolean;
   readonly openDraft: (options?: { readonly kind?: string }) => boolean;
   readonly startConnection: (fromSubjectId: string) => boolean;
+  /**
+   * Replaces the host's per-subject marks wholesale (#314, ADR 0119) - the
+   * map is the unit of exchange, never merged into what stood. Unlike its
+   * siblings this one needs no model and no pen: the marks are client state
+   * drawn when the graph (or its successor) is on screen, and decorating is
+   * reading, so a viewer accepts them too. It answers false only where every
+   * method does - a handle before the shell's first render or after disposal.
+   */
+  readonly setDecorations: (decorations: DecorationMap) => boolean;
 }
 
 /**
@@ -135,6 +145,7 @@ export const editorPointerFor = (
   context: () => EditorPointerContext,
   dispatch: (action: VisualWorkspaceAction) => void,
   seedDraftKind: (kind: string | undefined) => void,
+  replaceDecorations: (decorations: DecorationMap) => void,
 ): EditorPointer => ({
   select: (subjectId) => {
     const { graph } = context();
@@ -167,6 +178,16 @@ export const editorPointerFor = (
     // and an edge or an unknown id has no endpoint to draw from.
     if (!graph.nodes.some((node) => node.id === fromSubjectId)) return false;
     dispatch({ type: "connection.started", from: fromSubjectId });
+    return true;
+  },
+  setDecorations: (decorations) => {
+    // No graph gate and no read-only gate, deliberately (#314, ADR 0119):
+    // the marks are held client-side and rendered when a model is on screen,
+    // so handing them before the host's first frame is not "nothing moved" -
+    // the map landed, and the canvas draws it the moment there is one. And
+    // decorating is reading: the primary consumer decorates frozen snapshots
+    // under a read-only mount (#298).
+    replaceDecorations(decorations);
     return true;
   },
 });

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -1,6 +1,7 @@
 import cytoscape from 'cytoscape'
 import { describe, expect, it } from 'vitest'
 import {
+  applyDecorations,
   applyFilter,
   buildStylesheet,
   filteredSubjectCount,
@@ -493,5 +494,125 @@ describe('parallel relationships between the same pair', () => {
     expect(
       drawn.find((element) => element.data.id === 'e1')?.classes,
     ).toBeUndefined()
+  })
+})
+
+/**
+ * The host's marks (#314, ADR 0119): the viewer renders per-subject
+ * decorations it is handed and never computes them - comparison semantics
+ * stay on the host's side of the seam. The mechanism is the faults
+ * mechanism: classes toggled by id, styled by the stylesheet, where a fault
+ * outranks a decoration by declaration order.
+ */
+describe('applyDecorations', () => {
+  it("marks the named node and the named edge with their mark's class", () => {
+    const cy = buildCy()
+    applyDecorations(cy, {
+      node1: 'added',
+      node3: 'removed',
+      edge1: 'changed',
+    })
+
+    expect(cy.$id('node1').hasClass('deco-added')).toBe(true)
+    expect(cy.$id('node3').hasClass('deco-removed')).toBe(true)
+    expect(cy.$id('edge1').hasClass('deco-changed')).toBe(true)
+    // Marks name subjects, never neighbours.
+    expect(cy.$id('node2').classes()).toEqual([])
+    expect(cy.$id('edge2').classes()).toEqual([])
+  })
+
+  it('replaces the marks wholesale on the next map, the empty one included', () => {
+    const cy = buildCy()
+    applyDecorations(cy, { node1: 'added', edge1: 'changed' })
+    applyDecorations(cy, { node1: 'changed' })
+
+    // The second map is the whole picture: node1 carries only its new mark,
+    // and edge1's - absent from the map - is gone rather than remembered.
+    expect(cy.$id('node1').hasClass('deco-changed')).toBe(true)
+    expect(cy.$id('node1').hasClass('deco-added')).toBe(false)
+    expect(cy.$id('edge1').classes()).toEqual([])
+
+    applyDecorations(cy, {})
+    expect(cy.$id('node1').classes()).toEqual([])
+  })
+
+  it('leaves an unknown id silently inert', () => {
+    // The host may be describing subjects this model has not gained yet (or
+    // has already lost) - a mark with nothing to land on marks nothing and
+    // raises nothing.
+    const cy = buildCy()
+    expect(() =>
+      applyDecorations(cy, { 'app.gone': 'added', node1: 'changed' }),
+    ).not.toThrow()
+
+    expect(cy.$id('node1').hasClass('deco-changed')).toBe(true)
+    expect(cy.elements('.deco-added').length).toBe(0)
+  })
+
+  it('never disturbs the fault mark, which outranks it', () => {
+    // The real stylesheet against real elements, headless. Cytoscape
+    // resolves style by declaration order alone, and the fault rule is
+    // declared after the decoration rules: a subject both decorated and
+    // refused reads as refused - the failure red stays faults' own.
+    const cy = cytoscape({
+      styleEnabled: true,
+      elements: [
+        { data: { id: 'a' }, group: 'nodes' },
+        { data: { id: 'b' }, group: 'nodes' },
+        { data: { id: 'c', source: 'a', target: 'b' }, group: 'edges' },
+        { data: { id: 'd' }, group: 'nodes' },
+      ],
+      style: buildStylesheet(false, false, false, false),
+    })
+    cy.$id('a').addClass('faulted')
+    cy.$id('b').addClass('faulted')
+    cy.$id('c').addClass('faulted')
+    applyDecorations(cy, { b: 'added', c: 'changed', d: 'added' })
+
+    // applyDecorations left every faulted class standing...
+    expect(cy.$id('b').hasClass('faulted')).toBe(true)
+    expect(cy.$id('c').hasClass('faulted')).toBe(true)
+    // ...and the fault's colour wins wherever both marks land: the
+    // decorated-and-faulted node and edge render exactly as purely faulted
+    // ones do, while a purely decorated node renders differently.
+    expect(cy.$id('b').style('border-color')).toBe(
+      cy.$id('a').style('border-color'),
+    )
+    expect(cy.$id('d').style('border-color')).not.toBe(
+      cy.$id('a').style('border-color'),
+    )
+    expect(cy.$id('c').style('line-color')).toBe('rgb(163,64,58)')
+  })
+
+  it("renders each mark's own treatment: eucalyptus, quiet dash, ochre", () => {
+    const cy = cytoscape({
+      styleEnabled: true,
+      elements: [
+        { data: { id: 'a' }, group: 'nodes' },
+        { data: { id: 'b' }, group: 'nodes' },
+        { data: { id: 'c' }, group: 'nodes' },
+        { data: { id: 'ab', source: 'a', target: 'b' }, group: 'edges' },
+        { data: { id: 'bc', source: 'b', target: 'c' }, group: 'edges' },
+      ],
+      style: buildStylesheet(false, false, false, false),
+    })
+    applyDecorations(cy, {
+      a: 'added',
+      b: 'removed',
+      c: 'changed',
+      ab: 'removed',
+      bc: 'added',
+    })
+
+    expect(cy.$id('a').style('border-color')).toBe('rgb(65,111,101)')
+    expect(cy.$id('b').style('border-color')).toBe('rgb(103,112,116)')
+    // Removed is the one mark that dashes: an outline of an absence.
+    expect(cy.$id('b').style('border-style')).toBe('dashed')
+    expect(cy.$id('c').style('border-color')).toBe('rgb(140,77,24)')
+    expect(cy.$id('ab').style('line-color')).toBe('rgb(103,112,116)')
+    expect(cy.$id('ab').style('line-style')).toBe('dashed')
+    expect(cy.$id('bc').style('line-color')).toBe('rgb(65,111,101)')
+    // A mark never repaints what it did not name.
+    expect(cy.$id('a').style('border-style')).toBe('solid')
   })
 })

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -9,6 +9,7 @@ const createRoot = vi.hoisted(() => vi.fn(() => root))
 vi.mock('react-dom/client', () => ({ createRoot }))
 import {
   mountEditorWith,
+  type DecorationMap,
   type EditorHost,
   type RightSectionId,
 } from '../src/visual-app/mount.js'
@@ -69,6 +70,25 @@ describe('mountEditorWith', () => {
     expect(reading?.readOnly).toBe(true)
   })
 
+  it('threads the initial decorations to the shell (#314)', () => {
+    // The static option is the mount-time map; everything after it travels
+    // through the handle's setDecorations instead.
+    mountEditorWith({} as Element, host, sections, false, {
+      'app.checkout': 'added',
+      'checkout-serves-ledger': 'changed',
+    })
+
+    const rendered = (
+      root.render.mock.calls[0]![0] as {
+        props: { decorations: Record<string, string> }
+      }
+    ).props
+    expect(rendered.decorations).toEqual({
+      'app.checkout': 'added',
+      'checkout-serves-ledger': 'changed',
+    })
+  })
+
   it('answers false, without throwing, before the shell hands its pointer up (#297)', () => {
     // The mocked render never runs `App`, so `onReady` never fires: exactly
     // the window between mounting and the shell's first render.
@@ -77,6 +97,7 @@ describe('mountEditorWith', () => {
     expect(editor.select('app.checkout')).toBe(false)
     expect(editor.openDraft({ kind: 'goal' })).toBe(false)
     expect(editor.startConnection('app.checkout')).toBe(false)
+    expect(editor.setDecorations({ 'app.checkout': 'added' })).toBe(false)
   })
 
   it('delegates each method to the pointer the shell hands up (#297)', () => {
@@ -85,6 +106,7 @@ describe('mountEditorWith', () => {
       select: vi.fn(() => true),
       openDraft: vi.fn(() => true),
       startConnection: vi.fn(() => false),
+      setDecorations: vi.fn(() => true),
     }
     onReadyOf(root.render.mock.calls[0]!)(pointer)
 
@@ -95,6 +117,11 @@ describe('mountEditorWith', () => {
     // The pointer's own refusal travels back unchanged.
     expect(editor.startConnection('app.ledger')).toBe(false)
     expect(pointer.startConnection).toHaveBeenCalledWith('app.ledger')
+    // The whole map travels, replacement being the map's own contract (#314).
+    expect(editor.setDecorations({ 'app.ledger': 'removed' })).toBe(true)
+    expect(pointer.setDecorations).toHaveBeenCalledWith({
+      'app.ledger': 'removed',
+    })
   })
 
   it('still unmounts, and a disposed handle answers false again (#297)', () => {
@@ -103,6 +130,7 @@ describe('mountEditorWith', () => {
       select: vi.fn(() => true),
       openDraft: vi.fn(() => true),
       startConnection: vi.fn(() => true),
+      setDecorations: vi.fn(() => true),
     }
     onReadyOf(root.render.mock.calls[0]!)(pointer)
 
@@ -111,6 +139,8 @@ describe('mountEditorWith', () => {
     expect(root.unmount).toHaveBeenCalledOnce()
     expect(editor.select('app.checkout')).toBe(false)
     expect(pointer.select).not.toHaveBeenCalled()
+    expect(editor.setDecorations({})).toBe(false)
+    expect(pointer.setDecorations).not.toHaveBeenCalled()
   })
 })
 
@@ -170,12 +200,14 @@ describe('editorPointerFor', () => {
   const pointerOver = (context: EditorPointerContext) => {
     const dispatched: VisualWorkspaceAction[] = []
     const seeded: (string | undefined)[] = []
+    const decorated: DecorationMap[] = []
     const pointer = editorPointerFor(
       () => context,
       (action) => dispatched.push(action),
       (kind) => seeded.push(kind),
+      (decorations) => decorated.push(decorations),
     )
-    return { pointer, dispatched, seeded }
+    return { pointer, dispatched, seeded, decorated }
   }
 
   it('selects a concept exactly as a canvas tap would', () => {
@@ -276,6 +308,40 @@ describe('editorPointerFor', () => {
     expect(dispatched).toEqual([])
   })
 
+  it('replaces the marks wholesale, dispatching nothing (#314)', () => {
+    // The map is the unit of exchange: each hand-over is the whole picture,
+    // never a merge into the last one - and no workspace action moves,
+    // because a mark is rendering state, not a gesture.
+    const { pointer, dispatched, decorated } = pointerOver({
+      graph,
+      readOnly: false,
+    })
+
+    expect(pointer.setDecorations({ 'app.checkout': 'added' })).toBe(true)
+    expect(pointer.setDecorations({ 'app.ledger': 'changed' })).toBe(true)
+    expect(decorated).toEqual([
+      { 'app.checkout': 'added' },
+      { 'app.ledger': 'changed' },
+    ])
+    expect(dispatched).toEqual([])
+  })
+
+  it('accepts marks before the model arrives and in a viewer (#314)', () => {
+    // Unlike its siblings, no graph gate: the marks are client state, drawn
+    // the moment a model is on screen - a host hands the map with the mount,
+    // not after the first frame. And decorating is reading (#298), so the
+    // read-only posture refuses nothing here.
+    const early = pointerOver({ graph: null, readOnly: false })
+    expect(early.pointer.setDecorations({ 'app.checkout': 'removed' })).toBe(
+      true,
+    )
+    expect(early.decorated).toEqual([{ 'app.checkout': 'removed' }])
+
+    const viewer = pointerOver({ graph, readOnly: true })
+    expect(viewer.pointer.setDecorations({})).toBe(true)
+    expect(viewer.decorated).toEqual([{}])
+  })
+
   it('reads the model at call time, so the methods answer for the graph on screen', () => {
     // Before the host's first frame there is nothing to point at; the same
     // pointer starts answering true once the model arrives, with no re-bind.
@@ -284,6 +350,7 @@ describe('editorPointerFor', () => {
     const pointer = editorPointerFor(
       () => context,
       (action) => dispatched.push(action),
+      () => undefined,
       () => undefined,
     )
 


### PR DESCRIPTION
Closes #314. ADR: `docs/adr/0119-the-viewer-accepts-the-hosts-marks.md`.

The mounted viewer accepts host-supplied per-subject decorations; comparison SEMANTICS stay host-side (the viewer never diffs) — the host hands marks, the viewer renders them. This is the seam that lets ApertureX delete their parallel cytoscape renderer and use the one viewer for authoring, read-only viewing (#298) and decorated comparison.

## The issue's open points, resolved

- **Static option AND live handle.** `MountOptions.decorations?: Readonly<Record<string, 'added' | 'removed' | 'changed'>>` (subject ids — concepts and relationships alike, as the faults lane already marks both) is the initial map; `setDecorations(decorations)` on the `MountedEditor` handle rides the #297 `onReady` pointer bridge and **replaces the map wholesale** — never a merge, `{}` clears. It answers false only in the shared not-there window (pre-ready, after unmount); it needs no model (marks are client state, drawn when the graph lands) and no pen (decorating is reading, so a `readOnly` viewer accepts marks — the primary use case).
- **No custom-class escape hatch in v1**: the three-mark vocabulary is closed until demand names a fourth — recorded as an excluded option in the ADR.
- **No legend chrome**: the viewer cannot know what `changed` is relative to; the host owns meaning — recorded as an excluded option in the ADR.

## Rendering

Class-based like faults: `deco-added` / `deco-removed` / `deco-changed`, toggled by a dedicated effect keyed on the map + graph, styled by stylesheet rules. Added = eucalyptus border, removed = the quiet ink-grey with a dash (an outline of an absence — deliberately nothing like a defect), changed = ochre. Never the failure red: faults own it. Unknown ids are silently inert (ADR 0111's overlay discipline: absent means nothing drawn).

**Precedence, stated once: a fault outranks a decoration outranks selection.** Cytoscape resolves its stylesheet by declaration order alone (verified headless — no CSS-style specificity), so the marking rules land after the base and notation rules and the fault rule lands last. A side effect worth naming: the fault rule now sits after the base `edge` rule for the first time, which makes the failure red actually render on faulted **edges** — the base rule, declared later, had been silently winning their line colour back.

## Scope

Mounted editor path only: `wire.ts`, the adapters and session-server are untouched; a session-server equivalent is recorded as follow-up in the ADR, not built. `docs/CONSUMING-YARRAMATE.md` (ships in the tarball) documents the option and the handle method in the mount section.

## Tests

- `test/visual-mount.test.ts`: option threaded to the shell; `setDecorations` delegation through the handle; false pre-ready and after unmount consistent with the #297 methods; pointer-level replace-wholesale, no-dispatch, works with no model and under `readOnly`.
- `test/graph-canvas.test.ts` (headless cytoscape): classes applied to named node and edge; cleared wholesale on replacement (empty map included); unknown ids inert; fault precedence asserted against the real `buildStylesheet` (a decorated-and-faulted node/edge renders exactly as a purely faulted one); each mark's colour and the removed dash asserted.

`pnpm verify` real exit code 0 — 96 test files, 1716 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)