### PR TITLE
fix: a catalogue's unresolvable kind reference is refused (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+- **Fixed.** A catalogue naming a kind its profile does not have is refused,
+  rather than loading clean and asking a question that can never fire (#351).
+  `loadQuestionCatalogue` validated the schema and the undeclared-wave check
+  and nothing else, and it did not receive a profile at all, so a mistyped
+  kind produced a question that read perfectly in the source and was dead on
+  arrival. This is the first of the empty-set family found in three days
+  where nothing visible was wrong anywhere: the others all produced a zero
+  someone could look at, and this one produces a well-formed report with
+  consistent counts and a question that is simply never asked.
+
+  All three kind-bearing fields are checked, and two of them are easy to
+  forget. A **trigger** kind that does not resolve never matches. A **subject
+  selector** kind scopes the question to an empty set. A **wave gate** kind
+  never holds, and since a closed wave carries no questions at all, one typo
+  silently retires an entire wave and reads exactly like a wave legitimately
+  waiting on the model.
+
+  **The check is deliberately narrow, and the narrowness is the point.** A
+  kind is refused only when its profile is loaded and the kind is absent from
+  it, which is unambiguously a typo. A kind whose profile is not loaded at
+  all is left alone: `core-enrichment` names four `yarramate/policy@0.1`
+  constraint kinds, and that profile loads only when a document selects it,
+  so those questions are dormant by design rather than broken. Reporting them
+  would put four false positives on the catalogue this repository ships, and
+  a check that cries wolf on its own catalogue gets turned off. Resolution is
+  tested against the kind maps rather than a declared-kinds list, so a kind
+  inherited through `extends` counts.
+
 - **Fixed.** A visual session that cannot recompile the workspace says so,
   and keeps drawing the model that did compile (#349, ADR 0126). It used to
   say nothing at all: every view emptied while the rail kept its views, so

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -138,6 +138,34 @@ motivation before implementation is making a claim the engine now honours,
 where before the order was presentational and questions fired in whatever
 order the model happened to trip them.
 
+## A kind a catalogue names must exist where it says it does
+
+A catalogue is refused when it names a kind that its profile is loaded and
+does not declare (`YM914`). All three kind-bearing fields are checked: a
+question's `trigger`, its `subjects.kinds` selector, and a wave's `opensWhen`
+gate.
+
+The failure this prevents leaves nothing visibly wrong. A trigger whose kind
+does not resolve never matches, so the question never opens, and that is
+indistinguishable from a condition that is simply not met. A selector's kind
+scopes the question to an empty set. A gate's kind never holds, and since a
+closed wave carries no questions at all, one typo retires a whole wave and
+reads exactly like a wave waiting on the model.
+
+**A kind whose profile is not loaded is not an error.** That is a dormant
+cross-profile question, and it is a supported thing to write:
+`core-enrichment` names four `yarramate/policy@0.1` constraint kinds, and
+that profile loads only when a document selects it. Those four questions are
+correctly silent in a workspace with no policy, and refusing them would put
+four false positives on the shipped catalogue.
+
+The distinction is therefore between a kind that resolves **nowhere the
+catalogue could see** and one that resolves in a profile **this workspace did
+not load**. Only the first is a mistake. Resolution is tested through the
+kind maps rather than a declared-kinds list, so a kind inherited through
+`extends` counts: a profile that declares none of its own and inherits every
+one is exactly the case a declared-kinds check would call entirely missing.
+
 ## Evaluation model
 
 A question is **open** iff its trigger matches, and **closed** the moment it

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -812,10 +812,13 @@ export function runAskCommand(
       const current = entries.filter(({ status }) => status === 'current')
       const retired = entries.filter(({ status }) => status === 'retired')
 
-      const loadedCatalogue = loadQuestionCatalogue({
-        path: shippedCataloguePath,
-        source: readFileSync(shippedCataloguePath, 'utf8'),
-      })
+      const loadedCatalogue = loadQuestionCatalogue(
+        {
+          path: shippedCataloguePath,
+          source: readFileSync(shippedCataloguePath, 'utf8'),
+        },
+        compilation.profileContext,
+      )
       if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
       const report = evaluateCatalogue(
         loadedCatalogue.catalogue,
@@ -1107,10 +1110,13 @@ export function runAskCommand(
         cataloguePath === undefined
           ? shippedCataloguePath
           : resolve(cwd, cataloguePath)
-      const loadedCatalogue = loadQuestionCatalogue({
-        path: cataloguePath ?? resolvedCataloguePath,
-        source: readFileSync(resolvedCataloguePath, 'utf8'),
-      })
+      const loadedCatalogue = loadQuestionCatalogue(
+        {
+          path: cataloguePath ?? resolvedCataloguePath,
+          source: readFileSync(resolvedCataloguePath, 'utf8'),
+        },
+        compilation.profileContext,
+      )
       if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
       // The evidence overlay rides along for the one condition that
       // reads it (unchallenged-evidence); a workspace declaring no
@@ -1481,10 +1487,13 @@ export function runAskCommand(
       cataloguePath === undefined
         ? shippedCataloguePath
         : resolve(cwd, cataloguePath)
-    const loadedCatalogue = loadQuestionCatalogue({
-      path: cataloguePath ?? resolvedCataloguePath,
-      source: readFileSync(resolvedCataloguePath, 'utf8'),
-    })
+    const loadedCatalogue = loadQuestionCatalogue(
+      {
+        path: cataloguePath ?? resolvedCataloguePath,
+        source: readFileSync(resolvedCataloguePath, 'utf8'),
+      },
+      compilation.profileContext,
+    )
     if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
     // Loaded ahead of evaluation so the overlay feeds the one condition
     // that reads it (unchallenged-evidence), then reused for the

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -273,12 +273,10 @@ export function runDesignCommand(
       cataloguePath === undefined
         ? shippedCataloguePath
         : resolve(cwd, cataloguePath)
-    const loadedCatalogue = loadQuestionCatalogue({
-      path: cataloguePath ?? resolvedCataloguePath,
-      source: readFileSync(resolvedCataloguePath, 'utf8'),
-    })
-    if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
-
+    // Compiled BEFORE the catalogue loads, so the catalogue can be checked
+    // against the vocabulary its kinds are written against (#351). A
+    // catalogue naming a kind its own profile does not have loads clean
+    // otherwise, and the question it names is dead on arrival.
     const compilation = compileWorkspaceWithProfileContext(
       [
         ...workspace.profiles,
@@ -290,6 +288,15 @@ export function runDesignCommand(
       })),
     )
     if (!compilation.ok) return failed(compilation.diagnostics)
+
+    const loadedCatalogue = loadQuestionCatalogue(
+      {
+        path: cataloguePath ?? resolvedCataloguePath,
+        source: readFileSync(resolvedCataloguePath, 'utf8'),
+      },
+      compilation.profileContext,
+    )
+    if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
 
     // The evidence overlay rides along for the one condition that reads
     // it (unchallenged-evidence). A workspace declaring no evidence

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -923,10 +923,109 @@ export type CatalogueLoadResult =
   | { readonly ok: true; readonly catalogue: QuestionCatalogue }
   | { readonly ok: false; readonly diagnostics: readonly Diagnostic[] }
 
+/** One qualified kind a catalogue names, and where it names it. */
+interface CatalogueKindReference {
+  readonly kind: string
+  readonly path: readonly (string | number)[]
+}
+
+/**
+ * Every qualified kind a catalogue names, from all three fields that carry
+ * one.
+ *
+ * All three die the same way when the kind does not resolve, and two of them
+ * are easy to forget. A trigger's kind never matches, so the question never
+ * opens. A subject selector's kind selects nothing, so the question is scoped
+ * to an empty set. A wave gate's kind never holds, so after #334 the whole
+ * wave never opens and carries no questions at all - one typo silently
+ * retiring a wave (#351).
+ */
+const kindReferencesOf = (
+  catalogue: QuestionCatalogue,
+): readonly CatalogueKindReference[] => {
+  const found: CatalogueKindReference[] = []
+  const fromCondition = (
+    condition: unknown,
+    path: readonly (string | number)[],
+  ) => {
+    if (typeof condition !== 'object' || condition === null) return
+    for (const field of ['kinds', 'counterpartKinds'] as const) {
+      const value = (condition as Record<string, unknown>)[field]
+      if (!Array.isArray(value)) continue
+      value.forEach((kind, index) => {
+        if (typeof kind === 'string')
+          found.push({ kind, path: [...path, field, index] })
+      })
+    }
+  }
+  catalogue.waves.forEach((wave, waveIndex) => {
+    ;(wave.opensWhen ?? []).forEach((condition, conditionIndex) => {
+      fromCondition(condition, ['waves', waveIndex, 'opensWhen', conditionIndex])
+    })
+  })
+  catalogue.questions.forEach((question, questionIndex) => {
+    ;(question.subjects?.kinds ?? []).forEach((kind, index) => {
+      found.push({
+        kind,
+        path: ['questions', questionIndex, 'subjects', 'kinds', index],
+      })
+    })
+    question.trigger.forEach((condition, conditionIndex) => {
+      fromCondition(condition, [
+        'questions',
+        questionIndex,
+        'trigger',
+        conditionIndex,
+      ])
+    })
+  })
+  return found
+}
+
+/**
+ * Kinds this catalogue names that the profile they belong to does not have.
+ *
+ * The check is deliberately narrow, and the narrowness is the design (#351).
+ * A kind is reported ONLY when its profile is loaded and the kind is absent
+ * from it, which is unambiguously a typo. A kind whose profile is not loaded
+ * at all is left alone, because that is a legitimately dormant cross-profile
+ * question rather than a mistake: `core-enrichment` names four
+ * `yarramate/policy@0.1` constraint kinds, and `yarramate/policy@0.1` loads
+ * only when a document selects it or a profile extends it. Reporting those
+ * four would put four false positives on the catalogue this repository ships,
+ * and a check that cries wolf on its own catalogue gets turned off.
+ *
+ * Resolution is tested against the kind maps rather than a declared-kinds
+ * list, so a kind inherited through `extends` counts. A profile that declares
+ * no kinds of its own and inherits every one of them is the case a
+ * declared-kinds check would call entirely missing.
+ */
+const unresolvableKinds = (
+  catalogue: QuestionCatalogue,
+  profileContext: ResolvedProfileContext,
+): readonly CatalogueKindReference[] => {
+  const known = new Set<string>([
+    ...profileContext.conceptKindLineages.keys(),
+    ...profileContext.relationshipKindLineages.keys(),
+  ])
+  const loadedProfiles = new Set<string>()
+  for (const identity of known) {
+    const hash = identity.indexOf('#')
+    if (hash > 0) loadedProfiles.add(identity.slice(0, hash))
+  }
+  return kindReferencesOf(catalogue).filter(({ kind }) => {
+    if (known.has(kind)) return false
+    const hash = kind.indexOf('#')
+    // Profile absent entirely: dormant, not wrong.
+    return hash > 0 && loadedProfiles.has(kind.slice(0, hash))
+  })
+}
+
 // Shared by interrogate and design: schema validation plus the YM911
 // undeclared-wave check, both source-located against the catalogue file.
 export function loadQuestionCatalogue(
   catalogueSource: WorkspaceSource,
+  profileContext?: ResolvedProfileContext,
 ): CatalogueLoadResult {
   const loadedCatalogue = loadSourceDocument<QuestionCatalogue>(
     catalogueSource,
@@ -959,6 +1058,32 @@ export function loadQuestionCatalogue(
   )
   if (waveDiagnostics.length > 0) {
     return { ok: false, diagnostics: waveDiagnostics }
+  }
+  // Only when a caller has a compiled workspace to check against. Without one
+  // there is no way to tell a typo from a kind whose profile simply is not
+  // here, and guessing would be the false positive this check exists to avoid.
+  const kindDiagnostics =
+    profileContext === undefined
+      ? []
+      : unresolvableKinds(catalogue, profileContext).map(
+          ({ kind, path }): Diagnostic => ({
+            severity: 'error',
+            code: 'YM914',
+            message: `Kind "${kind}" is not declared by profile "${kind.slice(
+              0,
+              kind.indexOf('#'),
+            )}", which this workspace loads, so the question can never fire`,
+            ...locateSourcePath(
+              catalogueSource.path,
+              loadedCatalogue.document.yaml,
+              loadedCatalogue.document.lineCounter,
+              path,
+              `/${path.join('/')}`,
+            ),
+          }),
+        )
+  if (kindDiagnostics.length > 0) {
+    return { ok: false, diagnostics: kindDiagnostics }
   }
   return { ok: true, catalogue }
 }

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -297,6 +297,94 @@ describe('ask --open interrogation', () => {
     expect(result.stdout).toContain('Platform team?')
   })
 
+  it('locates a trigger kind the loaded profile does not declare (#351)', () => {
+    writeFileSync(
+      join(workspace, 'catalogue.yaml'),
+      catalogue.replace(
+        'kinds: ["yarramate/core@0.1#goal"]',
+        'kinds: ["yarramate/core@0.1#goul"]',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    // Nothing was visibly wrong before this: the question read perfectly and
+    // simply never fired, which is indistinguishable from a condition that
+    // is not met.
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM914')
+    expect(result.stdout).toContain('yarramate/core@0.1#goul')
+    expect(result.stdout).toMatch(/^catalogue\.yaml:\d+:\d+ /)
+  })
+
+  it('locates a subject selector kind, not only a trigger kind (#351)', () => {
+    writeFileSync(
+      join(workspace, 'catalogue.yaml'),
+      catalogue.replace(
+        'kinds: ["yarramate/core@0.1#businessActor"]',
+        'kinds: ["yarramate/core@0.1#businessActer"]',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    // A selector naming an absent kind scopes the question to an empty set,
+    // which is the same death as a trigger that never matches.
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM914')
+    expect(result.stdout).toContain('yarramate/core@0.1#businessActer')
+  })
+
+  it('locates a wave gate kind, which would retire a whole wave (#351)', () => {
+    writeFileSync(
+      join(workspace, 'catalogue.yaml'),
+      catalogue.replace(
+        '  - id: hygiene\n    name: Hygiene\n',
+        '  - id: hygiene\n' +
+          '    name: Hygiene\n' +
+          '    opensWhen:\n' +
+          '      - condition: no-subject-of-kind\n' +
+          '        kinds: ["yarramate/core@0.1#businessActer"]\n',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    // The worst of the three: after #334 a closed wave carries no questions
+    // at all, so one typo in a gate silently retires the whole wave and reads
+    // exactly like a wave legitimately waiting on the model.
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM914')
+  })
+
+  it('stays quiet about a kind whose profile is simply not loaded (#351)', () => {
+    writeFileSync(
+      join(workspace, 'catalogue.yaml'),
+      catalogue.replace(
+        'kinds: ["yarramate/core@0.1#goal"]',
+        'kinds: ["yarramate/policy@0.1#rate-limit-constraint"]',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    // The check that decides whether this check survives. `policy@0.1` is a
+    // real shipped profile that loads only when a document selects it, and
+    // `core-enrichment` names four of its kinds. Reporting those would put
+    // four false positives on the catalogue this repository ships, and a
+    // check that cries wolf on its own catalogue gets turned off.
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).not.toContain('YM914')
+  })
+
   it('locates a question referencing an undeclared wave', () => {
     writeFileSync(
       join(workspace, 'catalogue.yaml'),


### PR DESCRIPTION
Closes #351.

`loadQuestionCatalogue` validated the schema and the undeclared-wave check and
nothing else. It did not receive a profile at all, so a catalogue naming a
mistyped kind loaded clean and asked a question that could never fire.

**This is the first of the empty-set family found in three days where nothing
visible is wrong anywhere.** Every earlier one produced a zero someone could
look at: `implementation 0 open`, an empty wave heading, a blank canvas, a
zero-subject view. This one produces a question that reads perfectly in the
source, a well-formed report, consistent counts, and a question that is simply
never asked.

## All three kind-bearing fields

Two of them were easy to miss, and both were found by the ApertureX adopter
session while building the same guard on their side.

| Field | What an unresolvable kind does |
|---|---|
| `question.trigger[].kinds` | never matches, so the question never opens |
| `question.subjects.kinds` | selects nothing, so the question is scoped to an empty set |
| `wave.opensWhen[].kinds` | never holds, so **the whole wave never opens** |

The third is the worst. After #334 a closed wave carries no questions at all,
so one typo silently retires an entire wave and reads exactly like a wave
legitimately waiting on the model.

## The check is deliberately narrow, and the narrowness is the design

A kind is refused **only** when its profile is loaded and the kind is absent
from it, which is unambiguously a typo.

A kind whose profile is not loaded at all is left alone. `core-enrichment`
names four `yarramate/policy@0.1` constraint kinds, and that profile loads only
when a document selects it or a profile extends it, so those questions are
dormant by design. Refusing them would put **four false positives on the
catalogue this repository ships**, and a check that cries wolf on its own
catalogue gets turned off.

Resolution is tested through the kind maps rather than a declared-kinds list,
so a kind inherited through `extends` counts. A profile that declares none of
its own and inherits every one is exactly the case a declared-kinds check would
call entirely missing.

`design` now compiles **before** loading its catalogue, so the catalogue can be
checked against the vocabulary its kinds are written against.

## Verification: proven by mutation, not by passing

Watching a test pass proves nothing. Both mutations were run:

- **disable the check** → the three positive tests fail, the false-positive
  test stays green (it asserts absence)
- **remove the dormant-profile guard** → the false-positive test fails alone

So every test is load-bearing in a direction that was demonstrated rather than
assumed. This discipline came from the adopter session, after they found a test
of their own that could not fail: a mutation that leaves a test green is the
only check that does not depend on noticing anything.

Also verified against the real thing: `ask --open` on this repository's own
workspace still reports `0 open of 51`, with the four policy references
correctly silent.

`pnpm run verify` **exit 0** from a wiped `.yarramate-out`: 1809 tests, 99 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
