### PR TITLE
docs: if production assembles the input, test the assembly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,29 @@ consuming product, all of them fixtures, none of them readers. In the same
 release `ResolvedWorkspace` gained a required `patterns` and broke that
 product's manifest module, which is production code.
 
+### If production assembles the input, test the assembly
+
+A test that constructs the input a production caller assembles is not testing
+the assembly. It tests the constructor, and the assembly goes uncovered no
+matter how many such tests there are.
+
+The `patterns` manifest category shipped in 1.4.0 non-functional. The workspace
+loader resolved it and **no caller passed it to the compiler** — ten source
+lists said `[...profiles, ...documents]`. A workspace that declared a pattern
+compiled without it, every commit against one was refused, and a visual session
+drew every view empty. **1800 tests passed**, because every one of them handed
+the compiler an explicit source list and so not one exercised the path a real
+workspace takes. It was found by opening the editor.
+
+So: when a verb reads a manifest, at least one test should read that manifest
+rather than hand over a list. The repair here was to compile the journey
+fixture *through* its own manifest, which is the right shape precisely because
+it stops constructing the thing under test.
+
+The general form is the same family as readers-and-constructors above, seen
+from the other end: **know whether your fixture is standing in for the caller
+or for the caller's input.** Only the second is safe to fake.
+
 ### An empty set is not a finished one
 
 A surface that reports progress must not infer completion from emptiness.


### PR DESCRIPTION
## Summary

The third rule in two days, and the one with the highest cost behind it.

**1.4.0's `patterns` manifest category shipped non-functional and 1800 tests passed.** The workspace loader resolved it; no caller passed it to the compiler. Every test handed the compiler an explicit source list, so not one exercised the path a real workspace takes. It was found by opening the editor.

The formulation is ApertureX's and is sharper than mine:

> A test that constructs the input the production caller assembles is not testing the assembly.

It tests the constructor. The assembly goes uncovered no matter how many such tests there are.

## The actionable form

**When a verb reads a manifest, at least one test should read that manifest** rather than hand over a list. The repair here was to compile the journey fixture *through* its own manifest, which works precisely because it stops constructing the thing under test.

And the general question, which is the same family as readers-and-constructors seen from the other end:

> Know whether your fixture is standing in for the **caller** or for the caller's **input**. Only the second is safe to fake.

## On adding a third rule in one day

Judged on cost rather than novelty. This one let a feature ship broken; the other two caught wrong sentences. If `CONTRIBUTING.md` starts reading as a lessons-learned dump it should be pruned, but I would keep this one over either of the others.

## Validation

Documentation only. `Changelog: none` on the commit, per CONTRIBUTING's own rule.

## Contract impact

None.

## Related

#268 and PR #343, where it was learned.

## Checklist

- [x] Tests or documentation cover the change where appropriate.
- [x] `CHANGELOG.md` records the change under the unreleased version when it is user-visible — not applicable, and the commit says why.
- [x] Generated output and build artifacts are not committed.
- [x] Semantic or stable-interface changes have prior discussion and an ADR where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)