### PR TITLE
chore: release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.0
 
 - **Fixed.** "No open questions" no longer reads as a finished interview
   when nothing was asked (#334). A catalogue whose waves are all gated shut

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts 1.4.0. `package.json` to 1.4.0 and the `Unreleased` changelog section becomes `1.4.0`: **eight entries**, all merged verify-green.

**Features.** Structural patterns — all four phases of #268: the `yarramate/pattern/v1` format and its expansion stage (ADR 0123), ports and macro edges (ADR 0124), and the port-narrowed connect palette. A mounted editor takes the host's own catalogue and its dismissals (#328), drawing the division the product needed: **engine and UI yarramate's, questions the adopter's**.

**Fixed.** The cold start (#334, ADR 0125) — a blank `yarramate init` opened **nine** questions, six of them "you have nothing of kind X", including how the planned architecture becomes real, asked before anyone had named a subject. It now opens **three**, all motivation. Plus an expansion the relationship table forbids (#268), and two surfaces that read an empty set as a finished one.

## Compatibility — the part a consumer needs

**Two required fields on published formats:**

| Format | Field |
|---|---|
| `yarramate/visual-graph/v1` | `portKinds` on a canvas node |
| `yarramate/interrogation-report/v1` | `opened` on a wave |

**Reading either format is unaffected. Constructing one is not** — a consumer holding object literals (test fixtures, most likely) breaks at **typecheck** until each gains the field. A named consumer reports three such files; it took eighteen here. That distinction is now a rule in `CONTRIBUTING.md`, because it fired twice in a single day.

Catalogue `core-enrichment` 1.2 → **1.3**. Models will legitimately see **fewer** open questions and a smaller denominator on a young model — that is the cold-start fix working. `INTERROGATION_SEMANTICS_VERSION` stays at **1**: no existing question's answer moves for an unchanged model.

## Validation

Per `docs/RELEASING.md`:

- `pnpm install --frozen-lockfile` clean
- `pnpm run verify` **exit 0** from a wiped `.yarramate-out`: typecheck, build, 1800 tests across 99 files, `self:check` no errors, `likec4 validate` valid
- `pnpm changelog:check` clean, 11 commits checked since `v1.3.0`
- `npm pack --dry-run`: **248 files**, 1.9 MB — carries the new `yarramate-pattern.schema.json`, and no repository source, tests, fixtures, dogfooding inputs or generated output

The self-model is unchanged by the cold-start fix (51 questions, 0 open, no closed waves) because it has substance — the fix is visible only where it should be.

**Not eyeballed in a browser.** The wave gate changes what the questions pane shows and the palette change sits behind a connect gesture. Both are test-verified only, and that gap is the one thing I would flag before publishing.

## Contract impact

As above. Version is a **minor**: additive package surface, no removal, and the same shape 1.2.0 and 1.3.0 carried for required schema fields.

## After merge

I tag `v1.4.0` on the merge commit. **Publishing is yours** — from a fresh clone at the tag, never a branch tip. Then I notify ApertureX, who have a four-item adoption list queued: plumb `opened` into their wave counts first, then gate their Delivery wave, pass their catalogue through the new mount option, and add `portKinds` to three fixtures.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the version being prepared.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)