### PR TITLE
A workspace carries its own questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- **Added.** A workspace can carry its own questions (#345, ADR 0129). A
+  `questions:` manifest category resolves like `patterns` and `evidence`, and
+  is **additive** to the shipped catalogue, so a consultant can author a
+  question mid-engagement with no product release. `--catalogue` and
+  `MountOptions.catalogue` are unchanged: they replace the base.
+
+  **A wave is declared exactly once across the resolved set**, and any
+  catalogue may contribute questions to a wave it did not declare. That one
+  rule settles wave identity and ordering, and removes the `opensWhen`
+  precedence question ADR 0125 raised rather than answering it: there is only
+  ever one declarer. A second declaration is refused with **YM915**.
+
+  **Question ids are now qualified as `catalogue#question`.** Authors keep
+  writing local ids; the engine qualifies when it composes, and every CLI verb
+  composes even when only the shipped catalogue is in play. Two catalogues may
+  carry the same local id and remain two distinct questions.
+
+  **No version in the identity.** `core-enrichment` went 1.0 to 1.3 in a single
+  day renaming nothing, and a versioned identity would have stranded every
+  stored dismissal in every adopter's database three times that day. Versioned
+  identity is safe for things that are authored and unsafe for things that are
+  stored. Versions live in the report instead: `catalogue` keeps naming the
+  base with its existing value shape, and a new **optional** `catalogues` array
+  lists every contributor.
+
+- **Changed.** A consumer matching on question ids in an interrogation report,
+  a design step, or a host-supplied dismissal migrates once: `outcome-missing`
+  becomes `core-enrichment#outcome-missing`. A value change rather than a new
+  required field, so nothing that constructs these documents breaks.
+
+- **Fixed.** `check` now validates the question catalogues a workspace
+  declares, composed, so a broken one is refused and the cross-catalogue rules
+  are enforced where CI sees them.
+
 - **Added.** `check` resolves the references in a projection query (ADR 0128,
   YM921). A query naming a state, subject, document, kind, owner or constraint
   the workspace does not have is refused, and the diagnostic suggests the near

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   precedence question ADR 0125 raised rather than answering it: there is only
   ever one declarer. A second declaration is refused with **YM915**.
 
+  `waves` may now be **empty**. A catalogue that only contributes questions to
+  waves another declared is the ordinary shape of a project catalogue, and
+  `minItems: 1` forced it to declare a wave it did not want, which a second
+  such catalogue would then collide with.
+
   **Question ids are now qualified as `catalogue#question`.** Authors keep
   writing local ids; the engine qualifies when it composes, and every CLI verb
   composes even when only the shipped catalogue is in play. Two catalogues may

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -130,11 +130,16 @@ waves:
 ```
 
 ```yaml
-# the project catalogue just joins it
+# the project catalogue just joins it, declaring no wave of its own
+waves: []
 questions:
   - id: regulator-signoff
     wave: assurance
 ```
+
+`waves: []` is legal, and is the ordinary shape of a project catalogue. A
+catalogue evaluated ALONE with no waves and a question naming one is still
+YM911, correctly: nothing declares it.
 
 Declaring the same wave twice is refused (**YM915**). Only a declaration places
 a wave in the interview order, so the base's order is untouched and new waves

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -97,6 +97,70 @@ Catalogues are ordinary versioned data: extend the shipped one under a new
 identity or write one per organisation, then pass it with `--catalogue`.
 Composition via `extends` is deferred from v1 (ADR 0053).
 
+## A workspace can carry its own questions
+
+A consultancy has a domain catalogue: the questions it asks on every
+engagement. An individual engagement raises questions true of that client and
+nowhere else, discovered mid-engagement rather than at product-design time.
+Those live in the workspace (#345, ADR 0129):
+
+```yaml
+format: yarramate/workspace/v1
+id: icwa-web
+documents: ['documents/**/*.yaml']
+questions: ['questions/*.yaml']
+```
+
+**Additive.** `questions:` adds to the shipped catalogue; `--catalogue`
+replaces the base. Different powers on purpose: a host controls the catalogue
+that is not in the workspace, and a consultant adds to it without a release.
+
+**A wave is declared exactly once across the resolved set**, and any catalogue
+may contribute questions to a wave it did not declare. So a project catalogue
+adds "one more Assurance question for this client" by naming the wave, without
+redeclaring it:
+
+```yaml
+# the domain catalogue declares the wave, with its gate
+waves:
+  - id: assurance
+    name: Assurance
+    opensWhen:
+      - condition: has-any-subject
+```
+
+```yaml
+# the project catalogue just joins it
+questions:
+  - id: regulator-signoff
+    wave: assurance
+```
+
+Declaring the same wave twice is refused (**YM915**). Only a declaration places
+a wave in the interview order, so the base's order is untouched and new waves
+append. And because there is exactly one declarer, there is never a question
+about whose `opensWhen` governs.
+
+**Question ids are qualified as `catalogue#question` in the report.** Authors
+write local ids, and the engine qualifies when it composes. Two catalogues may
+carry the same local id and stay two distinct questions, so composition needs
+no collision rule.
+
+**The identity carries no version**, deliberately. A catalogue version bump
+must not strand a judgment someone stored against a question:
+`core-enrichment` had three version bumps in a single day, renaming nothing.
+Versioned identity is safe for things that are **authored**, because a document
+keeps naming the version it was written against and an author updates it
+deliberately; it is unsafe for things that are **stored**, because a row in a
+database has no author to update it. Versions live beside the identity instead:
+the report's `catalogue` names the base, and an optional `catalogues` array
+lists every contributor with its version.
+
+Qualification happens when catalogues COMPOSE, not when they evaluate. Every
+CLI verb composes even with one catalogue, so ids are qualified from the start
+and do not change when a workspace first carries a question of its own. A host
+calling `evaluateCatalogue` directly should compose first for the same reason.
+
 ## Waves open when the model has substance
 
 A wave may declare `opensWhen`, conditions that must all hold before it opens

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -16,11 +16,19 @@ adapterMappings:
   - adapters/*.mapping.yaml
 patterns:
   - patterns/*.yaml
+questions:
+  - questions/*.yaml
 evidence:
   - evidence/*.yaml
 contracts:
   - contracts/*.yaml
 ```
+
+`questions` carries question catalogues the workspace itself declares, ADDITIVE
+to the shipped catalogue (#345, ADR 0129). It is how a question true of one
+engagement and nowhere else gets versioned with the model, reviewed as a diff,
+and asked by the same interview loop as everything else. See
+[docs/INTERROGATION.md](INTERROGATION.md).
 
 Patterns are relative to the directory containing the manifest and use
 forward-slash paths. Resolution:

--- a/docs/adr/0129-catalogues-compose-as-a-resolved-set-and-a-question-id-carries-its-origin.md
+++ b/docs/adr/0129-catalogues-compose-as-a-resolved-set-and-a-question-id-carries-its-origin.md
@@ -104,6 +104,20 @@ version. Optional and additive is safe for readers, which ignore it, and does
 not force constructors, which is the break that hit a consumer's production
 code this month.
 
+## Found while building it
+
+**Qualification is a property of composition, not of evaluation.** A caller
+handing `evaluateCatalogue` a catalogue directly still gets local ids, exactly
+as before. Only `composeCatalogues` qualifies.
+
+That is deliberate — it leaves every existing direct caller untouched — but it
+means the guidance matters: **compose even when there is only one catalogue**,
+which is what every CLI verb now does. Then ids are qualified from the start
+and do not change later when a workspace first carries a question of its own.
+An adopter that evaluated directly, keyed stored judgments on local ids and
+then adopted composition would experience exactly the mass-orphan transition
+this design exists to prevent, one file at a time.
+
 ## Consequences
 
 **One migration, and it is a value change rather than a required-field

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -24,6 +24,15 @@
       "type": "string",
       "minLength": 1
     },
+    "catalogues": {
+      "description": "Every catalogue that contributed, as id@version, base first (#345, ADR 0129). Present only when more than one did. OPTIONAL, and `catalogue` keeps naming the base with its existing value shape, because turning that field into an array would break every reader: an optional additive field is free for readers and does not force constructors. Question ids in this report are qualified as catalogue#question and carry NO version, so a catalogue version bump strands no stored judgment keyed on them; the versions live here instead.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "semantics": {
       "type": "string",
       "minLength": 1,

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -44,9 +44,9 @@
       }
     },
     "waves": {
-      "description": "Ordered interview phases. Array order is interview order. The wave taxonomy is catalogue opinion, not engine semantics.",
+      "description": "Ordered interview phases. Array order is interview order. The wave taxonomy is catalogue opinion, not engine semantics. MAY BE EMPTY (#345, ADR 0129): a catalogue that only contributes questions to waves ANOTHER catalogue declared is the ordinary shape of a project catalogue, and requiring a wave here would force it to declare one it does not want - which is refused as a duplicate the moment two catalogues do it. Evaluated alone, a catalogue with no waves and a question naming one is YM911, correctly: nothing declares it.",
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -112,7 +112,6 @@
       "description": "Which subjects a subject-scope question applies to. Field vocabulary mirrors the projection query selector (ADR 0017).",
       "type": "object",
       "additionalProperties": false,
-      
       "properties": {
         "kinds": {
           "type": "array",

--- a/schema/yarramate-workspace.schema.json
+++ b/schema/yarramate-workspace.schema.json
@@ -32,6 +32,10 @@
       "description": "yarramate/pattern/v1 documents: the shape a concept kind promises, and the wiring the compiler mints between an instance and the parts it binds (ADR 0123). Structure, where profiles declare vocabulary. Optional, like evidence and contracts.",
       "$ref": "#/$defs/patterns"
     },
+    "questions": {
+      "description": "yarramate/question-catalogue/v1 documents the WORKSPACE carries: questions true of this engagement and nowhere else (#345, ADR 0129). ADDITIVE to the shipped catalogue rather than replacing it, which is what --catalogue and MountOptions.catalogue do. Question ids are qualified as catalogue#question on the way out, so two catalogues may carry the same local id. A wave is declared exactly once across the resolved set, and any catalogue may contribute questions to a wave it did not declare. Optional, like patterns, evidence and contracts.",
+      "$ref": "#/$defs/patterns"
+    },
     "adapterMappings": {
       "$ref": "#/$defs/patterns"
     },

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -241,6 +241,29 @@ const shippedCatalogue = ((): { path: string; source: string } | undefined => {
   }
 })();
 
+/**
+ * The shipped catalogue plus the ones the workspace carries (#345, ADR 0129).
+ *
+ * A catalogue that cannot be read is SKIPPED rather than failing the session,
+ * which is what the shipped one already did: an interrogation overlay is a
+ * garnish on a model, and losing a session over it would be worse than losing
+ * the questions. `check` is where a broken catalogue is refused.
+ */
+const catalogueSetFor = (
+  workspace: ResolvedWorkspace,
+): readonly { path: string; source: string }[] => {
+  if (shippedCatalogue === undefined) return [];
+  const carried: { path: string; source: string }[] = [];
+  for (const path of workspace.questions ?? []) {
+    try {
+      carried.push({ path, source: readFileSync(path, "utf8") });
+    } catch {
+      // Skipped, as above.
+    }
+  }
+  return [shippedCatalogue, ...carried];
+};
+
 export type VisualEventDelivery =
   | {
       readonly waiting: false;
@@ -926,7 +949,11 @@ export const startVisualServer = async (
         // that. A staged view operation pins against these (ADR 0103), and a
         // projection missing from the map is one the commit will create.
         projectionDigests: projectionDigestsNow(),
-      }, shippedCatalogue);
+        // The shipped catalogue plus whatever this workspace carries (#345),
+        // so the pane asks the interview `design` asks over the same files.
+        // Read on each recompile rather than once per process, because a
+        // consultant authoring a question mid-session is the whole point.
+      }, catalogueSetFor(resolvedWorkspace));
       // Closures below retain this array, so refresh its contents without
       // replacing the identity the session started with.
       views.splice(0, views.length, ...workspaceModel.views);

--- a/src/adapters/visual/workspace-model.ts
+++ b/src/adapters/visual/workspace-model.ts
@@ -24,7 +24,7 @@ import type {
 import { kindLabelOf } from "../../kind-label.js";
 import {
   evaluateCatalogue,
-  loadQuestionCatalogue,
+  composeCatalogues,
 } from "../../interrogate-command.js";
 import type { VisualKindOption, VisualViewSummary } from "./protocol-contract.js";
 import type {
@@ -104,7 +104,15 @@ export const interrogationOverlayOf = (
     readonly graph: SemanticGraph;
     readonly profileContext: ResolvedProfileContext;
   },
-  catalogue: { readonly path: string; readonly source: string },
+  /**
+   * The catalogue, or the composed SET a workspace carries (#345, ADR 0129).
+   * A set rather than one document so the pane asks the same interview the
+   * CLI does over the same workspace: an editor showing fewer questions than
+   * `design` does over the same files is a disagreement with no symptom.
+   */
+  catalogue:
+    | { readonly path: string; readonly source: string }
+    | readonly { readonly path: string; readonly source: string }[],
   /**
    * What the host has already dealt with (#328). Evaluation is unchanged and
    * the model is untouched: this decides only what the pane draws, because a
@@ -113,12 +121,16 @@ export const interrogationOverlayOf = (
    */
   dismissed: readonly DismissedQuestion[] = [],
 ): VisualInterrogationOverlay | undefined => {
-  const loaded = loadQuestionCatalogue(catalogue);
-  if (!loaded.ok) return undefined;
+  const composed = composeCatalogues(
+    Array.isArray(catalogue) ? catalogue : [catalogue as { path: string; source: string }],
+  );
+  if (!composed.ok) return undefined;
   const report = evaluateCatalogue(
-    loaded.catalogue,
+    composed.composed.catalogue,
     compiled.graph,
     compiled.profileContext,
+    undefined,
+    composed.composed.catalogues,
   );
   const dismissedEverywhere = new Set(
     dismissed
@@ -180,7 +192,9 @@ export const renderedWorkspaceOf = (
   },
   views: readonly VisualViewSummary[],
   metadata: Omit<VisualRenderedModel, "graph" | "vocabulary" | "interrogation">,
-  catalogue?: { readonly path: string; readonly source: string },
+  catalogue?:
+    | { readonly path: string; readonly source: string }
+    | readonly { readonly path: string; readonly source: string }[],
   dismissed?: readonly DismissedQuestion[],
 ): {
   readonly model: VisualRenderedModel;

--- a/src/ask-command.ts
+++ b/src/ask-command.ts
@@ -28,9 +28,10 @@ import {
   type EvidenceObservation,
   type EvidenceResult,
 } from './evidence.js'
+import { catalogueSources } from './catalogue-sources.js'
 import {
   evaluateCatalogue,
-  loadQuestionCatalogue,
+  composeCatalogues,
   renderInterrogationReport,
   type InterrogationReport,
 } from './interrogate-command.js'
@@ -812,19 +813,24 @@ export function runAskCommand(
       const current = entries.filter(({ status }) => status === 'current')
       const retired = entries.filter(({ status }) => status === 'retired')
 
-      const loadedCatalogue = loadQuestionCatalogue(
-        {
-          path: shippedCataloguePath,
-          source: readFileSync(shippedCataloguePath, 'utf8'),
-        },
+      const composed = composeCatalogues(
+        catalogueSources(
+          {
+            path: shippedCataloguePath,
+            source: readFileSync(shippedCataloguePath, 'utf8'),
+          },
+          workspace,
+          cwd,
+        ),
         compilation.profileContext,
       )
-      if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+      if (!composed.ok) return failed(composed.diagnostics)
       const report = evaluateCatalogue(
-        loadedCatalogue.catalogue,
+        composed.composed.catalogue,
         compilation.graph,
         compilation.profileContext,
         evidenceDocuments.flatMap(({ observations }) => observations),
+        composed.composed.catalogues,
       )
 
       const result: AskResult = {
@@ -1110,14 +1116,18 @@ export function runAskCommand(
         cataloguePath === undefined
           ? shippedCataloguePath
           : resolve(cwd, cataloguePath)
-      const loadedCatalogue = loadQuestionCatalogue(
-        {
-          path: cataloguePath ?? resolvedCataloguePath,
-          source: readFileSync(resolvedCataloguePath, 'utf8'),
-        },
+      const composed = composeCatalogues(
+        catalogueSources(
+          {
+            path: cataloguePath ?? resolvedCataloguePath,
+            source: readFileSync(resolvedCataloguePath, 'utf8'),
+          },
+          workspace,
+          cwd,
+        ),
         compilation.profileContext,
       )
-      if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+      if (!composed.ok) return failed(composed.diagnostics)
       // The evidence overlay rides along for the one condition that
       // reads it (unchallenged-evidence); a workspace declaring no
       // evidence passes an overlay known to be empty.
@@ -1132,17 +1142,26 @@ export function runAskCommand(
       }
       const report: InterrogationReport = {
         ...evaluateCatalogue(
-          loadedCatalogue.catalogue,
+          composed.composed.catalogue,
           graph,
           compilation.profileContext,
           evidenceObservations,
+          composed.composed.catalogues,
         ),
         workspace: workspace.id,
       }
+      // Field by field, to fix key ORDER in the emitted JSON. Every optional
+      // field has to be threaded through explicitly, which is why `catalogues`
+      // is here: a copier like this drops a new field silently and the only
+      // symptom is an absent one, which reads as "did not apply" rather than
+      // as "was lost".
       const ordered: InterrogationReport = {
         format: report.format,
         workspace: report.workspace,
         catalogue: report.catalogue,
+        ...(report.catalogues === undefined
+          ? {}
+          : { catalogues: report.catalogues }),
         semantics: report.semantics,
         summary: report.summary,
         waves: report.waves,
@@ -1487,14 +1506,18 @@ export function runAskCommand(
       cataloguePath === undefined
         ? shippedCataloguePath
         : resolve(cwd, cataloguePath)
-    const loadedCatalogue = loadQuestionCatalogue(
-      {
-        path: cataloguePath ?? resolvedCataloguePath,
-        source: readFileSync(resolvedCataloguePath, 'utf8'),
-      },
+    const composed = composeCatalogues(
+      catalogueSources(
+        {
+          path: cataloguePath ?? resolvedCataloguePath,
+          source: readFileSync(resolvedCataloguePath, 'utf8'),
+        },
+        workspace,
+        cwd,
+      ),
       compilation.profileContext,
     )
-    if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+    if (!composed.ok) return failed(composed.diagnostics)
     // Loaded ahead of evaluation so the overlay feeds the one condition
     // that reads it (unchallenged-evidence), then reused for the
     // reconciliation summary below.
@@ -1508,10 +1531,11 @@ export function runAskCommand(
       evidenceDocuments.push(loaded.evidence)
     }
     const report = evaluateCatalogue(
-      loadedCatalogue.catalogue,
+      composed.composed.catalogue,
       graph,
       compilation.profileContext,
       evidenceDocuments.flatMap(({ observations }) => observations),
+      composed.composed.catalogues,
     )
     const openQuestions: OpenQuestionRef[] = []
     for (const wave of report.waves) {

--- a/src/catalogue-sources.ts
+++ b/src/catalogue-sources.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { WorkspaceSource } from './compiler.js'
+import type { ResolvedWorkspace } from './workspace.js'
+
+// The catalogue ships inside the package, versioned with it, and harnesses
+// never pass catalogue paths. The relative hop works from both src/ (dev) and
+// dist/ (shipped). Defined ONCE: `design`, `ask` and `check` all need it, and
+// three copies of a path constant is three chances for them to disagree about
+// which catalogue is the base.
+const here = dirname(fileURLToPath(import.meta.url))
+
+export const shippedCataloguePath = join(
+  here,
+  '..',
+  'catalogues',
+  'core-enrichment.yaml',
+)
+
+/** The base catalogue as a source, read from disk. */
+export const shippedCatalogueSource = (): WorkspaceSource => ({
+  path: shippedCataloguePath,
+  source: readFileSync(shippedCataloguePath, 'utf8'),
+})
+
+/**
+ * The catalogues a verb should compose: the base, then whatever the workspace
+ * carries (#345, ADR 0129).
+ *
+ * Built in ONE place because every verb that interviews has to make the same
+ * choice, and a verb that forgot the workspace half would silently ask fewer
+ * questions than the workspace declares - a failure with no symptom, which is
+ * the shape this repository keeps being bitten by.
+ *
+ * The base is REPLACED by `--catalogue` and ADDED TO by `questions:`. Those
+ * are different powers on purpose: a host controls the catalogue that is not
+ * in the workspace (#328), and a consultant adds to it mid-engagement without
+ * a product release.
+ */
+export const catalogueSources = (
+  base: WorkspaceSource,
+  workspace: Pick<ResolvedWorkspace, 'questions'>,
+  cwd: string,
+): readonly WorkspaceSource[] => [
+  base,
+  // `?? []` because `questions` is optional on the published type: adding a
+  // required field to `ResolvedWorkspace` broke a consumer's production module
+  // once already.
+  ...(workspace.questions ?? []).map((path) => ({
+    path,
+    source: readFileSync(resolve(cwd, path), 'utf8'),
+  })),
+]

--- a/src/check-command.ts
+++ b/src/check-command.ts
@@ -1,4 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs'
+import {
+  catalogueSources,
+  shippedCatalogueSource,
+} from './catalogue-sources.js'
+import { composeCatalogues } from './interrogate-command.js'
 import { resolve } from 'node:path'
 import Ajv2020Module from 'ajv/dist/2020.js'
 import { parseDocument } from 'yaml'
@@ -292,6 +297,24 @@ export function runCheckCommand(
       evidenceEvaluation === undefined || evidenceEvaluation.ok
         ? []
         : evidenceEvaluation.diagnostics
+    // A catalogue the manifest declares is workspace content, so `check`
+    // refuses a broken one (#345, ADR 0129). Composed rather than checked one
+    // by one, because the refusals that matter are CROSS-catalogue: a wave
+    // declared twice, and a question naming a wave nothing in the set
+    // declares. Checking each file alone would miss both and would refuse the
+    // one thing the feature exists to allow, a question joining a wave another
+    // catalogue declared.
+    const catalogueDiagnostics =
+      result.ok && resolved.questions.length > 0
+        ? (() => {
+            const composed = composeCatalogues(
+              catalogueSources(shippedCatalogueSource(), resolved, cwd),
+              result.profileContext,
+            )
+            return composed.ok ? [] : composed.diagnostics
+          })()
+        : []
+
     // A projection is a document, and a query holds references the same way a
     // relationship does. Checked HERE rather than with the projection's own
     // schema load above, because a reference can only be resolved against a
@@ -313,6 +336,7 @@ export function runCheckCommand(
       ...mappingDiagnostics,
       ...evidenceDiagnostics,
       ...referenceDiagnostics,
+      ...catalogueDiagnostics,
     ])
     const ok = result.ok && optionalDiagnostics.length === 0
     // Published results name the subject a diagnostic is about wherever its

--- a/src/cli-support.ts
+++ b/src/cli-support.ts
@@ -116,6 +116,13 @@ export const resolveCliWorkspaceSources = (
       readonly contracts: readonly string[]
       /** Pattern documents, which ride in `paths` and are not documents. */
       readonly patterns: readonly string[]
+      /**
+       * Question catalogues the workspace carries (#345). Handed over rather
+       * than resolved-and-dropped, which is the #268 failure recorded below:
+       * a category a manifest declares and no verb receives is ignored with
+       * no symptom.
+       */
+      readonly questions: readonly string[]
     }
   | {
       readonly ok: false
@@ -129,6 +136,7 @@ export const resolveCliWorkspaceSources = (
       evidence: [],
       contracts: [],
       patterns: [],
+      questions: [],
     }
   }
   const manifestPath = paths[0]
@@ -140,6 +148,7 @@ export const resolveCliWorkspaceSources = (
       evidence: [],
       contracts: [],
       patterns: [],
+      questions: [],
     }
   }
   const source = readFileSync(resolve(cwd, manifestPath), 'utf8')
@@ -153,6 +162,7 @@ export const resolveCliWorkspaceSources = (
       evidence: [],
       contracts: [],
       patterns: [],
+      questions: [],
     }
   }
   const loaded = loadWorkspaceManifest(
@@ -182,6 +192,7 @@ export const resolveCliWorkspaceSources = (
         evidence: loaded.workspace.evidence,
         contracts: loaded.workspace.contracts,
         patterns: loaded.workspace.patterns,
+        questions: loaded.workspace.questions ?? [],
       }
     : { ok: false, diagnostics: loaded.diagnostics }
 }

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -14,8 +14,8 @@ import {
 } from './compiler.js'
 import { loadEvidence, type EvidenceObservation } from './evidence.js'
 import {
+  composeCatalogues,
   evaluateCatalogue,
-  loadQuestionCatalogue,
   renderQuestion,
   type CatalogueCondition,
   type InterrogationReport,
@@ -289,14 +289,25 @@ export function runDesignCommand(
     )
     if (!compilation.ok) return failed(compilation.diagnostics)
 
-    const loadedCatalogue = loadQuestionCatalogue(
-      {
-        path: cataloguePath ?? resolvedCataloguePath,
-        source: readFileSync(resolvedCataloguePath, 'utf8'),
-      },
+    // The base, then whatever the workspace carries (#345, ADR 0129). The
+    // base is REPLACED by `--catalogue` and ADDED TO by `questions:`, which is
+    // what lets a consultant author a question mid-engagement with no product
+    // release while a host still controls the catalogue that is not in the
+    // workspace.
+    const composed = composeCatalogues(
+      [
+        {
+          path: cataloguePath ?? resolvedCataloguePath,
+          source: readFileSync(resolvedCataloguePath, 'utf8'),
+        },
+        ...(workspace.questions ?? []).map((path) => ({
+          path,
+          source: readFileSync(resolve(cwd, path), 'utf8'),
+        })),
+      ],
       compilation.profileContext,
     )
-    if (!loadedCatalogue.ok) return failed(loadedCatalogue.diagnostics)
+    if (!composed.ok) return failed(composed.diagnostics)
 
     // The evidence overlay rides along for the one condition that reads
     // it (unchallenged-evidence). A workspace declaring no evidence
@@ -324,13 +335,15 @@ export function runDesignCommand(
     }
 
     const report = evaluateCatalogue(
-      loadedCatalogue.catalogue,
+      composed.composed.catalogue,
       compilation.graph,
       compilation.profileContext,
       evidenceObservations,
+      composed.composed.catalogues,
     )
+    // Keyed by the QUALIFIED id, matching what the report now carries.
     const askPlainById = new Map(
-      loadedCatalogue.catalogue.questions.flatMap((question) =>
+      composed.composed.catalogue.questions.flatMap((question) =>
         question.askPlain === undefined
           ? []
           : [[question.id, question.askPlain] as const],

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,8 @@ export {
 } from './deletion-drafting.js'
 export {
   INTERROGATION_SEMANTICS_VERSION,
+  composeCatalogues,
+  qualifiedQuestionId,
   evaluateCatalogue,
   loadQuestionCatalogue,
   renderInterrogationReport,

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -221,7 +221,14 @@ export interface InterrogationSummary {
 export interface InterrogationReport {
   readonly format: 'yarramate/interrogation-report/v1'
   readonly workspace: string
+  /** The BASE catalogue, `id@version`. Unchanged in shape by composition. */
   readonly catalogue: string
+  /**
+   * Every contributing catalogue as `id@version`, base first, when more than
+   * one contributed (#345, ADR 0129). Optional so that adding it breaks no
+   * constructor, and `catalogue` keeps its value shape so it breaks no reader.
+   */
+  readonly catalogues?: readonly string[]
   /** {@link INTERROGATION_SEMANTICS_VERSION} at the time of evaluation. */
   readonly semantics: string
   readonly summary: InterrogationSummary
@@ -822,6 +829,14 @@ export function evaluateCatalogue(
   graph: SemanticGraph,
   profileContext?: ResolvedProfileContext,
   evidence?: readonly CatalogueEvidenceObservation[],
+  /**
+   * Contributing catalogues, from {@link composeCatalogues}. Composition
+   * happens BEFORE evaluation and hands this function an ordinary catalogue,
+   * so the only thing evaluation learns about composition is what to name in
+   * the report. A fifth optional parameter rather than an options object,
+   * because this signature is published and a consumer already calls it.
+   */
+  catalogues?: readonly string[],
 ): Omit<InterrogationReport, 'workspace'> {
   const index = indexGraph(graph)
   let open = 0
@@ -903,6 +918,11 @@ export function evaluateCatalogue(
   return {
     format: 'yarramate/interrogation-report/v1',
     catalogue: `${catalogue.id}@${catalogue.version}`,
+    // Only when composition actually happened. A single-catalogue report is
+    // byte-identical to what it was before this existed.
+    ...(catalogues === undefined || catalogues.length < 2
+      ? {}
+      : { catalogues }),
     semantics: INTERROGATION_SEMANTICS_VERSION,
     summary: {
       // Questions in OPENED waves only (#334, ADR 0125). A closed wave's
@@ -1021,71 +1041,274 @@ const unresolvableKinds = (
   })
 }
 
+/** A catalogue parsed and located, before any cross-catalogue check. */
+interface LoadedCatalogueDocument {
+  readonly source: WorkspaceSource
+  readonly catalogue: QuestionCatalogue
+  readonly locate: (
+    path: readonly (string | number)[],
+  ) => Pick<Diagnostic, 'path' | 'pointer' | 'line' | 'column'>
+}
+
+type CatalogueDocumentResult =
+  | { readonly ok: true; readonly document: LoadedCatalogueDocument }
+  | { readonly ok: false; readonly diagnostics: readonly Diagnostic[] }
+
+const loadCatalogueDocument = (
+  catalogueSource: WorkspaceSource,
+): CatalogueDocumentResult => {
+  const loaded = loadSourceDocument<QuestionCatalogue>(
+    catalogueSource,
+    validateCatalogue,
+    'Question catalogue',
+  )
+  if (!loaded.ok) return { ok: false, diagnostics: loaded.diagnostics }
+  return {
+    ok: true,
+    document: {
+      source: catalogueSource,
+      catalogue: loaded.document.value,
+      locate: (path) =>
+        locateSourcePath(
+          catalogueSource.path,
+          loaded.document.yaml,
+          loaded.document.lineCounter,
+          path,
+          `/${path.join('/')}`,
+        ),
+    },
+  }
+}
+
+/**
+ * The YM911 undeclared-wave check, against a set of wave ids that may be
+ * WIDER than the catalogue's own.
+ *
+ * That width is the whole of #345. A project catalogue's reason to exist is
+ * adding "one more Assurance question for this client" to a wave the domain
+ * catalogue declared, so checking each file against only its own waves would
+ * refuse precisely the case the feature enables. Composed, the set is the
+ * union; alone, it is the catalogue's own and the check is what it always was.
+ */
+const undeclaredWaveDiagnostics = (
+  { catalogue, locate }: LoadedCatalogueDocument,
+  declaredWaves: ReadonlySet<string>,
+): readonly Diagnostic[] =>
+  catalogue.questions.flatMap((question, questionIndex) =>
+    declaredWaves.has(question.wave)
+      ? []
+      : [
+          {
+            severity: 'error' as const,
+            code: 'YM911',
+            message: `Question "${question.id}" references undeclared wave "${question.wave}"`,
+            ...locate(['questions', questionIndex, 'wave']),
+          },
+        ],
+  )
+
+const unresolvableKindDiagnostics = (
+  { catalogue, locate }: LoadedCatalogueDocument,
+  profileContext?: ResolvedProfileContext,
+): readonly Diagnostic[] =>
+  // Only when a caller has a compiled workspace to check against. Without one
+  // there is no way to tell a typo from a kind whose profile simply is not
+  // here, and guessing would be the false positive this check exists to avoid.
+  profileContext === undefined
+    ? []
+    : unresolvableKinds(catalogue, profileContext).map((reference) => ({
+        severity: 'error' as const,
+        code: 'YM914',
+        message: `Kind "${reference.kind}" is not declared by profile "${reference.kind.slice(
+          0,
+          reference.kind.indexOf('#'),
+        )}", which this workspace loads, so the question can never fire`,
+        ...locate(reference.path),
+      }))
+
+/**
+ * A catalogue is qualified on the way OUT, never in what an author writes.
+ *
+ * The authored schema keeps ids local (`^[a-z][a-z0-9-]*$`) and that does not
+ * change; a consultant writes `regulator-signoff`, not
+ * `consulting#regulator-signoff`. The engine qualifies when it composes, which
+ * is the only moment two catalogues can be confused for each other.
+ *
+ * NO VERSION, and that is the decision rather than an omission (ADR 0129).
+ * `core-enrichment` went 1.0 to 1.3 in a single day renaming nothing; a
+ * versioned identity would have stranded every stored dismissal in every
+ * adopter's database three times that day, for changes that removed no
+ * question. Versioned identity is safe for things that are AUTHORED - a
+ * document keeps naming the version it was written against and an author
+ * updates it deliberately - and unsafe for things that are STORED, because a
+ * row in someone's database has no author to update it.
+ */
+export const qualifiedQuestionId = (
+  catalogueId: string,
+  questionId: string,
+): string => `${catalogueId}#${questionId}`
+
+export interface ComposedCatalogue {
+  /**
+   * The composed catalogue, ready for `evaluateCatalogue`. Structurally a
+   * `QuestionCatalogue`, but its question ids are QUALIFIED, so it is a
+   * composition result rather than something an author could have written and
+   * must never be validated against the authored schema again.
+   */
+  readonly catalogue: QuestionCatalogue
+  /** Every contributing catalogue as `id@version`, base first. */
+  readonly catalogues: readonly string[]
+}
+
+export type CatalogueCompositionResult =
+  | { readonly ok: true; readonly composed: ComposedCatalogue }
+  | { readonly ok: false; readonly diagnostics: readonly Diagnostic[] }
+
+/**
+ * Compose a base catalogue with the ones a workspace carries (#345, ADR 0129).
+ *
+ * ADDITIVE. `--catalogue` and `MountOptions.catalogue` replace the base; this
+ * adds to it, which is what lets a consultant author a question at any point
+ * in an engagement with no product release.
+ *
+ * A WAVE IS DECLARED EXACTLY ONCE across the resolved set, and any catalogue
+ * may contribute questions to a wave it did not declare. That one rule settles
+ * three questions composition would otherwise raise. Wave identity: a project
+ * catalogue joins a declared wave rather than colliding with it. Ordering:
+ * only a declaration places a wave, so the base's order is untouched and new
+ * waves append. And the `opensWhen` precedence ADR 0125 made load-bearing does
+ * not arise at all, because there is only ever one declarer to ask.
+ *
+ * QUALIFICATION IS A PROPERTY OF COMPOSITION, NOT OF EVALUATION. A caller
+ * that hands `evaluateCatalogue` a catalogue directly still gets local ids,
+ * exactly as before this existed. Route through here even for ONE catalogue -
+ * which is what every CLI verb does - and ids are qualified from the start, so
+ * they do not change later when a workspace first carries a question of its
+ * own. That transition is the one thing an adopter keying stored judgments on
+ * a question id must not experience, and composing unconditionally is how it
+ * is avoided.
+ *
+ * ID COLLISIONS DISSOLVE rather than being resolved. Two catalogues may both
+ * carry `outcome-missing`; qualified, they are two different questions. There
+ * is no merge rule, no last-wins and no refusal, because there is nothing to
+ * merge.
+ */
+export function composeCatalogues(
+  sources: readonly WorkspaceSource[],
+  profileContext?: ResolvedProfileContext,
+): CatalogueCompositionResult {
+  const documents: LoadedCatalogueDocument[] = []
+  const loadDiagnostics: Diagnostic[] = []
+  for (const source of sources) {
+    const loaded = loadCatalogueDocument(source)
+    if (loaded.ok) documents.push(loaded.document)
+    else loadDiagnostics.push(...loaded.diagnostics)
+  }
+  if (loadDiagnostics.length > 0) {
+    return { ok: false, diagnostics: loadDiagnostics }
+  }
+  const base = documents[0]
+  if (base === undefined) {
+    // Never reached through the CLI, which always has the shipped catalogue,
+    // but an empty set must not compose into an empty catalogue that reports
+    // a finished interview.
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          severity: 'error',
+          code: 'YM915',
+          message: 'No question catalogue to compose',
+          path: '',
+          pointer: '',
+          line: 1,
+          column: 1,
+        },
+      ],
+    }
+  }
+
+  // Declared exactly once. A second declaration is refused rather than merged,
+  // because the two carry independent `opensWhen` gates and silently picking
+  // one would decide when a wave opens by file order.
+  const declaredBy = new Map<string, LoadedCatalogueDocument>()
+  const duplicates: Diagnostic[] = []
+  for (const document of documents) {
+    document.catalogue.waves.forEach((wave, waveIndex) => {
+      const first = declaredBy.get(wave.id)
+      if (first === undefined) {
+        declaredBy.set(wave.id, document)
+        return
+      }
+      duplicates.push({
+        severity: 'error',
+        code: 'YM915',
+        message:
+          `Wave "${wave.id}" is already declared by catalogue "${first.catalogue.id}" ` +
+          `(${first.source.path}). A wave is declared once and contributed to freely: ` +
+          'drop the declaration here and questions in this catalogue will join it.',
+        ...document.locate(['waves', waveIndex, 'id']),
+      })
+    })
+  }
+  if (duplicates.length > 0) return { ok: false, diagnostics: duplicates }
+
+  const declaredWaves = new Set(declaredBy.keys())
+  const crossDiagnostics = documents.flatMap((document) => [
+    ...undeclaredWaveDiagnostics(document, declaredWaves),
+    ...unresolvableKindDiagnostics(document, profileContext),
+  ])
+  if (crossDiagnostics.length > 0) {
+    return { ok: false, diagnostics: crossDiagnostics }
+  }
+
+  return {
+    ok: true,
+    composed: {
+      catalogue: {
+        ...base.catalogue,
+        // The base names the composition, which is why the report's
+        // `catalogue` field keeps its value shape while `catalogues` lists
+        // every contributor.
+        waves: documents.flatMap(({ catalogue }) => catalogue.waves),
+        questions: documents.flatMap(({ catalogue }) =>
+          catalogue.questions.map((question) => ({
+            ...question,
+            id: qualifiedQuestionId(catalogue.id, question.id),
+          })),
+        ),
+      },
+      catalogues: documents.map(
+        ({ catalogue }) => `${catalogue.id}@${catalogue.version}`,
+      ),
+    },
+  }
+}
+
 // Shared by interrogate and design: schema validation plus the YM911
 // undeclared-wave check, both source-located against the catalogue file.
 export function loadQuestionCatalogue(
   catalogueSource: WorkspaceSource,
   profileContext?: ResolvedProfileContext,
 ): CatalogueLoadResult {
-  const loadedCatalogue = loadSourceDocument<QuestionCatalogue>(
-    catalogueSource,
-    validateCatalogue,
-    'Question catalogue',
-  )
-  if (!loadedCatalogue.ok) {
-    return { ok: false, diagnostics: loadedCatalogue.diagnostics }
-  }
-  const catalogue = loadedCatalogue.document.value
-  const waveIds = new Set(catalogue.waves.map(({ id }) => id))
-  const waveDiagnostics = catalogue.questions.flatMap(
-    (question, questionIndex): readonly Diagnostic[] =>
-      waveIds.has(question.wave)
-        ? []
-        : [
-            {
-              severity: 'error',
-              code: 'YM911',
-              message: `Question "${question.id}" references undeclared wave "${question.wave}"`,
-              ...locateSourcePath(
-                catalogueSource.path,
-                loadedCatalogue.document.yaml,
-                loadedCatalogue.document.lineCounter,
-                ['questions', questionIndex, 'wave'],
-                `/questions/${questionIndex}/wave`,
-              ),
-            },
-          ],
+  const loaded = loadCatalogueDocument(catalogueSource)
+  if (!loaded.ok) return { ok: false, diagnostics: loaded.diagnostics }
+
+  const waveDiagnostics = undeclaredWaveDiagnostics(
+    loaded.document,
+    new Set(loaded.document.catalogue.waves.map(({ id }) => id)),
   )
   if (waveDiagnostics.length > 0) {
     return { ok: false, diagnostics: waveDiagnostics }
   }
-  // Only when a caller has a compiled workspace to check against. Without one
-  // there is no way to tell a typo from a kind whose profile simply is not
-  // here, and guessing would be the false positive this check exists to avoid.
-  const kindDiagnostics =
-    profileContext === undefined
-      ? []
-      : unresolvableKinds(catalogue, profileContext).map(
-          ({ kind, path }): Diagnostic => ({
-            severity: 'error',
-            code: 'YM914',
-            message: `Kind "${kind}" is not declared by profile "${kind.slice(
-              0,
-              kind.indexOf('#'),
-            )}", which this workspace loads, so the question can never fire`,
-            ...locateSourcePath(
-              catalogueSource.path,
-              loadedCatalogue.document.yaml,
-              loadedCatalogue.document.lineCounter,
-              path,
-              `/${path.join('/')}`,
-            ),
-          }),
-        )
+  const kindDiagnostics = unresolvableKindDiagnostics(
+    loaded.document,
+    profileContext,
+  )
   if (kindDiagnostics.length > 0) {
     return { ok: false, diagnostics: kindDiagnostics }
   }
-  return { ok: true, catalogue }
+  return { ok: true, catalogue: loaded.document.catalogue }
 }
 
 // Shared by interrogate and `ask --open`: the wave-by-wave human report.

--- a/src/interrogation-entry.ts
+++ b/src/interrogation-entry.ts
@@ -9,10 +9,14 @@
 // The same shape the visual-graph projector uses (`./adapter/visual-graph`).
 export {
   INTERROGATION_SEMANTICS_VERSION,
+  composeCatalogues,
+  qualifiedQuestionId,
   evaluateCatalogue,
   loadQuestionCatalogue,
   renderInterrogationReport,
   renderQuestion,
+  type CatalogueCompositionResult,
+  type ComposedCatalogue,
   type CatalogueCondition,
   type CatalogueEvidenceObservation,
   type CatalogueLoadResult,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -37,6 +37,7 @@ export interface WorkspaceManifest {
   readonly projections: readonly string[]
   readonly adapterMappings: readonly string[]
   readonly patterns?: readonly string[]
+  readonly questions?: readonly string[]
   readonly evidence?: readonly string[]
   readonly contracts?: readonly string[]
 }
@@ -48,6 +49,20 @@ export interface ResolvedWorkspace {
   readonly projections: readonly string[]
   readonly adapterMappings: readonly string[]
   readonly patterns: readonly string[]
+  /**
+   * Question catalogues the workspace itself carries (#345, ADR 0129).
+   * ADDITIVE to the shipped catalogue: `--catalogue` replaces the base, this
+   * adds to it, which is what lets a consultant author a question mid
+   * engagement without a product release.
+   *
+   * OPTIONAL in the type although `loadWorkspaceManifest` always populates it,
+   * and that is deliberate. `ResolvedWorkspace` is published, and adding
+   * `patterns` to it as a required field broke a consumer's production module:
+   * a required field is free for readers and a break for CONSTRUCTORS. Six
+   * fixtures in this repository construct one, which is the same signal from
+   * inside. Read it as `workspace.questions ?? []`.
+   */
+  readonly questions?: readonly string[]
   readonly evidence: readonly string[]
   readonly contracts: readonly string[]
 }
@@ -83,6 +98,7 @@ export function loadWorkspaceManifest(
       | 'projections'
       | 'adapterMappings'
       | 'patterns'
+      | 'questions'
       | 'evidence'
       | 'contracts',
     label: string,
@@ -184,6 +200,7 @@ export function loadWorkspaceManifest(
       value.adapterMappings,
     ),
     patterns: expand('patterns', 'pattern', value.patterns ?? []),
+    questions: expand('questions', 'question catalogue', value.questions ?? []),
     evidence: expand('evidence', 'evidence', value.evidence ?? []),
     contracts: expand(
       'contracts',

--- a/test/absent-layer-catalogue.test.ts
+++ b/test/absent-layer-catalogue.test.ts
@@ -72,11 +72,11 @@ describe('core-enrichment 1.2 asks about absent layers', () => {
 
   it('opens every absent front on a model with none of the layers', () => {
     const ids = openIds(workspace)
-    expect(ids).toContain('no-capability-declared')
-    expect(ids).toContain('no-event-declared')
-    expect(ids).toContain('no-contract-declared')
-    expect(ids).toContain('no-artifact-declared')
-    expect(ids).toContain('implementation-path-missing')
+    expect(ids).toContain('core-enrichment#no-capability-declared')
+    expect(ids).toContain('core-enrichment#no-event-declared')
+    expect(ids).toContain('core-enrichment#no-contract-declared')
+    expect(ids).toContain('core-enrichment#no-artifact-declared')
+    expect(ids).toContain('core-enrichment#implementation-path-missing')
   })
 
   it('closes a presence question the moment the layer has a subject', () => {
@@ -107,10 +107,10 @@ relationships:
       'utf8',
     )
     const ids = openIds(workspace)
-    expect(ids).not.toContain('no-capability-declared')
+    expect(ids).not.toContain('core-enrichment#no-capability-declared')
     // The citation question is satisfied by the reference; a capability
     // declared without one opens capability-uncited instead.
-    expect(ids).not.toContain('capability-uncited')
+    expect(ids).not.toContain('core-enrichment#capability-uncited')
   })
 
   it('asks a bare capability for its citation', () => {
@@ -128,7 +128,7 @@ relationships: []
       'utf8',
     )
     const ids = openIds(workspace)
-    expect(ids).toContain('capability-uncited')
+    expect(ids).toContain('core-enrichment#capability-uncited')
   })
 
   it('keeps no-contract-declared quiet where nothing interacts', () => {
@@ -146,7 +146,7 @@ relationships: []
       'utf8',
     )
     const ids = openIds(workspace)
-    expect(ids).not.toContain('no-contract-declared')
+    expect(ids).not.toContain('core-enrichment#no-contract-declared')
   })
 })
 
@@ -189,12 +189,12 @@ ${observation}`
   })
 
   it('opens where every observation is a frictionless confirmation', () => {
-    expect(openIds(workspace)).toContain('evidence-unchallenged')
+    expect(openIds(workspace)).toContain('core-enrichment#evidence-unchallenged')
   })
 
   it('stays quiet where the workspace declares no evidence at all', () => {
     writeFileSync(join(workspace, 'workspace.yaml'), manifest([]), 'utf8')
-    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+    expect(openIds(workspace)).not.toContain('core-enrichment#evidence-unchallenged')
   })
 
   it('closes on an honest non-confirmation', () => {
@@ -214,7 +214,7 @@ ${observation}`
       ),
       'utf8',
     )
-    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+    expect(openIds(workspace)).not.toContain('core-enrichment#evidence-unchallenged')
   })
 
   it('closes on a confirmed negative claim that records its empty search', () => {
@@ -237,7 +237,7 @@ ${observation}`
       ),
       'utf8',
     )
-    expect(openIds(workspace)).not.toContain('evidence-unchallenged')
+    expect(openIds(workspace)).not.toContain('core-enrichment#evidence-unchallenged')
   })
 
   it('serves the question through design with its trigger attached', () => {
@@ -265,7 +265,7 @@ relationships: []
     const open = runCli(['ask', 'workspace.yaml', '--open', '--json'], workspace)
     const question = JSON.parse(open.stdout)
       .report.waves.flatMap((wave: { questions: { id: string }[] }) => wave.questions)
-      .find((candidate: { id: string }) => candidate.id === 'evidence-unchallenged') as {
+      .find((candidate: { id: string }) => candidate.id === 'core-enrichment#evidence-unchallenged') as {
       open: boolean
       trigger: readonly { condition: string }[]
     }

--- a/test/ask-command.test.ts
+++ b/test/ask-command.test.ts
@@ -490,7 +490,7 @@ observations:
     expect(result.stdout).toContain('== Model slice ==')
     expect(result.stdout).toContain('Todo service')
     expect(result.stdout).toContain('== Open questions touching this slice ==')
-    expect(result.stdout).toContain('outcome-missing')
+    expect(result.stdout).toContain('core-enrichment#outcome-missing')
     expect(result.stdout).toContain('== Evidence drift ==')
     expect(result.stdout).toContain('no evidence declared')
 
@@ -506,7 +506,7 @@ observations:
     expect(payload.mode).toBe('advice')
     expect(payload.topic).toBe('todo')
     expect(
-      payload.openQuestions.some(({ id }) => id === 'outcome-missing'),
+      payload.openQuestions.some(({ id }) => id === 'core-enrichment#outcome-missing'),
     ).toBe(true)
     expect(validateAsk(payload), JSON.stringify(validateAsk.errors)).toBe(true)
   })

--- a/test/catalogue-composition.test.ts
+++ b/test/catalogue-composition.test.ts
@@ -1,0 +1,301 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
+import {
+  composeCatalogues,
+  evaluateCatalogue,
+  qualifiedQuestionId,
+} from '../src/interrogate-command.js'
+
+/**
+ * A workspace carries its own questions (#345, ADR 0129). Catalogues compose
+ * as a RESOLVED SET, additive to the base, and a question id is qualified as
+ * `catalogue#question` on the way out.
+ */
+
+const document = `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: user
+    kind: businessActor
+    name: User
+relationships: []
+`
+
+const domain = `format: yarramate/question-catalogue/v1
+id: domain
+version: "1.0"
+profile: yarramate/core@0.1
+waves:
+  - id: assurance
+    name: Assurance
+questions:
+  - id: shared-id
+    wave: assurance
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+    question: Domain phrasing?
+    materiality: Domain materiality.
+    resolution: Domain resolution.
+    authority: human
+`
+
+/** Declares no wave of its own: it joins the one the domain catalogue declared. */
+const project = `format: yarramate/question-catalogue/v1
+id: project
+version: "0.1"
+profile: yarramate/core@0.1
+waves:
+  - id: engagement
+    name: Engagement
+questions:
+  - id: shared-id
+    wave: assurance
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+    question: Project phrasing?
+    materiality: Project materiality.
+    resolution: Project resolution.
+    authority: human
+`
+
+const sourceOf = (path: string, source: string) => ({ path, source })
+
+describe('composing catalogues', () => {
+  it('qualifies a question id with the catalogue that asked it', () => {
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('project.yaml', project),
+    ])
+    if (!composed.ok) throw new Error(JSON.stringify(composed.diagnostics))
+    expect(composed.composed.catalogue.questions.map(({ id }) => id)).toEqual([
+      'domain#shared-id',
+      'project#shared-id',
+    ])
+  })
+
+  it('lets a catalogue contribute to a wave it did not declare', () => {
+    // The case the whole feature exists for: "one more Assurance question for
+    // this client". Checking each file against only its own waves would have
+    // refused exactly this with YM911.
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('project.yaml', project),
+    ])
+    if (!composed.ok) throw new Error(JSON.stringify(composed.diagnostics))
+    const joined = composed.composed.catalogue.questions.find(
+      ({ id }) => id === 'project#shared-id',
+    )
+    expect(joined?.wave).toBe('assurance')
+  })
+
+  it('keeps the base first, so its wave order is untouched and new waves append', () => {
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('project.yaml', project),
+    ])
+    if (!composed.ok) throw new Error(JSON.stringify(composed.diagnostics))
+    expect(composed.composed.catalogue.waves.map(({ id }) => id)).toEqual([
+      'assurance',
+      'engagement',
+    ])
+    expect(composed.composed.catalogue.id).toBe('domain')
+    expect(composed.composed.catalogues).toEqual(['domain@1.0', 'project@0.1'])
+  })
+
+  it('refuses a wave declared twice, naming who declared it first', () => {
+    // Refused rather than merged: the two carry independent `opensWhen` gates
+    // (ADR 0125) and silently picking one would decide when a wave opens by
+    // file order.
+    const rival = project.replace('id: engagement\n    name: Engagement', 'id: assurance\n    name: Rival Assurance')
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('rival.yaml', rival),
+    ])
+    expect(composed.ok).toBe(false)
+    if (composed.ok) return
+    expect(composed.diagnostics[0]).toMatchObject({
+      code: 'YM915',
+      path: 'rival.yaml',
+    })
+    expect(composed.diagnostics[0]?.message).toContain('domain')
+  })
+
+  it('still refuses a wave nothing in the set declares', () => {
+    const orphan = project.replace('wave: assurance', 'wave: nowhere')
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('orphan.yaml', orphan),
+    ])
+    expect(composed.ok).toBe(false)
+    if (composed.ok) return
+    expect(composed.diagnostics[0]).toMatchObject({ code: 'YM911' })
+  })
+
+  it('carries no version in an id, so a catalogue bump strands nothing', () => {
+    // The decision this design turns on. core-enrichment went 1.0 to 1.3 in a
+    // single day renaming nothing; a versioned identity would have stranded
+    // every stored dismissal three times that day.
+    const bumped = project.replace('version: "0.1"', 'version: "9.9"')
+    const before = composeCatalogues([sourceOf('d.yaml', domain), sourceOf('p.yaml', project)])
+    const after = composeCatalogues([sourceOf('d.yaml', domain), sourceOf('p.yaml', bumped)])
+    if (!before.ok || !after.ok) throw new Error('fixtures do not compose')
+    expect(after.composed.catalogue.questions.map(({ id }) => id)).toEqual(
+      before.composed.catalogue.questions.map(({ id }) => id),
+    )
+    // The version moved, and it moved where it belongs: beside the identity.
+    expect(after.composed.catalogues).toEqual(['domain@1.0', 'project@9.9'])
+    expect(qualifiedQuestionId('project', 'shared-id')).toBe('project#shared-id')
+  })
+
+  it('reports both same-named questions as distinct, rather than merging them', () => {
+    const compiled = compileWorkspaceWithProfileContext([
+      { path: 'main.yaml', source: document },
+    ])
+    if (!compiled.ok) throw new Error('fixture does not compile')
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('project.yaml', project),
+    ])
+    if (!composed.ok) throw new Error('fixtures do not compose')
+    const report = evaluateCatalogue(
+      composed.composed.catalogue,
+      compiled.graph,
+      compiled.profileContext,
+      undefined,
+      composed.composed.catalogues,
+    )
+    const assurance = report.waves.find(({ id }) => id === 'assurance')
+    expect(assurance?.questions.map(({ id }) => id)).toEqual([
+      'domain#shared-id',
+      'project#shared-id',
+    ])
+    expect(report.catalogue).toBe('domain@1.0')
+    expect(report.catalogues).toEqual(['domain@1.0', 'project@0.1'])
+  })
+
+  it('omits `catalogues` when only one contributed, so a lone report is unchanged', () => {
+    const compiled = compileWorkspaceWithProfileContext([
+      { path: 'main.yaml', source: document },
+    ])
+    if (!compiled.ok) throw new Error('fixture does not compile')
+    const composed = composeCatalogues([sourceOf('domain.yaml', domain)])
+    if (!composed.ok) throw new Error('fixture does not compose')
+    const report = evaluateCatalogue(
+      composed.composed.catalogue,
+      compiled.graph,
+      compiled.profileContext,
+      undefined,
+      composed.composed.catalogues,
+    )
+    expect(report.catalogues).toBeUndefined()
+    // But the id is qualified ANYWAY. Qualifying only when composed would mean
+    // adding one project question silently re-identifies every question in the
+    // base, stranding every dismissal keyed on them.
+    expect(report.waves[0]?.questions[0]?.id).toBe('domain#shared-id')
+  })
+})
+
+describe('a workspace that carries its own questions', () => {
+  let workspace = ''
+  const write = (relative: string, source: string) =>
+    writeFileSync(join(workspace, relative), source, 'utf8')
+
+  /** A glob matching no files is YM702, as it is for every other category. */
+  const manifest = (carriesQuestions: boolean) => `format: yarramate/workspace/v1
+id: engagement
+documents:
+  - architecture/*.yaml
+profiles: []
+projections: []
+${carriesQuestions ? 'questions:\n  - questions/*.yaml\n' : ''}adapterMappings: []
+evidence: []
+`
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-questions-'))
+    mkdirSync(join(workspace, '.yarramate/architecture'), { recursive: true })
+    mkdirSync(join(workspace, '.yarramate/questions'), { recursive: true })
+    write('.yarramate/workspace.yaml', manifest(false))
+    write('.yarramate/architecture/main.yaml', document)
+  })
+
+  afterEach(() => rmSync(workspace, { recursive: true, force: true }))
+
+  const engagementQuestion = `format: yarramate/question-catalogue/v1
+id: engagement
+version: "0.1"
+profile: yarramate/core@0.1
+waves:
+  - id: engagement
+    name: Engagement
+questions:
+  - id: regulator-signoff
+    wave: engagement
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+    question: Has the regulator signed off the retention rule?
+    materiality: Cutover cannot proceed without it.
+    resolution: Record the ruling.
+    authority: human
+`
+
+  it('adds the workspace question to the shipped interview', () => {
+    write('.yarramate/workspace.yaml', manifest(true))
+    write('.yarramate/questions/engagement.yaml', engagementQuestion)
+    const result = runCli(
+      ['ask', '.yarramate/workspace.yaml', '--open', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const { report } = JSON.parse(result.stdout) as {
+      report: {
+        catalogue: string
+        catalogues?: string[]
+        waves: { id: string; questions: { id: string }[] }[]
+      }
+    }
+    // Additive: the shipped catalogue is still the base and still asks.
+    expect(report.catalogue).toContain('core-enrichment@')
+    expect(report.catalogues?.[1]).toBe('engagement@0.1')
+    const engagement = report.waves.find(({ id }) => id === 'engagement')
+    expect(engagement?.questions.map(({ id }) => id)).toEqual([
+      'engagement#regulator-signoff',
+    ])
+  })
+
+  it('refuses at check when a workspace catalogue is broken', () => {
+    // A catalogue in the manifest is workspace content, and `check` refuses
+    // broken workspace content.
+    write('.yarramate/workspace.yaml', manifest(true))
+    write('.yarramate/questions/engagement.yaml', 'format: yarramate/question-catalogue/v1\nid: broken\n')
+    const result = runCli(['check', '.yarramate/workspace.yaml'], workspace)
+    expect(result.exitCode).toBe(1)
+  })
+
+  it('behaves exactly as before when the workspace carries none', () => {
+    const result = runCli(
+      ['ask', '.yarramate/workspace.yaml', '--open', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const { report } = JSON.parse(result.stdout) as {
+      report: { catalogue: string; catalogues?: string[] }
+    }
+    expect(report.catalogues).toBeUndefined()
+    expect(report.catalogue).toContain('core-enrichment@')
+  })
+})

--- a/test/catalogue-composition.test.ts
+++ b/test/catalogue-composition.test.ts
@@ -84,6 +84,35 @@ describe('composing catalogues', () => {
     ])
   })
 
+  it('accepts a catalogue that declares NO wave and only contributes', () => {
+    // The ordinary shape of a project catalogue, and the schema forbade it
+    // until this feature: `waves` had `minItems: 1`, so a catalogue wanting
+    // only to add "one more Assurance question for this client" had to declare
+    // a wave it did not want - which is then refused as a duplicate the moment
+    // a second catalogue does the same. Found by a barrel test, not by design.
+    const contributor = project
+      .replace('waves:\n  - id: engagement\n    name: Engagement\n', 'waves: []\n')
+    const composed = composeCatalogues([
+      sourceOf('domain.yaml', domain),
+      sourceOf('contributor.yaml', contributor),
+    ])
+    if (!composed.ok) throw new Error(JSON.stringify(composed.diagnostics))
+    expect(composed.composed.catalogue.waves.map(({ id }) => id)).toEqual(['assurance'])
+    expect(composed.composed.catalogue.questions.map(({ id }) => id)).toEqual([
+      'domain#shared-id',
+      'project#shared-id',
+    ])
+  })
+
+  it('still refuses a wave-less catalogue evaluated ALONE, since nothing declares it', () => {
+    const contributor = project
+      .replace('waves:\n  - id: engagement\n    name: Engagement\n', 'waves: []\n')
+    const composed = composeCatalogues([sourceOf('contributor.yaml', contributor)])
+    expect(composed.ok).toBe(false)
+    if (composed.ok) return
+    expect(composed.diagnostics[0]).toMatchObject({ code: 'YM911' })
+  })
+
   it('lets a catalogue contribute to a wave it did not declare', () => {
     // The case the whole feature exists for: "one more Assurance question for
     // this client". Checking each file against only its own waves would have

--- a/test/design-command.test.ts
+++ b/test/design-command.test.ts
@@ -68,7 +68,7 @@ describe('design command', () => {
     const result = runCli(['design', 'workspace.yaml'], workspace)
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('catalogue core-enrichment@')
-    expect(result.stdout).toContain('Q [motivation · outcome-missing]')
+    expect(result.stdout).toContain('Q [motivation · core-enrichment#outcome-missing]')
     expect(result.stdout).toContain('yarramate apply')
   })
 
@@ -81,7 +81,7 @@ describe('design command', () => {
     expect(result.stdout).toContain('Todo service')
     expect(result.stdout).toContain('Subject slice:')
     expect(result.stdout).toContain('You are building "Todo service"')
-    expect(result.stdout).not.toContain('outcome-missing')
+    expect(result.stdout).not.toContain('core-enrichment#outcome-missing')
   })
 
   it('fails loudly on an unknown subject', () => {
@@ -125,7 +125,7 @@ describe('design command', () => {
       workspace,
     )
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Q [motivation · goal-unrealized]')
+    expect(result.stdout).toContain('Q [motivation · core-enrichment#goal-unrealized]')
     expect(result.stdout).toContain('- op: add-relationship')
     expect(result.stdout).toContain('kind: realization')
     // goal-unrealized wants an incoming realization: the goal is the
@@ -154,7 +154,13 @@ describe('design command', () => {
       progress: { waves: readonly { id: string; open: number }[] }
     }
     expect(payload.format).toBe('yarramate/design-step/v1')
-    expect(payload.step?.questionId).toBe('outcome-missing')
+    // Qualified even though ONE catalogue is in play (#345, ADR 0129).
+    // Qualifying only when composed would mean a consultant adding a single
+    // project question silently changes the id of every question in the
+    // shipped catalogue, stranding every stored dismissal keyed on them -
+    // which is the exact failure the unversioned qualified id exists to
+    // prevent, triggered by adding a file.
+    expect(payload.step?.questionId).toBe('core-enrichment#outcome-missing')
     expect(payload.step?.wave).toBe('motivation')
     expect(payload.progress.waves.map(({ id }) => id)).toEqual([
       'motivation',
@@ -212,7 +218,7 @@ questions:
     )
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('catalogue tiny@1.0')
-    expect(result.stdout).toContain('states-question')
+    expect(result.stdout).toContain('tiny#states-question')
   })
 
   it('carries the full open-subject roster for shared questions', () => {
@@ -276,7 +282,7 @@ questions:
       workspace,
     )
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Q [motivation · outcome-missing]')
+    expect(result.stdout).toContain('Q [motivation · core-enrichment#outcome-missing]')
     // The shipped catalogue authors askPlain for the motivation wave.
     expect(result.stdout).toContain(
       'What would success look like for this system?',

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -120,6 +120,64 @@ describe('adapter/visual-graph barrel', () => {
   })
 })
 
+describe('the interrogation barrel', () => {
+  it('publishes composition, not only evaluation', async () => {
+    // A host is told to compose UNCONDITIONALLY, even with one catalogue, so
+    // its question ids never change later (#345, ADR 0129). Advice it cannot
+    // follow is worse than no advice: `yarramate/workbook` shipped a writer
+    // with no reader the same week, and this is the same defect one import
+    // away.
+    const entry = await import('../src/interrogation-entry.js')
+    expect(typeof entry.composeCatalogues).toBe('function')
+    expect(typeof entry.qualifiedQuestionId).toBe('function')
+    expect(typeof entry.evaluateCatalogue).toBe('function')
+
+    const barrel = await import('../src/index.js')
+    expect(typeof barrel.composeCatalogues).toBe('function')
+    expect(typeof barrel.qualifiedQuestionId).toBe('function')
+  })
+
+  it('composes end to end from the published entry alone', async () => {
+    // Through the entry, not through the module: an export that resolves but
+    // does not work is what a barrel test is for.
+    const { composeCatalogues } = await import('../src/interrogation-entry.js')
+    // Only the BASE declares the wave; the second joins it, which is the rule
+    // and is what a project catalogue actually does. Written the other way
+    // first, and YM915 refused it, which is the check earning its keep on its
+    // own test.
+    const catalogue = (id: string, declaresWave: boolean) => ({
+      path: `${id}.yaml`,
+      source: `format: yarramate/question-catalogue/v1
+id: ${id}
+version: "1.0"
+profile: yarramate/core@0.1
+${declaresWave ? 'waves:\n  - id: only\n    name: Only\n' : 'waves: []\n'}questions:
+  - id: same-name
+    wave: only
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+    question: Why?
+    materiality: Because.
+    resolution: Answer it.
+    authority: human
+`,
+    })
+    const composed = composeCatalogues([
+      catalogue('base', true),
+      catalogue('extra', false),
+    ])
+    if (!composed.ok) throw new Error(JSON.stringify(composed.diagnostics.map(({ code, message }) => `${code} ${message}`)))
+    expect(composed.composed.catalogue.questions.map(({ id }) => id)).toEqual([
+      'base#same-name',
+      'extra#same-name',
+    ])
+    expect(composed.composed.catalogues).toEqual(['base@1.0', 'extra@1.0'])
+  })
+})
+
 describe('workbook barrels', () => {
   it('yarramate/workbook hands a host everything it needs to WRITE one', async () => {
     const mod = await import('../src/workbook-entry.js')

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -89,7 +89,7 @@ describe('core-enrichment 1.0 interaction wave', () => {
       step: { questionId: string; wave: string }
     }
     expect(payload.step.wave).toBe('interaction')
-    expect(payload.step.questionId).toBe('hop-unrealised')
+    expect(payload.step.questionId).toBe('core-enrichment#hop-unrealised')
   })
 
   it('omits policy questions when yarramate/policy@0.1 is not selected', () => {
@@ -103,10 +103,10 @@ describe('core-enrichment 1.0 interaction wave', () => {
         (wave: { questions: { id: string }[] }) => wave.questions,
       )
       .map((question: { id: string }) => question.id)
-    expect(ids).toContain('hop-unrealised')
-    expect(ids).not.toContain('authn-standard-missing')
-    expect(ids).not.toContain('interaction-trust-unbound')
-    expect(ids).not.toContain('interaction-protocol-unbound')
+    expect(ids).toContain('core-enrichment#hop-unrealised')
+    expect(ids).not.toContain('core-enrichment#authn-standard-missing')
+    expect(ids).not.toContain('core-enrichment#interaction-trust-unbound')
+    expect(ids).not.toContain('core-enrichment#interaction-protocol-unbound')
   })
 
   it('keeps trust open when only a rate-limit constraint is bound', () => {
@@ -173,8 +173,8 @@ evidence: []
       )
       .filter((question: { open: boolean }) => question.open)
       .map((question: { id: string }) => question.id)
-    expect(ids).toContain('interaction-trust-unbound')
-    expect(ids).not.toContain('interaction-capacity-unbound')
+    expect(ids).toContain('core-enrichment#interaction-trust-unbound')
+    expect(ids).not.toContain('core-enrichment#interaction-capacity-unbound')
   })
 })
 
@@ -269,7 +269,7 @@ evidence: []
           (wave: { questions: { id: string; open: boolean }[] }) =>
             wave.questions,
         )
-        .find((question: { id: string }) => question.id === 'authn-standard-missing')
+        .find((question: { id: string }) => question.id === 'core-enrichment#authn-standard-missing')
       expect(authn?.open).toBe(false)
     } finally {
       rmSync(workspaceDir, { recursive: true, force: true })

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -117,7 +117,7 @@ describe('ask --open interrogation', () => {
     )
     expect(before.exitCode).toBe(0)
     expect(before.stdout).toContain(
-      'OPEN   goal-missing — What outcome justifies this system?',
+      'OPEN   fixture#goal-missing — What outcome justifies this system?',
     )
 
     writeFileSync(
@@ -136,7 +136,7 @@ describe('ask --open interrogation', () => {
       workspace,
     )
     expect(after.exitCode).toBe(0)
-    expect(after.stdout).toContain('closed goal-missing')
+    expect(after.stdout).toContain('closed fixture#goal-missing')
   })
 
   it.each(catalogueSchema.$defs.question.properties.authority.enum)(
@@ -254,7 +254,7 @@ describe('ask --open interrogation', () => {
     expect(payload.summary).toEqual({ questions: 2, openQuestions: 2, open: 3 })
     const owners = payload.waves
       .find(({ id }) => id === 'hygiene')!
-      .questions.find(({ id }) => id === 'actor-owner-missing')!
+      .questions.find(({ id }) => id === 'fixture#actor-owner-missing')!
     expect(owners.subjects!.map(({ id }) => id)).toEqual([
       'customer',
       'platform',
@@ -834,7 +834,7 @@ describe('ask --open interrogation', () => {
     const loadedReport = JSON.parse(loadedUnselected.stdout).report
     expect(loadedReport.summary.questions).toBe(1)
     expect(loadedReport.waves[0].questions.map((q: { id: string }) => q.id)).toEqual(
-      ['outcome-missing'],
+      ['policy-fixture#outcome-missing'],
     )
 
     writeFileSync(
@@ -897,7 +897,7 @@ describe('ask --open interrogation', () => {
       .flatMap((wave: { questions: { id: string; open: boolean }[] }) =>
         wave.questions,
       )
-      .find((question: { id: string }) => question.id === 'goal-missing')
+      .find((question: { id: string }) => question.id === 'fixture#goal-missing')
     expect(goalMissing.open).toBe(false)
   })
 

--- a/test/subject-identity.test.ts
+++ b/test/subject-identity.test.ts
@@ -445,7 +445,7 @@ describe('the near-duplicate question end to end', () => {
     const report = JSON.parse(result.stdout).report
     const question = report.waves
       .flatMap((wave: { questions: unknown[] }) => wave.questions)
-      .find((entry: { id: string }) => entry.id === 'subjects-near-duplicate')
+      .find((entry: { id: string }) => entry.id === 'core-enrichment#subjects-near-duplicate')
     expect(question.open).toBe(true)
     expect(question.subjects).toHaveLength(2)
     expect(question.subjects[0].question).toContain('orders-service')
@@ -458,7 +458,7 @@ describe('the near-duplicate question end to end', () => {
     const report = JSON.parse(result.stdout).report
     const question = report.waves
       .flatMap((wave: { questions: unknown[] }) => wave.questions)
-      .find((entry: { id: string }) => entry.id === 'subjects-near-duplicate')
+      .find((entry: { id: string }) => entry.id === 'core-enrichment#subjects-near-duplicate')
     expect(question.open).toBe(false)
     expect(question.subjects).toBeUndefined()
   })

--- a/test/visual-workspace-model.test.ts
+++ b/test/visual-workspace-model.test.ts
@@ -83,12 +83,19 @@ const metadata = {
   projectionDigests: {},
 } as const
 
+/**
+ * Dismissal ids are QUALIFIED now (#345, ADR 0129). A host matching a stored
+ * dismissal against a report question matches on `catalogue#question`, which
+ * is the migration every adopter makes once: two key fields collapse into one.
+ * Accepting a bare id as well would put the two identifiers back that
+ * qualification exists to remove.
+ */
 describe('interrogationOverlayOf', () => {
   it('splits workspace-scoped questions from per-subject ones', () => {
     const overlay = interrogationOverlayOf(compiled(), catalogue)
     expect(overlay).toBeDefined()
     expect(overlay!.workspace.map(({ questionId }) => questionId)).toEqual([
-      'goal-missing',
+      'fixture#goal-missing',
     ])
     expect(Object.keys(overlay!.subjects)).toEqual(['teller'])
     // The per-subject phrasing arrives already interpolated - the browser
@@ -122,31 +129,31 @@ describe('interrogationOverlayOf', () => {
   describe('a host that has already dealt with a question', () => {
     it('drops it from every subject when no subject is named', () => {
       const overlay = interrogationOverlayOf(compiled(), catalogue, [
-        { questionId: 'actor-owner-missing' },
+        { questionId: 'fixture#actor-owner-missing' },
       ])!
       expect(Object.keys(overlay.subjects)).toEqual([])
       // The workspace-scoped question is untouched: dismissing one says
       // nothing about the others.
       expect(overlay.workspace.map(({ questionId }) => questionId)).toEqual([
-        'goal-missing',
+        'fixture#goal-missing',
       ])
     })
 
     it('drops a workspace-scoped question by id alone', () => {
       const overlay = interrogationOverlayOf(compiled(), catalogue, [
-        { questionId: 'goal-missing' },
+        { questionId: 'fixture#goal-missing' },
       ])!
       expect(overlay.workspace).toEqual([])
     })
 
     it('drops it for the named subject only', () => {
       const kept = interrogationOverlayOf(compiled(), catalogue, [
-        { questionId: 'actor-owner-missing', subject: 'somebody-else' },
+        { questionId: 'fixture#actor-owner-missing', subject: 'somebody-else' },
       ])!
       expect(Object.keys(kept.subjects)).toEqual(['teller'])
 
       const dropped = interrogationOverlayOf(compiled(), catalogue, [
-        { questionId: 'actor-owner-missing', subject: 'teller' },
+        { questionId: 'fixture#actor-owner-missing', subject: 'teller' },
       ])!
       expect(Object.keys(dropped.subjects)).toEqual([])
     })
@@ -156,8 +163,8 @@ describe('interrogationOverlayOf', () => {
     // interview is not the editor's to settle.
     it('changes nothing about the catalogue the overlay names', () => {
       const overlay = interrogationOverlayOf(compiled(), catalogue, [
-        { questionId: 'goal-missing' },
-        { questionId: 'actor-owner-missing' },
+        { questionId: 'fixture#goal-missing' },
+        { questionId: 'fixture#actor-owner-missing' },
       ])!
       expect(overlay.catalogue).toBe('fixture@1.0')
       expect(overlay.semantics.length).toBeGreaterThan(0)

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -283,6 +283,7 @@ describe('workspace manifests', () => {
       // category resolves to an empty set the way evidence did before this
       // workspace declared any.
       patterns: [],
+      questions: [],
       projections: [
         '.yarramate/projections/core-contract-foundation.yaml',
         '.yarramate/projections/current-engine.yaml',


### PR DESCRIPTION
Builds ADR 0129. A consultancy has a domain catalogue: the questions it asks on every engagement. An individual engagement raises questions true of that client and nowhere else, discovered mid-engagement rather than at product-design time. Until now those had nowhere to live.

```yaml
format: yarramate/workspace/v1
id: icwa-web
documents: ['documents/**/*.yaml']
questions: ['questions/*.yaml']       # ← this
```

**Additive.** `--catalogue` and `MountOptions.catalogue` still replace the base; `questions:` adds to it. Different powers on purpose: a host controls the catalogue that is not in the workspace (#328), a consultant adds to it with no product release.

## A wave is declared exactly once

Any catalogue may contribute questions to a wave it did not declare. That one rule settles wave identity and ordering, and **removes** the `opensWhen` precedence question ADR 0125 raised rather than answering it: there is only ever one declarer to ask. A second declaration is `YM915`.

`YM911` moved from per-file to across the union — checked per-file, it would have refused exactly the case this feature enables.

## Ids qualify; collisions dissolve

`catalogue#question`, with authors still writing local ids. Two catalogues carrying `outcome-missing` are two questions, so composition needs no merge rule, no last-wins, no refusal.

**No version in the identity.** `core-enrichment` went 1.0 to 1.3 in one day renaming nothing; a versioned identity would have stranded every stored dismissal in every adopter's database three times that day. Versions live beside the identity: `catalogue` keeps its value shape, and a new **optional** `catalogues` lists every contributor.

## Three things the build turned up

**`ResolvedWorkspace.questions` is optional** although it is always populated. Adding `patterns` to that published type as a required field broke a consumer's production module once. Six fixtures in this repository construct one, which is the same signal from inside.

**`resolveCliWorkspaceSources` hands `questions` over.** Its own comment records #268, where a category the manifest declared reached no verb and was ignored with no symptom. Wiring one call site and not the rest would have repeated it — hence one `catalogueSources` helper used by `design`, all three `ask` paths, the visual session and `check`.

**Qualification is a property of composition, not of evaluation.** A direct `evaluateCatalogue` caller still gets local ids. Every CLI verb composes even with one catalogue, so ids are qualified from the start and never change when a workspace first carries a question of its own — which is the mass-orphan transition the whole design exists to prevent. Recorded in the ADR and in `docs/INTERROGATION.md`.

## Migration

A consumer matching on question ids migrates once: `outcome-missing` → `core-enrichment#outcome-missing`. A value change, not a new required field, so nothing that constructs these documents breaks. It shows up in this repo's own tests, including the host-dismissal path in `visual-workspace-model.test.ts`, which is ApertureX's migration in miniature.

## Verification

`pnpm run verify` from a wiped `dist` and `.yarramate-out`: exit 0, **1868 passed**, 1 skipped, 105 files. Both typecheck configs clean.

**Mutation-proven.** Dropping qualification, allowing a duplicate wave declaration, checking each catalogue against only its own waves, emitting `catalogues` for a single catalogue, and forgetting the workspace half each turn the intended tests red.

End-to-end through the CLI, on a scratch workspace: the engagement wave appends after the seven shipped waves and its question arrives as `engagement#regulator-signoff`.

Closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)