### PR TITLE
fix: a wave opens when the model has substance (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+- **Fixed.** A blank project is no longer greeted with six questions about
+  what it does not have (#334, ADR 0125). Measured against 1.3.0: a fresh
+  `yarramate init` opened **nine** questions, six of them of the form "you
+  have nothing of kind X" — including how the planned architecture becomes
+  real, asked before anyone had named a subject. It now opens **three**, all
+  motivation: why the system exists, who its stakeholders are, what
+  constrains it.
+
+  A wave may declare `opensWhen`, conditions that must all hold before it
+  opens, written in the same vocabulary a question's trigger uses so a
+  reviewer reads a gate the way they already read a trigger. The one new
+  condition is `has-any-subject`. The gate belongs to the **wave** rather
+  than to each question because "the implementation wave is premature" is
+  one fact, not one per question in it — a per-question guard is only as
+  good as an author's memory, and this fix exists because six questions
+  shipped here unguarded while a consuming product cut two rather than
+  guard them.
+
+  A closed wave asks nothing: its questions are not evaluated at all, rather
+  than evaluated and reported closed, so they reach neither the report nor
+  the summary, and the wave reports `opened: false` — the third state a
+  progress rail needs. `summary.questions` counts questions in opened waves
+  only, so a blank model reports 3 of 11 rather than 3 of 51, forty-eight of
+  which were never put.
+
+  ADR 0120 survives intact: the gate is about the **model** having
+  substance, never about a previous wave being answered, so a model that has
+  started and declares no work keeps the question open and goes on saying
+  nothing is changing. Wave order becomes load-bearing, which is what a wave
+  was always claiming to be.
+
+  Catalogue `core-enrichment` goes 1.2 to **1.3**, gating every wave after
+  motivation. `INTERROGATION_SEMANTICS_VERSION` stays at **1**: the engine
+  gained an optional field and a condition, and a catalogue using neither
+  evaluates exactly as before. `yarramate/interrogation-report/v1` gains a
+  **required** `opened` on a wave, so a consumer *constructing* one gains it
+  at typecheck; reading is unaffected.
+
 - **Added.** A mounted editor takes the host's questions, and what the host
   has already dealt with (#328). `LocalHostOptions` and `MountOptions` gain
   `catalogue` and `dismissed`. Until now a host could have the questions UI

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "1.2"
+version: "1.3"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -25,27 +25,39 @@ waves:
       Load-bearing hops: the behavior a component is assigned to or the
       interface it composes, the serving/triggering/flow mechanism,
       payload, trust, reliability, and capacity. Hygiene waits.
+    opensWhen:
+      - condition: has-any-subject
   - id: business
     name: Business
     description: Who acts, what is served, and what information matters.
+    opensWhen:
+      - condition: has-any-subject
   - id: application
     name: Application
     description: >-
       How declared services are realized, performed, and fed with
       information.
+    opensWhen:
+      - condition: has-any-subject
   - id: technology
     name: Technology
     description: >-
       Where the declared applications actually run and what materializes
       them.
+    opensWhen:
+      - condition: has-any-subject
   - id: implementation
     name: Implementation
     description: >-
       How the planned architecture becomes real: work, deliverables, and
       the plateaus between here and there.
+    opensWhen:
+      - condition: has-any-subject
   - id: hygiene
     name: Model hygiene
     description: Cross-cutting completeness that keeps every wave honest.
+    opensWhen:
+      - condition: has-any-subject
 
 questions:
   # ---- motivation ----------------------------------------------------------

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -64,6 +64,8 @@ questions. Each question binds:
   and design steps verbatim as the question's machine-readable answer
   shape, so a consumer builds its answering affordance from the report
   instead of re-deriving the shape from a catalogue copy (ADR 0110);
+  `has-any-subject` (the workspace holds at least one concept — the guard a
+  late wave needs to say "only once the model has substance"; see ADR 0125),
 - a **scope** — `workspace` (asked once) or `subject` (asked per matching
   subject, selected by kinds, statuses, and documents, with `descendants`
   kind matching by default so profile-derived kinds satisfy a catalogue
@@ -94,6 +96,39 @@ profile (ADR 0095).
 Catalogues are ordinary versioned data: extend the shipped one under a new
 identity or write one per organisation, then pass it with `--catalogue`.
 Composition via `extends` is deferred from v1 (ADR 0053).
+
+## Waves open when the model has substance
+
+A wave may declare `opensWhen`, conditions that must all hold before it opens
+([ADR 0125](adr/0125-a-wave-opens-when-the-model-has-substance.md)):
+
+```yaml
+waves:
+  - id: implementation
+    name: Implementation
+    opensWhen:
+      - condition: has-any-subject
+```
+
+A wave that has not opened **asks nothing**. Its questions are not evaluated
+at all — rather than evaluated and reported closed, which would say they had
+been asked and answered — so they appear in neither the report nor the
+summary, and the wave carries `opened: false`. That is the third state a
+progress rail needs: neither answered nor open, but not yet applicable.
+
+`summary.questions` therefore counts questions in **opened waves only**. A
+blank project reports 3 of 11 rather than 3 of 51, forty-eight of which were
+never put; the denominator grows as the model gains substance and waves open.
+
+The gate is about the **model** having substance, never about a previous wave
+being answered. A model that has started and declares no work keeps
+`implementation-path-missing` open, and that open question is still the model
+saying nothing is changing (ADR 0120).
+
+Wave order is load-bearing because of this. A catalogue that sequences
+motivation before implementation is making a claim the engine now honours,
+where before the order was presentational and questions fired in whatever
+order the model happened to trip them.
 
 ## Evaluation model
 

--- a/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
+++ b/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
@@ -1,0 +1,130 @@
+# A wave opens when the model has substance
+
+Status: accepted
+
+[ADR 0120](0120-the-interview-asks-about-what-is-not-there.md) gave the
+catalogue workspace-scoped absence questions, so a layer with zero
+subjects could be asked about at all. It argued that an unanswered
+presence question is information: an architecture genuinely at rest keeps
+`implementation-path-missing` open, and that open question is the model
+saying nothing is changing.
+
+That reasoning is right for a model with substance and wrong for an empty
+one. Measured on a blank `yarramate init` against 1.3.0's
+`core-enrichment@1.2`: **nine questions open, six of them of the form
+"you have nothing of kind X"**, including how the planned architecture
+becomes real and whether architecture states should be declared. A person
+opening an empty model was asked how the planned architecture becomes
+real before they had named one subject.
+
+**An empty model is not an architecture at rest. It has not started.** The
+catalogue could not tell those apart, so it said the same thing to both.
+
+The first external catalogue author reached the same wall from the other
+side, cutting two questions rather than shipping them for exactly this
+reason. Between the two catalogues, nine questions were either shipped
+unguarded or deleted.
+
+## Decision
+
+**A wave declares `opensWhen`: conditions that must all hold before it
+opens.** A wave that has not opened asks nothing.
+
+```yaml
+waves:
+  - id: implementation
+    name: Implementation
+    opensWhen:
+      - condition: has-any-subject
+```
+
+- **The gate belongs to the wave, not the question.** "The implementation
+  wave is premature on an empty model" is one fact, not one per question
+  in it. A per-question guard makes the right thing *possible* and not
+  *default*, and the evidence that authors forget is this decision's own
+  history: six questions shipped unguarded here, two cut rather than
+  guarded elsewhere. An author who never thinks about cold start still
+  gets the right behaviour, because the wave already knows.
+- **The gate is written in the condition vocabulary.** `opensWhen` takes
+  a condition list, so a reviewer reads a gate exactly as they read a
+  trigger, and `has-any-subject` is the only new condition — the one a
+  per-question guard would have needed anyway. A minimum-count condition
+  can join later without changing the mechanism, so nobody has to pick an
+  arbitrary N today to get the fix.
+- **A closed wave carries no questions and does not count.** Its
+  questions are not evaluated at all, rather than evaluated and reported
+  closed: the latter would say they had been asked and answered.
+  `summary.questions` counts questions in opened waves only, so a blank
+  model reports 3 of 11 rather than 3 of 51 — forty-eight of which were
+  never put. The denominator grows as the model gains substance and waves
+  open, which is the interview revealing itself rather than a rail
+  filling up.
+- **A wave reports `opened`, the third state a rail needs.** Neither
+  answered nor open: not yet applicable. A consultant can see that an
+  Implementation wave exists and is waiting, which excluding it from the
+  report would have hidden.
+- **The gate is about the MODEL having substance, never about a previous
+  wave being answered.** ADR 0120's point survives intact: a model that
+  has started and declares no work keeps the question open, and that open
+  question is still the model saying nothing is changing.
+- **Wave order becomes load-bearing, and that is the point.** Catalogues
+  already sequence their waves — motivation before implementation — and a
+  rail already shows that order. Until now the order was presentational
+  while questions fired in whatever order the model happened to trip
+  them. The gate makes the sequencing real, which is what a wave was
+  always claiming to be.
+
+`core-enrichment` goes 1.2 to **1.3**, gating every wave after motivation
+on `has-any-subject`. A blank project now opens on three motivation
+questions — why the system exists, who its stakeholders are, what
+constrains it — and nothing else. It went from 9 open to 3.
+
+`INTERROGATION_SEMANTICS_VERSION` stays at **1**. The engine gained an
+optional wave field and a condition; a catalogue that uses neither
+evaluates exactly as before, so no existing question's answer moves for
+an unchanged model. What changed answers is the *catalogue*, which is
+what a catalogue version is for.
+
+## Excluded options
+
+- **A per-question guard** (`has-any-subject` composed into a trigger).
+  Cheaper, additive, and it relocates the failure rather than fixing it:
+  every future late-wave absence question gets the same coin-flip. The
+  author who has just written fourteen questions against this vocabulary
+  put it plainly — they would have reached for it on the question in
+  front of them and forgotten it on the next one.
+- **A minimum-count guard** (`atLeast: N`) as the mechanism. Same
+  opt-in weakness, plus it forces an author to pick a number before
+  anyone knows what number means anything. It stays available as a
+  *condition* under this decision, which is the right layer for it.
+- **A per-question override of the wave gate.** Additive and forecloses
+  nothing, so it can be added the day a real question needs it. No such
+  question exists today: a wave is gated precisely because its questions
+  are premature on an empty model, and a question inside it that should
+  fire on an empty model is a question in the wrong wave. The failure
+  modes are also asymmetric — forgetting to opt *in* is this bug, while
+  forgetting to opt *out* leaves a question quieter than intended, which
+  is recoverable and visible in review — so the override can never
+  recreate what this fixes.
+- **Gating on the previous wave being answered.** It would make the
+  interview a sequence of locked doors and would destroy ADR 0120's
+  standing meaning for a model at rest, whose late waves are open and
+  correctly unanswered.
+- **Excluding a closed wave from the report entirely.** Cheaper for
+  consumers and it hides a real fact: a consultant cannot see that a wave
+  exists and is waiting, so the catalogue reads as having fewer waves
+  than it does.
+
+## Consequences
+
+The catalogue schema gains an optional `opensWhen`; the report schema a
+required `opened` on a wave; the condition vocabulary one member. The
+report change is a required field on a published format, so a consumer
+constructing a `ReportWave` — a test fixture, most likely — gains it at
+typecheck, per the rule in `CONTRIBUTING.md`. Reading is unaffected.
+
+Every existing catalogue behaves identically until it declares a gate.
+Models evaluated against `core-enrichment` will see fewer open questions
+and a smaller denominator on a young model, and no change at all once
+every wave has opened — this repository's own self-model reports the same
+51 questions and 0 open as before, because it has substance.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -537,6 +537,19 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "description": "The workspace holds at least one concept (#334, ADR 0125). The guard a late wave needs to say \"only once the model has substance\": an empty model is not an architecture at rest, it has not started, and asking it how the planned architecture becomes real greets someone ahead of question one.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-any-subject"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "description": "The workspace's evidence overlay records observations and every one is a frictionless confirmation: no contradicted, unknown, or not-observed result, and no recorded search (ADR 0107). A discovery that never records anything but success never tested a claim it might fail. The one condition that reads the evidence overlay rather than the compiled graph; where the evaluating consumer supplies no overlay it stays quiet (ADR 0120).",
           "required": [
             "condition"

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -66,6 +66,7 @@
       "required": [
         "id",
         "name",
+        "opened",
         "questions"
       ],
       "properties": {
@@ -76,6 +77,10 @@
         "name": {
           "type": "string",
           "minLength": 1
+        },
+        "opened": {
+          "description": "Whether this wave's gate is met (#334, ADR 0125). A wave with no `opensWhen` is always true. A wave reported false asks nothing and carries no questions: they are premature rather than answered, which is the third state a progress rail needs so a closed wave is not counted as done. Its questions are excluded from `summary` for the same reason.",
+          "type": "boolean"
         },
         "questions": {
           "type": "array",
@@ -530,6 +535,19 @@
           "properties": {
             "condition": {
               "const": "unscoped-succession"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The workspace holds at least one concept (#334, ADR 0125). The guard a late wave needs to say \"only once the model has substance\": an empty model is not an architecture at rest, it has not started, and asking it how the planned architecture becomes real greets someone ahead of question one.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-any-subject"
             }
           }
         },

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -63,6 +63,14 @@
           },
           "description": {
             "$ref": "#/$defs/nonEmptyText"
+          },
+          "opensWhen": {
+            "description": "Conditions that must all hold before this wave opens (#334, ADR 0125). A wave that has not opened asks nothing: its questions are premature rather than answered, and the report says so with `opened: false` and no questions rather than reporting them closed. Written in the same condition vocabulary a question's trigger uses, so a reviewer reads a gate the way they already read a trigger. Absent means the wave is always open, which is what every wave did before this existed.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/condition"
+            }
           }
         }
       }
@@ -500,6 +508,19 @@
           "properties": {
             "condition": {
               "const": "unscoped-succession"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The workspace holds at least one concept (#334, ADR 0125). The guard a late wave needs to say \"only once the model has substance\": an empty model is not an architecture at rest, it has not started, and asking it how the planned architecture becomes real greets someone ahead of question one.",
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-any-subject"
             }
           }
         },

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -114,6 +114,7 @@ export type CatalogueCondition =
   | { readonly condition: 'unconstrained-kind' }
   | { readonly condition: 'unscoped-succession' }
   | { readonly condition: 'unchallenged-evidence' }
+  | { readonly condition: 'has-any-subject' }
 
 /**
  * One observation from the workspace's evidence overlay, reduced to what
@@ -160,6 +161,11 @@ export interface QuestionCatalogue {
     readonly id: string
     readonly name: string
     readonly description?: string
+    /**
+     * Conditions that must all hold before this wave opens (#334, ADR 0125).
+     * Absent means always open, which is what every wave did before this.
+     */
+    readonly opensWhen?: readonly CatalogueCondition[]
   }[]
   readonly questions: readonly CatalogueQuestion[]
 }
@@ -193,6 +199,16 @@ export interface ReportQuestion {
 export interface ReportWave {
   readonly id: string
   readonly name: string
+  /**
+   * Whether the wave's gate is met (#334, ADR 0125). A wave with no
+   * `opensWhen` is always open.
+   *
+   * A wave reported `false` carries NO questions and contributes nothing to
+   * the summary. Its questions are premature rather than answered, and a
+   * progress rail that counted them as answered would flatter itself exactly
+   * where someone is most likely to trust it.
+   */
+  readonly opened: boolean
   readonly questions: readonly ReportQuestion[]
 }
 
@@ -507,6 +523,13 @@ const conditionHolds = (
   evidence: readonly CatalogueEvidenceObservation[] | undefined,
 ): boolean => {
   switch (condition.condition) {
+    case 'has-any-subject':
+      // The guard a late wave needs to say "only once the model has
+      // substance" (#334). An empty model is not an architecture at rest -
+      // ADR 0120's reading, which stays true for a model that HAS started -
+      // it has not begun, and asking it how the planned architecture becomes
+      // real greets someone ahead of question one.
+      return index.concepts.size > 0
     case 'unchallenged-evidence':
       // Fires where the overlay records observations and every one is a
       // frictionless confirmation: no contradicted, unknown, or
@@ -806,10 +829,22 @@ export function evaluateCatalogue(
   const applicableQuestions = catalogue.questions.filter((question) =>
     questionIsApplicable(question, graph.profiles),
   )
+  const waveOpens = (wave: QuestionCatalogue['waves'][number]): boolean =>
+    wave.opensWhen === undefined ||
+    wave.opensWhen.every((condition) =>
+      conditionHolds(index, condition, undefined, profileContext, evidence),
+    )
   const waves = catalogue.waves.map((wave) => ({
     id: wave.id,
     name: wave.name,
-    questions: applicableQuestions
+    opened: waveOpens(wave),
+    // A closed wave asks nothing. Its questions are not evaluated at all,
+    // rather than evaluated and reported closed - the latter would say they
+    // had been asked and answered - so they reach neither the report nor the
+    // summary.
+    questions: !waveOpens(wave)
+      ? []
+      : applicableQuestions
       .filter((question) => question.wave === wave.id)
       .map((question): ReportQuestion => {
         const base = {
@@ -870,7 +905,13 @@ export function evaluateCatalogue(
     catalogue: `${catalogue.id}@${catalogue.version}`,
     semantics: INTERROGATION_SEMANTICS_VERSION,
     summary: {
-      questions: applicableQuestions.length,
+      // Questions in OPENED waves only (#334, ADR 0125). A closed wave's
+      // questions have not been asked, so counting them in the denominator
+      // would report them as answered - "3 of 51" reading as forty-eight
+      // done when forty-eight were never put. The denominator grows as the
+      // model gains substance and waves open, which is the interview
+      // revealing itself rather than a rail filling up.
+      questions: waves.reduce((total, wave) => total + wave.questions.length, 0),
       openQuestions,
       open,
     },

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -71,7 +71,7 @@ describe('core-enrichment 1.0 interaction wave', () => {
         id: string
       }[]
     }
-    expect(catalogue.version).toBe('1.2')
+    expect(catalogue.version).toBe('1.3')
     const added = catalogue.questions.filter((question) => question.since === '0.9')
     expect(added.length).toBeGreaterThan(0)
     for (const question of added) {

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -22,7 +22,7 @@ import {
 // existing question answers.
 
 const EXPECTED_SEMANTICS = '1'
-const EXPECTED_FINGERPRINT = '3f1dec3d08690ce7'
+const EXPECTED_FINGERPRINT = 'c1d51437c346fb07'
 
 const profile = 'yarramate/core@0.1'
 
@@ -109,6 +109,7 @@ const conditions: readonly (readonly [string, readonly string[]])[] = [
   ['unconstrained-kind', ['      - condition: unconstrained-kind']],
   ['unscoped-succession', ['      - condition: unscoped-succession']],
   ['unchallenged-evidence', ['      - condition: unchallenged-evidence']],
+  ['has-any-subject', ['      - condition: has-any-subject']],
 ]
 
 // The overlay the unchallenged-evidence probe reads: one confirmed

--- a/test/wave-gate.test.ts
+++ b/test/wave-gate.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// The wave gate (#334, ADR 0125). A workspace-scoped absence question could
+// not say "only once the model has substance", so a blank project was greeted
+// with six questions of the form "you have nothing of kind X" - including how
+// the planned architecture becomes real, before anyone had named a subject.
+// The fix is a property of the WAVE rather than of each question, because "the
+// implementation wave is premature" is one fact and a per-question guard is
+// only as good as an author's memory.
+
+const graphOf = (concepts: string) => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:${concepts}
+relationships: []
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+}
+
+const EMPTY = graphOf(' []')
+const POPULATED = graphOf(`
+  - id: teller
+    kind: businessActor
+    name: Teller`)
+
+const catalogueOf = (opensWhen: string) => {
+  const loaded = loadQuestionCatalogue({
+    path: 'catalogues/fixture.yaml',
+    source: `format: yarramate/question-catalogue/v1
+id: fixture
+version: "1.0"
+profile: yarramate/core@0.1
+presentation:
+  title: Fixture
+  description: A gated late wave and an ungated early one.
+waves:
+  - id: early
+    name: Early
+    description: Always open.
+  - id: late
+    name: Late
+    description: Premature on an empty model.
+${opensWhen}questions:
+  - id: outcome-missing
+    wave: early
+    since: "1.0"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#outcome
+    question: What outcome justifies this system?
+    materiality: Without one, no alternative can be judged.
+    authority: human
+    resolution: Declare an outcome.
+  - id: implementation-path-missing
+    wave: late
+    since: "1.0"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#workPackage
+    question: How does the planned architecture become real?
+    materiality: A target with no work reaching it is a wish.
+    authority: human
+    resolution: Declare the work packages in flight.
+`,
+  })
+  if (!loaded.ok) throw new Error(JSON.stringify(loaded.diagnostics))
+  return loaded.catalogue
+}
+
+const GATED = catalogueOf(`    opensWhen:
+      - condition: has-any-subject
+`)
+const UNGATED = catalogueOf('')
+
+const reportOf = (
+  catalogue: ReturnType<typeof catalogueOf>,
+  compiled: typeof EMPTY,
+) => evaluateCatalogue(catalogue, compiled.graph, compiled.profileContext)
+
+describe('a gated wave asks nothing until the model has substance', () => {
+  it('reports the wave closed and carrying no questions on an empty model', () => {
+    const late = reportOf(GATED, EMPTY).waves.find(({ id }) => id === 'late')!
+    expect(late.opened).toBe(false)
+    // Not evaluated and reported closed - that would say the question had
+    // been asked and answered. Absent entirely.
+    expect(late.questions).toEqual([])
+  })
+
+  it('leaves the ungated wave open and asking on the same empty model', () => {
+    const early = reportOf(GATED, EMPTY).waves.find(({ id }) => id === 'early')!
+    expect(early.opened).toBe(true)
+    expect(early.questions.map(({ id, open }) => [id, open])).toEqual([
+      ['outcome-missing', true],
+    ])
+  })
+
+  it('opens the wave the moment one concept exists', () => {
+    const late = reportOf(GATED, POPULATED).waves.find(
+      ({ id }) => id === 'late',
+    )!
+    expect(late.opened).toBe(true)
+    expect(late.questions.map(({ id, open }) => [id, open])).toEqual([
+      ['implementation-path-missing', true],
+    ])
+  })
+
+  // ADR 0120's reading survives: an architecture that HAS started and declares
+  // no work is saying something true, and the question stays open to say it.
+  it('still lets a model at rest keep the question open', () => {
+    const late = reportOf(GATED, POPULATED).waves.find(
+      ({ id }) => id === 'late',
+    )!
+    expect(late.questions[0]!.open).toBe(true)
+  })
+
+  it('is what a wave without opensWhen never does', () => {
+    const late = reportOf(UNGATED, EMPTY).waves.find(({ id }) => id === 'late')!
+    expect(late.opened).toBe(true)
+    expect(late.questions[0]!.open).toBe(true)
+  })
+})
+
+describe('the counts stay honest through a closed gate', () => {
+  it('leaves a closed wave out of the denominator, not marked answered', () => {
+    // "1 of 2" would report the gated question as answered when it was never
+    // put. The denominator is what was ASKED.
+    expect(reportOf(GATED, EMPTY).summary).toEqual({
+      questions: 1,
+      openQuestions: 1,
+      open: 1,
+    })
+  })
+
+  it('grows the denominator as the model gains substance', () => {
+    expect(reportOf(GATED, POPULATED).summary).toEqual({
+      questions: 2,
+      openQuestions: 2,
+      open: 2,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #334. ADR 0125. You chose the wave-level gate over the two cheaper per-question shapes, and confirmed it directly.

**Measured** against 1.3.0: a fresh `yarramate init` opened **nine** questions, six of them of the form "you have nothing of kind X" — including how the planned architecture becomes real, asked before anyone had named a subject.

| | before | after |
|---|---|---|
| open on a blank `init` | 9 | **3** |
| of which "nothing of kind X" | 6 | 0 |
| summary denominator | 51 | 11 |

It now opens on three motivation questions: why the system exists, who its stakeholders are, what constrains it.

## ADR 0120 survives intact

0120 argued an unanswered presence question is information, because an architecture **at rest** keeps it open. That is right for a model with substance and wrong for an empty one. **An empty model is not at rest; it has not started** — and the catalogue could not tell those apart, so it said the same thing to both.

The gate is therefore about the **model** having substance, never about a previous wave being answered. A model that has started and declares no work keeps the question open and goes on saying nothing is changing.

## The gate belongs to the wave

```yaml
waves:
  - id: implementation
    name: Implementation
    opensWhen:
      - condition: has-any-subject
```

"The implementation wave is premature" is one fact, not one per question in it. A per-question guard makes the right thing *possible* and not *default* — and the evidence that authors forget is this fix's own history: six questions shipped unguarded here, two cut rather than guarded in a consuming product.

`opensWhen` takes a condition list, so a reviewer reads a gate exactly as they read a trigger, and `has-any-subject` is the only new condition — the one a per-question guard would have needed anyway. A minimum-count condition can join later without changing the mechanism, so nobody picks an arbitrary N today to get the fix.

## The counts stay honest

A closed wave asks nothing: its questions are **not evaluated at all**, rather than evaluated and reported closed — the latter would say they had been asked and answered. They reach neither the report nor the summary, and the wave reports `opened: false`, the third state you asked for.

`summary.questions` counts questions in opened waves only. A blank model reports **3 of 11** rather than 3 of 51, forty-eight of which were never put. The denominator grows as the model gains substance, which is the interview revealing itself rather than a rail filling up.

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: **1796 tests across 99 files**, `self:check` no errors, `likec4 validate` valid.

This repository's own self-model is **unchanged** — 51 questions, 0 open, no closed waves — because it has substance. The fix is visible only where it should be.

New `test/wave-gate.test.ts` covers the closed wave carrying no questions, the ungated wave still asking on the same empty model, the gate opening on one concept, a model at rest keeping the question open, an ungated catalogue behaving as before, and both summary shapes.

## Contract impact

- `yarramate/question-catalogue/v1` gains an optional `opensWhen` on a wave.
- `yarramate/interrogation-report/v1` gains a **required** `opened` on a wave — so a consumer *constructing* a report gains it at typecheck, per the rule `CONTRIBUTING.md` now states. Reading is unaffected.
- One new condition in the three schemas that carry the union.
- `core-enrichment` 1.2 → **1.3**.
- **`INTERROGATION_SEMANTICS_VERSION` stays at 1.** The engine gained an optional field and a condition; a catalogue using neither evaluates exactly as before. What changed answers is the *catalogue*, which is what a catalogue version is for. The fingerprint backstop diagnosed this correctly and unprompted — it named the case and told me not to bump.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)