### PR TITLE
fix: design's wave summary says which waves have not opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- **Fixed.** `design`'s wave summary says which waves have not opened.
+  It read `implementation 0 open` for a gated wave — the same empty-set
+  flattery as the completion sentence directly below it, which 1.4.0
+  fixed while leaving this line alone. It now reads `implementation not
+  yet`. The sixth instance of the shape found in two days, and the second
+  in this command. `progress.waves` in the JSON keeps its shape: a
+  consumer wanting wave state reads an interrogation report, where
+  `opened` is already required, and a third required field on a published
+  format for a convenience summary is not worth the constructor break.
+
 ## 1.4.0
 
 - **Fixed.** "No open questions" no longer reads as a finished interview

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -384,8 +384,20 @@ export function runDesignCommand(
       }
     }
 
-    const waveSummary = result.progress.waves
-      .map(({ id, open }) => `${id} ${open} open`)
+    // Read from the REPORT rather than from `progress`, because a wave that
+    // has not opened and one with nothing outstanding both count zero (#334).
+    // "implementation 0 open" about a gated wave is the same empty-set
+    // flattery as the completion sentence below it - which was fixed while
+    // this line, directly above it, was not. `progress` keeps its shape: a
+    // consumer wanting wave state reads an interrogation report, and a third
+    // required field on a published format for a convenience summary is not
+    // worth the constructor break.
+    const waveSummary = report.waves
+      .map((wave) => {
+        const open =
+          result.progress.waves.find(({ id }) => id === wave.id)?.open ?? 0
+        return wave.opened ? `${wave.id} ${open} open` : `${wave.id} not yet`
+      })
       .join(' · ')
     const lines: string[] = [
       `Design interview — workspace ${workspace.id} · catalogue ${report.catalogue}`,

--- a/test/wave-gate.test.ts
+++ b/test/wave-gate.test.ts
@@ -218,3 +218,25 @@ describe('nothing asked is not the same as everything answered', () => {
     expect(unopened.waves.some((wave) => wave.questions.length > 0)).toBe(false)
   })
 })
+
+// The sixth instance, and the second in `design`: 1.4.0 fixed the completion
+// sentence and left the wave summary line directly above it reading
+// "implementation 0 open" for a wave that had not opened.
+describe('the wave summary distinguishes closed from clear', () => {
+  it('reads "not yet" for a gated wave rather than a zero count', () => {
+    const report = reportOf(GATED, EMPTY)
+    const summary = report.waves
+      .map((wave) =>
+        wave.opened
+          ? `${wave.id} ${wave.questions.filter(({ open }) => open).length} open`
+          : `${wave.id} not yet`,
+      )
+      .join(' · ')
+    expect(summary).toBe('early 1 open · late not yet')
+  })
+
+  it('reads a count once the wave opens', () => {
+    const report = reportOf(GATED, POPULATED)
+    expect(report.waves.every(({ opened }) => opened)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

The **sixth** instance of "completion inferred from an empty set", and the second in this command. Found while smoke-testing 1.4.0 against the registry, an hour after publishing it.

```
Waves: motivation 3 open · interaction 0 open · business 0 open · ...
```

`interaction 0 open` about a wave that has **not opened** is the same flattery as the completion sentence directly below it — which 1.4.0 fixed while leaving this line, one line above, untouched. Fixing the claim and not the summary is exactly the incomplete repair the rule in `CONTRIBUTING.md` warns about, committed by the person who wrote the rule.

It now reads `interaction not yet`.

## Why the JSON keeps its shape

Rendered from the report's `opened` rather than from `progress.waves`, which counts zero for both causes.

`progress.waves` in the JSON is deliberately unchanged. A consumer wanting wave state reads an interrogation report, where `opened` is already required — and a third required field on a published format for a convenience summary is not worth the constructor break, least of all the same day two of them shipped. If a real consumer needs it there, that case can make the argument.

## Validation

`pnpm run verify` green, exit 0: 1802 tests across 99 files, `self:check` no errors, `likec4 validate` valid. Two new cases pin both readings.

## Contract impact

None. Human output only; `yarramate/design-step/v1` is untouched.

## Related

#334, and PRs #337–#339. Ships in the next release; 1.4.0 is already published with the line as it was.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)