### PR TITLE
chore: release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.6.0
 
 - **Added.** `yarramate import xlsx <workbook.xlsx> <workspace.yaml>` reads an
   edited workbook back into the model (#355, ADR 0127). **An unedited round

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The model as an Excel workbook an architect can actually work in, and read back
losslessly (#355, ADR 0127).

```
yarramate export xlsx <projection.yaml> <workspace.yaml> --out <file>
yarramate import xlsx <workbook.xlsx> <workspace.yaml>
```

plus `yarramate/workbook` for a host with no Node.

## An unedited round trip changes nothing

Byte for byte. That is the bar "no information lost" has to clear, and it is
proven through the CLI rather than asserted.

With edits, comments and key order survive, because import emits
`yarramate/operations/v1` through `apply` rather than regenerating documents:

```yaml
# A comment that must survive a round trip.
  - id: user
    description: The person who signs in.   # trailing comment
```

## No new dependency

An `.xlsx` is a zip of XML, and the writer and reader together are smaller than
any library that would do it. Both run on Cloudflare Workers, held to it by the
same purity test `./interrogation` meets: no Node builtins, no `ws`, no session
server, no runtime compiler import.

Writing is **synchronous** (stored entries), so it does not infect a
synchronous caller. Reading is **async**, because a workbook Excel has saved
comes back deflated and shared-string encoded — verified against a real
consulting template rather than assumed.

## A working document, not a report

Column A is always the id. Foreign keys sit inline, each followed by a
`↳ … (auto)` column carrying the referenced subject's name, so a sheet reads
without hunting across tabs. Kinds and statuses are drawn from the compiled
profile.

**Version selection needs no flag.** The workbook takes a projection, so it
inherits the `states` facet a projection query already has, along with kinds,
layers, owners, statuses and exclusions.

**Unrecognised claims land in an overflow sheet rather than being dropped**, so
a predicate added to the compiler later still survives a round trip.

## A three-way merge, not an overwrite

The workbook carries `~Baseline`, a hidden copy of its own rows as exported.
That ancestor distinguishes *the author changed this* from *the repository moved
underneath since the workbook was made*.

| Situation | Result |
|---|---|
| Author edits a field the workspace did not touch | merges, even after drift |
| Both moved the **same** field, differently | refused, naming both, nothing written |
| Both moved it to the **same** value | not a conflict |
| Row missing from the workbook | reported, **never** a deletion |
| New row with no `Document` | refused by name |
| No `~Baseline` | refused rather than guessed at |

## Also

A test refuses a raw NUL byte in any source file, reading every byte of every
tracked **and uncommitted** file. The two obvious detectors are each blind to a
case the other catches, and `git ls-files` cannot see the file being written
right now.

## Compatibility

Additive. No format changes and no new required fields, so nothing breaks at
typecheck. `runCli` keeps its signature: the async verb gets `runCliAsync`
rather than widening the type all 283 of its callers read.

## Known limits

- Editing the satellite sheets is reported as unsupported, not silently ignored.
- Renaming an id reads as a new row plus a missing one; both are reported and
  neither is guessed at.

## Verification

`pnpm run verify` exit 0 from a wiped `.yarramate-out`: 1840 tests, 103 files.
`npm pack` 262 files / 1.9 MB, no repository source, tests or fixtures.

Key checks were **mutation-proven** rather than watched passing: disabling
conflict detection fails the conflict test, dropping unrecognised claims fails
the losslessness test, reading cells positionally fails the column-reference
test, and a NUL in an untracked file fails the guard naming its offset.
