### PR TITLE
feat: the interview asks about what is not there (#272)

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -521,6 +521,14 @@ concepts:
     status: current
     presentIn:
       - core-contract-foundation
+  - id: published-formats-contract
+    kind: contract
+    owner: yarramate-maintainers
+    name: Published-formats contract
+    description: The standing agreement between the engine and its consumers that every published document format keeps its schema shipped and exported from the package. The Core contract manifest embodies it; check enforces it release by release.
+    status: current
+    presentIn:
+      - core-contract-foundation
   - id: workspace-manifest
     kind: dataObject
     owner: yarramate-maintainers
@@ -785,6 +793,11 @@ concepts:
     name: Expose the CLI over MCP
     description: Advertises the read-only CLI verbs as stdio Model Context Protocol tools and forwards each call to the same command surface a human runs.
     status: current
+  - id: visual-changeset-submitted
+    kind: applicationEvent
+    name: Visual changeset submitted
+    description: The changeset.commit session event; the one journaled happening in the visual conversation that asks for a write. Raised when the reviewer submits the staged changeset from the browser, and answered by the commit path; every other session event reads or renders.
+    status: current
   - id: commit-visual-changeset
     kind: applicationFunction
     name: Commit the visual changeset
@@ -812,6 +825,17 @@ concepts:
     description: Draws a 14×14 px single-stroke SVG icon per concept kind in the repository's graph, covering 19 kinds using ArchiMate element glyphs as descriptive notation only, with no trademark or conformance claim. Unknown kinds render nothing. Active only under archimate notation mode; falls back to native rendering when notation is native.
     status: current
 relationships:
+  - id: contract-manifest-realizes-published-formats
+    kind: realization
+    from: core-contract-manifest
+    to: published-formats-contract
+    description: The versioned manifest is the written form of the agreement; editing it is how the promise changes.
+  - id: contract-check-reads-published-formats
+    kind: access
+    from: check-core-contract
+    to: published-formats-contract
+    mode: read
+    description: The checker reads the agreement and fails the release that breaks it, which is what keeps the contract a promise rather than prose.
   - id: core-contract-checker-loads-contract
     kind: assignment
     from: core-contract-checker
@@ -1741,6 +1765,27 @@ relationships:
     from: recover-visual-session
     to: visual-handoff
     mode: write
+  - id: conversation-writes-session-events
+    kind: access
+    from: present-visual-conversation
+    to: visual-session-protocol
+    mode: write
+    description: What the reviewer does with the conversation surface lands as journaled session events, which are protocol documents like everything else the browser exchanges.
+  - id: conversation-raises-changeset-submitted
+    kind: triggering
+    from: present-visual-conversation
+    to: visual-changeset-submitted
+    description: Submitting the staged changeset is the one reviewer act the conversation turns into a write request rather than a read.
+  - id: changeset-submitted-triggers-commit
+    kind: triggering
+    from: visual-changeset-submitted
+    to: commit-visual-changeset
+  - id: changeset-submitted-writes-operations
+    kind: access
+    from: visual-changeset-submitted
+    to: apply-operations
+    mode: write
+    description: The submission carries the browser-authored operations batch; the commit path reads exactly what the event delivered.
   - id: visual-runtime-commits-changeset
     kind: assignment
     from: visual-runtime

--- a/.yarramate/architecture/product.yaml
+++ b/.yarramate/architecture/product.yaml
@@ -112,42 +112,63 @@ concepts:
     description: Turn declared native documents into the deterministic tool-neutral semantic graph.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: normative-output
+        ref: semantic-graph-schema
   - id: validate-native-architecture
     kind: capability
     name: Validate native architecture
     description: Check deterministic correctness of declared architecture; never completeness or taste.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: normative-input
+        ref: document-schema
   - id: provide-machine-context
     kind: capability
     name: Provide machine-readable context
     description: Serve bounded, verifiable slices of declared architecture to people, CI, and agent harnesses.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: normative-output
+        ref: projection-result-schema
   - id: evaluate-architecture-evidence
     kind: capability
     name: Evaluate architecture evidence
     description: Compare provider observations with existing semantic subjects and claims without changing canonical intent.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: normative-input
+        ref: evidence-schema
   - id: discover-project-architecture
     kind: capability
     name: Discover project architecture
     description: Guide an agent harness from existing project evidence to a reviewable native architecture proposal.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: documented-journey
+        ref: product-journeys-guide
   - id: design-solution-before-build
     kind: capability
     name: Design solution before build
     description: Guide people and an agent harness from intent and alternatives to a reviewable target solution.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: documented-journey
+        ref: product-journeys-guide
   - id: reconcile-intent-and-evidence
     kind: capability
     name: Reconcile intent and evidence
     description: Compare declared architecture with provider observations without allowing evidence to mutate intent.
     owner: yarramate-maintainers
     status: current
+    references:
+      - id: normative-output
+        ref: reconciliation-report-schema
 relationships:
   - id: repository-operation-supports-context
     kind: influence

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -905,3 +905,27 @@ observations:
     result: confirmed
     evidence:
       uri: repo:test/apply-operations.test.ts
+  - subject: visual-changeset-submitted
+    result: confirmed
+    evidence:
+      uri: repo:schema/yarramate-visual-event.schema.json
+      message: changeset.commit is a journaled session event type; the browser raises it and the runtime's commit path answers it.
+  - subject: published-formats-contract
+    result: confirmed
+    evidence:
+      uri: repo:.yarramate/contracts/yarramate-core-0.1.yaml
+      message: The manifest declares every published format with its schema and package export, and check verifies the declaration against the implementation surface.
+  - subject: evidence-intent-separation
+    result: confirmed
+    searched:
+      - grep: writeFileSync
+        paths:
+          - src/evidence.ts
+          - src/reconciliation.ts
+      - grep: "from 'node:"
+        paths:
+          - src/evidence.ts
+          - src/reconciliation.ts
+    evidence:
+      uri: repo:src/reconciliation.ts
+      message: A negative claim held up to failure - evidence evaluation and reconciliation have no write path and no runtime imports that could reach one, so observations cannot silently author intent. The searches that would find such a path come back empty; either one matching is this observation contradicted.

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1914,3 +1914,27 @@ mappings:
   - native: visual-kind-icons-tests-validate-icons
     external: visualKindIconsTestsValidateIcons
     type: relationship
+  - native: published-formats-contract
+    external: publishedFormatsContract
+    type: concept
+  - native: visual-changeset-submitted
+    external: visualChangesetSubmitted
+    type: concept
+  - native: contract-manifest-realizes-published-formats
+    external: contractManifestRealizesPublishedFormats
+    type: relationship
+  - native: contract-check-reads-published-formats
+    external: contractCheckReadsPublishedFormats
+    type: relationship
+  - native: conversation-writes-session-events
+    external: conversationWritesSessionEvents
+    type: relationship
+  - native: conversation-raises-changeset-submitted
+    external: conversationRaisesChangesetSubmitted
+    type: relationship
+  - native: changeset-submitted-triggers-commit
+    external: changesetSubmittedTriggersCommit
+    type: relationship
+  - native: changeset-submitted-writes-operations
+    external: changesetSubmittedWritesOperations
+    type: relationship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+- **Added.** The interview asks about what is not there (#272, ADR 0120).
+  Every question that fired before anchored on a declared subject, so a
+  kind with zero subjects could not be asked about and a whole absent
+  layer read exactly like a covered one: the GitLab FOSS run closed at 3
+  open items with the strategy layer empty, 559 feature-flag definitions
+  unasked, 62 domain events unmodelled and a live migration unrecorded.
+  Catalogue `core-enrichment` goes 1.1 to 1.2 (additive, every question
+  `since: "1.2"`) with five workspace-scoped presence questions:
+  `no-capability-declared`, `no-event-declared`, `no-artifact-declared`,
+  `implementation-path-missing`, and `no-contract-declared`, the last
+  gated on `exists-linkage` so a model where nothing interacts is not
+  asked what governs the exchange. An unanswered presence question is
+  information rather than noise: an architecture genuinely at rest keeps
+  `implementation-path-missing` open, and that is the model saying
+  nothing is changing. Also `capability-uncited` (a capability is the
+  layer with no code to point at, so its citation is the only thing an
+  audit can grade it against), and `states-undefined` now carries an
+  `askPlain` phrasing and points at the migration plan or target design
+  a repository already holds in-tree. `subjects-near-duplicate` names
+  succession as its third honest answer; a separate succession question
+  was assessed and not built, with the reasoning in the ADR.
+- **Added.** `unchallenged-evidence`, the one interrogation condition
+  that reads the workspace's evidence overlay rather than the compiled
+  graph (#272, ADR 0120). It holds where the overlay records
+  observations and every one is a frictionless confirmation, meaning no
+  contradicted, unknown or not-observed result and no recorded search,
+  because 39 confirmations in a row are not evidence of agreement but
+  evidence that nothing was put at risk. A recorded search closes it
+  even on a `confirmed` result: a confirmation resting on the empty
+  search ADR 0107 made auditable has tested a claim it might fail. An
+  absent or empty overlay stays quiet. `ask` and `design` now load the
+  workspace's declared evidence and pass it to `evaluateCatalogue`,
+  whose new trailing parameter is optional, so a consumer of the pure
+  engine that passes nothing gets exactly the report it got before. The
+  visual hosts read no evidence today and so omit this one question from
+  the canvas nudge overlay, recorded in the ADR as follow-up. The
+  trigger union in the three published schemas gains a branch, so a
+  consumer validating a 1.2 report against a pinned pre-1.2 schema copy
+  will reject a trigger it has never seen.
+- **Fixed.** Recorded probes survive the evidence loader (#272).
+  `loadEvidence` rebuilds each observation field by field and the
+  rebuild dropped `searched` and `measured`, so through the real load
+  path `reconcile` counted every `not-observed` as an unsupported
+  absence however carefully its author recorded the search that came
+  back empty, and the searches ADR 0107 exists to make auditable reached
+  nothing that reads them.
+
 - **Added.** The mounted viewer accepts the host's per-subject marks
   (#314, ADR 0119). `mountEditor` gains
   `decorations: Record<subjectId, 'added' | 'removed' | 'changed'>`

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "1.1"
+version: "1.2"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -880,6 +880,67 @@ questions:
       Add the externally meaningful services and serve them to their
       consumers.
 
+  - id: no-capability-declared
+    wave: business
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#capability
+    question: >-
+      No capability is declared. What can this system do, in its own terms?
+    askPlain: >-
+      Forget the parts list for a moment: what are the handful of things
+      this system is actually able to do for the people it serves?
+    materiality: >-
+      Capabilities name what the system can do apart from how it currently
+      does it; without them, investment and sourcing trade-offs can only be
+      argued in component names, and nothing in the model can say which
+      parts serve the same ability. A subject-driven interview never asks
+      about a layer with zero subjects, so an absent capability map reads
+      as a covered one until this question opens it.
+    authority: human
+    resolution: >-
+      Add the small set of capabilities this system provides — four to
+      seven usually carries the whole conversation — and relate each to
+      the services or components that realize it with realization.
+
+  - id: no-contract-declared
+    wave: business
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: exists-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+          - yarramate/core@0.1#flow
+          - yarramate/core@0.1#triggering
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#applicationComponent
+          - yarramate/core@0.1#applicationInterface
+          - yarramate/core@0.1#applicationService
+          - yarramate/core@0.1#businessActor
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#contract
+    question: >-
+      Interactions exist and no contract governs any of them. Which
+      agreements bind what this architecture exchanges?
+    askPlain: >-
+      Things here talk to each other and to the outside. Where is it
+      written down what each side may expect — the API description, the
+      published schema, the service agreement?
+    materiality: >-
+      A hop with no contract is renegotiated by every implementer who
+      touches it; compatibility and versioning obligations exist only
+      where the agreement is a subject someone can change deliberately.
+    authority: human
+    resolution: >-
+      Add a contract for each formal agreement and access it from the
+      behavior bound by it; realization from the data object or artifact
+      that embodies the agreement says where it lives.
 
   - id: service-realizes-no-motivation
     wave: business
@@ -1063,6 +1124,38 @@ questions:
       not perform application behavior: assign the actor to the business
       process that uses it and let the application service serve that
       process.
+  - id: no-event-declared
+    wave: application
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationEvent
+          - yarramate/core@0.1#businessEvent
+    question: >-
+      Nothing in this model reacts to an event. Does state change only
+      when something is called, or are there happenings the architecture
+      responds to?
+    askPlain: >-
+      Is everything here a direct request, or do things also happen on
+      their own — a message arrives, a job finishes, a threshold is
+      crossed — that the system has to react to?
+    materiality: >-
+      Whether change propagates by call or by event decides coupling,
+      ordering, and failure isolation. An event-driven seam modelled as
+      silence leaves every consumer to discover the event stream on its
+      own, and a repository full of event definitions the interview never
+      asked about reads as covered when it is absent.
+    authority: human
+    resolution: >-
+      Add the application or business events the system emits or responds
+      to and wire each with triggering from what raises it to what
+      responds. If there are genuinely none, that is a coupling decision
+      worth stating in a principle or a service description; this question
+      then stays on the agenda as the standing record that nobody has
+      declared one.
+
   - id: event-triggers-nothing
     wave: application
     since: "0.3"
@@ -1232,6 +1325,31 @@ questions:
       Add realization from the node, system software, or technology
       behavior that provides the service.
 
+  - id: no-artifact-declared
+    wave: technology
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#artifact
+    question: >-
+      No artifact is declared. What do the declared components actually
+      ship as?
+    askPlain: >-
+      When this system is deployed, what is the thing that moves — an
+      image, a package, a bundle? What are those called?
+    materiality: >-
+      Release engineering starts where a build output becomes a subject.
+      An architecture with components but no artifacts can say what should
+      exist and nothing about what is deployed, so drift between built and
+      declared has nowhere to register.
+    authority: human
+    resolution: >-
+      Add the artifacts the build produces, assignment from the node that
+      deploys each one, and realization from the artifact to the component
+      or data object it materializes.
+
   - id: artifact-unassigned
     wave: technology
     since: "0.4"
@@ -1258,6 +1376,37 @@ questions:
       realization from the artifact to the component or data object it
       materializes.
   # ---- implementation ------------------------------------------------------
+  - id: implementation-path-missing
+    wave: implementation
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#workPackage
+          - yarramate/core@0.1#deliverable
+          - yarramate/core@0.1#plateau
+    question: >-
+      No work package, deliverable, or plateau is declared. How does the
+      planned architecture become real?
+    askPlain: >-
+      Who is doing what to get from here to there? What are the packages
+      of work, and what does each one hand over?
+    materiality: >-
+      A model that names a target but no work reaching it is a wish with
+      an architecture diagram; committed work packages and their
+      deliverables are what make progress reviewable rather than
+      reported. A repository mid-migration that models none of the
+      migration is the sharpest form of the gap: the change is in the
+      tree and invisible in the model.
+    authority: human
+    resolution: >-
+      Add the work packages in flight, realization to the deliverables
+      each produces, and plateaus where an intermediate state needs a
+      name. An architecture genuinely at rest keeps this question open,
+      which is itself information: the model is saying nothing is
+      changing.
+
   - id: workpackage-delivers-nothing
     wave: implementation
     since: "0.4"
@@ -1426,6 +1575,36 @@ questions:
     resolution: >-
       Add a description claim stating meaning and explicit exclusions.
 
+  - id: capability-uncited
+    wave: hygiene
+    since: "1.2"
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#capability
+    trigger:
+      - condition: missing-reference
+        predicate: yarramate/reference/refers-to
+        direction: outgoing
+    question: >-
+      {subject.name} cites nothing. Where is this ability specified,
+      decided, or documented?
+    askPlain: >-
+      If someone asked where it says the system can do
+      "{subject.name}", what would you point at?
+    materiality: >-
+      A capability with no citation floats free of every record that
+      could confirm or correct it: an audit has nothing to grade the
+      claim against, and when its scope is disputed the dispute starts
+      from memory. The reference is where the model meets the
+      repository's own account of itself.
+    authority: either
+    resolution: >-
+      Add a references entry from the capability to the subject that
+      specifies it — the decision record, the published schema, the
+      guide that documents the journey. Model that record as a subject
+      first where it is not one yet.
+
   - id: status-missing
     wave: hygiene
     since: "0.1"
@@ -1479,6 +1658,12 @@ questions:
       genuinely different, say so in the model: add the counterpart's id to
       this subject's distinctFrom list. That answer is itself a claim, so it
       closes the question permanently and survives re-running the interview.
+      A third answer is ordinary in a repository mid-migration: they are
+      different subjects and one is taking over from the other. Record the
+      succession with supersedes, scoped where the takeover is partial
+      (ADR 0109), and record distinctFrom alongside it. Succession says what
+      the pair is to each other and distinctness is what this question asks,
+      so only the second closes it.
 
   - id: states-undefined
     wave: hygiene
@@ -1489,13 +1674,24 @@ questions:
     question: >-
       Does change shape matter here — should baseline, transition, or target
       states be declared?
+    askPlain: >-
+      Are we describing how things are, how they should become, or both?
+      If the repository already carries a migration plan or a target
+      design, that document is the answer.
     materiality: >-
       Without architecture states, current and target intent share one
-      undifferentiated model and comparisons are impossible.
+      undifferentiated model and comparisons are impossible. The answer is
+      often already on the record: a repository that carries its own
+      migration plan or target design in-tree has declared that change
+      shape matters, so evidence can bring this question its answer rather
+      than waiting for someone to remember it.
     authority: human
     resolution: >-
       Declare architecture states and mark presence with present-in where the
       distinction carries decisions; explicitly decline states otherwise.
+      Where in-tree documents already describe the target, model that
+      record and cite it with references from the subjects it changes, so
+      the declared states stand on evidence a reviewer can open.
 
   - id: kind-untested
     wave: hygiene
@@ -1580,3 +1776,30 @@ questions:
       which says the same thing without a qualifier. If the two subjects
       simply coexist and neither takes over from the other, the succession
       is the wrong claim; remove it.
+
+  - id: evidence-unchallenged
+    wave: hygiene
+    since: "1.2"
+    scope: workspace
+    trigger:
+      - condition: unchallenged-evidence
+    question: >-
+      Every observation this workspace records is a frictionless
+      confirmation. Did the inspection ever test a claim it might fail?
+    askPlain: >-
+      The evidence agrees with the model everywhere. Did we ever look
+      for something that might not be there — a documented piece missing
+      from the tree, a declared dependency nothing carries?
+    materiality: >-
+      An overlay that only ever says confirmed is indistinguishable from
+      one that only looked where success was guaranteed. One recorded
+      search or one honest non-confirmation is what makes the agreement
+      between model and reality worth believing; a reconcile summary of
+      pure confirmations has never put a claim at risk.
+    authority: either
+    resolution: >-
+      Probe at least one claim the sources assert that the tree might not
+      honour, and record the observation with its honest result. A
+      not-observed carries the searches that came back empty (ADR 0107);
+      a confirmed negative claim carries them too, because the empty
+      search is the confirmation. Either closes this.

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -44,11 +44,21 @@ questions. Each question binds:
   `near-duplicate` (the subject resembles another subject of the same
   kind closely enough to be the same thing under two names, and no
   `yarramate/identity/distinct-from` claim dismisses the pair; the
-  algorithm and its thresholds are stated in ADR 0077), or
+  algorithm and its thresholds are stated in ADR 0077),
   `unconstrained-kind` (every relationship the subject participates in
   would still be permitted by the ArchiMate relationship table if the
   subject were reclassified to a kind of another aspect, so its kind is a
-  label no check can contradict; see ADR 0083 as amended by ADR 0097).
+  label no check can contradict; see ADR 0083 as amended by ADR 0097), or
+  `unchallenged-evidence` (the one condition that reads the workspace's
+  evidence overlay rather than the compiled graph: it holds where the
+  overlay records observations and every one is a frictionless
+  confirmation — no contradicted, unknown, or not-observed result and no
+  recorded search (ADR 0107) — so a discovery that never tested a claim
+  it might fail is asked whether it did. An evaluation given no overlay
+  treats the overlay's diversity as unknown, not absent, and stays
+  quiet; the CLI paths supply the workspace's declared evidence, so only
+  a consumer of the pure engine that passes none is in that position.
+  See ADR 0120).
   Relationship kinds in conditions resolve through profile lineage by
   default, the same rule as subject selectors. The trigger rides reports
   and design steps verbatim as the question's machine-readable answer

--- a/docs/adr/0120-the-interview-asks-about-what-is-not-there.md
+++ b/docs/adr/0120-the-interview-asks-about-what-is-not-there.md
@@ -1,0 +1,152 @@
+# The interview asks about what is not there
+
+Status: accepted
+
+Running the full loop on GitLab FOSS v19.3.0 drove the interview from 55
+open items to 3, and every gate agreed the model was done: check green,
+reconcile 39 of 39 confirmed, no subject without evidence. It was not
+done. The strategy layer was empty while GitLab's stages are a textbook
+capability map, `config/feature_flags/` held 559 definitions nothing
+asked about, `app/events/` held 62 domain events with `applicationEvent`
+never appearing, and Zoekt and the Elasticsearch indexer sat
+version-pinned mid-migration with no succession recorded.
+
+The misses share one mechanism. Every question in the shipped catalogue
+that fired anchored on a declared subject: "this component realizes
+nothing", "this service has no motivation". A question about a kind with
+zero subjects has nothing to attach to, so it never fires, so **a whole
+absent layer is indistinguishable from a covered one**. The self-model
+showed the same failure on 2026-08-06 with six shipped features and no
+declared subjects, all gates green. Two models, one process, so it is a
+property of enrichment rather than of either model.
+
+`no-subject-of-kind` and `scope: workspace` were already in the engine
+(the catalogue barely spent them), and the audit on #272 added the
+second half of the finding: 39 confirmations in a row is not evidence of
+agreement, it is evidence that nothing was put at risk. Praefect is
+declared on GitLab's own architecture page and absent from the FOSS
+tree, a non-confirmation lying in the open that nothing asked for.
+
+## Decision
+
+Catalogue `core-enrichment` goes 1.1 to 1.2, additively, and the engine
+gains one condition.
+
+- **Five layer-presence questions, anchored on the workspace.**
+  `no-capability-declared`, `no-event-declared`, `no-artifact-declared`
+  and `implementation-path-missing` fire on `no-subject-of-kind` at
+  `scope: workspace`, so the question exists whether or not the layer
+  does. `no-contract-declared` is the one with a precondition: it pairs
+  `no-subject-of-kind` with `exists-linkage`, because a model where
+  nothing serves, flows to, or triggers anything else has no exchange to
+  govern and asking it for contracts would be noise.
+- **An unanswered presence question is information.** Each resolution
+  says what a genuine "none" means rather than pretending the question
+  goes away: an architecture truly at rest keeps
+  `implementation-path-missing` open, and that open question is the
+  model saying nothing is changing. This is the property that makes
+  absence legible; a question that could be dismissed silently would
+  restore the failure it exists to end.
+- **`unchallenged-evidence`, the one condition that reads the evidence
+  overlay.** It holds where the overlay records observations and every
+  one is a frictionless confirmation: no contradicted, unknown or
+  not-observed result, and no recorded search. `evidence-unchallenged`
+  spends it once, at workspace scope, in the hygiene wave.
+- **A recorded search closes it even on a confirmed result.** ADR 0107
+  made an absence auditable by recording the searches that came back
+  empty. A confirmation resting on such a search has tested a claim it
+  might fail, because the search could have come back non-empty, so it
+  counts as a challenge exactly as an honest non-confirmation does. The
+  question asks whether the inspection risked anything, not whether it
+  found fault.
+- **Absent and empty overlays both stay quiet.** No observations means
+  no inspection to interrogate. An overlay the caller never supplied
+  means the diversity is unknown rather than absent, the rule
+  `unconstrained-kind` already applies to a missing profile context. The
+  CLI paths (`ask`, `ask --open`, `ask --advise`, `design`) now load the
+  workspace's declared evidence and pass it in, so the condition is live
+  wherever a workspace declares an overlay.
+- **The visual hosts stay evidence-blind, and therefore quiet.** Neither
+  the session server nor the mounted host reads evidence today: the
+  mounted host's store carries documents and profiles, which is what
+  `applyOperations` compiles from (ADR 0100). A nudge that appeared in
+  one host and not the other would be worse than one that appears in
+  neither, so both pass no overlay and the canvas overlay omits this
+  question. Recorded as follow-up rather than built.
+- **The evidence loader stops dropping provenance.** `loadEvidence`
+  rebuilds every observation field by field, and until now the rebuild
+  dropped `searched` and `measured`. Through the real load path that
+  made `reconcile` count every `not-observed` as an unsupported absence
+  however carefully its author recorded the search, and it would have
+  made this new condition read every overlay as probe-free. Both fields
+  now survive normalization.
+- **Citation is asked of capabilities.** `capability-uncited` fires on
+  `missing-reference` for a capability with no `refers-to`. A capability
+  is the layer with no code to point at, so the record that specifies it
+  is the only thing an audit can grade the claim against.
+- **`states-undefined` learns that evidence can answer it.** It gains an
+  `askPlain` phrasing and says plainly that a repository carrying its
+  own migration plan or target design in-tree has already declared that
+  change shape matters. The question was `authority: human` and stayed
+  that way; what changed is that it now points at the record instead of
+  waiting for someone to remember it.
+- **Versioning.** Every new question carries `since: "1.2"`, so a model
+  that legitimately reopens does so under ADR 0063's honest-reopen
+  discipline. `INTERROGATION_SEMANTICS_VERSION` stays at 1: no existing
+  question's answer moves for an unchanged model, which is exactly the
+  promise that version makes.
+
+## Excluded options
+
+- **A succession question of its own** (candidate 4 on the issue). The
+  detection already exists: `near-duplicate` computes the overlapping
+  pairs and `subjects-near-duplicate` asks about them, so a new question
+  would fire on the same pairs and ask the same thing twice. The real
+  gap is narrower, that succession is not one of the answers that closes
+  it, and only `distinctFrom` dismisses a pair (ADR 0077). Teaching
+  `supersedes` to dismiss would change an existing question's answer for
+  an unchanged model and cost an `INTERROGATION_SEMANTICS_VERSION` bump,
+  which an additive catalogue release does not spend. What ships instead
+  is wording: the resolution now names succession as the third honest
+  answer, says to scope it where the takeover is partial (ADR 0109), and
+  says to record `distinctFrom` alongside it, because succession states
+  what the pair is to each other while distinctness is what the question
+  asks. Whether a recorded succession should dismiss the pair outright
+  is left as its own decision.
+- **A citation question across every kind.** `missing-reference` over
+  all subjects would open a line per subject on a model of any size and
+  turn the hygiene wave into a wall, which is how a catalogue teaches
+  people to skim it. Capability is where the citation carries the most
+  and the count stays small.
+- **A ratio threshold on evidence diversity** ("fewer than N per cent
+  non-confirmed"). No one can defend the number, and the honest line
+  needs no number: either the inspection risked something once or it
+  never did.
+- **Firing on a workspace with no evidence at all.** That is a different
+  question, about whether anything was inspected rather than about what
+  the inspection dared, and it belongs to the artifact-side coverage gap
+  #175 owns. Reading absence as failure here would also make the
+  condition fire on every model that has not started evidence work,
+  which is most of them.
+- **A presence question per concept kind.** Sixty-two kinds would give
+  sixty-two workspace questions and no interview survives that. The five
+  shipped are the layers whose absence changed a real answer on GitLab,
+  and the catalogue is data: an organisation that wants a sixth writes
+  it.
+
+## Consequences
+
+The shipped catalogue goes from 44 questions to 51. Models that pass
+today will legitimately reopen, which is the point, and `since: "1.2"`
+tells a reader which reopenings are new questions rather than
+regressions. The self-model reopened on four of them and was answered
+through: a published-formats contract, the `changeset.commit`
+application event, `refers-to` references on the seven capabilities, and
+one observation that holds a negative claim up to failure by recording
+the searches that would contradict it. It is back to 0 open of 51.
+
+The trigger union in the three published schemas gains a branch. A
+consumer validating a 1.2 report against a pinned pre-1.2 schema copy
+will reject a trigger it has never seen, the same compatibility shape
+the required `trigger` field carried in 1.2.0. A consumer of the pure
+engine that passes no overlay gets exactly the report it got before.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -533,6 +533,19 @@
               "const": "unscoped-succession"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The workspace's evidence overlay records observations and every one is a frictionless confirmation: no contradicted, unknown, or not-observed result, and no recorded search (ADR 0107). A discovery that never records anything but success never tested a claim it might fail. The one condition that reads the evidence overlay rather than the compiled graph; where the evaluating consumer supplies no overlay it stays quiet (ADR 0120).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unchallenged-evidence"
+            }
+          }
         }
       ]
     },

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -532,6 +532,19 @@
               "const": "unscoped-succession"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The workspace's evidence overlay records observations and every one is a frictionless confirmation: no contradicted, unknown, or not-observed result, and no recorded search (ADR 0107). A discovery that never records anything but success never tested a claim it might fail. The one condition that reads the evidence overlay rather than the compiled graph; where the evaluating consumer supplies no overlay it stays quiet (ADR 0120).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unchallenged-evidence"
+            }
+          }
         }
       ]
     },

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -502,6 +502,19 @@
               "const": "unscoped-succession"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The workspace's evidence overlay records observations and every one is a frictionless confirmation: no contradicted, unknown, or not-observed result, and no recorded search (ADR 0107). A discovery that never records anything but success never tested a claim it might fail. The one condition that reads the evidence overlay rather than the compiled graph; where the evaluating consumer supplies no overlay it stays quiet (ADR 0120).",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "unchallenged-evidence"
+            }
+          }
         }
       ]
     },

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -817,6 +817,7 @@ export function runAskCommand(
         loadedCatalogue.catalogue,
         compilation.graph,
         compilation.profileContext,
+        evidenceDocuments.flatMap(({ observations }) => observations),
       )
 
       const result: AskResult = {
@@ -1094,11 +1095,24 @@ export function runAskCommand(
         source: readFileSync(resolvedCataloguePath, 'utf8'),
       })
       if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+      // The evidence overlay rides along for the one condition that
+      // reads it (unchallenged-evidence); a workspace declaring no
+      // evidence passes an overlay known to be empty.
+      const evidenceObservations = []
+      for (const path of workspace.evidence) {
+        const loaded = loadEvidence({
+          path,
+          source: readFileSync(resolve(cwd, path), 'utf8'),
+        })
+        if (!loaded.ok) return failed(loaded.diagnostics)
+        evidenceObservations.push(...loaded.evidence.observations)
+      }
       const report: InterrogationReport = {
         ...evaluateCatalogue(
           loadedCatalogue.catalogue,
           graph,
           compilation.profileContext,
+          evidenceObservations,
         ),
         workspace: workspace.id,
       }
@@ -1455,10 +1469,23 @@ export function runAskCommand(
       source: readFileSync(resolvedCataloguePath, 'utf8'),
     })
     if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+    // Loaded ahead of evaluation so the overlay feeds the one condition
+    // that reads it (unchallenged-evidence), then reused for the
+    // reconciliation summary below.
+    const evidenceDocuments: EvidenceDocument[] = []
+    for (const path of workspace.evidence) {
+      const loaded = loadEvidence({
+        path,
+        source: readFileSync(resolve(cwd, path), 'utf8'),
+      })
+      if (!loaded.ok) return failed(loaded.diagnostics)
+      evidenceDocuments.push(loaded.evidence)
+    }
     const report = evaluateCatalogue(
       loadedCatalogue.catalogue,
       graph,
       compilation.profileContext,
+      evidenceDocuments.flatMap(({ observations }) => observations),
     )
     const openQuestions: OpenQuestionRef[] = []
     for (const wave of report.waves) {
@@ -1495,15 +1522,6 @@ export function runAskCommand(
         }
       | undefined
     if (workspace.evidence.length > 0) {
-      const evidenceDocuments = []
-      for (const path of workspace.evidence) {
-        const loaded = loadEvidence({
-          path,
-          source: readFileSync(resolve(cwd, path), 'utf8'),
-        })
-        if (!loaded.ok) return failed(loaded.diagnostics)
-        evidenceDocuments.push(loaded.evidence)
-      }
       const evaluation = evaluateEvidenceWorkspace(graph, evidenceDocuments)
       if (!evaluation.ok) return failed(evaluation.diagnostics)
       const reconciled = reconcileEvidenceReports(

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -12,6 +12,7 @@ import {
   compileWorkspaceWithProfileContext,
   type Diagnostic,
 } from './compiler.js'
+import { loadEvidence, type EvidenceObservation } from './evidence.js'
 import {
   evaluateCatalogue,
   loadQuestionCatalogue,
@@ -286,6 +287,20 @@ export function runDesignCommand(
     )
     if (!compilation.ok) return failed(compilation.diagnostics)
 
+    // The evidence overlay rides along for the one condition that reads
+    // it (unchallenged-evidence). A workspace declaring no evidence
+    // passes an empty overlay — known to be empty, which keeps that
+    // condition quiet — rather than an absent one.
+    const evidenceObservations: EvidenceObservation[] = []
+    for (const path of workspace.evidence) {
+      const loadedEvidence = loadEvidence({
+        path,
+        source: readFileSync(resolve(cwd, path), 'utf8'),
+      })
+      if (!loadedEvidence.ok) return failed(loadedEvidence.diagnostics)
+      evidenceObservations.push(...loadedEvidence.evidence.observations)
+    }
+
     if (subjectFilter !== undefined) {
       const known = new Set(compilation.graph.subjects.map(({ id }) => id))
       if (!known.has(subjectFilter)) {
@@ -301,6 +316,7 @@ export function runDesignCommand(
       loadedCatalogue.catalogue,
       compilation.graph,
       compilation.profileContext,
+      evidenceObservations,
     )
     const askPlainById = new Map(
       loadedCatalogue.catalogue.questions.flatMap((question) =>

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -150,6 +150,33 @@ export function loadEvidence(source: WorkspaceSource): EvidenceLoadResult {
         ...(observation.key === undefined || observation.value === undefined
           ? {}
           : { key: observation.key, value: observation.value }),
+        // Provenance survives normalization: reconcile counts a
+        // not-observed naming no search (ADR 0107) and interrogation's
+        // unchallenged-evidence reads recorded searches (ADR 0120), so a
+        // load path that dropped them made both read every overlay as
+        // probe-free however carefully its author recorded one.
+        ...(observation.searched === undefined
+          ? {}
+          : {
+              searched: observation.searched.map((probe) =>
+                'glob' in probe
+                  ? { glob: probe.glob }
+                  : {
+                      grep: probe.grep,
+                      ...(probe.paths === undefined
+                        ? {}
+                        : { paths: [...probe.paths] }),
+                    },
+              ),
+            }),
+        ...(observation.measured === undefined
+          ? {}
+          : {
+              measured: observation.measured.map(({ value, method }) => ({
+                value,
+                method,
+              })),
+            }),
         evidence: {
           uri: observation.evidence.uri,
           ...(observation.evidence.message === undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export {
   renderInterrogationReport,
   renderQuestion,
   type CatalogueCondition,
+  type CatalogueEvidenceObservation,
   type CatalogueLoadResult,
   type CatalogueQuestion,
   type CatalogueSelector,

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -113,6 +113,25 @@ export type CatalogueCondition =
   | { readonly condition: 'near-duplicate' }
   | { readonly condition: 'unconstrained-kind' }
   | { readonly condition: 'unscoped-succession' }
+  | { readonly condition: 'unchallenged-evidence' }
+
+/**
+ * One observation from the workspace's evidence overlay, reduced to what
+ * interrogation reads: the result, and whether a search was recorded with
+ * it. The only condition that reads the overlay is `unchallenged-evidence`;
+ * every other condition reads the compiled graph alone, and the overlay
+ * never influences which subjects a selector matches.
+ *
+ * Shaped structurally rather than importing {@link EvidenceObservation} so
+ * the pure engine entry (`./interrogation-entry`) keeps owning its whole
+ * input surface: a caller passes
+ * `evidenceDocuments.flatMap(({ observations }) => observations)` and the
+ * wider evidence shape is never dragged in.
+ */
+export interface CatalogueEvidenceObservation {
+  readonly result: 'confirmed' | 'contradicted' | 'unknown' | 'not-observed'
+  readonly searched?: readonly unknown[]
+}
 
 export interface CatalogueQuestion {
   readonly id: string
@@ -485,8 +504,33 @@ const conditionHolds = (
   condition: CatalogueCondition,
   subjectId: string | undefined,
   profileContext: ResolvedProfileContext | undefined,
+  evidence: readonly CatalogueEvidenceObservation[] | undefined,
 ): boolean => {
   switch (condition.condition) {
+    case 'unchallenged-evidence':
+      // Fires where the overlay records observations and every one is a
+      // frictionless confirmation: no contradicted, unknown, or
+      // not-observed result, and no recorded search. A discovery that
+      // never records anything but success never tested a claim it might
+      // fail — 39 of 39 GitLab observations said confirmed while Praefect
+      // sat declared upstream and absent from the tree (#272). A recorded
+      // search closes it even on a confirmed result, because a
+      // confirmation of a negative claim rests on exactly the empty
+      // search ADR 0107 made auditable; so does any honest non-confirmed
+      // result. An empty overlay stays quiet: with no observations there
+      // is no inspection to interrogate. An absent overlay also stays
+      // quiet — the caller did not supply one, so its diversity is
+      // unknown, not absent, the same rule `unconstrained-kind` applies
+      // to a missing profile context.
+      return (
+        evidence !== undefined &&
+        evidence.length > 0 &&
+        evidence.every(
+          ({ result, searched }) =>
+            result === 'confirmed' &&
+            (searched === undefined || searched.length === 0),
+        )
+      )
     case 'missing-claim':
       return !(index.claimsBySubject.get(subjectId!) ?? []).some(
         ({ predicate }) => predicate === condition.predicate,
@@ -754,6 +798,7 @@ export function evaluateCatalogue(
   catalogue: QuestionCatalogue,
   graph: SemanticGraph,
   profileContext?: ResolvedProfileContext,
+  evidence?: readonly CatalogueEvidenceObservation[],
 ): Omit<InterrogationReport, 'workspace'> {
   const index = indexGraph(graph)
   let open = 0
@@ -779,7 +824,7 @@ export function evaluateCatalogue(
         }
         if (question.scope === 'workspace') {
           const isOpen = question.trigger.every((condition) =>
-            conditionHolds(index, condition, undefined, profileContext),
+            conditionHolds(index, condition, undefined, profileContext, evidence),
           )
           if (isOpen) {
             open += 1
@@ -793,7 +838,7 @@ export function evaluateCatalogue(
           profileContext,
         ).filter((id) =>
           question.trigger.every((condition) =>
-            conditionHolds(index, condition, id, profileContext),
+            conditionHolds(index, condition, id, profileContext, evidence),
           ),
         )
         if (matches.length === 0) {

--- a/src/interrogation-entry.ts
+++ b/src/interrogation-entry.ts
@@ -14,6 +14,7 @@ export {
   renderInterrogationReport,
   renderQuestion,
   type CatalogueCondition,
+  type CatalogueEvidenceObservation,
   type CatalogueLoadResult,
   type CatalogueQuestion,
   type CatalogueSelector,

--- a/test/absent-layer-catalogue.test.ts
+++ b/test/absent-layer-catalogue.test.ts
@@ -1,0 +1,275 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+// The 1.2 layer-presence questions (#272, ADR 0120). A subject-driven
+// catalogue never asks about a layer with zero subjects, so the GitLab
+// discovery closed its interview with the strategy, event, contract, and
+// implementation layers silently absent: with nothing declared, nothing
+// fired. These questions anchor on the workspace instead of a subject, so
+// an absent layer is asked about rather than read as covered.
+
+const bare = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: customer
+    kind: businessActor
+    name: Customer
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+relationships:
+  - id: api-serves-customer
+    kind: serving
+    from: order-api
+    to: customer
+`
+
+const manifest = (evidence: readonly string[]) =>
+  `format: yarramate/workspace/v1
+id: absent-layer-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections: []
+adapterMappings: []
+evidence:${evidence.length === 0 ? ' []' : ''}
+${evidence.map((path) => `  - ${path}`).join('\n')}
+`
+
+const openIds = (workspace: string): readonly string[] => {
+  const result = runCli(['ask', 'workspace.yaml', '--open', '--json'], workspace)
+  expect(result.exitCode, result.stderr).toBe(0)
+  return JSON.parse(result.stdout)
+    .report.waves.flatMap(
+      (wave: { questions: { id: string; open: boolean }[] }) => wave.questions,
+    )
+    .filter((question: { open: boolean }) => question.open)
+    .map((question: { id: string }) => question.id)
+}
+
+describe('core-enrichment 1.2 asks about absent layers', () => {
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-absent-layer-'))
+    mkdirSync(join(workspace, 'architecture'))
+    writeFileSync(join(workspace, 'architecture/main.yaml'), bare, 'utf8')
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest([]), 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('opens every absent front on a model with none of the layers', () => {
+    const ids = openIds(workspace)
+    expect(ids).toContain('no-capability-declared')
+    expect(ids).toContain('no-event-declared')
+    expect(ids).toContain('no-contract-declared')
+    expect(ids).toContain('no-artifact-declared')
+    expect(ids).toContain('implementation-path-missing')
+  })
+
+  it('closes a presence question the moment the layer has a subject', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: customer
+    kind: businessActor
+    name: Customer
+  - id: order-api
+    kind: applicationComponent
+    name: Order API
+  - id: sell-orders
+    kind: capability
+    name: Sell orders
+    references:
+      - id: spec
+        ref: order-api
+relationships:
+  - id: api-serves-customer
+    kind: serving
+    from: order-api
+    to: customer
+`,
+      'utf8',
+    )
+    const ids = openIds(workspace)
+    expect(ids).not.toContain('no-capability-declared')
+    // The citation question is satisfied by the reference; a capability
+    // declared without one opens capability-uncited instead.
+    expect(ids).not.toContain('capability-uncited')
+  })
+
+  it('asks a bare capability for its citation', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: sell-orders
+    kind: capability
+    name: Sell orders
+relationships: []
+`,
+      'utf8',
+    )
+    const ids = openIds(workspace)
+    expect(ids).toContain('capability-uncited')
+  })
+
+  it('keeps no-contract-declared quiet where nothing interacts', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: order-record
+    kind: dataObject
+    name: Order record
+relationships: []
+`,
+      'utf8',
+    )
+    const ids = openIds(workspace)
+    expect(ids).not.toContain('no-contract-declared')
+  })
+})
+
+describe('evidence-unchallenged reads the evidence overlay (#272)', () => {
+  let workspace: string
+
+  const evidence = (observation: string) =>
+    `format: yarramate/evidence/v1
+id: repository
+version: "1.0"
+provider: repository-audit
+observations:
+${observation}`
+
+  const confirmedOnly = `  - subject: order-api
+    result: confirmed
+    evidence:
+      uri: repo:src/order-api.ts
+`
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-unchallenged-'))
+    mkdirSync(join(workspace, 'architecture'))
+    mkdirSync(join(workspace, 'evidence'))
+    writeFileSync(join(workspace, 'architecture/main.yaml'), bare, 'utf8')
+    writeFileSync(
+      join(workspace, 'workspace.yaml'),
+      manifest(['evidence/repository.yaml']),
+      'utf8',
+    )
+    writeFileSync(
+      join(workspace, 'evidence/repository.yaml'),
+      evidence(confirmedOnly),
+      'utf8',
+    )
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  it('opens where every observation is a frictionless confirmation', () => {
+    expect(openIds(workspace)).toContain('evidence-unchallenged')
+  })
+
+  it('stays quiet where the workspace declares no evidence at all', () => {
+    writeFileSync(join(workspace, 'workspace.yaml'), manifest([]), 'utf8')
+    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+  })
+
+  it('closes on an honest non-confirmation', () => {
+    writeFileSync(
+      join(workspace, 'evidence/repository.yaml'),
+      evidence(
+        confirmedOnly +
+          `  - subject: customer
+    result: not-observed
+    searched:
+      - grep: Customer
+        paths: ["src/"]
+    evidence:
+      uri: repo:docs/architecture.md
+      message: Declared in the docs, absent from the tree.
+`,
+      ),
+      'utf8',
+    )
+    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+  })
+
+  it('closes on a confirmed negative claim that records its empty search', () => {
+    // ADR 0107 made an absence auditable by recording the search that
+    // found nothing. A confirmation resting on such a search HAS tested a
+    // claim it might fail — the search could have come back non-empty —
+    // so it counts as diversity even though the result is confirmed.
+    writeFileSync(
+      join(workspace, 'evidence/repository.yaml'),
+      evidence(
+        `  - subject: order-api
+    result: confirmed
+    searched:
+      - grep: "privileged-write"
+        paths: ["src/"]
+    evidence:
+      uri: repo:src/order-api.ts
+      message: The API declares no privileged write path; the search that would find one is empty.
+`,
+      ),
+      'utf8',
+    )
+    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+  })
+
+  it('serves the question through design with its trigger attached', () => {
+    // design was subject-blind to evidence before 1.2: the overlay now
+    // rides into evaluation, so the interview and ask --open agree.
+    const enriched = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: customer
+    kind: businessActor
+    name: Customer
+relationships: []
+`
+    writeFileSync(join(workspace, 'architecture/main.yaml'), enriched, 'utf8')
+    const result = runCli(['design', 'workspace.yaml', '--json'], workspace)
+    expect(result.exitCode, result.stderr).toBe(0)
+    const payload = JSON.parse(result.stdout) as {
+      step: { questionId: string; trigger: readonly { condition: string }[] } | null
+      progress: { open: number }
+    }
+    // The motivation wave outranks hygiene, so the top step is not the
+    // evidence question; the report behind the progress count includes it.
+    expect(payload.progress.open).toBeGreaterThan(0)
+    const open = runCli(['ask', 'workspace.yaml', '--open', '--json'], workspace)
+    const question = JSON.parse(open.stdout)
+      .report.waves.flatMap((wave: { questions: { id: string }[] }) => wave.questions)
+      .find((candidate: { id: string }) => candidate.id === 'evidence-unchallenged') as {
+      open: boolean
+      trigger: readonly { condition: string }[]
+    }
+    expect(question.open).toBe(true)
+    expect(question.trigger).toEqual([{ condition: 'unchallenged-evidence' }])
+  })
+})

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -71,7 +71,7 @@ describe('core-enrichment 1.0 interaction wave', () => {
         id: string
       }[]
     }
-    expect(catalogue.version).toBe('1.1')
+    expect(catalogue.version).toBe('1.2')
     const added = catalogue.questions.filter((question) => question.since === '0.9')
     expect(added.length).toBeGreaterThan(0)
     for (const question of added) {

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -22,7 +22,7 @@ import {
 // existing question answers.
 
 const EXPECTED_SEMANTICS = '1'
-const EXPECTED_FINGERPRINT = '86669858b84e4d8f'
+const EXPECTED_FINGERPRINT = '3f1dec3d08690ce7'
 
 const profile = 'yarramate/core@0.1'
 
@@ -108,7 +108,14 @@ const conditions: readonly (readonly [string, readonly string[]])[] = [
   ['near-duplicate', ['      - condition: near-duplicate']],
   ['unconstrained-kind', ['      - condition: unconstrained-kind']],
   ['unscoped-succession', ['      - condition: unscoped-succession']],
+  ['unchallenged-evidence', ['      - condition: unchallenged-evidence']],
 ]
+
+// The overlay the unchallenged-evidence probe reads: one confirmed
+// observation and no recorded search, so the condition fires. Every other
+// condition ignores the overlay, which is itself part of what the
+// fingerprint pins.
+const evidenceOverlay = [{ result: 'confirmed' as const }]
 
 const catalogue = [
   'format: yarramate/question-catalogue/v1',
@@ -157,6 +164,7 @@ const answers = () => {
     loaded.catalogue,
     compilation.graph,
     compilation.profileContext,
+    evidenceOverlay,
   )
   // Answers only: which questions are open, and about which subjects.
   return report.waves

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2756,8 +2756,8 @@ mappings:
               'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
             subject: 'likec4-adapter-provides-export',
             path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/125',
-            line: 1386,
+            pointer: '/relationships/127',
+            line: 1410,
             column: 5,
           },
           {
@@ -2767,8 +2767,8 @@ mappings:
               'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
             subject: 'likec4-adapter-provides-check',
             path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/126',
-            line: 1390,
+            pointer: '/relationships/128',
+            line: 1414,
             column: 5,
           },
           {

--- a/test/recorded-probes.test.ts
+++ b/test/recorded-probes.test.ts
@@ -99,6 +99,27 @@ describe('the evidence document carries recorded probes', () => {
     )
     const loaded = loadEvidence({ path: 'evidence/repository.yaml', source })
     expect(loaded.ok, JSON.stringify('diagnostics' in loaded ? loaded.diagnostics : [])).toBe(true)
+    if (!loaded.ok) return
+    // The probes survive normalization. loadEvidence rebuilds each
+    // observation explicitly, and until 1.2 the rebuild dropped searched
+    // and measured, so through the real load path reconcile counted every
+    // not-observed as an unsupported absence however carefully its author
+    // recorded the search, and interrogation's unchallenged-evidence read
+    // every overlay as probe-free (#272).
+    const praefect = loaded.evidence.observations.find(
+      (observation) => 'subject' in observation && observation.subject === 'praefect',
+    )
+    const pipeline = loaded.evidence.observations.find(
+      (observation) =>
+        'subject' in observation && observation.subject === 'pipeline-processing',
+    )
+    expect(praefect?.searched).toEqual([
+      { glob: 'PRAEFECT_*' },
+      { grep: 'Praefect', paths: ['lib/', 'app/'] },
+    ])
+    expect(pipeline?.measured).toEqual([
+      { value: '68', method: "find app/services/ci -maxdepth 1 -name '*.rb' | wc -l" },
+    ])
   })
 
   it('refuses a search probe that names neither a glob nor a grep', () => {


### PR DESCRIPTION
## Summary

Closes #272.

Every question in the shipped catalogue that fired anchored on a declared subject, so a kind with zero subjects could not be asked about and a whole absent layer read exactly like a covered one. The GitLab FOSS v19.3.0 run closed at 3 open items with the strategy layer empty, 559 feature-flag definitions unasked, 62 domain events unmodelled and a live migration unrecorded. The self-model showed the same shape on 2026-08-06. Two models, one process, so it is a property of enrichment rather than of either model.

Catalogue `core-enrichment` goes 1.1 to 1.2, additively, every new question `since: "1.2"`.

**Layer presence (candidate 1).** Five workspace-scoped questions on `no-subject-of-kind`: `no-capability-declared`, `no-event-declared`, `no-artifact-declared`, `implementation-path-missing`, and `no-contract-declared`, the last gated on `exists-linkage` so a model where nothing interacts is not asked what governs the exchange. An unanswered presence question is information rather than noise: an architecture genuinely at rest keeps `implementation-path-missing` open, and that open question is the model saying nothing is changing.

**Evidence diversity (candidate 2).** New condition `unchallenged-evidence`, the one that reads the workspace's evidence overlay rather than the compiled graph. It holds where the overlay records observations and every one is a frictionless confirmation: no contradicted, unknown or not-observed result, and no recorded search. 39 confirmations in a row are not evidence of agreement, they are evidence that nothing was put at risk. A recorded search closes it even on a `confirmed` result, because a confirmation resting on the empty search ADR 0107 made auditable has tested a claim it might fail. Absent and empty overlays stay quiet.

**Citations (candidate 3).** `capability-uncited`, narrowed to capabilities: the layer with no code to point at, so the record that specifies it is the only thing an audit can grade the claim against.

**Succession (candidate 4): assessed, not built.** `near-duplicate` already computes the overlapping pairs and `subjects-near-duplicate` already asks about them, so a new question would ask the same thing twice. The real gap is narrower: only `distinctFrom` dismisses a pair, so a recorded succession leaves the question open. Teaching `supersedes` to dismiss would move an existing question's answer for an unchanged model and cost an `INTERROGATION_SEMANTICS_VERSION` bump, which an additive catalogue release does not spend. What ships is wording: the resolution names succession as the third honest answer, scoped where partial (ADR 0109), recorded alongside `distinctFrom`. The dismissal question is left as its own decision in the ADR.

**`states-undefined` (candidate 5).** Gains an `askPlain` phrasing and says that a repository carrying its own migration plan or target design in-tree has already declared that change shape matters.

**One defect found on the way.** `loadEvidence` rebuilds each observation field by field and the rebuild dropped `searched` and `measured`. Through the real load path that made `reconcile` count every `not-observed` as an unsupported absence however carefully its author recorded the search that came back empty. Both fields now survive normalization.

## Validation

`pnpm run verify` green, exit 0 from a clean `.yarramate-out`: typecheck, build, 1737 tests passing across 97 files, `self:check` no errors, `likec4 validate` valid.

Self-model dogfood: it reopened on exactly four questions (`no-contract-declared`, `no-event-declared`, `capability-uncited`, `evidence-unchallenged`, measured by evaluating 1.2 against the pre-enrichment model) and was answered through rather than suppressed: a published-formats contract, the `changeset.commit` application event, `refers-to` references on the seven capabilities, and one observation that holds a negative claim up to failure by recording the searches that would contradict it. Back to 0 open of 51 (was 0 of 44). `reconcile` stays 228 of 228 confirmed with 0 unsupported absences.

New `test/absent-layer-catalogue.test.ts` covers both halves through the CLI: every absent front opening on a bare model, each presence question closing the moment its layer gains a subject, `no-contract-declared` staying quiet where nothing interacts, and the four `unchallenged-evidence` cases (fires on confirmations only, quiet with no overlay declared, closes on an honest non-confirmation, closes on a confirmed negative claim that records its empty search).

## Related issue

#272, including the phase-2 GitLab audit comment. The audit's document-side half (telling "collapsed deliberately" from "never considered") is not addressed here and stays with #175, noted in the ADR.

## Contract impact

Additive. Catalogue 1.1 to 1.2. `INTERROGATION_SEMANTICS_VERSION` stays at 1, since no existing question's answer moves for an unchanged model, and the fingerprint test's new value reflects the added condition probe rather than a changed answer. `evaluateCatalogue` gains an optional trailing parameter, so a consumer of the pure engine that passes nothing gets exactly the report it got before. The trigger union in the three published schemas gains a branch: a consumer validating a 1.2 report against a pinned pre-1.2 schema copy will reject a trigger it has never seen, the same compatibility shape the required `trigger` field carried in 1.2.0. Models will legitimately reopen under ADR 0063's honest-reopen discipline; `since: "1.2"` tells a reader which reopenings are new questions rather than regressions.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)