### PR TITLE
chore: release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.1
 
 - **Fixed.** A pattern document declared in a workspace manifest is
   actually loaded (#268). 1.4.0 added the `patterns` manifest category and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
A patch release for one defect, and it is the whole reason for the release:
1.4.0's headline feature was unreachable in what shipped.

## Fixed

**A pattern document declared in a workspace manifest is actually loaded**
(#268, #343). 1.4.0 added the `patterns` manifest category and the workspace
loader resolved it, and **not one caller passed it to the compiler**. Ten
source lists across the CLI, the visual session server, the browser host, the
apply gate and the request builder each said `[...profiles, ...documents]`.
A workspace declaring a pattern therefore compiled without it:

- every instance binding `parts` failed `YM419` against a pattern sitting in
  its own manifest,
- **every commit against such a workspace was refused** by the atomic gate,
- a visual session recompiled to nothing and drew every view empty while the
  rail still showed the model.

Anyone adopting patterns from 1.4.0 hit a wall on their first document.

**`design`'s wave summary says which waves have not opened** (#342). It read
`implementation 0 open` for a gated wave, the same empty-set flattery the
completion sentence directly below it had already been fixed for.

## Why 1800 tests passed

Every test handed the compiler an explicit source list, so no test ever
exercised the assembly production does. The rule is now in `CONTRIBUTING.md`
(#347): **if production assembles the input, test the assembly.** When a verb
reads a manifest, at least one test reads that manifest. The contact-update
fixture now declares its pattern and is compiled through its own manifest by
a test.

## How it was found

By opening the browser, which 1.4.0 shipped without doing and said so.
Nothing else would have caught it: the suite was green, `check` was green,
and the failure surfaced only where a real workspace meets a real caller.

## Compatibility

No format changes, no catalogue change, no new required fields. A 1.4.0
consumer upgrades with no source edits.

## Release checks

- `pnpm install --frozen-lockfile` clean
- `pnpm run verify` **exit 0** from a wiped `.yarramate-out`: 1803 tests, 99 files
- `self:check` no errors across 269 concepts, 381 relationships
- `changelog:check` clean over 4 commits
- `npm pack --dry-run`: 248 files / 1.9MB, carries the pattern schema, no
  repository source, tests, fixtures or generated output
- **the defect itself re-checked through the built CLI rather than the
  suite**: the fixture manifest reports `1 pattern` and compiles with no errors
- **eyeballed in a browser this time**: a blank model's questions pane shows
  3 open on `core-enrichment@1.3`, and the fixture's folded APIs view draws
  four API boxes with three serving edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
