### PR TITLE
docs: an empty set is not a finished one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,29 @@ This is recorded because it was learned the hard way: `portKinds` (#268 phase
 point. Adding it required edits in eighteen files here and three in a
 consuming product, all of them fixtures, none of them readers.
 
+### An empty set is not a finished one
+
+A surface that reports progress must not infer completion from emptiness.
+The arithmetic that looks right is wrong at zero:
+
+- `done = answered === questions` ticks when a wave carries no questions;
+- "no open questions" reads as complete when nothing was asked;
+- a fallback group like `quiet` claims calm about a project nobody has begun.
+
+In each case the empty reading is the **flattering** one, and the honest
+question is not "is the count zero" but "was anything asked". Read the state
+that says so — `opened` on a wave, whether any wave carries a question —
+rather than a count that happens to be zero.
+
+This is recorded because it recurs. Five instances were found in a single day
+across this repository and one consuming product: a wave rail, this
+repository's report renderer, a project dashboard, this repository's `design`
+completion claim, and the same claim in that product's own interview surface.
+**Four of the five predated the release that made the shape visible.** Adding
+a legitimately-empty state is therefore a good moment to go looking for who
+infers completion from emptiness — the state is new, the fault usually is not.
+`docs/INTERROGATION.md` carries the interrogation-specific form.
+
 A change a user would notice belongs in `CHANGELOG.md`, under the version
 being prepared, in the same pull request that makes it. A change nobody outside
 the repository can see does not. When a `feat`, `fix` or `perf` commit


### PR DESCRIPTION
## Summary

The second rule from the same day and the same source, and the one with more evidence behind it than any single change it came from.

**Five instances found in one day**, across this repository and one consuming product:

| # | Surface | Predates the release? |
|---|---|---|
| 1 | a consuming product's wave rail (`done = answered === questions`) | yes |
| 2 | this repository's report renderer (bare wave heading) | no |
| 3 | that product's project dashboard (`quiet` on a fresh project) | yes |
| 4 | this repository's `design` completion claim | latent |
| 5 | that product's own interview surface, same claim | latent |

**Four of the five predated the release that made the shape visible.** The wave gate did not cause this; it exposed it.

## The rule

The arithmetic that looks right is wrong at zero:

- `done = answered === questions` ticks when a wave carries no questions
- "no open questions" reads as complete when nothing was asked
- a fallback group like `quiet` claims calm about a project nobody has begun

In each case **the empty reading is the flattering one**, and the honest question is not "is the count zero" but "was anything asked". Read the state that says so, rather than a count that happens to be zero.

The practical trigger: **adding a legitimately-empty state is a good moment to go looking for who infers completion from emptiness.** The state is new; the fault usually is not.

## Why CONTRIBUTING rather than the interrogation guide

`docs/INTERROGATION.md` already carries the wave-specific form, and that is right for a consumer reading `opened`. But instance #4 was in `design`'s completion sentence, which has nothing to do with waves as such, and instances #1 and #3 are in another product's rail and dashboard. The shape is about writing a surface that reports progress, so it belongs where a contributor meets it before writing one — beside the readers-and-constructors rule, which came from the same day and the same reporter.

## Validation

Documentation only. `Changelog: none` on the commit, per CONTRIBUTING's own rule for a change nobody outside the repository can see.

## Contract impact

None.

## Related

#334, and PRs #337, #338, #339 — the release that made the shape visible and the two fixes it produced here.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible — not applicable, and the commit says why.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)