### PR TITLE
docs: readers and constructors are not the same consumer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,30 @@ Keep changes narrowly scoped and explain:
 - any compatibility or migration effect;
 - whether generated output changed.
 
+### Readers and constructors are not the same consumer
+
+When assessing the compatibility effect of a change to a **projected type** —
+anything a consumer receives from this package and may also build, such as
+`CanvasNode` on `yarramate/visual-graph/v1` — ask about both directions,
+because they do not pay the same price:
+
+- **Reading is unaffected** by a new field. Existing code goes on reading the
+  fields it already knew about.
+- **Constructing breaks** on a *required* field, at typecheck rather than at
+  runtime, in every object literal that builds one. **Test fixtures are almost
+  always constructors**, so the break lands in a consumer's test suite, which
+  is where it is most confusing and least expected.
+
+"Consumers reading the graph see no change" is a true sentence that has
+misled someone by the time they read it in a red build. Say which direction
+you mean, and say it in the changelog entry rather than leaving it to be
+rediscovered.
+
+This is recorded because it was learned the hard way: `portKinds` (#268 phase
+3) was described as costing readers nothing, which was true and beside the
+point. Adding it required edits in eighteen files here and three in a
+consuming product, all of them fixtures, none of them readers.
+
 A change a user would notice belongs in `CHANGELOG.md`, under the version
 being prepared, in the same pull request that makes it. A change nobody outside
 the repository can see does not. When a `feat`, `fix` or `perf` commit


### PR DESCRIPTION
## Summary

A rule stated once, rather than re-derived at each wire change. Prompted by ApertureX after the `portKinds` correction, who put it better than I had:

> Any required addition to a projected type is free for readers and a typecheck break for constructors, and test fixtures are almost always constructors.

`CONTRIBUTING.md` gains a short subsection under the pull-request guidance, where compatibility effects are already meant to be explained.

## Why it earns a place

"Consumers reading the graph see no change" is a **true sentence that has already misled someone** by the time they read it in a red build. The `portKinds` entry said exactly that. It was true, and beside the point: adding the field took edits in **eighteen files here and three in a consuming product** — all of them fixtures, none of them readers.

The failure mode is specific and repeatable:

| Direction | Effect of a new **required** field |
|---|---|
| Reading | none — existing code reads the fields it knew about |
| Constructing | breaks at **typecheck**, in every object literal |

And the break lands in a consumer's *test suite*, which is where it is least expected and most confusing.

## Validation

Documentation only, no code. `Changelog: none` on the commit — this is guidance for contributors and invisible outside the repository, which is the rule CONTRIBUTING itself states for that trailer.

## Contract impact

None.

## Related

#268 phase 3 (#332) is where the lesson came from. #334 carries the other half of the same conversation.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible — not applicable, and the commit says why.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)