### PR TITLE
The half that reads a workbook back is published too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** `yarramate/workbook/import`, a published subpath carrying the half
+  that READS a workbook back: `readWorkbook`, `baselineSheets`, `mergeWorkbook`,
+  `operationsFrom` and `operationsDocument`. 1.6.0 published the writer only, so
+  a host without Node could generate a workbook and had no route back from an
+  edited one. The feature was scoped as fully reversible and only half of that
+  was reachable.
+
+  **A separate subpath, not more exports on `yarramate/workbook`.** The package
+  declares no `sideEffects` field, so a bundler must assume every module might
+  have one and cannot shake an unused re-export away. Adding the reader to the
+  writer entry would have grown every generate-only Worker by the whole import
+  half. `test/export-purity.test.ts` now holds the two entries **disjoint** as
+  well as pure, and asserts on the files the walk reaches rather than only on
+  what it fails to find, so a purity check cannot pass by visiting nothing.
+
+- **Changed.** The workbook's `00 Read Me` says what the file is: a projection
+  is a query, so the workbook is the slice it names, and the sheet now reports
+  the concept and relationship counts of **that slice**. It also states the two
+  things that make a narrow workbook safe to work in: every fact about a
+  subject that IS present is present, and a subject outside the slice has no
+  row and cannot be changed by importing the file.
+
 ## 1.6.0
 
 - **Added.** `yarramate import xlsx <workbook.xlsx> <workspace.yaml>` reads an

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -444,6 +444,18 @@ query:
     - target-state
 ```
 
+**Which makes a workbook a SLICE, and it is worth being plain about that.** An
+omitted facet imposes no constraint, so `query: {}` exports the whole model,
+and every facet you name narrows it. For a subject the query selected, nothing
+is dropped: the projection filters claims by subject membership rather than by
+predicate, so every fact about an included subject arrives, and `07 Other
+Facts` catches whatever the named columns do not model. For a subject it did
+not select, there is simply no row, and a missing row is never a deletion, so
+**a narrow workbook cannot damage a wide model on the way back in**. The
+`00 Read Me` sheet says all of this and reports the counts the slice actually
+has, because an FDE handed a filtered workbook with no note will read it as
+the model.
+
 **Reading the sheets.** Column A is always the id and is what the model is
 keyed on. A column headed `↳ … (auto)` is derived for readability and is
 ignored on the way back. Kind and status columns are drawn from the compiled
@@ -471,6 +483,57 @@ did not touch merges even if the repository moved on; only a field changed on
 **both** sides is refused, and a refusal writes nothing anywhere. A missing row
 is reported and never treated as a deletion, and a new row needs its `Document`
 column filled in.
+
+**On a host with no Node**, `yarramate/workbook/import` publishes the same
+three steps the CLI runs, so ingesting a workbook is not CLI-only:
+
+```ts
+import {
+  readWorkbook,
+  baselineSheets,
+  mergeWorkbook,
+  operationsFrom,
+  operationsDocument,
+} from 'yarramate/workbook/import'
+
+const read = await readWorkbook(bytes)
+if (!read.ok) return refuse(read.reason)
+
+const ancestor = read.sheets.get('~Baseline')
+if (ancestor === undefined) return refuse('not produced by yarramate export xlsx')
+
+const report = mergeWorkbook(
+  read.sheets,
+  baselineSheets(ancestor),
+  buildWorkbookSheets(currentResult, provenance),
+)
+if (report.conflicts.length > 0) return refuse(report.conflicts)
+
+const { operations, refusals } = operationsFrom(report, read.sheets)
+await apply(operationsDocument(operations))
+```
+
+`readWorkbook` is **async** while the writer is synchronous, and deliberately
+so: a workbook this package wrote has stored entries and inline strings, but
+one a person saved from Excel comes back deflated and shared-stringed, and
+inflation is only offered as a stream (`DecompressionStream('deflate-raw')`,
+present on Workers, in browsers and in Node 18+). Keeping the writer
+synchronous is what stops it infecting a synchronous store on the host side.
+
+It is a **separate subpath** from `yarramate/workbook` on purpose. The package
+declares no `sideEffects` field, so a bundler must assume every module might
+have one and cannot shake an unused re-export away; a host that only generates
+workbooks would otherwise carry the reader, the merge and the operations
+emitter it never calls. `test/export-purity.test.ts` holds the two entries
+disjoint as well as pure.
+
+The host keeps three jobs: reading the bytes, evaluating the projection that
+says what the model holds **now** (the third argument to `mergeWorkbook`, which
+is what measures repo drift in the same terms the author edited in), and
+applying the operations. Refusal wording is the host's too. The `Conflict`
+values name the sheet, row, column, what the author wrote, what the workspace
+now holds and their common ancestor, which reads like a merge tool rather than
+like something you hand a consultant.
 
 ## MCP server for agent harnesses
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
       "types": "./dist/workbook-entry.d.ts",
       "import": "./dist/workbook-entry.js"
     },
+    "./workbook/import": {
+      "types": "./dist/workbook-import-entry.d.ts",
+      "import": "./dist/workbook-import-entry.js"
+    },
     "./visual-app": {
       "types": "./dist/visual-app-lib/editor.d.ts",
       "import": "./dist/visual-app-lib/editor.js"

--- a/src/workbook-import-entry.ts
+++ b/src/workbook-import-entry.ts
@@ -1,0 +1,51 @@
+/**
+ * `yarramate/workbook/import` — reading an edited workbook back, for a host
+ * that has no Node.
+ *
+ * A SEPARATE subpath from `yarramate/workbook` rather than more exports on it,
+ * because the package declares no `sideEffects` field and a bundler must
+ * therefore assume every module might have one. A Worker that only GENERATES
+ * workbooks would otherwise carry the reader, the merge and the operations
+ * emitter it never calls, and small bundles are the reason the xlsx container
+ * is hand-written in the first place (#355).
+ *
+ * Held to the same bar as `./workbook` and `./interrogation` by
+ * `test/export-purity.test.ts`: no Node builtins, no `ws`, no session server,
+ * no runtime import of the compiler. `workbook-read.ts` imports nothing at
+ * all; inflation uses `DecompressionStream('deflate-raw')`, which Workers,
+ * browsers and Node 18+ all have.
+ *
+ * The reader is ASYNC and the writer is not, deliberately. A workbook this
+ * package wrote has stored entries and inline strings, but one a person saved
+ * from Excel comes back deflated and shared-stringed, and inflation is only
+ * offered as a stream.
+ *
+ * What a host still owns: reading the bytes, evaluating the projection that
+ * says what the workbook SHOULD hold now, and applying the operations. This
+ * entry turns bytes into sheets, sheets into a merge report, and a merge
+ * report into `yarramate/operations/v1`.
+ */
+export {
+  readWorkbook,
+  unzipEntries,
+  columnIndexOf,
+  decodeXmlText,
+  type WorkbookRead,
+  type ZipReadFailure,
+} from './workbook-read.js'
+export {
+  mergeWorkbook,
+  mergeSheet,
+  keySheet,
+  baselineSheets,
+  isDerivedColumn,
+  type KeyedSheet,
+  type CellChange,
+  type Conflict,
+  type MergeReport,
+} from './workbook-merge.js'
+export {
+  operationsFrom,
+  operationsDocument,
+  type OperationsResult,
+} from './workbook-operations.js'

--- a/src/workbook.ts
+++ b/src/workbook.ts
@@ -285,6 +285,23 @@ export const buildWorkbookSheets = (
     ['4.', 'Deleting a row does NOT delete anything. Removals are reported, never applied.'],
     ['5.', 'Send the file back and import it. Your edits are merged; only a field changed on both sides is refused.'],
     [],
+    [],
+    ['What this holds, and what it does not'],
+    [
+      '',
+      `A projection is a QUERY, so this workbook is the slice it names: ${
+        conceptRows.length - 1
+      } concepts and ${relationshipRows.length - 1} relationships.`,
+    ],
+    [
+      '',
+      'Everything the model knows about a subject that IS here is here, including anything these columns do not model, on 07 Other Facts.',
+    ],
+    [
+      '',
+      'A subject outside the slice has no row, and importing this file cannot change it. A narrow workbook is safe against a wide model.',
+    ],
+    [],
     ['Sheets beginning ~ are machinery. Do not edit them.'],
   ]
 

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -71,6 +71,37 @@ describe('package export purity', () => {
     expect(hits).toEqual([])
   })
 
+  it('workbook/import graph stays free of Node, ws, session, and compiler runtime', () => {
+    // The half that INGESTS a workbook, published separately from the half
+    // that writes one so a Worker that only generates never carries it.
+    const { files, hits } = runtimeImportGraph('workbook-import-entry.ts')
+    expect(hits).toEqual([])
+    // Asserted on the FILES, not only on the hits. A purity check that walks
+    // an entry reaching nothing passes for the wrong reason, and would keep
+    // passing if an export were dropped from the entry - the emptiness would
+    // read as cleanliness. Naming the three files makes the graph prove it
+    // actually visited the code the claim is about.
+    expect(files).toEqual(
+      expect.arrayContaining([
+        'workbook-read.ts',
+        'workbook-merge.ts',
+        'workbook-operations.ts',
+      ]),
+    )
+  })
+
+  it('the two workbook entries stay disjoint, so generating never pulls in reading', () => {
+    // The reason `workbook/import` is its own subpath: the package declares no
+    // `sideEffects`, so a bundler must assume every module might have one and
+    // cannot shake an unused re-export away. If the writer entry ever reaches
+    // the reader, ApertureX's generate-only Worker silently grows by the whole
+    // import half.
+    const writer = runtimeImportGraph('workbook-entry.ts').files
+    expect(writer).not.toContain('workbook-read.ts')
+    expect(writer).not.toContain('workbook-merge.ts')
+    expect(writer).not.toContain('workbook-operations.ts')
+  })
+
   it('interrogation import graph stays free of Node, ws, session, and compiler runtime', () => {
     // The engine is the one piece a Durable Object runs on every model write,
     // so the compiler's Ajv/YAML weight and every Node builtin have to stay
@@ -86,5 +117,26 @@ describe('adapter/visual-graph barrel', () => {
     // for the published subpath entry point.
     const mod = await import('../src/adapters/visual-graph-entry.js')
     expect(typeof mod.projectGraphForCanvas).toBe('function')
+  })
+})
+
+describe('workbook barrels', () => {
+  it('yarramate/workbook hands a host everything it needs to WRITE one', async () => {
+    const mod = await import('../src/workbook-entry.js')
+    expect(typeof mod.workbookFrom).toBe('function')
+    expect(typeof mod.buildWorkbookSheets).toBe('function')
+    expect(typeof mod.writeXlsx).toBe('function')
+  })
+
+  it('yarramate/workbook/import hands a host the whole way back to operations', async () => {
+    // Read -> merge -> operations. A host missing any one of the three has no
+    // route from an edited file to something `apply` can take, which is the
+    // state this entry exists to end.
+    const mod = await import('../src/workbook-import-entry.js')
+    expect(typeof mod.readWorkbook).toBe('function')
+    expect(typeof mod.baselineSheets).toBe('function')
+    expect(typeof mod.mergeWorkbook).toBe('function')
+    expect(typeof mod.operationsFrom).toBe('function')
+    expect(typeof mod.operationsDocument).toBe('function')
   })
 })

--- a/test/workbook.test.ts
+++ b/test/workbook.test.ts
@@ -287,6 +287,28 @@ describe('the baseline is the merge ancestor', () => {
     expect(mirrored).toEqual(concepts)
   })
 
+  it('tells the reader the workbook is a SLICE, and counts the slice it got', () => {
+    // A projection is a query, so a workbook is whatever it selected. An FDE
+    // handed a narrow one and told nothing will read it as the model, and
+    // everything outside the filter is then invisible to the person being
+    // asked to confirm the model is right.
+    const whole = named(sheetsFor({}).sheets, '00 Read Me')
+      .map((row) => row.join(' '))
+      .join('\n')
+    const slice = named(sheetsFor({ subjects: ['user'] }).sheets, '00 Read Me')
+      .map((row) => row.join(' '))
+      .join('\n')
+
+    expect(whole).toContain('this workbook is the slice it names')
+    // The counts must come from the RESULT, not from the model, or the
+    // sentence is worse than saying nothing: it would state a size the file
+    // does not have.
+    expect(slice).toContain('1 concepts')
+    expect(whole).not.toContain('1 concepts')
+    // And the reassurance that makes a narrow workbook usable at all.
+    expect(slice).toContain('cannot change it')
+  })
+
   it('keeps the Read Me out of the ancestor, since nothing imports prose', () => {
     const { sheets } = sheetsFor({})
     const sheetNames = named(sheets, '~Baseline')


### PR DESCRIPTION
1.6.0 published `yarramate/workbook`, which **writes** one. It did not publish the half that **reads** one back, so a host without Node could generate a workbook and had no route from an edited file to something `apply` can take. The feature was scoped as fully reversible and only half of that was reachable off the CLI.

## What is published

`yarramate/workbook/import` carries the three steps the CLI runs:

```ts
const read = await readWorkbook(bytes)
const report = mergeWorkbook(read.sheets, baselineSheets(read.sheets.get('~Baseline')), current)
const { operations, refusals } = operationsFrom(report, read.sheets)
await apply(operationsDocument(operations))
```

No refactor was needed. `workbook-read.ts` imports **nothing at all**, `workbook-merge.ts` imports one type, and the only Node dependency in the import half was always in `src/import-command.ts`, which is the CLI wrapper rather than the library.

## Why a separate subpath

The package declares no `sideEffects` field, so a bundler must assume every module might have one and cannot shake an unused re-export away. Adding the reader to the writer entry would have grown every generate-only Worker by the whole import half. Small bundles are why the xlsx container is hand-written in the first place, so the constraint that shaped the feature shapes its packaging too.

`test/export-purity.test.ts` now holds the two entries **disjoint** as well as pure.

## The purity check could have passed by visiting nothing

The existing check asserted only that the walk found no forbidden import. A walk that reaches no files satisfies that trivially, so dropping an export from an entry would have read as cleanliness. It now asserts on the **files** each walk reaches as well.

## Read Me says what the workbook is

A projection is a query, so a workbook is the slice it names. `00 Read Me` now reports that slice's own counts and the two facts that make a narrow workbook safe to work in: every fact about a subject that **is** present is present, and a subject outside the slice has no row and cannot be changed by importing the file. An FDE handed a filtered workbook with no note reads it as the model.

## Verification

Verified on the **packed package**, not the source tree. Installed the tarball into a scratch consumer, resolved both subpaths through the real exports map, exported a workbook with the CLI, edited a cell using only published subpaths, and merged:

| | |
|---|---|
| unedited | 0 operations, 0 conflicts, 0 refusals |
| one cell edited | exactly 1 `update-concept`, minimal |
| applied | edit landed, document comment intact |

The zero was real rather than a merge that read nothing, which the edited run proves.

**Mutation-proven.** Dropping the reader from the entry, pointing the writer entry at the reader, and adding a `node:fs` import to the reader each turn the intended test red. Hard-coding the Read Me count and deleting its safety sentence each turn the slice test red.

`pnpm run verify` from a wiped `dist` and `.yarramate-out`: exit 0, 1845 passed, 1 skipped, 103 files. Both typecheck configs clean.

Refs #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)