### PR TITLE
docs: a catalogue question's trigger should tell a UI what would answer it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,13 @@
   that comes out empty falls back to the table rather than leaving the
   edge undrawable. A `CanvasNode` carries `portKinds`, the resolved
   profile context carries `patternPortKinds`, and
-  `yarramate/visual-graph/v1` gains the field — a wire change, so a
-  consumer validating against a pinned copy of that schema needs it
-  upgraded alongside the package.
+  `yarramate/visual-graph/v1` gains the field — a wire change. Reading a
+  graph is unaffected, but **constructing** one is not: `portKinds` is
+  required, so a consumer with `CanvasNode` object literals (test
+  fixtures, most likely) breaks at typecheck until each gains the field.
+  A named consumer reports three such files. A consumer validating
+  against a pinned copy of that schema needs it upgraded alongside the
+  package.
 
   **Folding needed no canvas mode.** Because a macro edge survives its
   expansion and stays an ordinary subject, a projection over the pattern

--- a/docs/MODEL-REVIEW.md
+++ b/docs/MODEL-REVIEW.md
@@ -158,6 +158,37 @@ kinds inherit their deployable parent's hosting rather than answering
 separately. A kind whose inherited questions are mostly nonsense is evidence
 that the declared parent is wrong, not that the questions are.
 
+## An additional test for a catalogue question
+
+### 7. Does its trigger tell a UI what would answer it?
+
+Every question's trigger rides its report verbatim
+([ADR 0110](adr/0110-an-open-question-carries-its-answer-shape.md)), so a
+consumer builds its answering affordance from the condition rather than from
+prose. How much affordance it can build depends entirely on which condition
+was chosen, and two conditions that fire on the same subjects are not
+therefore equal.
+
+`missing-linkage` and `has-linkage` name their `counterpartKinds`, so a host
+can offer exactly the endpoints that would answer the question instead of
+everything the relationship table tolerates. `missing-relationship`,
+`no-subject-of-kind` and `missing-constraint` name their `kinds`.
+`missing-claim` names its predicate. Against those, `isolated`,
+`near-duplicate` and `missing-flow-content` say only *that* something is
+absent, and a consumer holding one has nothing to build with: the question
+degrades to prose, and a reviewer answers it by leaving the pane.
+
+The first external catalogue author reports exactly this, having written
+fourteen questions: ten use conditions that carry enough for their endpoint
+picker, and the ones that do not "degrade to prose and it shows."
+
+So when a question could be expressed by more than one condition, prefer the
+one that names what would answer it. This is not a rule that a vaguer
+condition is wrong — `isolated` says something no narrower condition can —
+but a question phrased against a condition that carries kinds is worth more
+to every consumer than the same question phrased against one that does not,
+and the choice is usually free at authoring time.
+
 ## Using this in review
 
 Ask the questions in the pull request. Record the answers where they will be
@@ -168,7 +199,7 @@ and an ADR when the decision governs future modelling rather than this model.
 An author may reasonably run the same questions against their own proposal
 before opening the pull request. That does not change what the document is.
 The questions are worth asking because someone independent asks them, and a
-self-review that answers all six is a well-prepared proposal, not an approved
+self-review that answers all seven is a well-prepared proposal, not an approved
 one.
 
 Approve growth that carries its rationale. The deliverable of this review is


### PR DESCRIPTION
## Summary

Two corrections from ApertureX, the first external catalogue author, who has now written fourteen questions against this engine. Both are small; both are things we would otherwise have learned from someone's red build.

## 1. A seventh test in `MODEL-REVIEW.md`

Every trigger rides its report verbatim (ADR 0110), so a consumer builds its answering affordance from the **condition** rather than from prose. How much it can build depends entirely on which condition was chosen — and two conditions that fire on the same subjects are not therefore equal.

| Carries enough for a UI | Says only *that* something is absent |
|---|---|
| `missing-linkage` / `has-linkage` (name `counterpartKinds`) | `isolated` |
| `missing-relationship`, `no-subject-of-kind`, `missing-constraint` (name `kinds`) | `near-duplicate` |
| `missing-claim` (names its predicate) | `missing-flow-content` |

Their report: ten of their fourteen use conditions that carry enough for their endpoint picker to offer the right candidates instead of everything the relationship table tolerates. The ones that do not *"degrade to prose and it shows."*

Not a rule that a vaguer condition is wrong — `isolated` says something no narrower condition can. But when a question could be expressed either way, the choice is usually free at authoring time and one answer is worth more to every consumer.

## 2. The `portKinds` changelog entry was wrong about who pays

It said the wire change costs a consumer nothing beyond upgrading a pinned schema. That is true of **readers** and not of **constructors**: `portKinds` is required, so any consumer holding `CanvasNode` object literals — test fixtures, most likely — breaks at **typecheck**, not at runtime.

ApertureX reports three such files. I hit exactly the same thing in eighteen of our own and did not think to generalise it. Saying "consumers reading the graph see no change" when the break is at typecheck is the kind of release note that produces a red build someone else has to diagnose.

The entry now names it.

## Related

Their other note is filed as #334 — a workspace-scoped absence question cannot say "only once the model has substance". That one is a defect in our own shipped catalogue, not a doc fix: on a blank `init`, six of nine open questions are "you have nothing of kind X", including the two questions they independently cut from theirs.

## Validation

`pnpm run verify` green, exit 0: 1789 tests, `self:check` no errors, `likec4 validate` valid. Documentation and changelog only — no code changes.

## Contract impact

None.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)