### PR TITLE
docs: constructors are not only test fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,18 @@ because they do not pay the same price:
 - **Reading is unaffected** by a new field. Existing code goes on reading the
   fields it already knew about.
 - **Constructing breaks** on a *required* field, at typecheck rather than at
-  runtime, in every object literal that builds one. **Test fixtures are almost
-  always constructors**, so the break lands in a consumer's test suite, which
-  is where it is most confusing and least expected.
+  runtime, in every object literal that builds one. Test fixtures are the
+  usual constructors, so the break often lands in a consumer's test suite,
+  which is where it is most confusing and least expected.
+
+**They are not the only constructors, and the exceptions are the ones that
+matter.** A type a consumer must *build* to satisfy an API of ours is
+guaranteed to have constructors in production code: `ResolvedWorkspace` is
+built by every embedder of the mounted editor, because ADR 0100 has the
+embedder resolve its own manifest. When it gained a required `patterns`, a
+consuming product's manifest module broke — not its fixtures. Ask which of
+your types a consumer has to construct in order to call you, and treat those
+as the sharp ones.
 
 "Consumers reading the graph see no change" is a true sentence that has
 misled someone by the time they read it in a red build. Say which direction
@@ -125,7 +134,9 @@ rediscovered.
 This is recorded because it was learned the hard way: `portKinds` (#268 phase
 3) was described as costing readers nothing, which was true and beside the
 point. Adding it required edits in eighteen files here and three in a
-consuming product, all of them fixtures, none of them readers.
+consuming product, all of them fixtures, none of them readers. In the same
+release `ResolvedWorkspace` gained a required `patterns` and broke that
+product's manifest module, which is production code.
 
 ### An empty set is not a finished one
 


### PR DESCRIPTION
## Summary

A **third** instance of the readers/constructors rule, reported by ApertureX on adoption day — and the one that shows the rule's wording was too reassuring.

`ResolvedWorkspace` gained a required `patterns` in 1.4.0 and broke a consuming product's **manifest module**. Production code, not a fixture. That type is built by every embedder of the mounted editor, because [ADR 0100](docs/adr/0100-apply-operations-reads-nothing-it-is-not-handed.md) has the embedder resolve its own manifest.

I listed two constructor breaks in the release note (`portKinds`, `opened`) and missed this one entirely, which is the point: **"test fixtures are almost always constructors" reads as reassurance**, and it made me stop looking.

## The change

The rule now says fixtures are the *usual* constructors rather than almost the only ones, names the exception, and gives the question worth asking:

> Ask which of your types a consumer has to construct in order to call you, and treat those as the sharp ones.

A type a consumer must **build** in order to call us is guaranteed to have constructors in the wild. That is a much sharper filter than "look for fixtures".

## Validation

Documentation only. `Changelog: none` on the commit, per CONTRIBUTING's own rule.

## Contract impact

None.

## Related

The rule went in at PR #336 on two instances; #343 is the release where the third appeared. Their framing — *"I would rather find it in a typecheck on adoption day than at runtime later"* — is why this is worth sharpening rather than leaving at two examples.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible — not applicable, and the commit says why.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)