### PR TITLE
fix: a wave that has not opened does not read as a finished one (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Fixed.** A wave that has not opened no longer reads as a finished one
+  (#334). `ask` printed a bare `== Implementation ==` heading with nothing
+  under it, which is visually identical to a wave whose questions are all
+  closed — and the empty reading is the flattering one: "nothing
+  outstanding here" rather than "nobody has been asked anything here". It
+  now prints `not yet — this wave has not opened`. `docs/INTERROGATION.md`
+  states the hazard for consumers, because the state is one this release
+  created: a rail computing `done` as `answered === questions` ticks at
+  zero, and both this renderer and a consuming product's wave rail had that
+  fault on the day the gate shipped.
+
 - **Fixed.** A blank project is no longer greeted with six questions about
   what it does not have (#334, ADR 0125). Measured against 1.3.0: a fresh
   `yarramate init` opened **nine** questions, six of them of the form "you

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -125,6 +125,14 @@ being answered. A model that has started and declares no work keeps
 `implementation-path-missing` open, and that open question is still the model
 saying nothing is changing (ADR 0120).
 
+**A closed wave must not be rendered as a finished one.** Both carry no open
+questions, and completion inferred from an empty set is the more flattering of
+the two readings — a rail computing `done` as `answered === questions` ticks at
+zero. `ask` prints `not yet — this wave has not opened` rather than an empty
+heading, and a consumer should read `opened` rather than counting. This is
+worth stating because both this repository's own renderer and a consuming
+product's wave rail had the same fault on the day the gate shipped.
+
 Wave order is load-bearing because of this. A catalogue that sequences
 motivation before implementation is making a claim the engine now honours,
 where before the order was presentational and questions fired in whatever

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -974,6 +974,16 @@ export function renderInterrogationReport(
   ]
   for (const wave of report.waves) {
     lines.push('', `== ${wave.name} ==`)
+    // A wave that has not opened must not read like one whose questions are
+    // all closed (#334). Both carry no OPEN questions, and a bare heading with
+    // nothing under it is the more flattering of the two readings: "nothing
+    // outstanding here" rather than "nobody has been asked anything here".
+    // The same shape - completion inferred from an empty set - was found in a
+    // consuming product's wave rail on the same day.
+    if (!wave.opened) {
+      lines.push('  not yet — this wave has not opened')
+      continue
+    }
     for (const question of wave.questions) {
       if (!question.open) {
         lines.push(`  closed ${question.id}`)

--- a/test/wave-gate.test.ts
+++ b/test/wave-gate.test.ts
@@ -3,6 +3,7 @@ import {
   compileWorkspaceWithProfileContext,
   evaluateCatalogue,
   loadQuestionCatalogue,
+  renderInterrogationReport,
 } from '../src/index.js'
 
 // The wave gate (#334, ADR 0125). A workspace-scoped absence question could
@@ -153,5 +154,31 @@ describe('the counts stay honest through a closed gate', () => {
       openQuestions: 2,
       open: 2,
     })
+  })
+})
+
+describe('a closed wave does not read like a finished one', () => {
+  // Both carry no OPEN questions, and a bare heading with nothing under it is
+  // the more flattering reading: "nothing outstanding here" rather than
+  // "nobody has been asked anything here". The identical shape - completion
+  // inferred from an empty set - was found in a consuming product's wave rail
+  // on the same day this gate shipped.
+  const rendered = (compiled: typeof EMPTY) =>
+    renderInterrogationReport({
+      ...reportOf(GATED, compiled),
+      workspace: 'fixture',
+    })
+
+  it('says the wave has not opened, rather than showing an empty heading', () => {
+    const text = rendered(EMPTY)
+    expect(text).toContain('== Late ==\n  not yet — this wave has not opened')
+    // And the open wave is unaffected.
+    expect(text).toContain('OPEN   outcome-missing')
+  })
+
+  it('renders the wave normally once it opens', () => {
+    const text = rendered(POPULATED)
+    expect(text).not.toContain('not yet')
+    expect(text).toContain('OPEN   implementation-path-missing')
   })
 })


### PR DESCRIPTION
## Summary

Found in our own renderer an hour after shipping #337, because ApertureX reported the identical fault in their wave rail and I went to check ours.

`ask` printed a bare heading with nothing under it:

```
== Interaction ==

== Business ==
```

That is **visually identical** to a wave whose questions are all `closed`, and the empty reading is the flattering one: *"nothing outstanding here"* rather than *"nobody has been asked anything here"*. It now prints:

```
== Interaction ==
  not yet — this wave has not opened
```

## Same fault, two shapes, two codebases, one day

Theirs was arithmetic rather than layout: a rail computing `done` as `answered === questions`, which is trivially true at zero, so a closed wave would have arrived wearing a completion tick on a project where nobody had been asked anything. Inert for them until they gate a wave; live for us the moment #337 merged.

**Completion inferred from an empty set** is the general shape, and `opened: false` with an empty `questions` array is a state *this release created*. That is why `docs/INTERROGATION.md` now states the hazard rather than leaving the fix silent — every consumer will meet this state, and the arithmetic that looks right is wrong at zero. A consumer should read `opened` rather than counting.

## Validation

`pnpm run verify` green, exit 0: 1798 tests across 99 files, `self:check` no errors, `likec4 validate` valid.

Two new cases in `test/wave-gate.test.ts` pin both directions — the closed wave saying so, and the wave rendering normally once it opens.

## Contract impact

None. `renderInterrogationReport` is human output; the report shape is unchanged. `opened` was already the field to read.

## Related

#334, #337. The report state is the one that PR introduced.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)