### PR TITLE
feat: a view says which way it runs (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+- **Changed.** A view says which way it runs, and the canvas listens
+  (#274, ADR 0121). `presentation.direction` has been in
+  `yarramate/projection/v1` all along and the LikeC4 export has always
+  honoured it; the canvas pinned `elk.direction: DOWN` and took no
+  argument that could say otherwise, so the format declared something one
+  of its two renderers silently discarded, and `docs/VISUAL-ADAPTER.md`
+  said both things in two different sections. The pin's reasoning was
+  right for a layer-band view and wrong for a deployment realization
+  chain or a fan-out, so it keeps the default rather than being the only
+  answer: `top-down` maps to `DOWN`, `left-right` to `RIGHT`, and a view
+  that declares nothing still runs top-down. Direction is derived from
+  the active view the same way `nesting` is, restored to the default on a
+  view that omits it rather than carried across from the view before, and
+  a direction edit re-arms the relayout so the canvas cannot keep the
+  geometry of a direction the view no longer declares. There is still no
+  direction control on screen: the view declares it, and a save carries a
+  declared direction through untouched.
+- **Changed.** Node placement is now `NETWORK_SIMPLEX` rather than ELK's
+  `BRANDES_KOEPF` default, on every view (#274, ADR 0121). Adopted on a
+  sweep of every authored view in the repository, the six contact-update
+  journey views and the self-model's twenty-two, rather than on the
+  single 8-subject view the proposal opened with. Holding direction
+  `DOWN`: total edge length across the 28 views falls from 1.46M px to
+  987k, summed layout width narrows 15%, and crossings move from 1888 to
+  1821, fewer on ten views, more on three, unchanged on fifteen. The
+  three that pay crossings are the three largest and each buys 12 to 40%
+  less edge with them. Every view's drawing changes; no saved layout
+  does, since a saved layout is applied over the result.
+
 - **Added.** The interview asks about what is not there (#272, ADR 0120).
   Every question that fired before anchored on a declared subject, so a
   kind with zero subjects could not be asked about and a whole absent

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -154,8 +154,18 @@ session.
 
 One backend: **`layered`** (`elk layered`), selected by `presentation.layout`,
 which now admits only that value. It honours `presentation.direction`
-(`top-down` → `elk.direction: DOWN`, `left-right` → `RIGHT`) and measured
-112 ms on this repository's 258-node graph.
+(`top-down` → `elk.direction: DOWN`, `left-right` → `RIGHT`), which a view that
+declares none runs as `top-down`, and measured 112 ms on this repository's
+258-node graph.
+
+Node placement is `NETWORK_SIMPLEX` rather than ELK's `BRANDES_KOEPF` default
+([ADR 0121](adr/0121-a-view-says-which-way-it-runs.md)), adopted on a sweep of
+every authored view here: the six contact-update journey views and the
+self-model's twenty-two. Holding direction `DOWN`, it cut total edge length
+across the 28 views from 1.46M px to 987k, narrowed the summed layout by 15%,
+and moved crossings from 1888 to 1821 (fewer on ten views, more on three,
+unchanged on fifteen). The three that pay crossings are the three largest, and
+each buys 12 to 40% less edge with them.
 
 `radial` (cytoscape `concentric`) and `force` (elk `stress` then
 `sporeOverlap`) were removed in 1.0. Measured against `layered` on every view
@@ -416,10 +426,13 @@ alone, so a second notation has somewhere to land — the same reason
 projection asking for `native` is refused rather than quietly drawn as
 ArchiMate.
 
-`presentation.direction` also stays, and the canvas ignores it: the LikeC4
-export reads it for its own `autoLayout`, and that export draws no layer bands.
-A save carries a view's declared direction through untouched rather than
-dropping a value the canvas never offered to set.
+`presentation.direction` is honoured rather than ignored (#274,
+[ADR 0121](adr/0121-a-view-says-which-way-it-runs.md)). The canvas was pinned
+`DOWN` on the reasoning that ArchiMate's layer bands only read top-down, which
+is right for a layer-band view and wrong for a deployment realization chain or
+a fan-out; the bands keep the default and stop being the only answer. There is
+still no on-screen direction control: the view declares it, the same as
+`nesting`, and a save carries a declared direction through untouched.
 
 The kind colours, aspect shapes, glyphs, and relationship line styles are
 defined once in the published `yarramate/notation/archimate` module; this app

--- a/docs/adr/0121-a-view-says-which-way-it-runs.md
+++ b/docs/adr/0121-a-view-says-which-way-it-runs.md
@@ -1,0 +1,140 @@
+# A view says which way it runs
+
+Status: accepted
+
+`presentation.direction` has been in `yarramate/projection/v1` since the
+format had a presentation block, with exactly two values, and the LikeC4
+export has always honoured it for its own `autoLayout`. The canvas did
+not: `buildLayoutConfig()` pinned `elk.direction: DOWN` and took no
+argument that could say otherwise.
+
+The pin had a reason, recorded beside it: ArchiMate's layer bands only
+read top-down, so a left-right run would draw bands corresponding to
+nothing. That reason is right for a layer-band view and wrong for the
+others. A deployment realization chain and a fan-out both read better
+left to right, and the format already lets each view say so, which left
+the canvas and the export disagreeing about a field they both read.
+`docs/VISUAL-ADAPTER.md` said both things in two different sections.
+
+Issue #274 also asked whether `elk.layered.nodePlacement.strategy:
+NETWORK_SIMPLEX` should become the placement default, and set the bar for
+answering: the crossing reduction behind the proposal was measured on one
+8-subject view, so it had to be evaluated across every view before being
+adopted.
+
+## Decision
+
+**The view decides the direction, and the default stays top-down.**
+`buildLayoutConfig(direction)` takes a `LayoutDirection` and maps it
+(`top-down` to `DOWN`, `left-right` to `RIGHT`). A view that declares
+none is handed `DEFAULT_DIRECTION` by the caller, so the canvas never has
+to decide what silence means, and the layer-band reasoning keeps the
+default it earned instead of being the only answer.
+
+- **The vocabulary is the format's, not ELK's.** `LayoutDirection` and
+  `DEFAULT_DIRECTION` live in `src/layout-direction.ts`, a module that
+  imports nothing, and `projection.ts` re-exports both. This is the split
+  `src/nesting.ts` already makes and for the same reason: the browser
+  needs the value, and importing `projection.ts` for one constant drags
+  Ajv and the projection schema into the bundle. ELK's spelling is a
+  lookup table inside the canvas and reaches nothing else.
+- **Direction is workspace state, derived like nesting.**
+  `presentationActionsFor` pushes a `direction.set` action
+  unconditionally, exactly as it does for `nesting.set`: a view that
+  omits the field is restored to top-down rather than left holding the
+  left-right run of the view the reviewer arrived from. Restating the
+  direction in force returns the same state object, because every
+  identity memo downstream reads its reference.
+- **There is still no direction control on screen.** The view declares
+  the direction, the way it declares its nesting vocabulary. A save
+  carries a declared direction through untouched, which is what it
+  already did back when the canvas ignored the field.
+- **A direction change re-arms the pending fit.** Direction is a variable
+  again, so the arming effect watches it alongside the active view id.
+  Without that, editing a view's `presentation.direction` and committing
+  would leave the canvas holding the geometry of the direction the view
+  no longer declares.
+- **`NETWORK_SIMPLEX` becomes the placement default, on a sweep rather
+  than on one view.** Measured across every authored view in this
+  repository: the six contact-update journey views and the self-model's
+  twenty-two, laid out headlessly through the same `graphToElements` and
+  `buildStylesheet` the canvas uses, each view filtered to what its own
+  query matches. Holding direction `DOWN`, against ELK's `BRANDES_KOEPF`
+  default:
+
+  | measure | BRANDES_KOEPF | NETWORK_SIMPLEX |
+  | --- | --- | --- |
+  | crossings, 28 views | 1888 | 1821 |
+  | edge length, 28 views | 1,463,386 px | 986,581 px |
+  | summed layout width | 94,216 px | 79,779 px |
+
+  Crossings fall on ten views, rise on three, and are unchanged on
+  fifteen. The three that rise are the three largest (`current-engine`
+  455 to 461, `starter-landscape` 203 to 216, the whole contact-update
+  view 126 to 128), and each buys those crossings with 12 to 40% less
+  edge and a narrower box. The trade is taken once here for every view
+  rather than offered per view: nothing in the format describes placement,
+  and a second knob would need its own reason to exist.
+
+- **The measurement is this repository's, and it does not reproduce the
+  issue's table.** #274 measured one deployment view at 1101x1050 under
+  `DOWN`; the deployment view in this repository's fixture is four named
+  subjects and one relationship, and draws 458x386. The issue's numbers
+  came from the journey workspace in the gallery rather than from the
+  fixture here, and the specific "crossings 3 to 1" result is not
+  reproduced by this sweep. What the sweep supports is the broader claim,
+  measured on 28 views instead of one.
+
+## Excluded options
+
+- **A direction control on the canvas.** Direction is a property of the
+  view, like its query and its nesting; a control would be a second place
+  to say it and would immediately raise what happens to the value on a
+  view switch. Nesting settled this question already and direction gets
+  the same answer.
+- **Keeping the pin and letting only the export read the field.** That is
+  today's behaviour, and it makes the format declare something one of its
+  two renderers silently discards. A format field that a surface refuses
+  to read is a lie the author cannot see.
+- **Per-view placement strategy.** `presentation` would gain a knob
+  describing ELK's internals rather than the view's intent, which is the
+  wrong altitude for the format. The sweep says one strategy is better
+  across the corpus; if a view is ever found that needs the other, that
+  finding is the reason to reopen this, not the absence of a knob.
+- **Declaring `left-right` on a view in this repository to demonstrate
+  it.** Several views measure better left to right (`starter-landscape`
+  drops from 216 crossings to 140 and 23% of its edge length,
+  `seven-verb-surface` 23% of its edge), but which shape reads better on
+  a screen is a look-at-it call rather than an arithmetic one, and the
+  numbers cut both ways: the same swap makes `starter-landscape` taller
+  than it was wide. The mechanism ships with the measurements recorded so
+  the call can be made with eyes on the canvas.
+- **Rotating the component packing ratio with the direction.**
+  `COMPONENT_ASPECT_RATIO` is applied in ELK's pre-rotation frame, so the
+  same 2.5 lands differently under `DOWN` and `RIGHT`. The disconnected
+  packing test now runs both ways and both stay grids, so there is
+  nothing to correct; a per-direction ratio would be two numbers where
+  the evidence supports one.
+
+## Consequences
+
+`buildLayoutConfig` and `relayoutVisible` each gain a required parameter,
+both internal to the visual app. `GraphCanvas` gains a required
+`direction` prop, and the workspace state a `direction` field with its
+`direction.set` action. Nothing in the wire protocol, the projection
+schema, or the CLI moves: `presentation.direction` was already declared,
+already validated, and already exported, and this is the surface that
+starts reading it.
+
+Every existing view keeps the layout it had, since none of them declares
+`left-right` and the default is what was pinned. What does change for
+every view is placement, which is why the measurement is recorded here
+rather than in a commit message.
+
+One unrelated repair rode along, because it made the file unreadable to
+the tools that would review this change: `graph-canvas.tsx` carried two
+raw NUL bytes in a template literal used as a pair key, so `grep` and
+`file` classified the largest UI module in the repository as binary and
+silently returned nothing for every search. They are now `\u0000`
+escapes, which is the spelling the badge cache key a few hundred lines
+above already used, and the built string is byte-for-byte the same.

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -86,7 +86,7 @@ export const declaredFolder = (view: {
  *
  * Every other presentation field the view declared is carried through by
  * `composeProjection`, so a rename cannot quietly drop a nesting vocabulary or
- * a direction the canvas never showed.
+ * the direction the view runs.
  */
 export const renameView = (
   view: SavedView,

--- a/src/layout-direction.ts
+++ b/src/layout-direction.ts
@@ -1,0 +1,15 @@
+/**
+ * Which way a view runs its layers, kept in a module that imports nothing.
+ *
+ * Here rather than in `projection.ts` for the reason `./nesting.ts` gives: the
+ * browser needs the value and not only the type, and `projection.ts` drags Ajv
+ * and the projection schema in for one constant. `projection.ts` re-exports
+ * both.
+ */
+export type LayoutDirection = 'top-down' | 'left-right'
+
+/**
+ * How a view runs when it does not say. Top-down is the behaviour that
+ * shipped, and it is what ArchiMate's layer bands read as (ADR 0121).
+ */
+export const DEFAULT_DIRECTION: LayoutDirection = 'top-down'

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -59,12 +59,12 @@ export interface ProjectionDefinition {
     readonly description?: string
     readonly layout?: 'layered'
     /**
-     * Read by the LikeC4 export for its `autoLayout`, and by nothing else. The
-     * canvas draws ArchiMate, whose layer bands only read top-down, so it
-     * ignores this rather than offering a control that would tilt the bands
-     * away from what they mean.
+     * Which way this view runs its layers. Read by the LikeC4 export for its
+     * `autoLayout` and by the canvas for ELK's `elk.direction` (ADR 0121); a
+     * view that says nothing runs `top-down`, which is what ArchiMate's layer
+     * bands read as.
      */
-    readonly direction?: 'top-down' | 'left-right'
+    readonly direction?: LayoutDirection
     /**
      * The relationship kinds that draw as nesting in this view, in precedence
      * order (ADR 0101). Absent means `['composition']`, which is the behaviour
@@ -100,6 +100,13 @@ export interface ProjectionDefinition {
  */
 export { DEFAULT_NESTING, type NestingKind } from './nesting.js'
 import type { NestingKind } from './nesting.js'
+
+/**
+ * Which way a view runs, and the default. Split out for the same reason as the
+ * nesting vocabulary above, and re-exported here on the same terms (ADR 0121).
+ */
+export { DEFAULT_DIRECTION, type LayoutDirection } from './layout-direction.js'
+import type { LayoutDirection } from './layout-direction.js'
 
 export type ProjectionQuery = ProjectionDefinition['query']
 

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -30,6 +30,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { NestingKind } from "../nesting.js";
+import type { LayoutDirection } from "../layout-direction.js";
 import type { ProjectionQuery } from "../projection.js";
 import type { VisualRenderedModel } from "../adapters/visual/wire.js";
 import type { YarramateOperation } from "../operations.js";
@@ -234,6 +235,7 @@ const DiagramWorkspace = ({
   waiting,
   layout,
   nesting,
+  direction,
   showLifecycle,
   showEvidence,
   showOwnership,
@@ -272,6 +274,8 @@ const DiagramWorkspace = ({
   readonly waiting: string | null;
   readonly layout: "layered";
   readonly nesting: readonly NestingKind[];
+  /** Which way the active view runs its layers (#274, ADR 0121). */
+  readonly direction: LayoutDirection;
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
@@ -513,6 +517,7 @@ const DiagramWorkspace = ({
             showNudges={showNudges}
             openQuestionCounts={openQuestionCounts}
             activeViewId={state.activeView}
+            direction={direction}
             savedPositions={state.model.layouts[state.activeView]}
             // A read-only drag still moves the node - arranging what is on
             // screen is reading - but the debounced save it would queue goes
@@ -1556,6 +1561,7 @@ export const App = ({
           waiting={waiting}
           layout={workspace.layout}
           nesting={workspace.nesting}
+          direction={workspace.direction}
           decorations={decorations}
           connection={workspace.connection}
           onConnectTarget={(id) =>

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -9,6 +9,7 @@ import type {
   CanvasEdge,
 } from '../graph-projection.js'
 import { DEFAULT_NESTING, type NestingKind } from '../nesting.js'
+import { DEFAULT_DIRECTION, type LayoutDirection } from '../layout-direction.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -201,18 +202,34 @@ const COMPONENT_ASPECT_RATIO = 2.5
 // `force` ever read went with them - the projection schema had required a
 // seed of every view that declared a layout at all, for one backend's benefit.
 //
-// `elk.direction` is read only by `layered`, and it is `DOWN`: ArchiMate's
-// layer bands only read top-down, so a left-right run would draw bands
-// corresponding to nothing. This used to be a pin applied over a reviewer's
-// stored `direction`, kept so that returning to native notation restored what
-// they declared. There is no native notation to return to, so the pin is now
-// simply the value. `presentation.direction` stays in the projection format:
-// the LikeC4 export reads it for its own `autoLayout`, which is not drawing
-// ArchiMate bands and has no reason to be held top-down.
-export function buildLayoutConfig(): cytoscape.LayoutOptions {
+// `elk.direction` is read only by `layered`, and the view says which way it
+// runs (#274, ADR 0121). It was pinned `DOWN` on the reasoning that ArchiMate's
+// layer bands only read top-down, which is right for a layer-band view and
+// wrong for the others: a deployment realization chain and a fan-out both read
+// better left to right, and `presentation.direction` has been in the projection
+// format all along, honoured by the LikeC4 export for its own `autoLayout`. A
+// view that says nothing still runs top-down, so the band reasoning keeps the
+// default it earned and stops being the only answer.
+const ELK_DIRECTION: Readonly<Record<LayoutDirection, 'DOWN' | 'RIGHT'>> = {
+  'top-down': 'DOWN',
+  'left-right': 'RIGHT',
+}
+
+export function buildLayoutConfig(direction: LayoutDirection): cytoscape.LayoutOptions {
   const elk: ElkLayoutOptions['elk'] = {
     algorithm: 'layered',
-    'elk.direction': 'DOWN',
+    'elk.direction': ELK_DIRECTION[direction],
+    // Placement measured across every authored view in this repository - the
+    // six contact-update journey views and the self-model's twenty-two - and
+    // adopted on that sweep rather than on the single 8-subject view #274
+    // opened with (ADR 0121). Holding direction DOWN, NETWORK_SIMPLEX against
+    // the BRANDES_KOEPF default cut total edge length by a third (1.46M px to
+    // 987k), narrowed the summed layout by 15%, and moved crossings 1888 to
+    // 1821: fewer on ten views, more on three, unchanged on fifteen. The three
+    // it costs crossings are the three largest, and each pays for them with 12
+    // to 40% less edge - which is why the trade is taken here once for every
+    // view rather than declared per view.
+    'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
     // Bare key on purpose - replaces cytoscape-elk's injected viewport
     // ratio; see COMPONENT_ASPECT_RATIO.
     aspectRatio: COMPONENT_ASPECT_RATIO,
@@ -872,8 +889,8 @@ export function graphToElements(
   const drawnPerPair = new Map<string, number>()
   const pairKey = (edge: CanvasEdge): string =>
     edge.from < edge.to
-      ? `${edge.from} ${edge.to}`
-      : `${edge.to} ${edge.from}`
+      ? `${edge.from}\u0000${edge.to}`
+      : `${edge.to}\u0000${edge.from}`
   for (const edge of drawnEdges) {
     const key = pairKey(edge)
     drawnPerPair.set(key, (drawnPerPair.get(key) ?? 0) + 1)
@@ -1022,8 +1039,11 @@ export function applyFilter(
 // the nodes it left overlapping. With `layered` the only backend a layout run
 // cannot still be in flight when the next one is requested, so none of that
 // apparatus has anything left to guard.
-function runLayout(eles: Core | CollectionReturnValue): void {
-  eles.layout(buildLayoutConfig()).run()
+function runLayout(
+  eles: Core | CollectionReturnValue,
+  direction: LayoutDirection,
+): void {
+  eles.layout(buildLayoutConfig(direction)).run()
 }
 
 
@@ -1035,8 +1055,8 @@ function runLayout(eles: Core | CollectionReturnValue): void {
 // default re-frames the viewport to the result, so no separate fit call is
 // needed; `layout()` is a no-op on an empty visible collection, so callers
 // never need to guard against "the new view matched nothing".
-export function relayoutVisible(cy: Core): void {
-  runLayout(cy.elements(':visible'))
+export function relayoutVisible(cy: Core, direction: LayoutDirection): void {
+  runLayout(cy.elements(':visible'), direction)
 }
 
 // Re-frames the viewport around what is visible without moving a single node.
@@ -1220,6 +1240,12 @@ interface GraphCanvasProps {
    * overlay; an empty map (host shipped no overlay) draws no chips. */
   readonly openQuestionCounts: ReadonlyMap<string, number>
   readonly activeViewId: string
+  /**
+   * Which way the active view runs its layers (#274, ADR 0121), from its
+   * `presentation.direction`. A view that declares none is handed
+   * `DEFAULT_DIRECTION`, so the canvas never has to decide what silence means.
+   */
+  readonly direction: LayoutDirection
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
@@ -1263,6 +1289,7 @@ export function GraphCanvas({
   faultedIds,
   decorations,
   activeViewId,
+  direction,
   savedPositions,
   onSaveLayout,
   onKindDrop,
@@ -1297,6 +1324,7 @@ export function GraphCanvas({
   const isInitialSyncRef = useRef(true)
   const isInitialPresentationSyncRef = useRef(true)
   const activeViewIdRef = useRef(activeViewId)
+  const directionRef = useRef(direction)
   const pendingViewFitRef = useRef(false)
   const matchedIdsRef = useRef(matchedIds)
   // Seeded with the prop so the mount render never reads as "the quick filter
@@ -1529,7 +1557,7 @@ export function GraphCanvas({
       cyRef.current.add(elements)
     }
 
-    runLayout(cyRef.current)
+    runLayout(cyRef.current, direction)
     // `openQuestionCounts` is derived from the same model frame as `graph`,
     // so its identity moves exactly when the graph's does - listed for
     // honesty, never an extra rerun.
@@ -1571,21 +1599,25 @@ export function GraphCanvas({
     }
   }, [selectedId, graph])
 
-  // Arms a pending fit when the active view changes. It used to arm on layout
-  // direction and notation too, because both fed `buildLayoutConfig` and a
-  // notation swap would otherwise leave ArchiMate shapes sitting in the native
-  // direction's geometry. Neither is a variable any more: there is one
-  // notation and one direction, so the view is the only thing left that can
-  // change what the layout should be.
+  // Arms a pending fit when the active view changes, or when the direction it
+  // declares does (#274). Direction is a variable again: it feeds
+  // `buildLayoutConfig`, so a view whose `presentation.direction` is edited
+  // and committed would otherwise keep the geometry of the direction it no
+  // longer declares. Notation is still not one - there is a single notation -
+  // so the view and its direction are all that can change what the layout
+  // should be.
   // Declared before the filter-apply effect below - same-phase effects commit
   // in source order, so a view switch whose filter result lands in the very
   // same render (e.g. clearing back to "All") is still armed in time for that
   // commit.
   useEffect(() => {
-    if (activeViewId === activeViewIdRef.current) return
+    if (activeViewId === activeViewIdRef.current && direction === directionRef.current) {
+      return
+    }
     activeViewIdRef.current = activeViewId
+    directionRef.current = direction
     pendingViewFitRef.current = true
-  }, [activeViewId])
+  }, [activeViewId, direction])
 
   // Apply structural filter (matchedIds) and quick-filter narrowing, then,
   // only once a pending view-switch relayout is armed and its filter result
@@ -1617,7 +1649,7 @@ export function GraphCanvas({
     quickFilterTextRef.current = quickFilterText
     if (pendingViewFitRef.current || matchedChanged) {
       pendingViewFitRef.current = false
-      relayoutVisible(cyRef.current)
+      relayoutVisible(cyRef.current, direction)
     } else if (quickFilterChanged && fitVisible(cyRef.current)) {
       // A quick-filter keystroke never relayouts - the survivors keep their
       // positions (a reviewer's drags included) and the viewport re-frames
@@ -1633,7 +1665,7 @@ export function GraphCanvas({
         pan: { ...cyRef.current.pan() },
       }
     }
-  }, [matchedIds, quickFilterText, graph])
+  }, [matchedIds, quickFilterText, graph, direction])
 
   // Session-local discard of the active view's saved layout: record the
   // discard, drop the pin the layoutstop handler would re-apply, and run a
@@ -1647,7 +1679,7 @@ export function GraphCanvas({
     setDiscardedViews((prev) => new Set(prev).add(activeViewId))
     savedPositionsRef.current = undefined
     dragSaveHandleRef.current?.cancelPending()
-    if (cyRef.current !== null) relayoutVisible(cyRef.current)
+    if (cyRef.current !== null) relayoutVisible(cyRef.current, direction)
   }
 
   // The on-canvas zoom cluster (#308). A press zooms about the viewport's own
@@ -1655,11 +1687,11 @@ export function GraphCanvas({
   // meaningful position. The reviewer's resulting viewport is theirs: it is
   // deliberately not recorded as automatic framing, so a later panel resize
   // leaves it standing, exactly as a wheel zoom is left standing.
-  const zoomStep = (direction: 1 | -1): void => {
+  const zoomStep = (step: 1 | -1): void => {
     const cy = cyRef.current
     if (cy === null) return
     cy.zoom({
-      level: steppedZoom(cy.zoom(), direction),
+      level: steppedZoom(cy.zoom(), step),
       renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 },
     })
   }

--- a/src/visual-app/query-panel.tsx
+++ b/src/visual-app/query-panel.tsx
@@ -224,8 +224,8 @@ const badgePresentation = (
       ? { [key]: badges[key] }
       : {};
   return {
-    // Every field the view declared, carried rather than restated: a direction
-    // the canvas never shows and a nesting vocabulary it does are both dropped
+    // Every field the view declared, carried rather than restated: the
+    // direction it runs and the nesting vocabulary it draws are both dropped
     // by a document that composes only what this tab can edit.
     ...declared,
     ...write("showLifecycle"),

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { LayoutDirection } from "../layout-direction.js";
 import type { ProjectionQuery } from "../projection.js";
 import type {
   VisualViewOperation,
@@ -63,12 +64,12 @@ export interface BuildPayloadParams {
   readonly showOwnership: boolean;
   /**
    * Whatever the view being overwritten already declared, carried through
-   * rather than restated. The canvas has no direction control - it draws
-   * ArchiMate, which is top-down by construction - but the LikeC4 export reads
-   * `presentation.direction`, so a save that simply omitted it would quietly
-   * drop a value the reviewer never saw and cannot have meant to discard.
+   * rather than restated. The canvas draws the direction now (#274, ADR 0121)
+   * and the LikeC4 export has always read it, but there is still no control
+   * that sets one: the view declares it, so a save that simply omitted it
+   * would drop a value the reviewer never asked to discard.
    */
-  readonly carriedDirection: "top-down" | "left-right" | undefined;
+  readonly carriedDirection: LayoutDirection | undefined;
 }
 
 /**

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -4,6 +4,10 @@ import type {
   CanvasNode,
 } from "../graph-projection.js";
 import { DEFAULT_NESTING, type NestingKind } from "../nesting.js";
+import {
+  DEFAULT_DIRECTION,
+  type LayoutDirection,
+} from "../layout-direction.js";
 import type { DecorationMap } from "./graph-canvas.js";
 import type { ContextMenuTarget } from "./context-menu-model.js";
 import type { BottomPanelTabId } from "./query-panel.js";
@@ -345,6 +349,13 @@ export interface VisualWorkspaceState {
    * alone - the behaviour that shipped before a view could say.
    */
   readonly nesting: readonly NestingKind[];
+  /**
+   * Which way the active view runs its layers (#274, ADR 0121). A view that
+   * says nothing runs `DEFAULT_DIRECTION`, the same rule `nesting` follows:
+   * silence restores the default rather than carrying the previous view's
+   * answer across.
+   */
+  readonly direction: LayoutDirection;
   readonly layout: "layered";
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
@@ -413,6 +424,10 @@ export type VisualWorkspaceAction =
       readonly nesting: readonly NestingKind[];
     }
   | {
+      readonly type: "direction.set";
+      readonly direction: LayoutDirection;
+    }
+  | {
       readonly type: "layout.set";
       readonly layout: "layered";
     }
@@ -449,6 +464,7 @@ export const presentationActionsFor = (
     | {
         readonly layout?: "layered";
         readonly nesting?: readonly NestingKind[];
+        readonly direction?: LayoutDirection;
         readonly showLifecycle?: boolean;
         readonly showEvidence?: boolean;
         readonly showOwnership?: boolean;
@@ -465,6 +481,13 @@ export const presentationActionsFor = (
   actions.push({
     type: "nesting.set",
     nesting: presentation?.nesting ?? DEFAULT_NESTING,
+  });
+  // Unconditional for the same reason as nesting above: a view that omits
+  // `direction` runs top-down, and must not inherit the left-right run of the
+  // view the reviewer came from.
+  actions.push({
+    type: "direction.set",
+    direction: presentation?.direction ?? DEFAULT_DIRECTION,
   });
   if (presentation?.showLifecycle !== undefined) {
     actions.push({
@@ -580,6 +603,7 @@ export const createVisualWorkspaceState = (
   pendingViewRename: null,
   contextMenu: null,
   nesting: DEFAULT_NESTING,
+  direction: DEFAULT_DIRECTION,
   layout: "layered",
   showLifecycle: true,
   showEvidence: true,
@@ -828,6 +852,14 @@ export const visualWorkspaceReducer = (
       return sameNesting(state.nesting, action.nesting)
         ? state
         : { ...state, nesting: action.nesting };
+    case "direction.set":
+      // Restating the same direction is not a change, the rule `nesting.set`
+      // states above: every view declares one, so without this a view switch
+      // would mint a new state object and every identity memo downstream would
+      // miss.
+      return state.direction === action.direction
+        ? state
+        : { ...state, direction: action.direction };
     case "layout.set":
       return { ...state, layout: action.layout };
     case "presentation.toggled":

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -13,6 +13,10 @@ import {
   steppedZoom,
 } from '../src/visual-app/graph-canvas.js'
 import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.js'
+import {
+  DEFAULT_DIRECTION,
+  type LayoutDirection,
+} from '../src/layout-direction.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -306,18 +310,38 @@ const countOverlappingPairs = (cy: cytoscape.Core): number => {
 describe('buildLayoutConfig', () => {
   it('lays out with zero overlapping node bounding boxes', async () => {
     const cy = buildLayoutFixture()
-    await runLayout(cy, buildLayoutConfig())
+    await runLayout(cy, buildLayoutConfig('top-down'))
     expect(countOverlappingPairs(cy)).toBe(0)
   })
 
-  // ArchiMate's layer bands only read top-down, so the canvas lays out DOWN
-  // and takes no direction to be told otherwise. `presentation.direction`
-  // survives in the projection format for the LikeC4 export, which draws no
-  // bands, and this config is deliberately blind to it.
-  it('lays out DOWN, and takes nothing that could say otherwise', () => {
-    const config = buildLayoutConfig() as unknown as { elk: Record<string, unknown> }
-    expect(config.elk['elk.direction']).toBe('DOWN')
-    expect(buildLayoutConfig.length).toBe(0)
+  // The view says which way it runs (#274, ADR 0121). The DOWN pin was right
+  // for a layer-band view and wrong for the others, and the format has
+  // declared `presentation.direction` all along - honoured by the LikeC4
+  // export and, until now, by nothing on the canvas.
+  const elkOf = (direction: LayoutDirection): Record<string, unknown> =>
+    (buildLayoutConfig(direction) as unknown as { elk: Record<string, unknown> })
+      .elk
+
+  it('runs the direction the view declares', () => {
+    expect(elkOf('top-down')['elk.direction']).toBe('DOWN')
+    expect(elkOf('left-right')['elk.direction']).toBe('RIGHT')
+    // The default is the format's, not a second opinion held here: a view that
+    // declares nothing is handed DEFAULT_DIRECTION by the caller and lands on
+    // the top-down the layer bands earned.
+    expect(elkOf(DEFAULT_DIRECTION)['elk.direction']).toBe('DOWN')
+  })
+
+  // Adopted on a sweep of every authored view in this repository rather than
+  // on the single 8-subject view #274 opened with: holding direction DOWN,
+  // NETWORK_SIMPLEX cut total edge length across the 28 views by a third and
+  // moved crossings 1888 to 1821. Direction-independent, so it is stated once
+  // for both.
+  it('places with NETWORK_SIMPLEX whichever way the view runs (#274)', () => {
+    for (const direction of ['top-down', 'left-right'] as const) {
+      expect(elkOf(direction)['elk.layered.nodePlacement.strategy']).toBe(
+        'NETWORK_SIMPLEX',
+      )
+    }
   })
 
   // Nine subjects, no relationships (#308). Before the packing ratio was
@@ -325,28 +349,35 @@ describe('buildLayoutConfig', () => {
   // shape - NaN headless) let ELK's component packing emit one 172x1092
   // column: w/h 0.16, every node in the same 250px-wide lane. A grid has
   // several lanes in both axes and bounded elongation either way.
-  it('packs disconnected subjects into a grid, never one column (#308)', async () => {
-    const cy = buildDisconnectedFixture(9)
-    await runLayout(cy, buildLayoutConfig())
-    const bb = cy.nodes().boundingBox()
-    expect(bb.w / bb.h).toBeGreaterThan(0.5)
-    expect(bb.w / bb.h).toBeLessThan(4)
-    // Grid-ish, stated structurally as well as proportionally: more than one
-    // distinct column of node centres, and more than one distinct row.
-    const xs = new Set(cy.nodes().map((node) => Math.round(node.position().x)))
-    const ys = new Set(cy.nodes().map((node) => Math.round(node.position().y)))
-    expect(xs.size).toBeGreaterThan(1)
-    expect(ys.size).toBeGreaterThan(1)
-    expect(countOverlappingPairs(cy)).toBe(0)
-  })
+  //
+  // Asserted for BOTH directions since #274: the packer breaks rows in the
+  // pre-rotation frame, so the same requested ratio lands differently under
+  // DOWN and RIGHT, and a left-right view must not be the one that gets the
+  // column back.
+  it.each(['top-down', 'left-right'] as const)(
+    'packs disconnected subjects into a grid, never one column, running %s (#308)',
+    async (direction) => {
+      const cy = buildDisconnectedFixture(9)
+      await runLayout(cy, buildLayoutConfig(direction))
+      const bb = cy.nodes().boundingBox()
+      expect(bb.w / bb.h).toBeGreaterThan(0.5)
+      expect(bb.w / bb.h).toBeLessThan(4)
+      // Grid-ish, stated structurally as well as proportionally: more than one
+      // distinct column of node centres, and more than one distinct row.
+      const xs = new Set(cy.nodes().map((node) => Math.round(node.position().x)))
+      const ys = new Set(cy.nodes().map((node) => Math.round(node.position().y)))
+      expect(xs.size).toBeGreaterThan(1)
+      expect(ys.size).toBeGreaterThan(1)
+      expect(countOverlappingPairs(cy)).toBe(0)
+    },
+  )
 
   // The packing ratio is this config's own, stated on the bare `aspectRatio`
   // key on purpose: cytoscape-elk injects `aspectRatio: cy.width() /
   // cy.height()` into the very bag it forwards to ELK, and only the same
   // spelling replaces that injection instead of racing it as a second key.
   it('pins the component packing ratio, replacing the injected viewport shape (#308)', () => {
-    const config = buildLayoutConfig() as unknown as { elk: Record<string, unknown> }
-    expect(config.elk['aspectRatio']).toBe(2.5)
+    expect(elkOf('top-down')['aspectRatio']).toBe(2.5)
   })
 
   // `layered` is the only backend, so a layout run is one synchronous elk
@@ -355,7 +386,7 @@ describe('buildLayoutConfig', () => {
   // guard that `force` needed.
   it('relayouts the visible subgraph in one synchronous pass', () => {
     const cy = buildHubFixture()
-    relayoutVisible(cy)
+    relayoutVisible(cy, 'top-down')
     expect(buildPositionMap(cy.nodes()).size ?? Object.keys(buildPositionMap(cy.nodes())).length)
       .toBeGreaterThan(0)
   })

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -184,7 +184,7 @@ describe('relayoutVisible', () => {
     const visibleBefore = { ...cy.getElementById('node1').position() }
     const settled = new Promise<void>((resolve) => cy.one('layoutstop', () => resolve()))
 
-    relayoutVisible(cy)
+    relayoutVisible(cy, 'top-down')
     await settled
 
     expect(cy.getElementById('node3').position()).toEqual(hiddenBefore)
@@ -194,7 +194,7 @@ describe('relayoutVisible', () => {
   it('is a safe no-op when nothing is visible', () => {
     const cy = buildPositionedCy()
     applyFilter(cy, [], '')
-    expect(() => relayoutVisible(cy)).not.toThrow()
+    expect(() => relayoutVisible(cy, 'top-down')).not.toThrow()
   })
 })
 

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -128,9 +128,9 @@ describe('buildPayload', () => {
     expect(projectionOf(build()).presentation?.notation).toBeUndefined()
   })
 
-  // The canvas has no direction control, so a save must carry through what the
-  // view already declared. Dropping it would discard a value the LikeC4 export
-  // reads and the reviewer never saw.
+  // There is no direction control on screen - the view declares one (#274,
+  // ADR 0121) - so a save must carry through what it already said. Dropping it
+  // would discard a value the canvas and the LikeC4 export both read.
   it('omits direction entirely when there is none to carry', () => {
     expect(
       projectionOf(build({ carriedDirection: undefined })).presentation,

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -327,18 +327,49 @@ describe("visualWorkspaceReducer layout", () => {
     expect(next.layout).toBe("layered");
   });
 
-  // A view may still declare `direction` - the LikeC4 export reads it - and
-  // the canvas must take no notice: it draws ArchiMate, which is top-down by
-  // construction, and there is no control for a declared direction to move.
-  it("ignores a direction a view declares", () => {
+  // A view says which way it runs and the canvas takes notice (#274, ADR
+  // 0121). The ArchiMate bands that pinned this top-down keep the DEFAULT, not
+  // the only answer: a deployment chain or a fan-out reads better left to
+  // right, and the format has carried the field all along for the LikeC4
+  // export.
+  it("adopts a direction a view declares", () => {
     const actions = presentationActionsFor({
       layout: "layered",
       direction: "left-right",
-    } as Parameters<typeof presentationActionsFor>[0]);
+    });
     expect(actions).toEqual([
       { type: "layout.set", layout: "layered" },
       { type: "nesting.set", nesting: ["composition"] },
+      { type: "direction.set", direction: "left-right" },
     ]);
+    const next = actions.reduce(visualWorkspaceReducer, workspaceState);
+    expect(next.direction).toBe("left-right");
+  });
+
+  // Restored to the default rather than left holding the previous view's run,
+  // the rule `nesting` follows: a view that says nothing is top-down, and
+  // arriving from a left-right view must not tilt it.
+  it("restores the default direction for a view that declares none", () => {
+    const leftRight = presentationActionsFor({ direction: "left-right" }).reduce(
+      visualWorkspaceReducer,
+      workspaceState,
+    );
+    expect(leftRight.direction).toBe("left-right");
+    const back = presentationActionsFor({}).reduce(
+      visualWorkspaceReducer,
+      leftRight,
+    );
+    expect(back.direction).toBe("top-down");
+  });
+
+  // Every identity memo downstream of this state reads its reference, so
+  // restating the same direction must not mint a new object - the rule
+  // `nesting.set` states for the same reason.
+  it("returns the same state when a view restates the direction in force", () => {
+    const actions = presentationActionsFor({ direction: "top-down" });
+    expect(actions.reduce(visualWorkspaceReducer, workspaceState)).toBe(
+      workspaceState,
+    );
   });
 
   it("leaves layout untouched when a view declares none", () => {
@@ -358,6 +389,7 @@ describe("visualWorkspaceReducer layout", () => {
     expect(actions).toEqual([
       { type: "layout.set", layout: "layered" },
       { type: "nesting.set", nesting: ["composition"] },
+      { type: "direction.set", direction: "top-down" },
     ]);
   });
 });
@@ -416,6 +448,7 @@ describe("visualWorkspaceReducer presentation", () => {
     const actions = presentationActionsFor({ showOwnership: true });
     expect(actions).toEqual([
       { type: "nesting.set", nesting: ["composition"] },
+      { type: "direction.set", direction: "top-down" },
       { type: "presentation.toggled", flag: "showOwnership", value: true },
     ]);
   });


### PR DESCRIPTION
## Summary

Closes #274.

`presentation.direction` has been in `yarramate/projection/v1` all along, with exactly two values, and the LikeC4 export has always honoured it for its `autoLayout`. The canvas pinned `elk.direction: DOWN` and took no argument that could say otherwise, so the format declared something one of its two renderers silently discarded. `docs/VISUAL-ADAPTER.md` said both things in two different sections.

The pin's reasoning (ArchiMate's layer bands only read top-down) is right for a layer-band view and wrong for a deployment realization chain or a fan-out, so it keeps the **default** rather than being the only answer. `buildLayoutConfig(direction)` maps `top-down` to `DOWN` and `left-right` to `RIGHT`; a view declaring none is handed `DEFAULT_DIRECTION` by the caller, so the canvas never has to decide what silence means.

`LayoutDirection` and `DEFAULT_DIRECTION` live in `src/layout-direction.ts`, the split `src/nesting.ts` already makes for the same reason: the browser needs the value and `projection.ts` drags Ajv in for one constant. ELK's spelling is a lookup table inside the canvas and reaches nothing else.

Direction is workspace state derived like `nesting`: `presentationActionsFor` pushes `direction.set` unconditionally, so a view that omits the field is restored to top-down rather than left holding the run of the view the reviewer came from, and restating the direction in force returns the same state object. The arming effect watches direction alongside the active view id, so editing a view's direction and committing cannot leave the canvas holding the geometry of a direction the view no longer declares. There is still no direction control on screen: the view declares it, and a save carries a declared direction through untouched.

## The NETWORK_SIMPLEX evaluation you asked for

The issue set the bar: evaluate it across every view before adopting, since the crossing reduction was measured on one 8-subject view. Measured on all 28 authored views in this repository (the six contact-update journey views and the self-model's twenty-two), laid out headlessly through the same `graphToElements` and `buildStylesheet` the canvas uses, each view filtered to what its own query matches. Holding direction `DOWN`:

| measure | BRANDES_KOEPF (today) | NETWORK_SIMPLEX |
| --- | --- | --- |
| crossings, 28 views | 1888 | 1821 |
| edge length, 28 views | 1,463,386 px | 986,581 px |
| summed layout width | 94,216 px | 79,779 px |

Crossings fall on ten views, rise on three, unchanged on fifteen. The three that rise are the three largest (`current-engine` 455→461, `starter-landscape` 203→216, the whole contact-update view 126→128) and each buys those crossings with 12 to 40% less edge and a narrower box. **Adopted**, once for every view rather than as a per-view knob: nothing in the format describes placement, and a knob at ELK's altitude would be the wrong thing in `presentation`.

**One honest note.** Your table measured a deployment view at 1101x1050 under `DOWN`; the deployment view in this repository's fixture is four named subjects plus `relationships: between` and draws 458x386. Your numbers came from the journey workspace in the gallery, not the fixture here, so the specific "crossings 3 → 1" result is not reproduced by this sweep. What the sweep supports is the broader claim, on 28 views instead of one.

## What is deliberately not here

No view in this repository declares `left-right` yet. Several measure better that way (`starter-landscape` drops from 216 crossings to 140 and 23% of its edge length; `seven-verb-surface` 23% of its edge), but which shape reads better on a screen is a look-at-it call rather than an arithmetic one, and the numbers cut both ways: the same swap makes `starter-landscape` taller than it was wide. The mechanism ships with the measurements recorded so the call can be made with eyes on the canvas. `elk.edgeRouting` is untouched, for the reason your scope note gives.

## One repair riding along

`graph-canvas.tsx` carried two raw NUL bytes in a template literal used as a pair key, so `grep` and `file` classified the largest UI module in the repository as **binary** and silently returned nothing for every search against it. They are now `\u0000` escapes, the spelling the badge cache key a few hundred lines above already uses; the built string is byte-for-byte the same. Included here rather than split out because it is what made this change reviewable at all.

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: typecheck, build, 1741 tests across 97 files, `self:check` no errors, `likec4 validate` valid.

Tests: `buildLayoutConfig` asserts the mapping both ways and that `DEFAULT_DIRECTION` lands on `DOWN`; `NETWORK_SIMPLEX` is asserted for both directions; the #308 disconnected-packing test now runs under **both** directions, since the packer breaks rows in the pre-rotation frame and a left-right view must not be the one that gets the single column back. Reducer tests cover adopting a declared direction, restoring the default for a view that declares none, and returning the same state object when a view restates the direction in force.

**Not eyeballed in a browser.** No browser automation this session per your standing instruction, so this is test-verified only, like the rest of the sweep's UI work.

## Related issue

#274.

## Contract impact

None to the published surface. `presentation.direction` was already declared, validated and exported; this is the surface that starts reading it. `buildLayoutConfig` and `relayoutVisible` gain a required parameter and `GraphCanvas` a required prop, all internal to the visual app. Every existing view keeps its direction, since none declares `left-right`. Every view's **placement** changes; no saved layout does, since a saved layout is applied over the layout result.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
