### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.3.0
 
 - **Added.** A rule can name its exception (#267, ADR 0122).
   `yarramate/projection/v1` gains `query.exclude`, a list of subjects the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts 1.3.0, closing the extended backlog sweep. `package.json` to 1.3.0 and the `Unreleased` changelog section becomes `1.3.0`: **23 entries**, every one merged verify-green.

**Features.** The trigger surface (#289, released as 1.2.0), canvas nudges (#292), CLI papercuts (#275), the subject popover (#296), the saved-layout pill (#273), the staged rail (#299), the collapsible column (#294), the kind palette (#295), `readOnly` mount (#298), the mount pointer handle (#297), the decoration seam (#314), catalogue 1.2's absent-layer questions and `unchallenged-evidence` (#272), per-view layout direction with NETWORK_SIMPLEX placement (#274), and the `exclude` facet (#267).

**Defects from ApertureX's 54-subject field soak.** Parallel-edge swallow (#306, the data-loss one), filter blanking (#307), disconnected packing (#308), concept-id reservation (#315), rail filter parity (#317), and the evidence loader dropping recorded probes (#272).

## Compatibility

- The interrogation trigger union gains a branch in three published schemas, so a consumer validating 1.3 output against a **pinned pre-1.2 schema copy** rejects a trigger it has never seen. Same shape as the required `trigger` field in 1.2.0; consumers upgrading package and schemas together are unaffected.
- `yarramate/projection/v1` gains an optional `query.exclude`.
- **No semantics bump.** `INTERROGATION_SEMANTICS_VERSION` stays at 1: no existing question's answer moves for an unchanged model.
- Models **will** legitimately reopen on catalogue 1.2's new questions, under ADR 0063's honest-reopen discipline. `since: "1.2"` is what tells a reader which reopenings are new questions rather than regressions.
- Every view's **placement** changes (#274). No saved layout does, since a saved layout is applied over the layout result.

## Validation

Per `docs/RELEASING.md`:

- `pnpm install --frozen-lockfile` clean
- `pnpm run verify` **exit 0** from a wiped `.yarramate-out`: typecheck, build, 1757 tests across 97 files, `self:check` no errors, `likec4 validate` valid
- `pnpm changelog:check` clean, 18 commits checked since `v1.2.0`
- `npm pack --dry-run`: 247 files, 1.9 MB. Runtime, 38 normative schemas, `docs/CONSUMING-YARRAMATE.md`, the agent skill, README, LICENCE. **No** repository source, tests, fixtures, dogfooding inputs, or generated output.

The UI work was also driven in a browser, the first time this sweep: #267's exclusion offer appearing on a faceted view and staging `-deterministic-correctness`, #317's id-shaped rail filter keeping the row it used to drop, #274's direction end to end (a view declaring `left-right` drew left to right), #307's empty-filter pill and #308's zoom/fit controls. Two pre-existing console findings were filed as #325 rather than fixed inside a release commit.

## Contract impact

As above. Version is a **minor**: additive schema and API surface, no removal from the published interface.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the version being prepared.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

## After merge

I tag `v1.3.0` on the merge commit. **Publishing is yours**: from a fresh clone at the tag, never a branch tip, per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)