### PR TITLE
chore: release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.5.0
 
 - **Fixed.** The cytoscape container declares `position: relative`, so
   cytoscape stops warning that it "can not use UI extensions properly"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Three fixes, all of the same family: **a surface that was quietly saying nothing
now says what is wrong.**

## UPGRADE HAZARD, and it is deliberate

**#351 turns a previously silent fault into a hard failure.** A catalogue naming
a kind its loaded profile does not declare now exits 1 where it exited 0.

If you carry such a typo you have had no way of knowing: the symptom was a
question that quietly never fired, which is indistinguishable from a question
whose condition was not met. `ask --open` and `design` will start failing on
upgrade, and the diagnostic names the kind and the line.

A kind whose profile is **not loaded at all** is not an error. That is a dormant
cross-profile question and it stays silent.

## Fixed

**A visual session that cannot recompile the workspace says so, and keeps
drawing the model that did compile** (#349, ADR 0126). It used to say nothing:
every view emptied while the rail kept its views, so the page read as a session
over an architecture that had gone blank rather than one that had failed. Three
paths were silent and the fourth could not name the fault. The browser now
receives the compiler's own diagnostics, with code and path and line, in a
faults panel that moves over the canvas.

An unreadable source is no longer served as an **empty workspace**. Compiling an
empty source list *succeeds*, returning an empty graph rather than a failure, so
swallowing a read error made a workspace the session could not read
indistinguishable from one with nothing in it.

Only a failure the runtime caused is fatal. A post-commit failure still freezes;
the others do not, because a source going uncompilable while someone edits a
file is an ordinary mid-edit state rather than grounds to end a session holding
staged work.

**A catalogue's unresolvable kind reference is refused** (#351). All three
kind-bearing fields are checked. A trigger kind never matches; a subject
selector's kind scopes the question to an empty set; and a wave gate's kind
never holds, which retires an entire wave, because a closed wave carries no
questions at all.

**The canvas container is positioned** (#325), so cytoscape stops warning that
it cannot use UI extensions properly. The blocked inline style in the same
console is now identified as cytoscape's own, confirmed by hash, and
deliberately not allowlisted: the rule it carries is the one now set directly.

**The consumer docs published the wrong wire version.** `visual-protocol/v4` in
two docs against `v5` in the constant and all three schemas.

## Compatibility

No format changes and **no new required fields**, so nothing breaks at
typecheck. That is the difference from 1.4.0, which added two required fields
and broke a consumer's production module.

The behavioural change is #351's refusal, above.

## Verification

`pnpm run verify` exit 0 from a wiped `.yarramate-out`: 1809 tests, 99 files.

**Eyeballed in a browser**, on the surface that changed: a session whose source
was made unreadable draws the last good diagram with a banner reading
`YMVS319 … cannot be read … EACCES: permission denied`. The `position: static`
warning was verified gone by running two sessions side by side, one on each
build.

**#351's tests were proven by mutation rather than by passing.** Disabling the
check fails the three positive tests; removing the false-positive guard fails
the guard test alone. A test that has only been watched passing has not been
shown to be capable of failing.
