### PR TITLE
fix(visual): the canvas container is positioned, and the blocked style is identified (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Fixed.** The cytoscape container declares `position: relative`, so
+  cytoscape stops warning that it "can not use UI extensions properly"
+  (#325). Harmless while this app draws its own React context menu positioned
+  against the window, and a trap for whoever first reaches for a cytoscape UI
+  extension and finds it mispositioned with the reason already printed and
+  ignored on every session.
+
+  **The blocked inline style in the same console is now identified**, which
+  was the open half of that issue. It is cytoscape's own: it inserts a
+  `<style>` element whose entire content is
+  `.__________cytoscape_container { position: relative; }`, the session CSP
+  refuses it, and the refusal is why the position stayed static and the
+  warning fired. Confirmed rather than inferred: the hash the CSP names,
+  `sha256-pgvDUBa4IjFA2yuSJ2cqcyxmNYJMborsd0ORcRv9vw8=`, is the SHA-256 of
+  exactly that rule. It is deliberately **not** allowlisted. The rule it
+  carries is the one now set directly, so permitting it would admit an inline
+  style the application provably does not need.
+
 - **Fixed.** A catalogue naming a kind its profile does not have is refused,
   rather than loading clean and asking a question that can never fire (#351).
   `loadQuestionCatalogue` validated the schema and the undeclared-wave check

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -1728,7 +1728,16 @@ export function GraphCanvas({
     <>
       <div
         ref={containerRef}
-        style={{ width: '100%', height: '100%' }}
+        // `position: relative` because cytoscape checks the COMPUTED position
+        // of its container and refuses to set one itself: static earns
+        // "A Cytoscape container has style position:static and so can not use
+        // UI extensions properly" on every session, and then leaves it (#325).
+        // Harmless while this app draws its own React context menu positioned
+        // against the window, and a trap for whoever first reaches for a
+        // cytoscape UI extension and finds it mispositioned with the reason
+        // already printed and ignored. Rendering is unaffected: the layer
+        // holder cytoscape creates inside is already relative.
+        style={{ position: 'relative', width: '100%', height: '100%' }}
         onContextMenu={(event) => event.preventDefault()}
         // A kind dragged from the palette (#295). Accepted on the container
         // rather than on any cytoscape element: a new subject belongs to no


### PR DESCRIPTION
Closes #325.

**Two console messages, one cause.** Finding that was the substance of the
issue; the fix is one line.

## `position: relative` on the cytoscape container

Cytoscape checks the *computed* position of its container and refuses to set
one itself, so a static container earns this on every session and is then left
alone:

```
A Cytoscape container has style position:static and so can not use UI
extensions properly
```

Harmless while this app draws its own React context menu positioned against
the window. A trap for whoever first reaches for a cytoscape UI extension and
finds it mispositioned with the reason already printed and ignored.

## The blocked inline style is cytoscape's own, and it is the same eleven lines

`cytoscape.cjs.js:28137` inserts a `<style>` element whose entire content is:

```css
.__________cytoscape_container { position: relative; }
```

The session CSP refuses it. The position therefore stays static. So it warns.
The two messages were never independent.

**Confirmed rather than inferred.** The hash the CSP names is the SHA-256 of
exactly that rule:

```
computed: sha256-pgvDUBa4IjFA2yuSJ2cqcyxmNYJMborsd0ORcRv9vw8=
from CSP: sha256-pgvDUBa4IjFA2yuSJ2cqcyxmNYJMborsd0ORcRv9vw8=
```

## Deliberately not allowlisted

The rule it carries is the one now set directly, so permitting it by hash or
nonce would admit an inline style the application **provably does not need** —
and the issue is right that a canvas app needing `unsafe-inline` has given up
something worth keeping.

Suppressing it instead by pre-empting cytoscape's private stylesheet id
(`__________cytoscape_stylesheet`, which it checks before inserting) was
considered and rejected: coupling to a library's internals to silence one
console line is a worse trap than the line.

## Verified by A/B in one browser

Two live sessions at once:

| | previous build | this build |
|---|---|---|
| `position:static` warning | **present** | **gone** |
| CSP refusal + hash | present | present, identical |

The identical refusal on both is what shows it is independent of the position
fix rather than caused by it.

`pnpm run verify` **exit 0** from a wiped `.yarramate-out`: 1809 tests, 99 files.

## Noted in passing

The same console reports `A form field element should have an id or name
attribute (count: 2)` — recorded on #309, which was waiting for exactly this
kind of located evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
