### PR TITLE
check resolves the references in a projection query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **Added.** `check` resolves the references in a projection query (ADR 0128,
+  YM921). A query naming a state, subject, document, kind, owner or constraint
+  the workspace does not have is refused, and the diagnostic suggests the near
+  miss: `Projection query \`states\` names "target-stat" ... Did you mean
+  "target-state"?`
+
+  **Referential, not emptiness.** A query whose every name resolves and which
+  selects nothing is NOT refused. An architecture state nobody has populated
+  yet is empty, correctly, and asking about it is a real question. The
+  mechanism is a dangling reference, so the check is for a dangling reference;
+  the symptom was an empty file, and a detector shaped like the symptom would
+  have refused honest queries too.
+
+  Previously a mistyped selector produced a clean empty artifact and exit 0
+  from every export kind, because `check` validated a projection against its
+  schema and never against the model. `owners` and `constraints` are included:
+  they look like free text and are refs to concepts, which the compiler proves
+  by refusing an unresolved owner with YM304.
+
 - **Added.** `yarramate/workbook/import`, a published subpath carrying the half
   that READS a workbook back: `readWorkbook`, `baselineSheets`, `mergeWorkbook`,
   `operationsFrom` and `operationsDocument`. 1.6.0 published the writer only, so

--- a/docs/PROJECTIONS.md
+++ b/docs/PROJECTIONS.md
@@ -98,10 +98,27 @@ query into a transitive reference closure.
 
 Selectors are portable by default. A well-formed subject, document, kind,
 owner, or constraint identity that is absent from the current graph
-contributes no matches and is not a validation error. This supports partial
+contributes no matches and is not an evaluation error. This supports partial
 models and reuse across repositories without weakening schema validation.
 Explicit subjects are useful for deliberately bounded contexts that should
 not expand merely because their source document gains another concept.
+
+**Portability is about evaluation, and it is not a licence for a typo in your
+own repository.** `check` resolves the selectors of every projection the
+workspace manifest DECLARES, and refuses one naming something the model does
+not have (YM921, ADR 0128). A mistyped state selects no state, which selects
+no subject, which writes a clean empty artifact and exits 0; the failure is
+silent and the artifact reaches whoever asked for it.
+
+The two hold together because they are about different documents. A projection
+in this workspace's manifest is this repository's own document and is checked
+against this repository's model. A projection handed to `ask` or `export` as a
+path, including one written for another repository, is evaluated and never
+reference-checked, so it still degrades to no matches rather than to an error.
+
+The check is referential, not emptiness. A query whose every name resolves and
+which selects nothing is not refused: an architecture state nobody has
+populated yet is empty, correctly.
 
 `title` and `description` are presentation hints. They do not affect selection
 or carry semantic authority.

--- a/docs/adr/0128-a-projection-query-holds-references-and-check-resolves-them.md
+++ b/docs/adr/0128-a-projection-query-holds-references-and-check-resolves-them.md
@@ -1,0 +1,108 @@
+# A projection query holds references, and `check` resolves them
+
+Status: accepted
+
+A projection is a document in the workspace, and its `query` block is a WHERE
+clause: `states`, `subjects`, `kinds`, `owners` and the rest name things in the
+model. YarraMate refuses a relationship pointing at a concept that does not
+exist. It did not refuse a query naming a state that does not exist.
+
+The symptom is silent, and it reaches a client:
+
+```yaml
+query:
+  states:
+    - target-stat        # target-state, mistyped
+```
+
+That selects no state, which selects no subject, which writes a clean empty
+artifact and exits 0. `check` passed, because `check` loaded every projection
+against its schema and never against the model. Every export kind is affected:
+`graph`, `markdown`, `briefs`, `rtm`, `likec4` and `xlsx` alike.
+
+Found by asking whether YarraMate refuses an empty compile the way an adopter's
+own projection call had just started to.
+
+## Decision
+
+**The check is REFERENTIAL, not emptiness.** A query value that names nothing
+is refused. A query whose every name resolves and which selects nothing is not.
+
+That distinction is the whole decision. An architecture state nobody has
+populated yet is empty, correctly, and asking about it is a real question with
+an honest answer. Refusing every empty result would catch the typo and break
+that workflow with it. The mechanism is a dangling reference, so the check is
+for a dangling reference — the symptom was an empty file, and a detector shaped
+like the symptom would have been wrong.
+
+**It runs at `check`, and only on projections the MANIFEST declares.**
+
+This is the part that took a correction. `docs/PROJECTIONS.md` already recorded
+a deliberate principle: *"Selectors are portable by default... absent from the
+current graph contributes no matches and is not a validation error. This
+supports partial models and reuse across repositories."* A blanket referential
+check reverses that, and reversing a recorded decision by accident is worse
+than the defect it fixes.
+
+They hold together because they are about different documents. A projection in
+the workspace manifest is **this repository's own document**, checked against
+this repository's model, and portability was never the point of it. A
+projection handed to `ask` or `export` as a path — including one written for
+another repository, against a partial model — is evaluated and never
+reference-checked, so it still degrades to no matches rather than to an error.
+
+`check` iterates `resolved.projections`, which is the manifest list, so the
+implementation lands on that line by construction rather than by a special
+case. The typo is in a file rather than in an invocation, which is why CI is
+the right place to catch it, and every verb over a declared projection inherits
+the guard rather than each growing its own.
+
+It runs AFTER compilation succeeds, alongside the adapter-mapping and evidence
+diagnostics, rather than beside the projection's own schema load. A reference
+can only be resolved against a model that built; reporting dangling names out
+of a workspace that does not compile buries the real failure under its
+consequences.
+
+**Every facet with a closed namespace is checked**, and each namespace is
+derived the way the FILTER derives it, so the check cannot drift from what it
+guards. `documents` reads the same provenance the `documents` facet compares
+against; `states` is the same `yarramate/state/type` scan `conceptSelector`
+runs.
+
+`owners` and `constraints` are included. They look like free text and are not:
+both are refs to concepts, which the compiler proves by refusing an unresolved
+owner with YM304. They are checked against the SUBJECT list rather than against
+owners currently in use, because a team that owns nothing yet is a real concept
+and selecting it is a real question with an empty answer.
+
+`statuses` and `excludeStatuses` are schema enums, refused upstream.
+
+**A kind whose profile is not loaded is dormant, not wrong.** The kind facets
+are checked only when a profile context is present, the same distinction #351
+drew for question catalogues.
+
+**The diagnostic suggests the near miss.** `similarity` already exists for
+near-duplicate subject detection, so the suggestion reuses it rather than
+introducing a second string-distance function. A diagnostic aimed at a typo
+should offer the correction.
+
+## Consequences
+
+`check` compiles with `compileWorkspaceWithProfileContext` rather than
+`compileWorkspace`. These do identical work; the former simply keeps the
+profile context the kind facets need.
+
+A workspace with a mistyped projection now fails `check`. That is a breaking
+change for anyone whose projection has been quietly selecting nothing, which is
+the point.
+
+The rule is exported as `unmatchedSelectors` and `projectionReferenceDiagnostics`
+so `ask` or a visual session can adopt it and refuse in identical words with an
+identical code (YM921), rather than each rebuilding it.
+
+An empty export is still written, silently, when the query is honest. If that
+should change it is a separate decision about deliverables, not about queries.
+
+A projection used across repositories keeps its portable behaviour, but only
+while it stays out of the consuming workspace's manifest. Declaring it is the
+act that says "this is ours", and it is then held to this model.

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -14,7 +14,10 @@ import {
   usage,
   type CliResult,
 } from './cli-support.js'
-import { compileWorkspace, withDiagnosticSubjects } from './compiler.js'
+import {
+  compileWorkspaceWithProfileContext,
+  withDiagnosticSubjects,
+} from './compiler.js'
 import {
   checkCoreContract,
   loadCoreContract,
@@ -23,7 +26,10 @@ import {
   evaluateEvidenceWorkspace,
   loadEvidence,
 } from './evidence.js'
-import { loadProjection } from './projection.js'
+import {
+  loadProjection,
+  projectionReferenceDiagnostics,
+} from './projection.js'
 import {
   reconcileEvidenceReports,
   type EvidenceFinding,
@@ -198,14 +204,18 @@ export function runCheckCommand(
         : humanDiagnostics(contractDiagnostics)
       return { exitCode: 1, stdout: output, stderr: '' }
     }
+    const projectionSources = resolved.projections.map((path) => ({
+      path,
+      source: readFileSync(resolve(cwd, path), 'utf8'),
+    }))
+    const loadedProjections = projectionSources.map((source) => ({
+      source,
+      loaded: loadProjection(source),
+    }))
     const projectionDiagnostics = sortDiagnostics(
-      resolved.projections.flatMap((path) => {
-        const loaded = loadProjection({
-          path,
-          source: readFileSync(resolve(cwd, path), 'utf8'),
-        })
-        return loaded.ok ? [] : loaded.diagnostics
-      }),
+      loadedProjections.flatMap(({ loaded }) =>
+        loaded.ok ? [] : loaded.diagnostics,
+      ),
     )
     if (projectionDiagnostics.length > 0) {
       const output = json
@@ -257,7 +267,7 @@ export function runCheckCommand(
       return { exitCode: 1, stdout: output, stderr: '' }
     }
 
-    const result = compileWorkspace(coreSources)
+    const result = compileWorkspaceWithProfileContext(coreSources)
     const mappingValidation = result.ok
       ? validateAdapterMappings(
           result.graph,
@@ -282,9 +292,27 @@ export function runCheckCommand(
       evidenceEvaluation === undefined || evidenceEvaluation.ok
         ? []
         : evidenceEvaluation.diagnostics
+    // A projection is a document, and a query holds references the same way a
+    // relationship does. Checked HERE rather than with the projection's own
+    // schema load above, because a reference can only be resolved against a
+    // model that compiled: reporting dangling names out of a workspace that
+    // does not build would bury the real failure under its consequences.
+    const referenceDiagnostics = result.ok
+      ? loadedProjections.flatMap(({ source, loaded }) =>
+          loaded.ok
+            ? projectionReferenceDiagnostics(
+                source,
+                loaded.projection,
+                result.graph,
+                result.profileContext,
+              )
+            : [],
+        )
+      : []
     const optionalDiagnostics = sortDiagnostics([
       ...mappingDiagnostics,
       ...evidenceDiagnostics,
+      ...referenceDiagnostics,
     ])
     const ok = result.ok && optionalDiagnostics.length === 0
     // Published results name the subject a diagnostic is about wherever its

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceSource,
 } from './compiler.js'
 import { loadSourceDocument } from './source-document.js'
+import { similarity } from './subject-identity.js'
 import projectionSchema from '../schema/yarramate-projection.schema.json' with {
   type: 'json',
 }
@@ -400,6 +401,170 @@ const conceptSelector = (
       return undefined
     },
   }
+}
+
+/** A query facet naming something the model does not have. */
+export interface UnmatchedSelector {
+  readonly facet: string
+  readonly value: string
+  /** The closest name the facet does offer, when one is close enough to be a likely typo. */
+  readonly nearest?: string
+}
+
+/** Below this, a suggestion is noise rather than a hint. */
+const SUGGESTION_THRESHOLD = 0.6
+
+/**
+ * Every value in a projection query that names nothing.
+ *
+ * A projection is a DOCUMENT, and a query holds references the same way a
+ * relationship does. YarraMate refuses a relationship pointing at a concept
+ * that does not exist; it did not refuse a query naming a state that does not
+ * exist, and the symptom is silent. `states: [target-stat]` selects no state,
+ * which selects no subject, which exports a clean empty artifact with exit 0.
+ * Someone hands that to a client.
+ *
+ * Checked at `check`, not at `export`, because the typo is in a file rather
+ * than in an invocation: CI catches it, and every verb over the same
+ * projection inherits the guard instead of each growing its own.
+ *
+ * ONLY FACETS WITH A CLOSED NAMESPACE ARE CHECKED. `statuses` and
+ * `excludeStatuses` are schema enums, refused upstream before this runs.
+ * Everything else names something: `owners` and `constraints` are REFS to
+ * concepts, which the compiler itself proves by refusing an unresolved owner
+ * with YM304, so their namespace is the subject list like `subjects`.
+ *
+ * Each namespace is derived the way the FILTER derives it, so the check cannot
+ * drift from what it guards: `documents` reads the same provenance the
+ * `documents` facet compares against, and `states` is the same
+ * `yarramate/state/type` scan `conceptSelector` runs.
+ *
+ * A kind whose profile is not loaded is DORMANT rather than wrong, the same
+ * distinction #351 drew for question catalogues, so the kind facets are
+ * checked only when a profile context is present.
+ *
+ * An empty RESULT is not reported here and must not be. A query whose every
+ * name resolves and which selects nothing is a real answer to a real question:
+ * a target state nobody has populated yet is empty, correctly.
+ */
+export function unmatchedSelectors(
+  graph: SemanticGraph,
+  projection: ProjectionDefinition,
+  profileContext?: ResolvedProfileContext,
+): readonly UnmatchedSelector[] {
+  const query = projection.query
+  const found: UnmatchedSelector[] = []
+
+  const check = (
+    facet: string,
+    values: readonly string[] | undefined,
+    known: ReadonlySet<string>,
+  ): void => {
+    if (values === undefined) return
+    for (const value of values) {
+      if (known.has(value)) continue
+      let nearest: string | undefined
+      let best = 0
+      for (const candidate of known) {
+        const score = similarity(value, candidate)
+        if (score > best) {
+          best = score
+          nearest = candidate
+        }
+      }
+      found.push({
+        facet,
+        value,
+        ...(nearest !== undefined && best >= SUGGESTION_THRESHOLD
+          ? { nearest }
+          : {}),
+      })
+    }
+  }
+
+  const subjectIds = new Set(graph.subjects.map(({ id }) => id))
+  check('subjects', query.subjects, subjectIds)
+  check('exclude', query.exclude, subjectIds)
+  // Against the SUBJECT list rather than against owners currently in use: a
+  // team that owns nothing yet is a real concept and selecting it is a real
+  // question with an empty answer, which is exactly what must not be refused.
+  check('owners', query.owners, subjectIds)
+  check('constraints', query.constraints, subjectIds)
+
+  // The same provenance `documents` filters on: a subject id no longer carries
+  // the document that declared it, so both read it off the kind claim.
+  const documentIds = new Set<string>()
+  for (const claim of graph.claims) {
+    if (claim.predicate !== 'yarramate/concept/kind') continue
+    const document = claim.source?.document
+    if (typeof document === 'string') documentIds.add(document)
+  }
+  check('documents', query.documents, documentIds)
+
+  check(
+    'states',
+    query.states,
+    new Set(
+      graph.claims
+        .filter(({ predicate }) => predicate === 'yarramate/state/type')
+        .map(({ subject }) => subject),
+    ),
+  )
+
+  if (profileContext !== undefined) {
+    check('kinds', query.kinds, new Set(profileContext.conceptKindLineages.keys()))
+    check(
+      'relationshipKinds',
+      query.relationshipKinds,
+      new Set(profileContext.relationshipKindLineages.keys()),
+    )
+    check('layers', query.layers, new Set(profileContext.conceptKindLayers.values()))
+  }
+
+  return found
+}
+
+/**
+ * Where a value sits in the projection source, so the diagnostic is clickable.
+ * A query value appears once in a list item, and finding it by text is enough:
+ * the alternative is threading a YAML CST through a check that only needs to
+ * point at a line.
+ */
+const locate = (source: string, value: string): { line: number; column: number } => {
+  const lines = source.split('\n')
+  for (let index = 0; index < lines.length; index += 1) {
+    const at = lines[index]!.indexOf(value)
+    if (at >= 0) return { line: index + 1, column: at + 1 }
+  }
+  return { line: 1, column: 1 }
+}
+
+/**
+ * {@link unmatchedSelectors} as diagnostics, built HERE rather than at each
+ * caller so `check`, and anything that adopts this later, refuse in identical
+ * words with an identical code.
+ */
+export function projectionReferenceDiagnostics(
+  source: WorkspaceSource,
+  projection: ProjectionDefinition,
+  graph: SemanticGraph,
+  profileContext?: ResolvedProfileContext,
+): readonly Diagnostic[] {
+  return unmatchedSelectors(graph, projection, profileContext).map(
+    ({ facet, value, nearest }) => ({
+      severity: 'error' as const,
+      code: 'YM921',
+      message:
+        `Projection query \`${facet}\` names ${JSON.stringify(value)}, ` +
+        'which this workspace does not have, so it can never match. ' +
+        (nearest === undefined
+          ? 'Check the spelling against the model.'
+          : `Did you mean ${JSON.stringify(nearest)}?`),
+      path: source.path,
+      pointer: `/query/${facet}`,
+      ...locate(source.source, value),
+    }),
+  )
 }
 
 /**

--- a/test/projection-references.test.ts
+++ b/test/projection-references.test.ts
@@ -1,0 +1,289 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import {
+  evaluateProjection,
+  loadProjection,
+  projectionReferenceDiagnostics,
+  unmatchedSelectors,
+} from '../src/projection.js'
+
+/**
+ * A projection query holds references the same way a relationship does, and
+ * until #359 nothing checked them. The symptom is silent: a state that does
+ * not exist selects no state, which selects no subject, which exports a clean
+ * empty artifact and exits 0. Someone hands that to a client.
+ */
+
+const document = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+states:
+  - id: today
+    kind: baseline
+    name: Today
+  - id: tomorrow
+    kind: target
+    name: Tomorrow
+    after: today
+concepts:
+  - id: platform-team
+    kind: businessActor
+    name: Platform team
+  - id: user
+    kind: businessActor
+    name: User
+    owner: platform-team
+    presentIn:
+      - today
+  - id: store
+    kind: dataObject
+    name: Store
+    presentIn:
+      - tomorrow
+relationships: []
+`
+
+const compiled = () => {
+  const result = compileWorkspaceWithProfileContext([
+    { path: 'main.yaml', source: document },
+  ])
+  if (!result.ok) throw new Error('fixture does not compile')
+  return result
+}
+
+const queryOf = (query: Record<string, unknown>) => ({
+  format: 'yarramate/projection/v1' as const,
+  id: 'q',
+  version: '1.0',
+  query: query as never,
+})
+
+describe('a query that names something the model does not have', () => {
+  it('reports the facet and the value, and suggests the near miss', () => {
+    const { graph, profileContext } = compiled()
+    const found = unmatchedSelectors(
+      graph,
+      queryOf({ states: ['tomorow'] }),
+      profileContext,
+    )
+    expect(found).toEqual([
+      { facet: 'states', value: 'tomorow', nearest: 'tomorrow' },
+    ])
+  })
+
+  it('says nothing about a query whose every name resolves', () => {
+    const { graph, profileContext } = compiled()
+    expect(
+      unmatchedSelectors(
+        graph,
+        queryOf({ states: ['tomorrow'], subjects: ['store'] }),
+        profileContext,
+      ),
+    ).toEqual([])
+  })
+
+  /**
+   * The distinction the whole check rests on. Nothing is broken about asking
+   * for a state nobody has populated yet, and the honest answer is an empty
+   * one. Refusing it would break a legitimate workflow to catch a typo.
+   */
+  it('does NOT report a query that resolves and simply selects nothing', () => {
+    const { graph, profileContext } = compiled()
+    // Every name is real and the intersection is genuinely EMPTY: `store` is
+    // the only subject named and it is a dataObject, not a businessActor.
+    // Asserted rather than assumed, because a fixture that quietly selects
+    // something makes this test pass without ever reaching the branch it
+    // exists to protect - which is how the first version of it was written.
+    const projection = queryOf({
+      subjects: ['store'],
+      kinds: ['yarramate/core@0.1#businessActor'],
+    })
+    expect(
+      evaluateProjection(graph, projection, profileContext).subjects,
+    ).toEqual([])
+    expect(unmatchedSelectors(graph, projection, profileContext)).toEqual([])
+  })
+
+  it('checks owners and constraints too, because both are refs to concepts', () => {
+    const { graph, profileContext } = compiled()
+    // Not free text: the compiler refuses an unresolved owner with YM304, so
+    // the namespace is the subject list.
+    expect(
+      unmatchedSelectors(
+        graph,
+        queryOf({ owners: ['nobody-at-all'], constraints: ['no-such-constraint'] }),
+        profileContext,
+      ).map(({ facet }) => facet),
+    ).toEqual(['owners', 'constraints'])
+  })
+
+  it('accepts an owner that exists but owns nothing yet', () => {
+    const { graph, profileContext } = compiled()
+    // The reason owners are checked against SUBJECTS rather than against
+    // owners in use. `store` owns nothing; asking for what it owns is a real
+    // question whose honest answer is nothing.
+    expect(
+      unmatchedSelectors(graph, queryOf({ owners: ['store'] }), profileContext),
+    ).toEqual([])
+  })
+
+  it('leaves a status alone, since the schema already refused a bad one', () => {
+    const { graph, profileContext } = compiled()
+    expect(
+      unmatchedSelectors(
+        graph,
+        queryOf({ statuses: ['current'], excludeStatuses: ['retired'] }),
+        profileContext,
+      ),
+    ).toEqual([])
+  })
+
+  it('treats a kind as dormant when no profile is loaded, not as wrong', () => {
+    const { graph } = compiled()
+    // Same distinction #351 drew for question catalogues: without the profile
+    // there is nothing to be absent FROM.
+    expect(
+      unmatchedSelectors(graph, queryOf({ kinds: ['made-up-kind'] })),
+    ).toEqual([])
+    expect(
+      unmatchedSelectors(graph, queryOf({ kinds: ['made-up-kind'] }), compiled().profileContext),
+    ).toHaveLength(1)
+  })
+
+  it('points at the line the value is on, so the diagnostic is clickable', () => {
+    const { graph, profileContext } = compiled()
+    const source = {
+      path: 'q.yaml',
+      source: `format: yarramate/projection/v1
+id: q
+version: "1.0"
+query:
+  states:
+    - tomorow
+`,
+    }
+    const loaded = loadProjection(source)
+    if (!loaded.ok) throw new Error('fixture projection does not load')
+    const [diagnostic] = projectionReferenceDiagnostics(
+      source,
+      loaded.projection,
+      graph,
+      profileContext,
+    )
+    expect(diagnostic).toMatchObject({
+      severity: 'error',
+      code: 'YM921',
+      path: 'q.yaml',
+      pointer: '/query/states',
+      line: 6,
+    })
+    expect(diagnostic?.message).toContain('Did you mean "tomorrow"?')
+  })
+})
+
+describe('check refuses the projection, not the export', () => {
+  let workspace = ''
+
+  const write = (relative: string, source: string): void => {
+    writeFileSync(join(workspace, relative), source, 'utf8')
+  }
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-projection-refs-'))
+    mkdirSync(join(workspace, '.yarramate/architecture'), { recursive: true })
+    mkdirSync(join(workspace, '.yarramate/projections'), { recursive: true })
+    write(
+      '.yarramate/workspace.yaml',
+      `format: yarramate/workspace/v1
+id: refs
+documents:
+  - architecture/*.yaml
+profiles: []
+projections:
+  - projections/*.yaml
+adapterMappings: []
+evidence: []
+`,
+    )
+    write('.yarramate/architecture/main.yaml', document)
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  const projection = (query: string) =>
+    `format: yarramate/projection/v1
+id: slice
+version: "1.0"
+query:
+${query}
+presentation:
+  title: Slice
+`
+
+  it('fails the check, so CI catches the typo before a client does', () => {
+    write('.yarramate/projections/slice.yaml', projection('  states:\n    - tomorow'))
+    const result = runCli(['check', '.yarramate/workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('YM921')
+    expect(result.stdout).toContain('Did you mean "tomorrow"?')
+  })
+
+  const emptyButValid =
+    '  subjects:\n    - store\n  kinds:\n    - yarramate/core@0.1#businessActor'
+
+  it('passes a projection whose names resolve but which selects nothing', () => {
+    // The legitimate empty. `store` exists and businessActor exists; the
+    // intersection is empty, and that is a real answer to a real question.
+    // Refusing it would break asking about a state nobody has populated yet.
+    write('.yarramate/projections/slice.yaml', projection(emptyButValid))
+    const result = runCli(['check', '.yarramate/workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(0)
+  })
+
+  /**
+   * The boundary the check has to respect. `docs/PROJECTIONS.md` records that
+   * selectors are portable by default so a projection can be reused across
+   * repositories and against partial models. Declaring one in the manifest is
+   * the act that says "this is ours"; handing one to a verb as a path is not.
+   */
+  it('leaves a projection the manifest does not declare portable', () => {
+    // A declared projection so the manifest glob still matches, plus the same
+    // typo in a file that lives OUTSIDE `projections/*.yaml`.
+    write('.yarramate/projections/slice.yaml', projection('  states:\n    - tomorrow'))
+    writeFileSync(
+      join(workspace, 'foreign.yaml'),
+      projection('  states:\n    - tomorow'),
+      'utf8',
+    )
+    expect(runCli(['check', '.yarramate/workspace.yaml'], workspace).exitCode).toBe(0)
+    const exported = runCli(
+      ['export', 'xlsx', 'foreign.yaml', '.yarramate/workspace.yaml', '--out', 'f.xlsx'],
+      workspace,
+    )
+    // No matches rather than an error, which is what makes a projection
+    // written for another repository usable here at all.
+    expect(exported.exitCode).toBe(0)
+  })
+
+  it('still exports that empty slice without complaint', () => {
+    write('.yarramate/projections/slice.yaml', projection(emptyButValid))
+    const result = runCli(
+      [
+        'export',
+        'xlsx',
+        '.yarramate/projections/slice.yaml',
+        '.yarramate/workspace.yaml',
+        '--out',
+        'slice.xlsx',
+      ],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+  })
+})


### PR DESCRIPTION
A projection is a document, and its `query` block holds references the same way a relationship does. YarraMate refuses a relationship pointing at a concept that does not exist. It did not refuse a query naming a state that does not exist:

```yaml
query:
  states:
    - target-stat        # target-state, mistyped
```

That selects no state, which selects no subject, which writes a clean empty artifact and exits **0**. `check` passed, because it loaded every projection against its schema and never against the model. Every export kind was affected: `graph`, `markdown`, `briefs`, `rtm`, `likec4`, `xlsx`.

Found by asking whether we refuse an empty compile the way ApertureX's own projection call had just started to. We did not.

```
.yarramate/projections/slice.yaml:6:7 error YM921 Projection query `states` names
"core-contract-foundtion", which this workspace does not have, so it can never
match. Did you mean "core-contract-foundation"?
```

## Referential, not emptiness

A query whose every name resolves and which **selects nothing** is not refused. An architecture state nobody has populated yet is empty, correctly, and asking about it is a real question with an honest answer.

The mechanism is a dangling reference, so the check is for a dangling reference. A detector shaped like the symptom (an empty file) would have refused honest queries too.

## Only the projections the manifest declares

This part took a correction mid-change. `docs/PROJECTIONS.md` already recorded a deliberate principle:

> Selectors are portable by default... absent from the current graph contributes no matches and is not a validation error. This supports partial models and reuse across repositories.

A blanket referential check reverses that, and reversing a recorded decision by accident is worse than the defect it fixes. They hold together because they are about **different documents**: a projection in the workspace manifest is this repository's own document and is checked against this repository's model; one handed to `ask` or `export` as a path stays portable and degrades to no matches. `check` iterates the manifest list, so the implementation lands on that line by construction. A test holds the boundary.

## What is checked

| Facet | Namespace |
|---|---|
| `subjects`, `exclude`, `owners`, `constraints` | subject ids |
| `documents` | the same provenance the `documents` facet filters on |
| `states` | the same `yarramate/state/type` scan `conceptSelector` runs |
| `kinds`, `relationshipKinds`, `layers` | profile context, **only when a profile is loaded** |
| `statuses`, `excludeStatuses` | not checked; schema enums, refused upstream |

`owners` and `constraints` look like free text and are **refs to concepts**, which the compiler proved by refusing my own fixture with `YM304 Unresolved owner reference`. They resolve against the subject list rather than against owners in use, because a team that owns nothing yet is a real concept.

A kind whose profile is not loaded stays dormant rather than wrong, the same distinction #351 drew for question catalogues. The suggestion reuses `similarity` from near-duplicate detection rather than adding a second string-distance function.

## The mutations found a defect in the tests

Running "refuse any empty result" as a mutation left the two **headline** cases green. The fixtures were not actually empty: a subject with no `presentIn` participates in every state, so `platform-team` survived both queries. The tests passed without ever reaching the branch they existed to protect. The fixtures now assert emptiness before asserting the check is silent about it.

With that corrected, five mutations turn the intended tests red: never matching, checking owners against owners-in-use, dropping the dormant-profile guard, disabling suggestions, and refusing empty results.

## Verification

`pnpm run verify` from a wiped `dist` and `.yarramate-out`: exit 0, 1857 passed, 1 skipped, 104 files. Both typecheck configs clean. The self-model's own **22 projections pass unchanged**, so no false positives on a real 269-concept model; typing one selector wrong makes `check` exit 1 with the right suggestion.

ADR 0128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)