### PR TITLE
fix: a pattern declared in a manifest is actually loaded (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Fixed.** A pattern document declared in a workspace manifest is
+  actually loaded (#268). 1.4.0 added the `patterns` manifest category and
+  the workspace loader resolved it — and **not one caller passed it to the
+  compiler**. Ten source lists across the CLI, the visual session server,
+  the browser host, the apply gate and the request builder each said
+  `[...profiles, ...documents]`. So a workspace that declared a pattern
+  compiled without it: every instance binding `parts` failed `YM419` for a
+  pattern sitting in its own manifest, **every commit against such a
+  workspace was refused** by the atomic gate, and a visual session
+  recompiled to nothing and drew every view empty while the rail still
+  showed the model. The feature was unreachable except by handing the
+  compiler an explicit source list — which is exactly what every test did,
+  which is why 1800 of them passed. `check`'s summary counts patterns
+  rather than reporting them as profiles, and the contact-update fixture
+  now declares its pattern and is compiled through its own manifest by a
+  test.
+
 - **Fixed.** `design`'s wave summary says which waves have not opened.
   It read `implementation 0 open` for a gated wave — the same empty-set
   flattery as the completion sentence directly below it, which 1.4.0

--- a/src/adapters/visual/request.ts
+++ b/src/adapters/visual/request.ts
@@ -93,7 +93,14 @@ export const buildVisualSessionRequest = (
 
   // Same order the session's own recompile uses, so the request's graph and
   // every graph the session rebuilds after a commit come from one input list.
-  const sourcePaths = [...workspace.profiles, ...workspace.documents]
+  // Patterns are compiler input like profiles (#268). Omitting them compiled a
+  // different workspace than the manifest describes, and an instance binding
+  // parts then failed YM419 for a pattern the manifest declared.
+  const sourcePaths = [
+    ...workspace.profiles,
+    ...workspace.patterns,
+    ...workspace.documents,
+  ]
   const sources: { readonly path: string; readonly source: string }[] = []
   for (const path of sourcePaths) {
     try {

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -787,6 +787,13 @@ export const startVisualServer = async (
     try {
       return [
         ...resolvedWorkspace.profiles,
+        // Patterns are compiler input like profiles (#268). Without them a
+        // session recompiles a workspace the manifest does not describe: an
+        // instance binding parts fails YM419, `compiledWorkspace` becomes
+        // undefined, and every view's filter then matches nothing while the
+        // rail still shows the initial model - which reads as a filter bug
+        // rather than as a compile that failed.
+        ...resolvedWorkspace.patterns,
         ...resolvedWorkspace.documents,
       ].map((path) => ({
         path,

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -1078,6 +1078,10 @@ export const applyOperations = (
   // single byte is written; any diagnostic rejects the entire batch.
   const compiled = [
     ...resolvedWorkspace.profiles,
+    // Without patterns this gate compiles a workspace the manifest does not
+    // describe, so every commit against a workspace holding pattern instances
+    // was refused with YM419 for a pattern that was declared (#268).
+    ...resolvedWorkspace.patterns,
     ...resolvedWorkspace.documents,
   ].map((path) => ({
     path,
@@ -1208,6 +1212,9 @@ export const planOperations = (
     // workspace that declares a profile died on it. No operation can target a
     // profile, so they are read to be COMPILED against, never to be written.
     ...input.workspace.profiles,
+    // Patterns are compiled against too, and are no more writable than a
+    // profile: no operation can target one.
+    ...input.workspace.patterns,
     ...input.workspace.documents,
     ...input.workspace.projections,
     ...input.workspace.evidence,

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -758,7 +758,11 @@ export function runAskCommand(
       }
 
       const compilation = compileWorkspaceWithProfileContext(
-        [...workspace.profiles, ...workspace.documents].map((path) => ({
+        [
+          ...workspace.profiles,
+          ...workspace.patterns,
+          ...workspace.documents,
+        ].map((path) => ({
           path,
           source: readFileSync(resolve(cwd, path), 'utf8'),
         })),
@@ -875,7 +879,11 @@ export function runAskCommand(
 
     // Every other mode reads the compiled model directly.
     const compilation = compileWorkspaceWithProfileContext(
-      [...workspace.profiles, ...workspace.documents].map((path) => ({
+      [
+          ...workspace.profiles,
+          ...workspace.patterns,
+          ...workspace.documents,
+        ].map((path) => ({
         path,
         source: readFileSync(resolve(cwd, path), 'utf8'),
       })),

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -409,7 +409,11 @@ export function runCheckCommand(
     if (ok && result.ok) {
       const successfulCounts = counted!
       const documentCount = result.graph.documents.length
-      const profileCount = coreSources.length - documentCount
+      const patternCount = resolved.patterns.length
+      // Everything in `coreSources` that is not a document was a profile until
+      // patterns joined the source list (#268), and counting them as profiles
+      // said "2 profiles" about a workspace with one.
+      const profileCount = coreSources.length - documentCount - patternCount
       const mappingCount = mappingSources.length
       const projectionCount = resolved.projections.length
       const evidenceCount = resolved.evidence.length
@@ -419,6 +423,11 @@ export function runCheckCommand(
         ...(profileCount > 0
           ? [
               `${profileCount} ${profileCount === 1 ? 'profile' : 'profiles'}`,
+            ]
+          : []),
+        ...(patternCount > 0
+          ? [
+              `${patternCount} ${patternCount === 1 ? 'pattern' : 'patterns'}`,
             ]
           : []),
         ...(mappingCount > 0

--- a/src/cli-support.ts
+++ b/src/cli-support.ts
@@ -114,6 +114,8 @@ export const resolveCliWorkspaceSources = (
       readonly projections: readonly string[]
       readonly evidence: readonly string[]
       readonly contracts: readonly string[]
+      /** Pattern documents, which ride in `paths` and are not documents. */
+      readonly patterns: readonly string[]
     }
   | {
       readonly ok: false
@@ -126,6 +128,7 @@ export const resolveCliWorkspaceSources = (
       projections: [],
       evidence: [],
       contracts: [],
+      patterns: [],
     }
   }
   const manifestPath = paths[0]
@@ -136,6 +139,7 @@ export const resolveCliWorkspaceSources = (
       projections: [],
       evidence: [],
       contracts: [],
+      patterns: [],
     }
   }
   const source = readFileSync(resolve(cwd, manifestPath), 'utf8')
@@ -148,6 +152,7 @@ export const resolveCliWorkspaceSources = (
       projections: [],
       evidence: [],
       contracts: [],
+      patterns: [],
     }
   }
   const loaded = loadWorkspaceManifest(
@@ -159,6 +164,15 @@ export const resolveCliWorkspaceSources = (
         ok: true,
         paths: [
           ...loaded.workspace.profiles,
+          // Patterns are compiler input like profiles, and were resolved from
+          // the manifest without ever being handed over (#268): a pattern
+          // document a workspace declared was silently ignored by every verb,
+          // and an instance binding parts then failed YM419 for a pattern that
+          // was sitting right there in the manifest. Every test passed because
+          // each hands the compiler an explicit source list rather than
+          // resolving a workspace - the check that passes was not the check
+          // that mattered.
+          ...loaded.workspace.patterns,
           ...loaded.workspace.documents,
           ...(options.includeAdapterMappings === true
             ? loaded.workspace.adapterMappings
@@ -167,6 +181,7 @@ export const resolveCliWorkspaceSources = (
         projections: loaded.workspace.projections,
         evidence: loaded.workspace.evidence,
         contracts: loaded.workspace.contracts,
+        patterns: loaded.workspace.patterns,
       }
     : { ok: false, diagnostics: loaded.diagnostics }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ const runReconciliation = (
     }
     const sourcePaths = [
       ...loadedWorkspace.workspace.profiles,
+      ...loadedWorkspace.workspace.patterns,
       ...loadedWorkspace.workspace.documents,
     ]
     const compilation = compileWorkspace(

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -280,7 +280,11 @@ export function runDesignCommand(
     if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
 
     const compilation = compileWorkspaceWithProfileContext(
-      [...workspace.profiles, ...workspace.documents].map((path) => ({
+      [
+        ...workspace.profiles,
+        ...workspace.patterns,
+        ...workspace.documents,
+      ].map((path) => ({
         path,
         source: readFileSync(resolve(cwd, path), 'utf8'),
       })),

--- a/src/export-command.ts
+++ b/src/export-command.ts
@@ -213,7 +213,11 @@ export function runExportCommand(
     const workspace = loadedWorkspace.workspace
 
     const compilation = compileWorkspaceWithProfileContext(
-      [...workspace.profiles, ...workspace.documents].map((path) => ({
+      [
+        ...workspace.profiles,
+        ...workspace.patterns,
+        ...workspace.documents,
+      ].map((path) => ({
         path,
         source: readFileSync(resolve(cwd, path), 'utf8'),
       })),

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -149,7 +149,11 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
    * shown no profile is shown an empty string where one should be.
    */
   const sourcesOf = (): readonly WorkspaceSource[] =>
-    [...workspace.profiles, ...workspace.documents].flatMap((path) => {
+    [
+      ...workspace.profiles,
+      ...workspace.patterns,
+      ...workspace.documents,
+    ].flatMap((path) => {
       const held = store.read(path)
       return held === undefined ? [] : [{ path, source: held.source }]
     })
@@ -193,6 +197,7 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
       // would have to invent a crypto library to compute.
       sourceDigests: revisionsOf([
         ...workspace.profiles,
+        ...workspace.patterns,
         ...workspace.documents,
       ]),
       // The manifest's resolved projections are static. Pins belong to the

--- a/test/contact-update-fixture.test.ts
+++ b/test/contact-update-fixture.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { resolveCliWorkspaceSources } from '../src/cli-support.js'
 import { describe, expect, it } from 'vitest'
 import {
   compileWorkspaceWithProfileContext,
@@ -163,5 +165,46 @@ describe('the contact-update journey fixture', () => {
     expect(
       interaction?.questions.filter((question) => question.open).map((q) => q.id),
     ).toEqual([])
+  })
+})
+
+// The journey fixture is meant to represent a REAL workspace, and nothing
+// resolved its manifest until this. Every other test here hands the compiler
+// an explicit source list, which is why `patterns` being declared in the
+// manifest and never passed to the compiler was invisible: the fixture failed
+// YM419 on all four api instances through its own manifest while every test
+// passed. The check that passes was not the check that mattered (#268).
+describe('the fixture compiles through its own manifest', () => {
+  it('resolves and checks clean, patterns included', () => {
+    const root = fileURLToPath(
+      new URL('./fixtures/journeys/contact-update/', import.meta.url),
+    )
+    const resolved = resolveCliWorkspaceSources(
+      ['.yarramate/workspace.yaml'],
+      root,
+      { includeAdapterMappings: true },
+    )
+    expect(resolved.ok, JSON.stringify(resolved)).toBe(true)
+    if (!resolved.ok) return
+
+    // Declared AND handed over are two different things; only the first was
+    // true.
+    expect(resolved.patterns).toEqual(['.yarramate/patterns/api-led.yaml'])
+    expect(resolved.paths).toContain('.yarramate/patterns/api-led.yaml')
+
+    const compiled = compileWorkspaceWithProfileContext(
+      resolved.paths.map((path) => ({
+        path,
+        source: readFileSync(join(root, path), 'utf8'),
+      })),
+    )
+    expect(
+      compiled.ok,
+      compiled.ok
+        ? ''
+        : compiled.diagnostics
+            .map(({ code, message }) => `${code} ${message}`)
+            .join('; '),
+    ).toBe(true)
   })
 })

--- a/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
+++ b/test/fixtures/journeys/contact-update/.yarramate/workspace.yaml
@@ -4,6 +4,8 @@ documents:
   - architecture/*.yaml
 profiles:
   - profiles/*.yaml
+patterns:
+  - patterns/*.yaml
 projections:
   - projections/*.yaml
 adapterMappings: []


### PR DESCRIPTION
## Summary

**Found by opening the editor**, which is the only way it could have been found.

1.4.0 added the `patterns` manifest category. The workspace loader resolved it. **Not one caller passed it to the compiler.** Ten source lists — the CLI entry, `ask` (twice), `design`, `export`, `apply`, the visual request builder, the session server, and the browser host — each said `[...profiles, ...documents]`.

So a workspace that *declared* a pattern compiled without it:

- every instance binding `parts` failed **`YM419` for a pattern sitting in its own manifest**;
- **every commit against such a workspace was refused**, because the atomic gate compiles the candidate workspace and it too was missing them;
- a visual session recompiled to nothing, set `compiledWorkspace` to `undefined`, and drew **every view empty** while the rail went on showing the model — which reads as a filter bug rather than a failed compile.

The feature was unreachable except by handing the compiler an explicit source list. Which is exactly what every test does, which is why 1800 of them passed while **the fixture's own manifest did not compile**.

## What it looked like

Before, on the contact-update fixture — the folded APIs view that #268's whole argument rests on:

```
Nothing matches this filter: kinds: yarrasys/api-led@1.0#api
0 subjects · 41 excluded
```

Every authored view showed `0`. The kind palette said "No model yet."

After: four API boxes and three `serving` edges, Salesforce → System → Process → Experience. Views count 12, 20, 4, 16, 37, 4. Palette shows 67 kinds.

## Also fixed

- **`check` counted a pattern as a profile** — "2 profiles" for a workspace with one. It now reports patterns in their own right.
- **The contact-update fixture never declared its pattern.** I wired the document into the *test* in #327 and not into the workspace it describes.
- **Nothing resolved that fixture's manifest.** Now a test compiles the fixture *through* it — the guard that would have caught every part of this, since the fixture is meant to represent a real workspace.

## The pattern in the mistake

Third time in two days that the check which passes was not the check that mattered, and this time on the largest thing I shipped. A test that hands the compiler a source list is not testing the workspace; it is testing the list. The new fixture test closes that specific hole, and it is worth noting the general one: **a manifest category is not wired until something resolves a manifest.**

## Validation

`pnpm run verify` green, exit 0, from a wiped `.yarramate-out`: 1803 tests across 99 files, `self:check` no errors, `likec4 validate` valid. Confirmed by eye in the browser, before and after.

## Contract impact

None to any published format. `resolveCliWorkspaceSources` gains a `patterns` field on its result, used by `check` to count honestly.

## Related

#268. Ships in the next release; 1.4.0 is published with the category non-functional.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)