### PR TITLE
feat: a mounted editor takes the host's questions (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- **Added.** A mounted editor takes the host's questions, and what the host
+  has already dealt with (#328). `LocalHostOptions` and `MountOptions` gain
+  `catalogue` and `dismissed`. Until now a host could have the questions UI
+  only by also running yarramate's `core-enrichment`, so a product with its
+  own interview had to omit the section entirely and show its questions on a
+  separate surface, away from the model they were about. The division this
+  draws: **the engine is yarramate's and so is the UI; the questions belong
+  to whoever adopted it.** A general modelling interview is right for this
+  repository's own CLI and wrong for a product whose interview is about its
+  own subject matter. A catalogue that does not load leaves the overlay
+  absent rather than failing the mount, as before. `dismissed` covers what a
+  supplied catalogue cannot: the editor evaluates the catalogue itself and
+  cannot know a reviewer set a question aside with a reason recorded
+  somewhere the editor cannot see, so without it the pane would go on asking
+  a question the host had answered. Naming a `subject` dismisses the
+  question for that subject alone; omitting it dismisses it wherever it
+  appears. Dismissal decides what the pane draws and nothing else: the model
+  is untouched and `ask --open` still reports the question, because the
+  interview is not the editor's to settle. Neither field changes any
+  published format, and a host that passes neither behaves exactly as
+  before.
+
 - **Added.** The connect palette narrows to a pattern's ports (#268 phase
   3, ADR 0124). Between two pattern instances an editor now offers only
   the relationship kinds *both* patterns port, rather than the ten of

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -298,6 +298,47 @@ const editor = mountEditor(document.querySelector('#editor')!, {
 editor.unmount()
 ```
 
+### The questions are yours
+
+The questions section evaluates the shipped `core-enrichment` catalogue by
+default. A host with its own interrogation supplies its own instead (#328):
+
+```ts
+const editor = mountEditor(element, {
+  store,
+  workspace,
+  sections: ['palette', 'properties', 'questions', 'changes'],
+  catalogue: { path: 'catalogues/consulting.yaml', source: catalogueText },
+  dismissed: [
+    { questionId: 'register-fidelity', subject: 'crm-integration' },
+    { questionId: 'engagement-framing' },
+  ],
+})
+```
+
+The division this draws is deliberate. **The engine is yarramate's and so is
+the UI; the questions belong to whoever adopted it.** `core-enrichment` is a
+general modelling interview — right for yarramate's own CLI, and right for a
+host with no domain of its own — and wrong for a product whose interview is
+about its own subject matter. Inheriting it would mean asking a consultant
+about modelling hygiene in the pane where they are asking a client about
+sign-off.
+
+`catalogue` takes bytes, and a catalogue that does not load leaves the overlay
+absent rather than failing the mount: the overlay is a garnish on the model,
+and a model frame must not be blocked by it.
+
+`dismissed` is what the host has already dealt with. A supplied catalogue
+alone does not cover this — the editor evaluates the catalogue itself and
+cannot know that a reviewer set a question aside, with a reason, recorded
+somewhere the editor cannot see, so the pane would go on asking a question the
+host's own product had answered. Naming a `subject` dismisses the question for
+that subject alone; omitting it dismisses the question wherever it appears.
+
+Dismissal decides what the **pane draws** and nothing else. The model is
+untouched and `ask --open` still reports the question, because the interview is
+not the editor's to settle.
+
 Pass `readOnly: true` to mount a viewer over the same surface — for a frozen
 published snapshot, say ([ADR 0117](adr/0117-a-mounted-editor-can-refuse-the-pen.md)).
 The reviewer still selects, filters, navigates views and reads questions and

--- a/src/adapters/visual/workspace-model.ts
+++ b/src/adapters/visual/workspace-model.ts
@@ -93,12 +93,25 @@ export const conceptCountOf = (
  * Subject ids come from the same compiled graph as `CanvasNode.id`, so the
  * join in the browser is a plain lookup.
  */
+export interface DismissedQuestion {
+  readonly questionId: string;
+  /** Absent dismisses the question wherever it appears. */
+  readonly subject?: string;
+}
+
 export const interrogationOverlayOf = (
   compiled: {
     readonly graph: SemanticGraph;
     readonly profileContext: ResolvedProfileContext;
   },
   catalogue: { readonly path: string; readonly source: string },
+  /**
+   * What the host has already dealt with (#328). Evaluation is unchanged and
+   * the model is untouched: this decides only what the pane draws, because a
+   * question set aside in the host's own product should not be asked again by
+   * a pane embedded in it.
+   */
+  dismissed: readonly DismissedQuestion[] = [],
 ): VisualInterrogationOverlay | undefined => {
   const loaded = loadQuestionCatalogue(catalogue);
   if (!loaded.ok) return undefined;
@@ -107,11 +120,22 @@ export const interrogationOverlayOf = (
     compiled.graph,
     compiled.profileContext,
   );
+  const dismissedEverywhere = new Set(
+    dismissed
+      .filter(({ subject }) => subject === undefined)
+      .map(({ questionId }) => questionId),
+  );
+  const dismissedForSubject = new Set(
+    dismissed
+      .filter(({ subject }) => subject !== undefined)
+      .map(({ questionId, subject }) => `${questionId}\u0000${subject}`),
+  );
   const workspace: VisualQuestionEntry[] = [];
   const subjects: Record<string, VisualQuestionEntry[]> = {};
   for (const wave of report.waves) {
     for (const question of wave.questions) {
       if (!question.open) continue;
+      if (dismissedEverywhere.has(question.id)) continue;
       const base = {
         questionId: question.id,
         authority: question.authority,
@@ -122,6 +146,9 @@ export const interrogationOverlayOf = (
         continue;
       }
       for (const subject of question.subjects) {
+        if (dismissedForSubject.has(`${question.id}\u0000${subject.id}`)) {
+          continue;
+        }
         (subjects[subject.id] ??= []).push({
           ...base,
           question: subject.question,
@@ -154,6 +181,7 @@ export const renderedWorkspaceOf = (
   views: readonly VisualViewSummary[],
   metadata: Omit<VisualRenderedModel, "graph" | "vocabulary" | "interrogation">,
   catalogue?: { readonly path: string; readonly source: string },
+  dismissed?: readonly DismissedQuestion[],
 ): {
   readonly model: VisualRenderedModel;
   readonly views: readonly VisualViewSummary[];
@@ -169,7 +197,7 @@ export const renderedWorkspaceOf = (
   const interrogation =
     catalogue === undefined
       ? undefined
-      : interrogationOverlayOf(compiled, catalogue);
+      : interrogationOverlayOf(compiled, catalogue, dismissed);
   return {
     model: {
       ...metadata,

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -62,6 +62,45 @@ export interface LocalHostOptions {
   readonly description?: string
   /** Told after every landed commit, so a host can persist what it was given. */
   readonly onCommit?: (documents: readonly string[]) => void
+  /**
+   * The question catalogue the questions section evaluates, or the shipped
+   * `core-enrichment` one when absent (#328).
+   *
+   * The engine is yarramate's and so is the UI; the QUESTIONS belong to
+   * whoever adopted it. `core-enrichment` is a general modelling interview,
+   * right for this repository's own CLI and for a host with no domain of its
+   * own, and wrong for a product whose interview is about its own subject
+   * matter. Until this existed a host could have the questions UI only by
+   * also running yarramate's catalogue, so a product with its own interview
+   * had to omit the section and show its questions on a separate surface,
+   * away from the model they are about.
+   *
+   * Bytes rather than a parsed catalogue, matching what the seam beneath
+   * already takes: a catalogue that does not load leaves the overlay absent
+   * rather than failing the mount, because the overlay is a garnish on the
+   * model and a model frame must not be blocked by it.
+   */
+  readonly catalogue?: { readonly path: string; readonly source: string }
+  /**
+   * Questions this host has already dealt with and does not want asked again
+   * (#328).
+   *
+   * A host-supplied catalogue alone does not close this: the editor evaluates
+   * the catalogue itself and cannot know that a reviewer set a question aside,
+   * with a reason, recorded somewhere the editor cannot see. Without this the
+   * pane would go on asking a question its own product had answered.
+   *
+   * `subject` absent dismisses the question wherever it appears - the
+   * workspace-scoped entry and every subject's - which is "stop asking this".
+   * `subject` present dismisses it for that subject alone, which is "not for
+   * this one". Dismissal hides a question from the pane and changes nothing
+   * about the model or about what `ask --open` reports; the interview is not
+   * the editor's to settle.
+   */
+  readonly dismissed?: readonly {
+    readonly questionId: string
+    readonly subject?: string
+  }[]
 }
 
 const EMPTY_MODEL: VisualRenderedModel = {
@@ -160,7 +199,7 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
       // live list so a view created or removed during this editor session is
       // represented exactly as it is in the rail.
       projectionDigests: revisionsOf(views.map(({ path }) => path)),
-    }, SHIPPED_CATALOGUE)
+    }, options.catalogue ?? SHIPPED_CATALOGUE, options.dismissed)
     views = workspaceModel.views
     model = workspaceModel.model
     return true

--- a/test/visual-workspace-model.test.ts
+++ b/test/visual-workspace-model.test.ts
@@ -114,6 +114,62 @@ describe('interrogationOverlayOf', () => {
     expect(twice).toEqual(once)
   })
 
+  // A host with its own interrogation supplies its own questions AND what it
+  // has already dealt with (#328). The engine is yarramate's and so is the UI;
+  // the questions belong to whoever adopted it, and a question a reviewer set
+  // aside in the host's own product must not be asked again by a pane embedded
+  // in it.
+  describe('a host that has already dealt with a question', () => {
+    it('drops it from every subject when no subject is named', () => {
+      const overlay = interrogationOverlayOf(compiled(), catalogue, [
+        { questionId: 'actor-owner-missing' },
+      ])!
+      expect(Object.keys(overlay.subjects)).toEqual([])
+      // The workspace-scoped question is untouched: dismissing one says
+      // nothing about the others.
+      expect(overlay.workspace.map(({ questionId }) => questionId)).toEqual([
+        'goal-missing',
+      ])
+    })
+
+    it('drops a workspace-scoped question by id alone', () => {
+      const overlay = interrogationOverlayOf(compiled(), catalogue, [
+        { questionId: 'goal-missing' },
+      ])!
+      expect(overlay.workspace).toEqual([])
+    })
+
+    it('drops it for the named subject only', () => {
+      const kept = interrogationOverlayOf(compiled(), catalogue, [
+        { questionId: 'actor-owner-missing', subject: 'somebody-else' },
+      ])!
+      expect(Object.keys(kept.subjects)).toEqual(['teller'])
+
+      const dropped = interrogationOverlayOf(compiled(), catalogue, [
+        { questionId: 'actor-owner-missing', subject: 'teller' },
+      ])!
+      expect(Object.keys(dropped.subjects)).toEqual([])
+    })
+
+    // Dismissal decides what the PANE draws and nothing else: the model is
+    // untouched and `ask --open` still reports the question, because the
+    // interview is not the editor's to settle.
+    it('changes nothing about the catalogue the overlay names', () => {
+      const overlay = interrogationOverlayOf(compiled(), catalogue, [
+        { questionId: 'goal-missing' },
+        { questionId: 'actor-owner-missing' },
+      ])!
+      expect(overlay.catalogue).toBe('fixture@1.0')
+      expect(overlay.semantics.length).toBeGreaterThan(0)
+    })
+
+    it('is a no-op when the host has dismissed nothing', () => {
+      expect(interrogationOverlayOf(compiled(), catalogue, [])).toEqual(
+        interrogationOverlayOf(compiled(), catalogue),
+      )
+    })
+  })
+
   it('returns undefined for a catalogue that does not load, never a throw', () => {
     expect(
       interrogationOverlayOf(compiled(), {


### PR DESCRIPTION
## Summary

Closes #328. You chose option 1 (host-supplied catalogue); this folds in the dismissal half ApertureX raised, for the reason below.

Until now a host could have the questions UI **only by also running yarramate's `core-enrichment`** — `createLocalHost` closed over `SHIPPED_CATALOGUE` and `LocalHostOptions` had no way to say otherwise. A product with its own interview had to omit the section entirely and show its questions on a separate surface, away from the model they were about. `READ_SECTIONS` made it worse by defaulting a read-only mount *into* the shipped catalogue.

The division this draws, in ApertureX's words on the issue: **the engine is yarramate's and so is the UI; the questions belong to whoever adopted it.** A general modelling interview is right for this repository's own CLI, and wrong for a product whose interview is about engagement framing and client sign-off.

```ts
mountEditor(element, {
  store,
  workspace,
  sections: ['palette', 'properties', 'questions', 'changes'],
  catalogue: { path: 'catalogues/consulting.yaml', source: catalogueText },
  dismissed: [
    { questionId: 'register-fidelity', subject: 'crm-integration' },
    { questionId: 'engagement-framing' },
  ],
})
```

`MountOptions extends LocalHostOptions` and `mount.tsx` is the library entry, so both fields reach the published mount surface with no further plumbing.

## Why `dismissed` rather than accepting a report

ApertureX suggested a host-supplied **report** would close both problems at once and "may be cheaper than it sounds". I think it is the other way round, and the reason is worth recording:

- **The overlay is rebuilt on every recompile.** `renderedWorkspaceOf` runs inside `recompileWorkspace()`, so a catalogue keeps the pane live as the model changes. A report is a snapshot that goes stale the moment the reviewer commits.
- **Nothing lets a host push a fresh report into a live session.** `EditorHost` delivers frames one way, and options are read at construction. A report shape needs a new mechanism or a remount.

A catalogue plus a small suppression set keeps liveness and closes the gap. `dismissed` covers exactly what a supplied catalogue cannot: the editor evaluates the catalogue itself, so it cannot know a reviewer set a question aside with a reason recorded somewhere the editor cannot see.

Naming a `subject` dismisses the question for that subject alone; omitting it dismisses the question wherever it appears.

**Dismissal decides what the pane draws and nothing else.** The model is untouched and `ask --open` still reports the question, because the interview is not the editor's to settle.

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: 1789 tests across 98 files, `self:check` no errors, `likec4 validate` valid.

Six new cases: dismissal by id dropping every subject entry, by id dropping a workspace-scoped question, by id+subject dropping one subject and leaving its sibling, dismissal leaving the named catalogue and engine semantics untouched, and an empty dismissal set being identical to none.

**Not eyeballed in a browser** — the change is in what the overlay contains, and the pane renders it unchanged.

## Contract impact

**None to any published format.** Two optional fields on the mount surface; a host that passes neither behaves exactly as before. Also documented in `docs/CONSUMING-YARRAMATE.md`, which is the line ApertureX asked for so nobody re-derives the division.

## Not in this PR

`READ_SECTIONS` still defaults a read-only mount to `['properties', 'questions']`. With a host catalogue available that default is defensible again — it now shows *your* questions if you supply them — but it is still an undocumented choice, and I have left it alone rather than changing a default in the same PR that adds the escape from it.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)