### PR TITLE
fix: an expansion the relationship table forbids is refused (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Fixed.** An expansion the relationship table forbids is refused
+  (#268, ADR 0124). A port's landing pair was minted without being judged
+  against the table, so a pattern could emit a relationship `check` would
+  refuse if anyone had written it by hand — the one thing `check` exists
+  to make impossible. Wiring never had this hole: its legality is settled
+  when the pattern resolves, because the slot kinds fix both endpoint
+  kinds. A port's cannot be, because the two ends belong to different
+  patterns and neither knows the other's slots, so the pair is judged at
+  expansion instead and a forbidden one is `YM404` against the macro
+  edge. The macro edge itself is often perfectly legal while its landing
+  pair is not — two groupings permit nearly everything — which is why
+  nothing earlier caught it.
+
 - **Added.** A port says where a macro edge lands (#268 phase 2, ADR
   0124). A pattern may declare `ports`, and a relationship authored
   between two pattern instances whose kind both patterns port is expanded

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -152,6 +152,13 @@ serving prc-component`.
   `-expansion`, and its claim is sourced to the macro edge's line.
 - `out` is never `self` — an edge leaving the instance is the macro edge
   again.
+- **The expanded pair is judged against the relationship table**, and a
+  forbidden one is `YM404` against the macro edge. Wiring's legality is
+  settled when the pattern resolves, because the slot kinds fix both
+  endpoint kinds; a port's cannot be, because the two ends belong to
+  different patterns and neither knows the other's slots. Note that the
+  macro edge itself can be perfectly legal — two groupings permit almost
+  everything — while the pair it lands on is not.
 
 ## Diagnostics
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3167,6 +3167,15 @@ function compileWorkspaceResolved(
     const instanceByIdForPorts = new Map(
       patternInstances.map((entry) => [entry.instance, entry] as const),
     )
+    const kindOfSubjectForPorts = new Map<string, string>()
+    for (const claim of claims) {
+      if (
+        claim.predicate === 'yarramate/concept/kind' &&
+        'value' in claim.object
+      ) {
+        kindOfSubjectForPorts.set(claim.subject, claim.object.value)
+      }
+    }
     const declaredIdsForPorts = new Set(subjects.map(({ id }) => id))
     const relationshipIdsForPorts = new Set(
       subjects.filter(({ type }) => type === 'relationship').map(({ id }) => id),
@@ -3216,6 +3225,37 @@ function compileWorkspaceResolved(
           column: edge.source.column,
         })
         continue
+      }
+      // Legality cannot be settled when the pattern resolves, the way wiring's
+      // is: the two ends belong to DIFFERENT patterns, and neither knows the
+      // other's slot kinds. So the pair the ports actually name is judged here,
+      // against the macro edge that asked for it. Without this the compiler
+      // would emit a relationship the table forbids - the one thing `check`
+      // exists to make impossible.
+      const expandedKind = relationshipKindByIdentity.get(edge.predicate)
+      const fromKind = kindOfSubjectForPorts.get(from)
+      const toKind = kindOfSubjectForPorts.get(to)
+      if (
+        expandedKind !== undefined &&
+        fromKind !== undefined &&
+        toKind !== undefined
+      ) {
+        const permitted = permittedBetween(fromKind, toKind)
+        if (permitted !== undefined && !permitted.has(expandedKind.coreKind)) {
+          diagnostics.push({
+            severity: 'error',
+            code: 'YM404',
+            message:
+              `Expanding "${edge.id}" through the ports lands ` +
+              `"${expandedKind.coreKind}" from "${from}" to "${to}", which is ` +
+              `not permitted between "${fromKind}" and "${toKind}"`,
+            path: edge.source.path,
+            pointer: edge.source.pointer,
+            line: edge.source.line,
+            column: edge.source.column,
+          })
+          continue
+        }
       }
       if (
         authoredPairs.has(`${from}\u0000${edge.predicate}\u0000${to}`)

--- a/test/pattern-expansion.test.ts
+++ b/test/pattern-expansion.test.ts
@@ -559,6 +559,33 @@ describe('a port says where a macro edge lands', () => {
     ).toContain('YM421')
   })
 
+  // The one legality question ports CANNOT settle when the pattern resolves:
+  // the two ends belong to different patterns, and neither knows the other's
+  // slot kinds. So the pair the ports actually name is judged at expansion,
+  // against the macro edge that asked for it. Without it the compiler emits a
+  // relationship the table forbids, which is the one thing check exists to
+  // make impossible.
+  it('refuses an expansion the relationship table forbids (YM404)', () => {
+    // composition is not permitted from an application service to an
+    // application component, though it IS permitted between the two groupings
+    // the macro edge joins - so nothing before this point can catch it.
+    const forbidden = pattern(
+      undefined,
+      `    ports:
+      - kind: yarramate/core@0.1#composition
+        out: service
+        in: component
+`,
+    )
+    const macroComposition = twoApis(`
+  - id: sys-composes-prc
+    kind: composition
+    from: sys-api
+    to: prc-api
+`)
+    expect(codes([profile, forbidden, macroComposition])).toContain('YM404')
+  })
+
   it('refuses a port naming a part the pattern does not declare (YM302)', () => {
     const stray = pattern(
       undefined,


### PR DESCRIPTION
## Summary

A hole in phase 2 (#330), found by probing the new code rather than by a failing test. Worth fixing before phase 3 builds on it.

A port's landing pair was minted **without being judged against the vendored 3.2 table**, so a pattern could put a relationship into the graph that `check` would refuse if anyone had written it by hand. That is the one thing `check` exists to make impossible.

It was reachable from a single pattern document:

```yaml
    ports:
      - kind: yarramate/core@0.1#composition
        out: service
        in: component
```

Two `api` instances, one macro `composition` between them, and the compiler emitted `applicationService --composition--> applicationComponent` and reported no errors.

## Why wiring never had this hole

Wiring's legality is settled **once, when the pattern resolves**, because the slot kinds fix both endpoint kinds — that was a deliberate property of ADR 0123 and it holds.

A port's cannot be settled there. The two ends belong to **different patterns**, and neither knows the other's slots at resolution time. So the pair is judged at expansion instead, against the macro edge that asked for it, and a forbidden one is `YM404` there.

## Why nothing earlier caught it

The macro edge itself is usually **perfectly legal** — two groupings permit ten of the eleven kinds — while the member pair it lands on is not. The check that passes is not the check that matters, which is exactly the shape of thing a phase-boundary hides.

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: 1781 tests across 98 files, `self:check` no errors, `likec4 validate` valid.

One regression test, written from the reproduction above. It uses `composition` deliberately: legal between the two groupings the macro edge joins, forbidden between the service and component the ports land on, so nothing before expansion can catch it.

## Contract impact

None to any published format. One more condition under which compilation fails — which is the point, since the alternative is emitting a graph the table forbids.

## Related issue

#268. No phase moves; this repairs phase 2 before phase 3 reads it.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)