### PR TITLE
feat: a rule can name its exception (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+- **Added.** A rule can name its exception (#267, ADR 0122).
+  `yarramate/projection/v1` gains `query.exclude`, a list of subjects the
+  query would otherwise select and the author has taken out. A facet view
+  states a rule, and every interesting rule has an exception someone
+  would rather state than abandon the rule for; until now the only ways
+  out were to enumerate every subject by hand or to leave the unwanted
+  one on the canvas. The exclusion is final: it is a concept facet and an
+  endpoint veto, so `relationships: connected` cannot walk an excluded
+  subject back in by the far end of a relationship, and relationships
+  touching one are dropped with it. A relationship can be excluded by
+  name too. It is also the first reason `explainProjection` reaches, so a
+  subject taken out reads as taken out rather than as dropped by whatever
+  rule would also have dropped it, and the query panel labels it "Taken
+  out of this view". Naming a subject no facet selects is allowed and
+  inert until the model grows into the rule. The LikeC4 export inherits
+  all of this without change, since it evaluates the query rather than
+  translating it.
+- **Changed.** `Remove from view` and `Add to this view` are offered on a
+  view that describes its subjects with facets (#267, ADR 0122), where
+  the whole View group used to vanish. It was absent on half the authored
+  views of the contact-update journey. On a faceted view, removing names
+  the subject in `exclude` and adding lifts an exception the view already
+  holds; adding a subject the facets never selected is still not offered,
+  because that would need an `include` tier and writing it into
+  `subjects` would quietly convert the rule into a list. The changeset
+  tray reports what happened to the VIEW rather than to the list, so a
+  name arriving in `exclude` reads as the subject leaving.
+  `activeViewMembership` changes shape accordingly, from a list or `null`
+  to a union naming which kind of view it describes; `null` now means
+  only that no view is active.
+
 - **Changed.** A view says which way it runs, and the canvas listens
   (#274, ADR 0121). `presentation.direction` has been in
   `yarramate/projection/v1` all along and the LikeC4 export has always

--- a/docs/PROJECTIONS.md
+++ b/docs/PROJECTIONS.md
@@ -29,6 +29,13 @@ presentation:
 Query fields combine with logical AND:
 
 - `subjects` filters globally qualified concept subject identities;
+- `exclude` names subjects this query would otherwise select and the author
+  has taken out: the exception a rule cannot state (#267,
+  [ADR 0122](adr/0122-a-rule-can-name-its-exception.md)). It applies after
+  every other facet AND after `connected` expansion, so an excluded subject is
+  out whichever way it would have come back in, and relationships touching one
+  are dropped with it. A relationship can be named too. Naming a subject no
+  facet selects is allowed and inert until the model grows into the rule;
 - `documents` filters canonical document IDs;
 - `kinds` filters globally qualified concept kind identities;
 - `kindMatching` is `exact` or `descendants` and defaults to `exact`;

--- a/docs/adr/0122-a-rule-can-name-its-exception.md
+++ b/docs/adr/0122-a-rule-can-name-its-exception.md
@@ -1,0 +1,134 @@
+# A rule can name its exception
+
+Status: accepted
+
+`Remove from view` and `Add to this view` (#255, shipped in #263) were
+offered only where the active view named its subjects.
+`activeViewMembership` answered `null` for a view that describes its
+subjects with facets, and the whole View group left the menu. The reason
+was recorded in the test: an item that could only ever do nothing is
+worse than no item.
+
+That reasoning is sound about adding, and it was never true about
+removing. A facet view is precisely where a reviewer most wants to say
+"not that one": `layers: [application]` is a rule, and every interesting
+rule has an exception the author would rather state than abandon the rule
+for. Measured on the contact-update journey, the group was absent on half
+the authored views. The only ways out were to abandon the facet and
+enumerate every subject by hand, or to leave the unwanted subject on the
+canvas.
+
+The alternative a diagramming tool offers is worse than either. In Archi
+a removed element simply stops being in the view and the diagram never
+records that anyone decided it.
+
+## Decision
+
+`yarramate/projection/v1` gains `query.exclude`, a list of subjects the
+query would otherwise select and the author has taken out. The view stays
+declarative, the rule goes on refreshing as the model grows, and the
+exception is a reviewable line in Git rather than a silent absence.
+
+- **An exclusion is final.** It is applied as a concept facet AND as an
+  endpoint veto, so it survives everything that could put the subject
+  back: `relationships: connected` adds the far end of every relationship
+  it draws, and an exclusion applied only to the initial selection would
+  let an excluded subject walk back in by the other end of a relationship
+  to one that stayed. Relationships touching an excluded subject go with
+  it, because a line drawn to something not on the canvas has nowhere to
+  land. This is the same veto `excludeStatuses` already holds, and it is
+  stated here for the same reason.
+- **A relationship can be excluded by name.** `exclude` names subjects,
+  and a relationship is a subject. Excluding one leaves both its ends
+  drawn.
+- **The exception outranks every rule as an explanation.** `exclude` is
+  the first facet `droppedBy` checks, ahead of `states`. When someone has
+  written a subject down as taken out, that is the first reason a reader
+  would reach for, whatever else would also have dropped it. The query
+  panel labels the facet "Taken out of this view" (#248).
+- **An exclusion is a statement about the rule, not about today's match
+  set.** Naming a subject no facet currently selects is allowed, and is
+  simply inert until the model grows into the rule. This is what lets the
+  menu offer the item without first knowing what the query matches, and
+  it means an exception survives a model that has not caught up with it
+  yet.
+- **The menu is asymmetric on a faceted view, deliberately.** `Remove
+  from view` names the subject in `exclude`. `Add to this view` is
+  offered only to lift an exception the view already holds. Adding a
+  subject the facets do not select would need an `include` tier, and
+  writing it into `subjects` instead would quietly convert the rule into
+  a list. So `withMembership` returns its usual `null` for that case, and
+  the original reasoning still governs it: an item that could only ever
+  do nothing is worse than no item.
+- **The last exception takes the key with it.** Lifting the final
+  exclusion rebuilds the query without an `exclude` key rather than
+  leaving `exclude: []`, which says the same thing and which the schema's
+  `minItems: 1` refuses anyway.
+- **The tray reads the view, not the list.** `membershipDelta` reports a
+  name arriving in `exclude` as `-id` and a name leaving it as `+id`,
+  because the row says what happened to the view. On an enumerating view
+  the two coincide; on a faceted one they are inverted, and reporting the
+  list's own motion would tell the reviewer the opposite of what they
+  did.
+
+### The three questions the issue left open
+
+**Does `exclude` belong in `yarramate/projection/v1`, and is adding it
+breaking?** Yes, and no. It is an optional field on `query`, so every
+existing projection is unchanged and still valid. The LikeC4 export needs
+no work at all: it evaluates the query through `evaluateProjection` and
+reads only `query.states` for itself, so it inherits exclusion with the
+rest. The `presentation` round-trip is untouched, since this is a query
+field. A consumer validating against a pinned pre-`exclude` copy of the
+schema will reject a projection that uses one, the ordinary shape of an
+additive schema change here. The one place that did need telling is
+`SUBJECT_REFERENCE_POSITIONS`: `exclude` holds subject addresses, so a
+rename has to move them, and the schema-derived completeness test is what
+said so.
+
+**Should the canvas mark an excluded subject when it is drawn anyway?**
+The question does not arise, because it is never drawn anyway. The
+endpoint veto above is what makes that true, and it is the reason the
+veto is part of this decision rather than a refinement of it. A mark
+would have been a second vocabulary for a state that cannot occur.
+
+**Does `Add to this view` imply the full three-tier model?** No, and that
+is the point of the asymmetry. `exclude` alone closes the half that is
+expressible. A `query` / `include` / `exclude` model is a bigger decision
+about what a view IS, and it is left to whoever meets a view that needs
+it.
+
+## Excluded options
+
+- **The full three-tier `query` / `include` / `exclude` model.** It would
+  answer "add a subject the facets do not select" as well, but a view
+  that both states a rule and carries a hand-written addition is close to
+  a list with extra steps, and nothing has asked for it yet. Recorded as
+  the follow-up if a real view does.
+- **Marking an excluded subject on the canvas.** Nothing to mark, as
+  above.
+- **Refusing an exclusion that no facet would have selected.** It would
+  need the match set at the moment the menu is drawn, which the menu does
+  not have, and it would make the exception a statement about the model
+  as it stands today rather than about the rule.
+- **Naming it `excludeSubjects`, beside `excludeStatuses`.** Parallel in
+  spelling and wrong in meaning: `excludeStatuses` is a facet with its
+  own selection semantics, while this is the veto over every facet.
+  `exclude` reads as what it is, and sits beside `subjects` as its
+  opposite.
+- **Applying the exclusion only to concepts.** A view can be spoiled by
+  one relationship as easily as by one subject, and `exclude` names
+  subjects, which relationships are.
+
+## Consequences
+
+`ProjectionQuery` gains one optional field, the schema one property, and
+`ConceptFacet` one member. `activeViewMembership` changes shape, from
+`readonly string[] | null` to a union naming which kind of view it
+describes; `null` now means only "no view is active", which is the
+question it was always meant to answer. Nothing in the wire protocol
+moves and no CLI verb changes.
+
+The View group returns to the half of the authored views that lost it,
+and it returns saying the truthful thing: on a rule, removing is stating
+an exception, and adding is lifting one.

--- a/schema/yarramate-projection.schema.json
+++ b/schema/yarramate-projection.schema.json
@@ -36,6 +36,15 @@
             "$ref": "#/$defs/subjectIdentity"
           }
         },
+        "exclude": {
+          "description": "Subjects this query would otherwise select and the author has taken out: the exception a rule cannot state (#267, ADR 0122). Applied after every other facet and after relationship expansion, so an excluded subject is out whichever way it would have come back in. Naming a subject no facet selects is allowed and inert until the model grows into the rule.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/subjectIdentity"
+          }
+        },
         "documents": {
           "type": "array",
           "uniqueItems": true,

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -185,7 +185,9 @@ export const withMembership = (
   subjectId: string,
   membership: "add" | "remove",
 ): ProjectionDefinition | null => {
-  if (!enumeratesSubjects(projection.query)) return null;
+  if (!enumeratesSubjects(projection.query)) {
+    return withExclusion(projection, subjectId, membership);
+  }
   const subjects = projection.query.subjects;
   const holds = subjects.includes(subjectId);
   if (membership === "add" ? holds : !holds) return null;
@@ -204,6 +206,49 @@ export const withMembership = (
 };
 
 /**
+ * The same faceted view, holding one more exception or one fewer (#267,
+ * ADR 0122).
+ *
+ * A view that describes its subjects with facets states a RULE, and there is
+ * no list to edit — which is why membership used to stop here. But every
+ * interesting rule has an exception, and `exclude` is where the author writes
+ * one down instead of abandoning the facet for a hand-enumerated list. So
+ * "remove from view" names the subject in `exclude`, and "add to this view"
+ * takes the name back out.
+ *
+ * The asymmetry is deliberate and is the whole reason there is no `include`
+ * tier here: taking an exception BACK is expressible, while adding a subject
+ * the facets do not select is not — that would silently convert the rule into
+ * a list. A subject that is neither excluded nor selected therefore gets
+ * `null`, the same answer this returns for every other no-op.
+ *
+ * `exclude` is a statement about the rule rather than about today's match set,
+ * so it is written whether or not the subject happens to be drawn: a model
+ * that later grows into the facet still honours the decision someone made.
+ */
+const withExclusion = (
+  projection: ProjectionDefinition,
+  subjectId: string,
+  membership: "add" | "remove",
+): ProjectionDefinition | null => {
+  const excluded = projection.query.exclude ?? [];
+  const isExcluded = excluded.includes(subjectId);
+  if (membership === "add" ? !isExcluded : isExcluded) return null;
+  const next = membership === "add"
+    ? excluded.filter((id) => id !== subjectId)
+    : // Appended rather than sorted in, the rule the subjects list follows.
+      [...excluded, subjectId];
+  // The last exception leaving takes the key with it: `exclude: []` says the
+  // same thing as no key at all, and the schema's `minItems` refuses it
+  // anyway. Rebuilt rather than spread-over so the key is genuinely absent.
+  const { exclude: _dropped, ...rest } = projection.query;
+  return {
+    ...projection,
+    query: next.length === 0 ? rest : { ...rest, exclude: next },
+  };
+};
+
+/**
  * What a membership edit did to a view, as the tray reads it: `+id` for a
  * subject this row adds, `-id` for one it drops, against the document the
  * workspace holds. Empty when the row changed something else — a title, a
@@ -213,6 +258,24 @@ export const membershipDelta = (
   saved: ProjectionQuery,
   staged: ProjectionQuery,
 ): readonly string[] => {
+  if (!enumeratesSubjects(saved) && !enumeratesSubjects(staged)) {
+    // A faceted view's membership moves through `exclude`, and reads inverted
+    // there: a name ARRIVING in the exclusion list is a subject leaving the
+    // view (#267). The tray says what happened to the view, not what happened
+    // to the list.
+    const savedExclusions = saved.exclude ?? [];
+    const stagedExclusions = staged.exclude ?? [];
+    return [
+      ...savedExclusions
+        .filter((id) => !stagedExclusions.includes(id))
+        .map((id) => `+${id}`),
+      ...stagedExclusions
+        .filter((id) => !savedExclusions.includes(id))
+        .map((id) => `-${id}`),
+    ];
+  }
+  // One side enumerates and the other does not: the query changed shape rather
+  // than its membership, which the row says by other means.
   if (!enumeratesSubjects(saved) || !enumeratesSubjects(staged)) return [];
   return [
     ...staged.subjects

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -41,6 +41,16 @@ export interface ProjectionDefinition {
   readonly version: string
   readonly query: {
     readonly subjects?: readonly string[]
+    /**
+     * Subjects this query would otherwise select and the author has taken out
+     * (#267, ADR 0122). A facet view states a rule, and every interesting rule
+     * has an exception someone would rather state than abandon the rule for;
+     * this is where that exception is written down instead of being the silent
+     * absence a hand-enumerated list produces. Applied after every other facet
+     * AND after `relationships: connected` expansion, so an excluded subject is
+     * out whichever way it would have come back in.
+     */
+    readonly exclude?: readonly string[]
     readonly documents?: readonly string[]
     readonly kinds?: readonly string[]
     readonly layers?: readonly string[]
@@ -216,6 +226,7 @@ const claimReferences = (
  * {@link explainProjection} reports as the reason a subject is not in a view.
  */
 export type ConceptFacet =
+  | 'exclude'
   | 'states'
   | 'subjects'
   | 'documents'
@@ -314,7 +325,13 @@ const conceptSelector = (
           : profileContext?.conceptKindLayers.get(kind)
 
       // Ordered the way a query declares its facets, so "the first reason" is
-      // the one a reader would reach first themselves.
+      // the one a reader would reach first themselves - except the explicit
+      // exception, which outranks every rule: when someone has written the
+      // subject down as taken out, that IS the first reason, whatever else
+      // would also have dropped it (#267).
+      if (query.exclude?.includes(id) === true) {
+        return 'exclude'
+      }
       if (
         query.states !== undefined &&
         (architectureStateIds.has(id) || !participatesInSelectedState(id))
@@ -423,6 +440,11 @@ export function evaluateProjection(
   const { droppedBy, architectureStateIds, participatesInSelectedState } =
     conceptSelector(graph, projection, profileContext)
   const endpointExcluded = (id: string): boolean => {
+    // An exclusion is final (#267, ADR 0122). Dropping the subject from the
+    // initial selection alone would not be: `relationships: connected` adds
+    // the far end of every relationship it draws, so an excluded subject would
+    // walk back in by the other end of a relationship to one that stayed.
+    if (projection.query.exclude?.includes(id) === true) return true
     if (!participatesInSelectedState(id)) return true
     const status = claimValue(
       graph.claims,
@@ -458,6 +480,9 @@ export function evaluateProjection(
         'yarramate/lifecycle/status',
       )
       if (
+        // A relationship can be taken out by name too: `exclude` names
+        // subjects, and a relationship is a subject.
+        projection.query.exclude?.includes(subject.id) === true ||
         relationship === undefined ||
         !('ref' in relationship.object) ||
         (projection.query.excludeStatuses !== undefined &&

--- a/src/subject-references.ts
+++ b/src/subject-references.ts
@@ -90,6 +90,11 @@ export const SUBJECT_REFERENCE_POSITIONS: readonly SubjectReferencePosition[] =
       path: ['query', 'subjects', '*'],
       form: 'qualified',
     },
+    {
+      group: 'projection',
+      path: ['query', 'exclude', '*'],
+      form: 'qualified',
+    },
     { group: 'projection', path: ['query', 'owners', '*'], form: 'qualified' },
     {
       group: 'projection',

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1390,8 +1390,11 @@ export const App = ({
       case "view.add-subject":
       case "view.remove-subject":
         // Always the ACTIVE view: the menu only offers these where that view
-        // has a membership list, and `activeViewMembership` is what decided
-        // which of the two it offered.
+        // can be told what it holds, and `activeViewMembership` is what
+        // decided which of the two it offered. Which document field moves is
+        // the view's own business - a list for a view that enumerates, the
+        // `exclude` exception for one that describes (#267, ADR 0122) - and
+        // `withMembership` decides it from the query it is handed.
         stageViewMembership(
           state.activeView,
           intent.id,

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -25,6 +25,7 @@
 import type { CanvasGraph } from "../graph-projection.js";
 import type { VisualKindOption } from "../adapters/visual/protocol-contract.js";
 import { relationshipKindOffer } from "./relationship-kind-options.js";
+import type { ActiveViewMembership } from "./state.js";
 
 /** The id of the "All subjects" row, which is the absence of a view. */
 export const ALL_SUBJECTS_VIEW = "";
@@ -109,14 +110,16 @@ export interface ContextMenuContext {
   /** Whether anything at all is narrowing the canvas right now. */
   readonly filtered: boolean;
   /**
-   * The active view's own membership list, or `null`.
+   * How the active view can be told what it holds, or `null` when no view is
+   * active and there is nothing to tell.
    *
-   * `null` covers both "no view is active" and "the active view describes its
-   * subjects with facets": in neither case is there a list to put a subject
-   * into or take it out of, so neither offers a membership item at all rather
-   * than offering one that would do nothing (#255).
+   * A view that enumerates its subjects is told by its list; one that
+   * describes them with facets is told by `exclude` (#267, ADR 0122). A
+   * faceted view used to be `null` here, on the reasoning that an item which
+   * could only ever do nothing is worse than no item (#255) - true of adding a
+   * subject to a rule, and never true of taking one out of it.
    */
-  readonly membership: readonly string[] | null;
+  readonly membership: ActiveViewMembership | null;
   /**
    * A viewer, not an author (#298, ADR 0117). A read-only menu keeps the items
    * that read or navigate and drops every item whose intent stages a change -
@@ -143,15 +146,25 @@ const READING_INTENTS: ReadonlySet<ContextMenuIntent["type"]> = new Set([
 
 /**
  * Putting a subject into the active view, or taking it out — whichever the
- * view's list does not already say. One group, because a subject is either in
- * the list or not and only one of the two items is ever true.
+ * view does not already say. One group, because a subject is either in the
+ * view or not and only one of the two items is ever true.
+ *
+ * The two kinds of view read the same question from opposite fields: an
+ * enumerating view holds a subject when its list names it, a faceted one holds
+ * a subject unless `exclude` names it. On a faceted view the item that is NOT
+ * offered is the honest one: "add" only ever lifts an exception, because
+ * adding a subject the facets do not select would need an `include` tier that
+ * does not exist and would quietly turn the rule into a list (#267).
  */
 const membershipGroup = (
   id: string,
   context: ContextMenuContext,
 ): readonly ContextMenuGroup[] => {
   if (context.membership === null) return [];
-  const held = context.membership.includes(id);
+  const held =
+    context.membership.kind === "enumerated"
+      ? context.membership.subjects.includes(id)
+      : !context.membership.excluded.includes(id);
   return [
     {
       key: "view",

--- a/src/visual-app/describe-query.ts
+++ b/src/visual-app/describe-query.ts
@@ -16,7 +16,12 @@ export function describeQuery(query: ProjectionQuery): string {
     query.subjects.length > 0
   ) {
     const verb = query.relationships === 'connected' ? 'connected to' : 'between'
-    return `${verb} ${query.subjects.join(', ')}`
+    const whole = `${verb} ${query.subjects.join(', ')}`
+    // The exception still has to be read back: a gloss that dropped it would
+    // describe a view drawing subjects the reviewer took out (#267).
+    return query.exclude === undefined || query.exclude.length === 0
+      ? whole
+      : `${whole} · except: ${query.exclude.join(', ')}`
   }
 
   const parts: string[] = []
@@ -39,6 +44,10 @@ export function describeQuery(query: ProjectionQuery): string {
   list('owners', query.owners)
   list('constraints', query.constraints)
   list('relationship kinds', query.relationshipKinds)
+  // Read as what it does to the view rather than as the field's name: the
+  // list holds what the rule would have taken and the author took back out
+  // (#267).
+  list('except', query.exclude)
 
   if (query.isolatedConcepts === 'exclude') parts.push('connected concepts only')
   if (query.isolatedConcepts === 'include') parts.push('including isolated concepts')

--- a/src/visual-app/query-panel.tsx
+++ b/src/visual-app/query-panel.tsx
@@ -91,7 +91,9 @@ export const EXCLUSION_LABELS: {
   readonly [Reason in ExclusionReason]: string;
 } = {
   // Ordered the way `explainProjection` reaches them, so a reader meets the
-  // reasons in the order the query applies them.
+  // reasons in the order the query applies them - the explicit exception
+  // first, because it outranks every rule (#267).
+  exclude: "Taken out of this view",
   states: "States",
   subjects: "Subjects",
   documents: "Documents",

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -957,19 +957,27 @@ export const visualBrowserInputFor = (
  * reporting itself as the reviewer's own.
  */
 /**
- * The active view's membership list, as the menus must read it.
+ * How the active view can be told what it holds, as the menus must read it.
  *
- * `null` where there is no list to edit: no view is active, or the view
- * describes its subjects with facets rather than naming them.
+ * `null` only where there is no view at all. A view that ENUMERATES its
+ * subjects is told by editing that list; a view that describes them with
+ * FACETS is told by editing `exclude`, the exception a rule cannot state
+ * (#267, ADR 0122). Both are membership; they differ in which field moves and
+ * in which direction, which is why the shape is a union rather than a list
+ * with a flag.
  *
  * Read through the PENDING row when one is staged, not off the saved document.
  * A reviewer who has just added a subject and right-clicks it again must be
  * offered "Remove from view"; a menu built from the saved list would offer
  * "Add to this view" a second time and stage nothing.
  */
+export type ActiveViewMembership =
+  | { readonly kind: "enumerated"; readonly subjects: readonly string[] }
+  | { readonly kind: "faceted"; readonly excluded: readonly string[] };
+
 export const activeViewMembership = (
   state: VisualAppState,
-): readonly string[] | null => {
+): ActiveViewMembership | null => {
   const view = state.views.find(({ id }) => id === state.activeView);
   if (view === undefined) return null;
   const pending = state.pendingChangeset.viewOperations.find(
@@ -977,7 +985,9 @@ export const activeViewMembership = (
   );
   const query =
     pending?.op === "write-view" ? pending.projection.query : view.query;
-  return enumeratesSubjects(query) ? query.subjects : null;
+  return enumeratesSubjects(query)
+    ? { kind: "enumerated", subjects: query.subjects }
+    : { kind: "faceted", excluded: query.exclude ?? [] };
 };
 
 export const filterToReresolve = (

--- a/test/describe-query.test.ts
+++ b/test/describe-query.test.ts
@@ -49,6 +49,22 @@ describe('describeQuery', () => {
     )
   })
 
+  // The exception a rule states about itself (#267, ADR 0122). It has to be
+  // read back either way a query can be glossed, or the pill describes a view
+  // that draws subjects the reviewer took out.
+  it('reads the exception back, in both glosses', () => {
+    expect(
+      describeQuery({ layers: ['application'], exclude: ['legacy-gateway'] }),
+    ).toBe('layers: application · except: legacy-gateway')
+    expect(
+      describeQuery({
+        subjects: ['checkout'],
+        relationships: 'connected',
+        exclude: ['ledger'],
+      }),
+    ).toBe('connected to checkout · except: ledger')
+  })
+
   it('falls back to "all" for a query with nothing populated', () => {
     expect(describeQuery({})).toBe('all')
   })

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -262,6 +262,150 @@ relationships:
     ])
   })
 
+  // The exception a rule cannot state (#267, ADR 0122). A facet view says
+  // `layers: [application]`, and the author would rather write down the one
+  // subject that does not belong than abandon the facet for a hand-enumerated
+  // list.
+  describe('exclude takes a subject out of a rule', () => {
+    const graphOf = () => {
+      const compilation = compileWorkspace([
+        { path: 'projection-model.yaml', source },
+      ])
+      if (!compilation.ok) throw new Error('the fixture must compile')
+      return compilation.graph
+    }
+
+    const evaluate = (query: ProjectionDefinition['query']) =>
+      evaluateProjection(graphOf(), {
+        format: 'yarramate/projection/v1',
+        id: 'excepted',
+        version: '1.0',
+        query,
+      } as ProjectionDefinition).subjects.map(({ id }) => id)
+
+    it('drops the named concept from a facet the query still states', () => {
+      expect(evaluate({ kinds: ['yarramate/core@0.1#capability'] })).toEqual([
+        'first',
+        'first-supports-second',
+        'second',
+      ])
+      expect(
+        evaluate({
+          kinds: ['yarramate/core@0.1#capability'],
+          exclude: ['second'],
+        }),
+      ).toEqual(['first'])
+    })
+
+    // The relationship goes with its endpoint: a line drawn to a subject that
+    // is not on the canvas has nowhere to land.
+    it('takes the relationships that touched it with it', () => {
+      expect(evaluate({ exclude: ['second'] })).toEqual([
+        'australia-only',
+        'first',
+        'first-influences-future',
+        'future',
+        'platform-team',
+      ])
+    })
+
+    // The half that makes the exclusion final rather than advisory:
+    // `relationships: connected` adds the far end of every relationship it
+    // draws, so an exclusion applied only to the initial selection would let
+    // the subject walk back in by the other end.
+    it('is not undone by relationships: connected pulling the far end back', () => {
+      expect(
+        evaluate({
+          subjects: ['first'],
+          relationships: 'connected',
+        }),
+      ).toEqual(['first', 'first-influences-future', 'first-supports-second', 'future', 'second'])
+      expect(
+        evaluate({
+          subjects: ['first'],
+          relationships: 'connected',
+          exclude: ['second'],
+        }),
+      ).toEqual(['first', 'first-influences-future', 'future'])
+    })
+
+    it('takes a relationship out by name, leaving both its ends drawn', () => {
+      expect(evaluate({ exclude: ['first-supports-second'] })).toEqual([
+        'australia-only',
+        'first',
+        'first-influences-future',
+        'future',
+        'platform-team',
+        'second',
+        'second-supports-future',
+      ])
+    })
+
+    // An exclusion is a statement about the rule, not about today's match set,
+    // so naming a subject no facet selects is allowed and simply inert. It
+    // becomes meaningful the moment the model grows into the facet.
+    it('is inert where the query would not have selected the subject anyway', () => {
+      expect(
+        evaluate({ kinds: ['yarramate/core@0.1#goal'], exclude: ['first'] }),
+      ).toEqual(['future'])
+    })
+
+    it('reports itself as the reason, ahead of any rule that also dropped it', () => {
+      const explained = explainProjection(graphOf(), {
+        format: 'yarramate/projection/v1',
+        id: 'excepted',
+        version: '1.0',
+        // `second` is dropped by the kind facet as well; the explicit
+        // exception is what a reader would reach for first.
+        query: { kinds: ['yarramate/core@0.1#goal'], exclude: ['second'] },
+      } as ProjectionDefinition)
+
+      expect(explained).toContainEqual({ id: 'second', facet: 'exclude' })
+      expect(explained).toContainEqual({ id: 'first', facet: 'kinds' })
+    })
+
+    it('loads through the normative schema and round-trips canonically', () => {
+      const loaded = loadProjection({
+        path: 'excepted.projection.yaml',
+        source: `format: yarramate/projection/v1
+id: excepted
+version: "1.0"
+query:
+  layers:
+    - application
+  exclude:
+    - legacy-gateway
+`,
+      })
+
+      expect(loaded).toEqual({
+        ok: true,
+        projection: {
+          format: 'yarramate/projection/v1',
+          id: 'excepted',
+          version: '1.0',
+          query: { layers: ['application'], exclude: ['legacy-gateway'] },
+        },
+      })
+    })
+
+    it('refuses an empty exclusion list, which says nothing', () => {
+      const loaded = loadProjection({
+        path: 'excepted.projection.yaml',
+        source: `format: yarramate/projection/v1
+id: excepted
+version: "1.0"
+query:
+  layers:
+    - application
+  exclude: []
+`,
+      })
+
+      expect(loaded.ok).toBe(false)
+    })
+  })
+
   it('loads relationship-kind and connected-endpoint selectors through the normative schema', () => {
     const loaded = loadProjection({
       path: 'connected.projection.yaml',

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -280,11 +280,41 @@ describe('view membership', () => {
     ])
   })
 
-  it('has nothing to say to a view that describes its subjects', () => {
-    // A facet query already includes anything matching it: membership is
-    // decided by what the subject IS, so there is no list to amend.
+  // A facet query states a RULE, and every interesting rule has an exception
+  // the author would rather state than abandon the rule for (#267, ADR 0122).
+  // `exclude` is where that exception is written down; there is deliberately no
+  // matching `include`, so the two directions are not symmetric here.
+  it('takes a subject out of a described view by naming the exception', () => {
+    expect(withMembership(described, 'checkout', 'remove')?.query).toEqual({
+      layers: ['application'],
+      exclude: ['checkout'],
+    })
+  })
+
+  it('appends the exception, and refuses to say it twice', () => {
+    const once = withMembership(described, 'checkout', 'remove')
+    expect(
+      withMembership(once!, 'ledger', 'remove')?.query.exclude,
+    ).toEqual(['checkout', 'ledger'])
+    expect(withMembership(once!, 'checkout', 'remove')).toBeNull()
+  })
+
+  it('lifts an exception it holds, and takes the key with the last one', () => {
+    const excepted: ProjectionDefinition = {
+      ...described,
+      query: { layers: ['application'], exclude: ['checkout'] },
+    }
+    const lifted = withMembership(excepted, 'checkout', 'add')
+    expect(lifted?.query).toEqual({ layers: ['application'] })
+    // Genuinely absent, not an empty list: `exclude: []` says the same thing
+    // as no key, and the schema's minItems refuses it.
+    expect(lifted?.query).not.toHaveProperty('exclude')
+  })
+
+  it('cannot add a subject a facet does not already select', () => {
+    // That would need an `include` tier, which would quietly turn the rule
+    // into a list. Adding only ever LIFTS an exception.
     expect(withMembership(described, 'checkout', 'add')).toBeNull()
-    expect(withMembership(described, 'checkout', 'remove')).toBeNull()
   })
 
   it('has nothing to say when the list already says it', () => {

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -2043,27 +2043,45 @@ describe("activeViewMembership", () => {
     subjectCount: 1,
   };
 
-  it("is the active view's list", () => {
+  it("is the active view's list where the view enumerates", () => {
     expect(
       activeViewMembership({
         ...initialVisualAppState,
         activeView: "payment-flow",
         views: [summary],
       }),
-    ).toEqual(["checkout"]);
+    ).toEqual({ kind: "enumerated", subjects: ["checkout"] });
   });
 
-  it("is null where no view is active, or the view describes its subjects", () => {
+  it("is null only where no view is active", () => {
     expect(
       activeViewMembership({ ...initialVisualAppState, views: [summary] }),
     ).toBeNull();
+  });
+
+  // A faceted view is told what it holds through `exclude`, the exception a
+  // rule cannot state (#267, ADR 0122). It used to answer null here, which
+  // took the whole View group off the menu on half the authored views.
+  it("is the exclusion list where the view describes its subjects", () => {
     expect(
       activeViewMembership({
         ...initialVisualAppState,
         activeView: "payment-flow",
         views: [{ ...summary, query: { layers: ["application"] } }],
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "faceted", excluded: [] });
+    expect(
+      activeViewMembership({
+        ...initialVisualAppState,
+        activeView: "payment-flow",
+        views: [
+          {
+            ...summary,
+            query: { layers: ["application"], exclude: ["ledger"] },
+          },
+        ],
+      }),
+    ).toEqual({ kind: "faceted", excluded: ["ledger"] });
   });
 
   it("reads through the staged row, so a menu never offers the same edit twice", () => {
@@ -2080,7 +2098,31 @@ describe("activeViewMembership", () => {
       },
     );
 
-    expect(activeViewMembership(staged)).toEqual(["checkout", "ledger"]);
+    expect(activeViewMembership(staged)).toEqual({
+      kind: "enumerated",
+      subjects: ["checkout", "ledger"],
+    });
+  });
+
+  // The same motion on a faceted view, staged through the same action: the
+  // reducer writes to `exclude` because `withMembership` reads the query it is
+  // handed, and the menu is offered Add next time round.
+  it("stages a removal from a faceted view as an exclusion", () => {
+    const faceted = { ...summary, query: { layers: ["application"] } };
+    const staged = visualAppReducer(
+      { ...initialVisualAppState, activeView: "payment-flow", views: [faceted] },
+      {
+        type: "changeset.viewMembership",
+        viewId: "payment-flow",
+        subjectId: "ledger",
+        membership: "remove",
+      },
+    );
+
+    expect(activeViewMembership(staged)).toEqual({
+      kind: "faceted",
+      excluded: ["ledger"],
+    });
   });
 });
 

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -434,8 +434,12 @@ describe("what the menu draws", () => {
  * model entirely (#255).
  */
 describe("putting a subject into a view, and taking it out", () => {
-  const held = context({ membership: ["api", "ui"] });
-  const notHeld = context({ membership: ["ui"] });
+  const held = context({
+    membership: { kind: "enumerated", subjects: ["api", "ui"] },
+  });
+  const notHeld = context({
+    membership: { kind: "enumerated", subjects: ["ui"] },
+  });
 
   it("offers Remove from view for a subject the view lists", () => {
     expect(labels(contextMenuFor({ kind: "subject", id: "api" }, held))).toEqual(
@@ -452,13 +456,40 @@ describe("putting a subject into a view, and taking it out", () => {
     ).toContain("Add to this view");
   });
 
-  it("offers neither where the view has no list to edit", () => {
-    // No view active, or a view that describes its subjects with facets: an
-    // item that could only ever do nothing is worse than no item.
+  it("offers neither where no view is active", () => {
+    // Nothing to tell: the item would have no document to write to at all.
     const groups = contextMenuFor({ kind: "subject", id: "api" }, context());
     expect(labels(groups)).not.toContain("Remove from view");
     expect(labels(groups)).not.toContain("Add to this view");
     expect(groups.every((group) => group.scope === "model")).toBe(true);
+  });
+
+  // A facet view states a rule, and the exception it cannot state is exactly
+  // where a reviewer most wants to say "not that one" (#267, ADR 0122). The
+  // group used to vanish here on the reasoning that an item which could only
+  // ever do nothing is worse than no item - true of ADDING a subject to a
+  // rule, and never true of taking one out of it.
+  describe("a view that describes its subjects with facets", () => {
+    const faceted = context({ membership: { kind: "faceted", excluded: [] } });
+    const withException = context({
+      membership: { kind: "faceted", excluded: ["api"] },
+    });
+
+    it("offers Remove from view, which stages the exception", () => {
+      expect(
+        labels(contextMenuFor({ kind: "subject", id: "api" }, faceted)),
+      ).toContain("Remove from view");
+    });
+
+    it("offers Add to this view only to lift an exception it already holds", () => {
+      expect(
+        labels(contextMenuFor({ kind: "subject", id: "api" }, withException)),
+      ).toContain("Add to this view");
+      // The other subject is not excepted, so its own offer is the removal.
+      expect(
+        labels(contextMenuFor({ kind: "subject", id: "ui" }, withException)),
+      ).toContain("Remove from view");
+    });
   });
 
   it("gives the rail's model rows the same offer, which is what a drag would do", () => {
@@ -482,7 +513,10 @@ describe("putting a subject into a view, and taking it out", () => {
  * them.
  */
 describe("a read-only menu offers no way to stage", () => {
-  const readOnly = context({ readOnly: true, membership: ["api"] });
+  const readOnly = context({
+    readOnly: true,
+    membership: { kind: "enumerated", subjects: ["api"] },
+  });
 
   it("leaves a subject its Properties and nothing that stages", () => {
     expect(


### PR DESCRIPTION
## Summary

Closes #267.

`Remove from view` and `Add to this view` were offered only where the active view **named** its subjects. `activeViewMembership` answered `null` for a faceted view and the whole View group left the menu. The recorded reasoning, that an item which could only ever do nothing is worse than no item, is sound about **adding** and was never true about **removing**. A facet view is precisely where a reviewer most wants to say "not that one", and the item was absent on half the contact-update journey's authored views.

`yarramate/projection/v1` gains `query.exclude`: the subjects the query would otherwise select and the author has taken out. The view stays declarative, the rule goes on refreshing as the model grows, and the exception is a reviewable line in Git rather than the silent absence a hand-enumerated list produces.

**The exclusion is final.** It is a concept facet *and* an endpoint veto, so `relationships: connected` cannot walk an excluded subject back in by the far end of a relationship to one that stayed, and relationships touching an excluded subject are dropped with it. A relationship can be excluded by name too, leaving both its ends drawn. It is also the first facet `droppedBy` reaches, ahead of `states`, so a subject someone took out reads as taken out rather than as dropped by whatever rule would also have dropped it; the query panel labels the facet "Taken out of this view" (#248).

**The menu is asymmetric on a faceted view, deliberately.** Removing names the subject in `exclude`; adding only ever lifts an exception the view already holds. Adding a subject the facets do not select would need an `include` tier, and writing it into `subjects` would quietly convert the rule into a list, so `withMembership` returns its usual `null` there and your original reasoning still governs that case. Lifting the last exception takes the key with it rather than leaving `exclude: []`. `membershipDelta` reports what happened to the **view**, so a name arriving in `exclude` reads as `-id` in the tray.

## Your three open questions, answered

**Does `exclude` belong in `yarramate/projection/v1`, and is adding it breaking for the LikeC4 export and the presentation round-trip?** Yes, and no. Optional field on `query`, so every existing projection is unchanged. The LikeC4 export needs no work: it evaluates the query through `evaluateProjection` and reads only `query.states` for itself, so it inherits exclusion with everything else. The `presentation` round-trip is untouched, since this is a query field. A consumer validating against a pinned pre-`exclude` schema copy will reject a projection using one, the ordinary shape of an additive schema change here. The one place that genuinely needed telling was `SUBJECT_REFERENCE_POSITIONS`: `exclude` holds subject addresses, so a rename has to move them, and the schema-derived completeness test is what said so rather than my noticing.

**Should the canvas mark an excluded subject when it is drawn anyway?** The question does not arise, because it is never drawn anyway. The endpoint veto is what makes that true, which is why it is part of the decision rather than a refinement of it. A mark would have been a second vocabulary for a state that cannot occur.

**Does `Add to this view` imply the full three-tier model?** No, and that asymmetry is the point. `exclude` alone closes the half that is expressible. `query` / `include` / `exclude` is a bigger decision about what a view *is*, recorded as the follow-up for whoever meets a view that needs it.

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: typecheck, build, 1757 tests across 97 files, `self:check` no errors, `likec4 validate` valid.

New engine tests cover the facet dropping its subject, the relationships going with it, the `connected` pull-back being refused (the half that makes it final), excluding a relationship by name, an exclusion of an unselected subject staying inert, `explainProjection` reporting `exclude` ahead of a rule that would also have dropped the subject, loading through the normative schema, and `exclude: []` being refused. Menu tests cover both offers on a faceted view; `withMembership` tests cover appending, refusing to say it twice, lifting the last exception and taking the key with it, and refusing to add a subject a facet does not select. `describeQuery` reads the exception back in both of its glosses.

**Not eyeballed in a browser**, per your standing instruction this session, so the menu half is test-verified only.

## Related issue

#267.

## Contract impact

Additive. `yarramate/projection/v1` gains one optional query field and the schema one property; `ConceptFacet` gains one member. `activeViewMembership` changes shape (browser-internal). Nothing in the wire protocol moves and no CLI verb changes. `exclude` is not editable in the query panel: the menu is how an exception is stated, and the panel carries a declared one through untouched with every other field it does not edit.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
