### PR TITLE
fix(visual): a failed recompile says so, and keeps the picture (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## Unreleased
+
+- **Fixed.** A visual session that cannot recompile the workspace says so,
+  and keeps drawing the model that did compile (#349, ADR 0126). It used to
+  say nothing at all: every view emptied while the rail kept its views, so
+  the page read as a session over an architecture that had gone blank rather
+  than one that had failed. That is what made the 1.4.1 patterns bug take ten
+  minutes to diagnose instead of ten seconds - the compiler had a `YM419`
+  naming the missing pattern, and the browser was the one surface that could
+  not see it. Three paths were silent (a startup failure, a refused apply
+  whose refresh also failed, and an unreadable source) and the fourth could
+  not name the fault: `YMVS310` is built with a hardcoded path of
+  `visual-session-server`, and the compiler's own diagnostics were discarded
+  one function earlier. The browser now gets those diagnostics, with code and
+  path and line, in the faults panel. That panel also moves out of the
+  conversation column and over the canvas, into a rule that was written for
+  it and had nothing rendering into it: a reviewer studying a diagram has no
+  reason to look at the conversation to learn that what they are looking at
+  is stale.
+
+  **An unreadable source is no longer served as an empty workspace.**
+  Compiling an empty source list *succeeds*, returning an empty graph rather
+  than a failure, so swallowing a read error made a workspace the session
+  could not read indistinguishable from one with nothing in it - reported as
+  a healthy compile, with every view at zero subjects and nothing frozen.
+
+  **Only a failure the runtime caused is fatal.** A post-commit failure still
+  freezes the session; the others do not. A source going uncompilable because
+  the reviewer edited a file or switched branches is an ordinary mid-edit
+  state, not grounds to end a session holding staged work. The mounted editor
+  gets the same treatment, where a batch that landed and left the workspace
+  uncompilable previously reported `ok: true` and then silence.
+
+- **Fixed.** The consumer docs published the wrong wire version. `docs/VISUAL-ADAPTER.md`
+  and `docs/ROADMAP.md` both named `yarramate/visual-protocol/v4`; the
+  constant and all three schemas have been at `v5`. A host embedding the
+  editor and pinning what the doc said would pin a version the runtime does
+  not speak.
+
 ## 1.4.1
 
 - **Fixed.** A pattern document declared in a workspace manifest is

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,7 +150,7 @@ notation.
   `.yarramate/visual-layout` sidecars. Dropdown-constrained field edits
   accumulate in a changeset that commits through `yarramate/operations/v1` and
   `yarramate apply`, so the browser holds no private write path. The wire is
-  the published `yarramate/visual-protocol/v4` contract; see
+  the published `yarramate/visual-protocol/v5` contract; see
   `docs/VISUAL-ADAPTER.md` and ADRs 0081, 0084 to 0088, and 0096. Ordered in-app
   undo and redo over the staged changeset walks an ordered history of whole
   staged-operation snapshots, covering staging, one discarded row, and a

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -553,7 +553,7 @@ Eleven closed `yarramate/visual-*/v1` JSON documents, each with
 `additionalProperties: false`, published from `./schema`:
 session request, session started, session descriptor, event, response,
 status, handoff, model, graph, layout, and diagnostic result.
-`yarramate/visual-protocol/v4` is the version the started result, the
+`yarramate/visual-protocol/v5` is the version the started result, the
 descriptor, and status agree on. Every filesystem path any of these documents
 carries - `sessionRoot`, `descriptorPath`, `journalPath`, `transcriptPath` - is
 a canonical local `file:` URI rather than a bare path string, which is why the
@@ -582,6 +582,42 @@ back to the browser carry nine response types.
 mechanical edit is not a question. A successful commit is followed by a fresh
 `model` frame, so the browser renders what actually landed rather than an
 optimistic local guess.
+
+## A failed recompile keeps the picture and names what broke
+
+A session recompiles the workspace at start and after every landed
+changeset. When that compile fails, the session **keeps the last good model
+and says why**, rather than clearing it (ADR 0126).
+
+It used to clear it. Every view emptied, the rail kept its views, and the
+page read as a session over an architecture that had gone blank rather than
+one that had failed - which is the flattering reading of the two, and the
+wrong one. An empty canvas looks like an answer ("your model is empty")
+rather than like a failure. The browser's own fault panel has always
+promised the opposite: *the diagram still shows the model that did compile*.
+
+What a consumer sees:
+
+- a `diagnostic` response carrying **the compiler's own diagnostics**, code
+  and path and line, not a summary line. `YMVS310` when a landed changeset
+  caused it, `YMVS319` otherwise;
+- the faults panel over the canvas, cleared by the next `model` frame, so a
+  recompile that succeeds clears it without anything clearing it explicitly;
+- a failure that happened before the browser connected - a startup one, most
+  often - delivered to the first browser that connects, and dropped if a
+  later recompile succeeds first.
+
+**Only a failure the runtime caused is fatal.** A post-commit failure still
+freezes the session with `recompile-failed`: a batch the runtime landed that
+leaves the workspace uncompilable is a bug, not a reviewer's error. Nothing
+else freezes. A source going uncompilable because the reviewer edited a file
+or switched branches is an ordinary mid-edit state, and ending their session
+for it would discard whatever is staged in the changeset tray.
+
+An unreadable source is never treated as an absent one. Compiling an empty
+source list SUCCEEDS - it yields an empty graph, not a failure - so a
+swallowed read error used to be indistinguishable from a workspace with
+nothing in it.
 
 ## Boundary
 

--- a/docs/adr/0126-a-failed-recompile-keeps-the-last-good-model-and-names-what-broke.md
+++ b/docs/adr/0126-a-failed-recompile-keeps-the-last-good-model-and-names-what-broke.md
@@ -1,0 +1,134 @@
+# A failed recompile keeps the last good model and names what broke
+
+Status: accepted
+
+A visual session that could not recompile the workspace told the browser
+nothing. Every view emptied, the rail kept the views it was drawn with, and
+the page read as a working session over an architecture that had gone blank
+rather than a session that had failed.
+
+That is what made #343 take ten minutes to diagnose instead of ten seconds.
+The compiler had a `YM419` naming the pattern the manifest declared and no
+caller passed, and the browser was the one surface that could not see it.
+Every other consumer of a failed compile already gets the diagnostic: `check`
+prints it, `apply` refuses on it, the request builder returns it. The session
+server alone dropped it.
+
+Reading the path turned up three silent failures and a wrong default.
+
+- **An unreadable source was served as an empty workspace.**
+  `workspaceSources` caught any read error and returned `[]`, and compiling
+  an empty list **succeeds**. `compileWorkspaceResolved` over no sources
+  returns an empty graph, not a failure. So the recompile reported success,
+  the session broadcast a model whose every view read `subjectCount: 0`, and
+  nothing froze. The code asserted that a workspace it could not read was a
+  workspace with nothing in it.
+- **A startup failure was discarded**: the boolean was not read.
+- **A refused apply whose refresh also failed emitted nothing at all**: no
+  model, no diagnostic, no freeze.
+- **The one handled path could not name the fault.** `YMVS310` said
+  "Workspace failed to recompile after a landed changeset" and was built by
+  `serverDiagnostic`, which hardcodes `path: "visual-session-server"` and
+  `line: 1`. The compiler's diagnostics were thrown away one function
+  earlier.
+
+Underneath all four, `filterMatchedIds` answered `[]` whenever the compile
+was gone, defended in comment as degrading "rather than failing the session".
+
+## Decision
+
+**A failed recompile keeps the last good model and says what broke, naming
+the compiler's own diagnostics.**
+
+- **The last good compile is retained rather than cleared.** An empty canvas
+  is not a neutral failure state. It looks like an answer, "your model is
+  empty", rather than like a failure, and it is the flattering reading of
+  the two. Keeping the previous graph leaves the reviewer something true to
+  look at while telling them it is stale. This also makes the browser's own
+  `Faults` heading true; it has always read *"the diagram still shows the
+  model that did"*, and the server was the reason it was not.
+- **The compiler's diagnostics are what the browser is shown**, via the
+  existing `published()` bridge. `Diagnostic` and `VisualDiagnostic` are
+  structurally identical, so nothing is resynthesised. A banner that says
+  "recompile failed" without a code and a path is the ten-minute diagnosis
+  again, which is the whole reason this decision exists.
+- **Only a failure we caused is fatal.** A post-commit failure stays
+  terminal: a changeset the runtime landed that leaves the workspace
+  uncompilable is a runtime bug, and `LIMIT_FREEZE` already treats it as one.
+  The other three do not freeze. A source going uncompilable because the
+  reviewer edited a file, or switched branches, is an ordinary mid-edit
+  state; ending their session for it would punish them for the tool's blind
+  spot and would throw away staged work in the changeset tray.
+- **A failure with nobody to tell is held, not dropped.** The startup
+  recompile runs before any socket exists, so its diagnostics are kept and
+  delivered to the first browser that connects. A recompile that later
+  succeeds clears them, so a fault that has been fixed is not handed to a
+  browser arriving afterwards.
+- **`YMVS319` for a failure that is not a landed changeset's fault**, beside
+  the existing `YMVS310` for one that is. The distinction is the freeze: one
+  ends the session, the other does not.
+- **An empty source list is never compiled.** `workspaceSources` returns a
+  discriminated result and an unreadable source is a failure naming its path.
+  The old contract stays correct for the two callers that only decorate an
+  existing refusal with subjects, which is what it was written for; it was
+  wrong only for the compile that produces what the browser draws.
+
+**The faults panel MOVES over the canvas rather than being added there.** It
+lived in the conversation column, which a reviewer studying a diagram has no
+reason to glance at to learn that what they are looking at is stale, and the
+sentence it renders is about the diagram rather than about the conversation.
+Rendering it in both places was tried first and is worse: the same block
+appears twice on one screen, which reads as two faults.
+
+The rule it lands in was already written, `.diagram-workspace > .faults`,
+with the comment *"the renderer's own fault is laid over the drawing it
+could not replace rather than clipped out of the page"*, and had nothing
+rendering into it. This moves the server's frame refusals (`YMVS30x`) with
+it, which is the same improvement for the same reason.
+
+`local-host.ts` takes the same treatment. It was worse: a batch that landed
+and left the workspace uncompilable reported `ok: true` and then silence. It
+reports a diagnostic rather than a refusal, because the commit did land, and
+refusing it would report the opposite of what happened. It has no freeze
+machinery, so nothing there is terminal.
+
+No new frame kind and no protocol bump: the `diagnostic` response already
+reaches `Faults`, and a `model` frame already clears it, so recovery clears
+the banner without anything clearing it explicitly. That matters because the
+mount surface is a published contract others embed.
+
+## Excluded options
+
+- **A new frame kind for a compile failure.** The wire is a published
+  contract and the browser's frame switch is exhaustive, so a new kind is a
+  protocol change every embedder must absorb, to carry a payload the
+  existing `diagnostic` response already carries to the surface that already
+  renders it.
+- **Refusing to start a session whose workspace does not compile.** Honest,
+  and it removes the one case where a reviewer most wants to see the model:
+  the manifest is resolved once at startup, so this fires on a workspace that
+  was fine a moment ago. It also cannot help the mount path, which has no
+  "refuse to start".
+- **Freezing on every failed recompile.** One behaviour, simplest to reason
+  about, and it kills a live session holding staged work because someone
+  saved a file mid-edit. It also makes the banner nearly pointless, since the
+  session dies immediately after showing it.
+- **Never freezing.** Drops the property the terminal freeze exists for:
+  after a commit the runtime wrote produced an uncompilable workspace,
+  continuing to serve the pre-commit graph means the browser shows a model
+  that no longer matches disk with no hard stop.
+- **Clearing the compile and answering filters with `[]`.** The status quo.
+  `local-host.ts` had already overturned it for its own filter path with
+  `YMVS318`, *"the last good model stays as it is"*, and recorded the
+  reasoning: an empty match set is a claim about the subjects, when the truth
+  is that the question could not be asked.
+
+## Consequences
+
+`VisualFreezeReason` is unchanged. The condition vocabulary gains `YMVS319`.
+No published format changes shape, so no consumer gains a required field and
+nothing breaks at typecheck, unlike the two required fields 1.4.0 added.
+
+A session over a workspace that stops compiling now behaves visibly
+differently: it keeps drawing, says why, and recovers. Previously it emptied
+and said nothing.

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -780,12 +780,18 @@ export const startVisualServer = async (
    * Returns whether it compiled, so a post-write failure can freeze the
    * session instead of serving a stale graph.
    */
-  const workspaceSources = (): readonly {
-    readonly path: string;
-    readonly source: string;
-  }[] => {
+  const workspaceSources = ():
+    | {
+        readonly ok: true;
+        readonly sources: readonly {
+          readonly path: string;
+          readonly source: string;
+        }[];
+      }
+    | { readonly ok: false; readonly path: string; readonly reason: string } => {
+    let reading = "";
     try {
-      return [
+      const paths = [
         ...resolvedWorkspace.profiles,
         // Patterns are compiler input like profiles (#268). Without them a
         // session recompiles a workspace the manifest does not describe: an
@@ -795,16 +801,48 @@ export const startVisualServer = async (
         // rather than as a compile that failed.
         ...resolvedWorkspace.patterns,
         ...resolvedWorkspace.documents,
-      ].map((path) => ({
-        path,
-        source: readFileSync(resolve(options.cwd, path), "utf8"),
-      }));
-    } catch {
-      // A source that cannot be read is one whose diagnostics belong to no
-      // subject anyway, so an empty list is the right answer rather than a
-      // throw from a path that is only trying to add detail.
-      return [];
+      ];
+      return {
+        ok: true,
+        sources: paths.map((path) => {
+          reading = path;
+          return {
+            path,
+            source: readFileSync(resolve(options.cwd, path), "utf8"),
+          };
+        }),
+      };
+    } catch (cause) {
+      // Never an empty list. Compiling one SUCCEEDS - `compileWorkspaceResolved`
+      // over no sources returns an empty graph, not a failure - so swallowing
+      // the read error here made an unreadable workspace indistinguishable
+      // from an empty one, and the session then served "your model has nothing
+      // in it" as though it were an answer (#349). The older comment defended
+      // the empty list as belonging to a path "only trying to add detail";
+      // this feeds the single compile that produces what the browser draws.
+      return {
+        ok: false,
+        path: reading,
+        reason: cause instanceof Error ? cause.message : String(cause),
+      };
     }
+  };
+
+  /**
+   * The sources, for attaching subjects to a diagnostic that already exists.
+   *
+   * Here an unreadable source really is nothing worth reporting: the caller is
+   * decorating a refusal it has already decided on, so a missing file costs a
+   * subject marker and nothing else. That was the whole of the old
+   * `workspaceSources` contract, and it stayed correct for exactly these two
+   * callers while being wrong for the compile (#349).
+   */
+  const sourcesForDetail = (): readonly {
+    readonly path: string;
+    readonly source: string;
+  }[] => {
+    const read = workspaceSources();
+    return read.ok ? read.sources : [];
   };
 
   /**
@@ -832,13 +870,42 @@ export const startVisualServer = async (
     return digests;
   };
 
-  const recompileWorkspace = (): boolean => {
+  /**
+   * Why a recompile failed, in the browser's own diagnostic shape.
+   *
+   * A failure KEEPS the last good `compiledWorkspace` and `rendered` rather
+   * than clearing them (#349). Clearing them emptied every view and every
+   * filter answer, which reads as a model that has gone blank rather than a
+   * compile that failed - and it made the browser's own `Faults` heading
+   * ("the diagram still shows the model that did") untrue. `local-host.ts`
+   * already takes this posture, refusing a filter with YMVS318 while the last
+   * good model stays as it is.
+   */
+  type RecompileOutcome =
+    | { readonly ok: true }
+    | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] };
+
+  const recompileWorkspace = (): RecompileOutcome => {
     try {
-      const sources = workspaceSources();
+      const read = workspaceSources();
+      if (!read.ok) {
+        return {
+          ok: false,
+          diagnostics: [
+            serverDiagnostic(
+              "YMVS319",
+              `Workspace source ${read.path} cannot be read, so the workspace was not recompiled; the last good model stays as it is: ${read.reason}`,
+            ),
+          ],
+        };
+      }
+      const sources = read.sources;
       const compiled = compileWorkspaceWithProfileContext(sources);
       if (!compiled.ok) {
-        compiledWorkspace = undefined;
-        return false;
+        return {
+          ok: false,
+          diagnostics: published(compiled.diagnostics, sources),
+        };
       }
       compiledWorkspace = {
         graph: compiled.graph,
@@ -864,13 +931,40 @@ export const startVisualServer = async (
       // replacing the identity the session started with.
       views.splice(0, views.length, ...workspaceModel.views);
       rendered = workspaceModel.model;
-      return true;
-    } catch {
-      compiledWorkspace = undefined;
-      return false;
+      // Recovered: a browser connecting now is not handed a fault that has
+      // been fixed since. The connected ones clear it on the `model` frame
+      // this success is about to broadcast.
+      standingDiagnostics = [];
+      return { ok: true };
+    } catch (cause) {
+      return {
+        ok: false,
+        diagnostics: [
+          serverDiagnostic(
+            "YMVS319",
+            `Workspace could not be recompiled, so the last good model stays as it is: ${
+              cause instanceof Error ? cause.message : String(cause)
+            }`,
+          ),
+        ],
+      };
     }
   };
-  recompileWorkspace();
+
+  /**
+   * What the last recompile could not do, held for a browser that is not
+   * connected yet.
+   *
+   * The startup recompile runs before any socket exists, so a failure there
+   * has nobody to tell. Holding it means the first browser to arrive is told
+   * what every later one would have heard, rather than opening onto a session
+   * that looks well and answers nothing.
+   */
+  let standingDiagnostics: readonly VisualDiagnostic[] = [];
+  {
+    const started = recompileWorkspace();
+    if (!started.ok) standingDiagnostics = started.diagnostics;
+  }
 
   const filterMatchedIds = (query: ProjectionQuery): readonly string[] =>
     compiledWorkspace === undefined
@@ -1169,6 +1263,39 @@ export const startVisualServer = async (
 
   const broadcast = (frame: VisualServerFrame) => {
     for (const socket of connections.values()) sendFrame(socket, frame);
+  };
+
+  /**
+   * Tells the browser the workspace no longer compiles, and what said so.
+   *
+   * Journalled as an ordinary `diagnostic` response rather than a new frame
+   * kind, because that is the one the browser already renders - `Faults`
+   * reads `state.diagnostics`, which a `model` frame clears, so a recovered
+   * recompile clears the banner without anyone clearing it (#349). Held in
+   * `standingDiagnostics` too, for the browser that has not connected yet.
+   */
+  const reportRecompileFailure = async (
+    diagnostics: readonly VisualDiagnostic[],
+    eventId = drawHex(16),
+  ): Promise<void> => {
+    standingDiagnostics = diagnostics;
+    const response: VisualResponse = {
+      format: "yarramate/visual-response/v1",
+      sessionId,
+      responseId: drawHex(16),
+      eventId,
+      type: "diagnostic",
+      timestamp: stamp(),
+      payload: { diagnostics },
+    };
+    const appended = await appendVisualResponse(paths, response);
+    if (appended.ok) {
+      transcriptBytes = appended.transcriptBytes;
+      recordResponse(response);
+      broadcast({ kind: "response", response });
+    } else if (appended.freeze !== undefined) {
+      freeze(appended.freeze);
+    }
   };
 
   const idleDelivery = (): VisualEventDelivery => ({
@@ -1546,8 +1673,16 @@ export const startVisualServer = async (
             kind: "apply-result",
             result: { ok: false, diagnostics: refused },
           });
-          if (recompileWorkspace())
+          const refreshed = recompileWorkspace();
+          if (refreshed.ok) {
             broadcast({ kind: "model", model: rendered, views });
+          } else {
+            // Nothing at all reached the browser here before (#349): a refused
+            // apply whose refresh also failed left the reviewer with a
+            // refusal about their rows and no word that the workspace itself
+            // had stopped compiling.
+            await reportRecompileFailure(refreshed.diagnostics);
+          }
           return;
         }
         const operationsSource = stringify({
@@ -1572,7 +1707,7 @@ export const startVisualServer = async (
               ok: false,
               diagnostics: published(
                 loadedWorkspace.diagnostics,
-                workspaceSources(),
+                sourcesForDetail(),
               ),
             },
           });
@@ -1625,7 +1760,7 @@ export const startVisualServer = async (
             kind: "apply-result",
             result: {
               ok: false,
-              diagnostics: published(outcome.diagnostics, workspaceSources()),
+              diagnostics: published(outcome.diagnostics, sourcesForDetail()),
             },
           });
           return;
@@ -1650,7 +1785,8 @@ export const startVisualServer = async (
           kind: "apply-result",
           result: { ok: true, result: outcome.result },
         });
-        if (recompileWorkspace()) {
+        const recompiled = recompileWorkspace();
+        if (recompiled.ok) {
           broadcast({ kind: "model", model: rendered, views });
           return;
         }
@@ -1658,34 +1794,19 @@ export const startVisualServer = async (
         // landed but produced a document Core itself can no longer parse.
         // The freeze alone only tells the browser input is refused, not why
         // the graph on screen has gone stale, so a diagnostic response is
-        // journaled alongside it.
-        const diagnosticResponse: VisualResponse = {
-          format: "yarramate/visual-response/v1",
-          sessionId,
-          responseId: drawHex(16),
-          eventId: event.eventId,
-          type: "diagnostic",
-          timestamp: stamp(),
-          payload: {
-            diagnostics: [
-              serverDiagnostic(
-                "YMVS310",
-                "Workspace failed to recompile after a landed changeset",
-              ),
-            ],
-          },
-        };
-        const appendedResponse = await appendVisualResponse(
-          paths,
-          diagnosticResponse,
+        // journaled alongside it - and it carries the compiler's OWN
+        // diagnostics, because YMVS310 by itself names no document, no code
+        // and no line (#349).
+        await reportRecompileFailure(
+          [
+            serverDiagnostic(
+              "YMVS310",
+              "Workspace failed to recompile after a landed changeset",
+            ),
+            ...recompiled.diagnostics,
+          ],
+          event.eventId,
         );
-        if (appendedResponse.ok) {
-          transcriptBytes = appendedResponse.transcriptBytes;
-          recordResponse(diagnosticResponse);
-          broadcast({ kind: "response", response: diagnosticResponse });
-        } else if (appendedResponse.freeze !== undefined) {
-          freeze(appendedResponse.freeze);
-        }
         freeze("recompile-failed");
         return;
       }
@@ -1853,6 +1974,22 @@ export const startVisualServer = async (
         return;
       }
       sendFrame(socket, { kind: "ready", snapshot: snapshot() });
+      // A recompile that failed before this socket existed - the one at
+      // startup, most often - has had nobody to tell until now (#349).
+      if (standingDiagnostics.length > 0) {
+        sendFrame(socket, {
+          kind: "response",
+          response: {
+            format: "yarramate/visual-response/v1",
+            sessionId,
+            responseId: drawHex(16),
+            eventId: drawHex(16),
+            type: "diagnostic",
+            timestamp: stamp(),
+            payload: { diagnostics: standingDiagnostics },
+          },
+        });
+      }
     });
   };
 

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -199,11 +199,17 @@ const Choices = ({
   </div>
 );
 /**
- * The server's own refusals of a browser frame (`YMVS...`). These are about the
- * frame rather than about a subject, so they carry no `subjects` and there is
- * nothing on the diagram to mark. A refused COMMIT is a different thing and
- * lands in the changeset tray, where what it names is counted and marked
- * (ADR 0102).
+ * The server's own refusals of a browser frame (`YMVS...`), and the compiler's
+ * diagnostics when a recompile fails (ADR 0126). These are about the frame or
+ * the workspace rather than about a subject, so they mostly carry no
+ * `subjects` and there is nothing on the diagram to mark. A refused COMMIT is
+ * a different thing and lands in the changeset tray, where what it names is
+ * counted and marked (ADR 0102).
+ *
+ * Drawn OVER the canvas, once. It used to sit in the conversation column,
+ * which a reviewer studying the diagram has no reason to look at to learn
+ * that what they are looking at is stale - and the sentence it renders is
+ * about the diagram, not about the conversation.
  */
 const Faults = ({
   diagnostics,
@@ -213,7 +219,7 @@ const Faults = ({
   diagnostics.length === 0 ? null : (
     <div className="faults" role="alert">
       <p className="faults-title">
-        The last change did not compile. The diagram still shows the model that
+        The workspace did not compile. The diagram still shows the model that
         did.
       </p>
       <ul>
@@ -591,6 +597,15 @@ const DiagramWorkspace = ({
         onStage={onStageView}
         readOnly={readOnly}
       />
+      {/*
+       * Over the drawing, not only beside it. A failed recompile leaves the
+       * canvas showing the last model that did compile, and a reviewer looking
+       * at the diagram has no reason to glance at the conversation column to
+       * find out that what they are looking at is stale (#349). The
+       * `.diagram-workspace > .faults` rule this lands in was written for
+       * exactly this and had nothing rendering into it.
+       */}
+      <Faults diagnostics={state.diagnostics} />
     </section>
   );
 };
@@ -832,8 +847,6 @@ const ChatSection = ({
             ))
           )}
         </ol>
-
-        <Faults diagnostics={state.diagnostics} />
 
         {state.choices === null ? null : (
           <Choices

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -14,7 +14,10 @@ import type {
   VisualDiagnostic,
   VisualViewSummary,
 } from '../adapters/visual/protocol-contract.js'
-import type { VisualRenderedModel } from '../adapters/visual/wire.js'
+import type {
+  VisualRenderedModel,
+  VisualServerFrame,
+} from '../adapters/visual/wire.js'
 import {
   adoptLandedViews,
   exclusionsOf,
@@ -169,22 +172,27 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
     )
 
   /**
-   * Recompiles and rebuilds what the canvas draws. `false` when the workspace
-   * does not compile, which leaves the previous model standing rather than
-   * blanking the canvas under the reviewer.
+   * Recompiles and rebuilds what the canvas draws. On failure it returns the
+   * compiler's own diagnostics and leaves the previous model standing rather
+   * than blanking the canvas under the reviewer. Returning them rather than
+   * `false` is what lets the caller SAY what broke: a bare failure told the
+   * reviewer nothing, and the commit path below did not even do that (#349).
    */
-  const recompile = (): boolean => {
+  const recompile = ():
+    | { readonly ok: true }
+    | { readonly ok: false; readonly diagnostics: readonly VisualDiagnostic[] } => {
     const sources = sourcesOf()
     const result = compileWorkspaceWithProfileContext(sources)
     if (!result.ok) {
       compiled = undefined
-      return false
+      return { ok: false, diagnostics: published(result.diagnostics, sources) }
     }
     const refreshed = {
       graph: result.graph,
       profileContext: result.profileContext,
     }
     compiled = refreshed
+    standingDiagnostics = []
     const workspaceModel = renderedWorkspaceOf(refreshed, views, {
       authority: 'canonical',
       initialView: views[0]?.id ?? '',
@@ -207,8 +215,35 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
     }, options.catalogue ?? SHIPPED_CATALOGUE, options.dismissed)
     views = workspaceModel.views
     model = workspaceModel.model
-    return true
+    return { ok: true }
   }
+
+  /**
+   * What the last recompile could not do, held for a browser that has not
+   * opened yet. `open` recompiles before `deliver` exists, so a failure there
+   * has nobody to tell until the editor arrives (#349).
+   */
+  let standingDiagnostics: readonly VisualDiagnostic[] = []
+  let responses = 0
+  const nextResponseId = (): string => {
+    responses += 1
+    return responses.toString(16).padStart(32, '0')
+  }
+
+  const diagnosticFrame = (
+    diagnostics: readonly VisualDiagnostic[],
+  ): VisualServerFrame => ({
+    kind: 'response',
+    response: {
+      format: 'yarramate/visual-response/v1',
+      sessionId: 'local',
+      responseId: nextResponseId(),
+      eventId: nextResponseId(),
+      type: 'diagnostic',
+      timestamp: new Date().toISOString(),
+      payload: { diagnostics },
+    },
+  })
 
   const refuse = (
     input: VisualBrowserInput,
@@ -296,7 +331,25 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
           : { ok: true, result: { ...result, documents } },
     })
     options.onCommit?.(documents)
-    if (recompile()) deliver?.frame({ kind: 'model', model, views })
+    const recompiled = recompile()
+    if (recompiled.ok) {
+      deliver?.frame({ kind: 'model', model, views })
+      return
+    }
+    // Previously this emitted NOTHING: a batch that landed and left the
+    // workspace uncompilable reported `ok: true` and then silence, so the
+    // browser went on drawing a stale graph with no word that it was stale
+    // (#349). A `diagnostic` response rather than a refusal, because the
+    // commit did land - refusing it would report the opposite of what
+    // happened.
+    standingDiagnostics = [
+      serverDiagnostic(
+        'YMVS319',
+        'The batch landed but left the workspace unable to compile; the last good model stays as it is',
+      ),
+      ...recompiled.diagnostics,
+    ]
+    deliver?.frame(diagnosticFrame(standingDiagnostics))
   }
 
   /** What a batch that changed no subject reports. */
@@ -322,7 +375,8 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
   return {
     open: (events: EditorHostEvents) => {
       deliver = events
-      recompile()
+      const opened = recompile()
+      if (!opened.ok) standingDiagnostics = opened.diagnostics
       events.connected(true)
       events.frame({
         kind: 'ready',
@@ -352,6 +406,11 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
           frozen: false,
         },
       })
+      // A recompile that failed before the editor opened has had nobody to
+      // tell until now (#349).
+      if (standingDiagnostics.length > 0) {
+        events.frame(diagnosticFrame(standingDiagnostics))
+      }
       return () => {
         deliver = undefined
       }

--- a/test/visual-session-server.test.ts
+++ b/test/visual-session-server.test.ts
@@ -3175,3 +3175,166 @@ it("keeps the fixture asset root free of anything the server must not serve", as
   expect(page).not.toMatch(/https?:\/\//);
   expect(page).not.toMatch(/<script(?![^>]*\ssrc=)/);
 });
+
+describe("startVisualServer says why a recompile failed (#349)", () => {
+  const document = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+relationships: []
+`;
+  const manifest = `format: yarramate/workspace/v1
+id: recompile-fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+projections:
+  - projections/*.yaml
+adapterMappings: []
+evidence: []
+`;
+
+  const withWorkspace = async () => {
+    await mkdir(join(baseDir, ".yarramate/architecture"), { recursive: true });
+    await mkdir(join(baseDir, ".yarramate/projections"), { recursive: true });
+    await writeFile(
+      join(baseDir, ".yarramate/architecture/main.yaml"),
+      document,
+      "utf8",
+    );
+    await writeFile(
+      join(baseDir, ".yarramate/projections/seeded.yaml"),
+      `format: yarramate/projection/v1
+id: seeded
+version: "1.0"
+query:
+  kinds:
+    - yarramate/core@0.1#businessActor
+presentation:
+  title: Seeded
+  description: seeded
+`,
+      "utf8",
+    );
+    await writeFile(join(baseDir, ".yarramate/workspace.yaml"), manifest, "utf8");
+  };
+
+  const sendViewCommit = (socket: WebSocket) => {
+    const result = nextFrame(socket, "apply-result");
+    socket.send(
+      JSON.stringify({
+        type: "changeset.commit",
+        lastAcknowledgedSequence: 0,
+        payload: {
+          operations: [],
+          viewOperations: [
+            {
+              op: "write-view",
+              path: ".yarramate/projections/added.yaml",
+              projection: {
+                format: "yarramate/projection/v1",
+                id: "added",
+                version: "1.0",
+                query: { kinds: ["yarramate/core@0.1#businessActor"] },
+                presentation: { title: "Added", description: "staged" },
+              },
+            },
+          ],
+          sourceDigests: {},
+        },
+      }),
+    );
+    return result;
+  };
+
+  const enforcesPermissions =
+    process.platform !== "win32" && process.getuid?.() !== 0;
+
+  /** Every frame the socket has taken in, for asserting on what did NOT arrive. */
+  const settle = async (socket: WebSocket) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return buffered.get(socket) ?? [];
+  };
+
+  const diagnosticsFrom = (frames: readonly VisualServerFrame[]) =>
+    frames.flatMap((frame) =>
+      frame.kind === "response" && frame.response.type === "diagnostic"
+        ? (frame.response.payload.diagnostics as readonly {
+            readonly code: string;
+            readonly message: string;
+            readonly path: string;
+          }[])
+        : [],
+    );
+
+  /**
+   * A source the manifest resolves and the process cannot read. `globSync`
+   * matches it, so the manifest loads; `workspaceSources` then swallows the
+   * read error and returns an EMPTY list, and compiling an empty list
+   * SUCCEEDS. So the session starts, reports a healthy compile, and draws a
+   * workspace holding nothing - rather than saying it could not read a file.
+   *
+   * `local-host.ts` already refuses the analogous case with YMVS318, "the
+   * last good model stays as it is". The session server is the one that
+   * degrades silently.
+   */
+  it.skipIf(!enforcesPermissions)(
+    "does not serve an unreadable source as an empty workspace",
+    async () => {
+      await withWorkspace();
+      await chmod(join(baseDir, ".yarramate/architecture/main.yaml"), 0o000);
+      const server = await start();
+      const { cookie } = await bootstrap(server);
+      const socket = await openBrowserSocket(server, cookie);
+
+      const ready = await nextFrame(socket, "ready");
+      const diagnostics = diagnosticsFrom(await settle(socket));
+
+      // Either of these alone would be enough to stop the ten-minute
+      // diagnosis: do not claim an empty model, and name the file.
+      expect(ready.snapshot.model.graph.nodes).not.toEqual([]);
+      expect(diagnostics.map((one) => one.code)).toContain("YMVS319");
+      expect(
+        diagnostics.some((one) =>
+          `${one.message} ${one.path}`.includes("architecture/main.yaml"),
+        ),
+      ).toBe(true);
+
+      await chmod(join(baseDir, ".yarramate/architecture/main.yaml"), 0o600);
+      socket.close();
+    },
+  );
+
+  /**
+   * The fault has to clear itself. A `model` frame is what clears the banner
+   * in the browser (`model.received` resets `state.diagnostics`), so a
+   * recompile that succeeds after one that failed has to broadcast one -
+   * and `standingDiagnostics` is dropped with it, so a browser connecting
+   * afterwards is not handed a fault that no longer exists.
+   */
+  it.skipIf(!enforcesPermissions)(
+    "stops reporting a fault once the source is readable again",
+    async () => {
+      await withWorkspace();
+      await chmod(join(baseDir, ".yarramate/architecture/main.yaml"), 0o000);
+      const server = await start();
+      const { cookie } = await bootstrap(server);
+      const socket = await openBrowserSocket(server, cookie);
+
+      await nextFrame(socket, "ready");
+      expect(diagnosticsFrom(await settle(socket)).length).toBeGreaterThan(0);
+
+      await chmod(join(baseDir, ".yarramate/architecture/main.yaml"), 0o600);
+      const model = nextFrame(socket, "model");
+      await sendViewCommit(socket);
+
+      expect((await model).model.graph.nodes.map((node) => node.id)).toEqual([
+        "user",
+      ]);
+      socket.close();
+    },
+  );
+});


### PR DESCRIPTION
Closes #349.

A visual session that could not recompile told the browser **nothing**. Every
view emptied while the rail kept its views, so the page read as a session over
an architecture that had gone blank rather than one that had failed. That is
what made the 1.4.1 patterns bug take ten minutes to diagnose instead of ten
seconds: the compiler had a `YM419` naming the missing pattern, and the browser
was the one surface that could not see it.

## Three silent failures, not the one filed

**1. An unreadable source was served as an empty workspace**, and this is worse
than what the issue reported. `workspaceSources` caught any read error and
returned `[]`, and **compiling an empty list succeeds** — it yields an empty
graph, not a failure:

```
compileWorkspaceWithProfileContext([])
  -> ok: true
  -> {"format":"yarramate/graph/v2","profiles":[],"documents":[],"subjects":[],"claims":[]}
```

So the recompile reported success, every view dropped to zero subjects, and
nothing froze. The code asserted the lie rather than merely failing to report
it.

**2. A startup failure was discarded** — the boolean was never read.
**3. A refused apply whose refresh also failed emitted nothing at all.**

And the one handled path could not name the fault: `YMVS310` is built by
`serverDiagnostic`, which hardcodes `visual-session-server` as its path, and
the compiler's diagnostics were thrown away one function earlier.

## The fix (ADR 0126)

`recompileWorkspace` returns the diagnostics instead of a boolean, via the
existing `published()` bridge, and a failure **keeps the last good compile**
rather than clearing it — so filters keep answering and the canvas keeps
drawing. That also makes the browser's own faults heading true; it has always
promised *"the diagram still shows the model that did"*.

**Only a failure the runtime caused is fatal.** A post-commit failure still
freezes. The others do not: a source going uncompilable because the reviewer
edited a file or switched branches is an ordinary mid-edit state, not grounds
to end a session holding staged work.

The faults panel **moves** out of the conversation column and over the canvas,
into a CSS rule written for exactly this that had nothing rendering into it.
Rendering it in both was tried and was plainly worse in the browser.

`local-host.ts` gets the same treatment, where it was worse still: a batch that
landed and left the workspace uncompilable reported `ok: true` and then silence.

**No new frame kind and no protocol bump** — the `diagnostic` response already
reaches the panel and a `model` frame already clears it, so recovery clears the
banner with nothing clearing it explicitly. The mount surface is a published
contract and embedders should not have to absorb a wire change.

**Also fixed:** the consumer docs published `visual-protocol/v4` while the
constant and all three schemas have been at `v5`. A host pinning what the doc
said pinned a version the runtime does not speak.

## Verification

**Tests watched failing first.** The unreadable-source test was run against
unmodified source and failed with `expected [] to not deeply equal []` — the
ready snapshot carried a zero-node graph. It failed twice for the *wrong*
reason before that (a missing file is already refused by `YMVS132`; a deleted
one by `YM702` before any recompile), which is what located the actually
reachable path.

A post-commit test was written and **dropped rather than contrived**: that
branch needs a batch that lands and *then* fails to compile, which is reachable
only from a runtime bug. It is the one improvement here covered by inspection
rather than by test, and worth saying so.

**Verified by eye in a browser**, not only by the suite: the banner reads
`YMVS319 Workspace source .yarramate/architecture/contact-update.yaml cannot be
read ... EACCES: permission denied`, over a diagram still drawing the model that
did compile.

`pnpm run verify` **exit 0** from a wiped `.yarramate-out`: 1805 tests, 99
files, self-check no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
