### PR TITLE
Model maintenance: declare the workbook, import, and catalogue composition

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -655,6 +655,8 @@ concepts:
     supersedes:
       - compile-command
       - view-command
+    distinctFrom:
+      - import-command
   - id: consumer-host
     kind: node
     name: Consumer host
@@ -823,6 +825,56 @@ concepts:
     kind: applicationFunction
     name: Render ArchiMate kind icons
     description: Draws a 14×14 px single-stroke SVG icon per concept kind in the repository's graph, covering 19 kinds using ArchiMate element glyphs as descriptive notation only, with no trademark or conformance claim. Unknown kinds render nothing. Active only under archimate notation mode; falls back to native rendering when notation is native.
+    status: current
+  - id: import-command
+    kind: applicationService
+    name: Import command
+    description: Merges an edited architecture workbook back into the model as an operations batch through the existing apply write path. It adds no write surface of its own, so a workbook edit passes the same atomic compile gate every other write does and a workbook that would produce an uncompilable model is refused whole rather than half written.
+    owner: yarramate-maintainers
+    status: current
+    distinctFrom:
+      - export-command
+  - id: derive-architecture-workbook
+    kind: applicationFunction
+    name: Derive the architecture workbook
+    description: Derives the spreadsheet an architect or FDE actually works in - identity in column A, foreign keys inline with a derived name beside them, and dropdowns drawn from the compiled profile. It takes a projection, so choosing which version to export is an existing query facet rather than a competing flag, and it writes a hidden ancestor so a later import can tell an author's edit from repository drift.
+    owner: yarramate-maintainers
+    status: current
+  - id: architecture-workbook
+    kind: dataObject
+    name: Architecture workbook
+    description: The yarramate/workbook/v1 spreadsheet a reviewer edits and sends back. It is a slice rather than the model - every fact about a subject it carries is present, including anything the named columns do not model, and a subject the projection did not select has no row and cannot be changed by importing the file.
+    owner: yarramate-maintainers
+    status: current
+  - id: merge-edited-workbook
+    kind: applicationFunction
+    name: Merge an edited workbook
+    description: Decides for every changed cell whether it merges or is refused. The workbook's own hidden ancestor is the common baseline, so a field the workspace did not touch merges even after the repository moved on, and only a field moved on both sides is a conflict. A missing row is reported and never actioned, because a row deleted by accident in a spreadsheet has no symptom.
+    owner: yarramate-maintainers
+    status: current
+  - id: workspace-question-catalogue
+    kind: dataObject
+    name: Workspace question catalogue
+    description: Question catalogues a workspace declares in its manifest, additive to the shipped one. It decides who may author a question and when - a consultant adds one true of a single engagement at any point, versioned with the model and reviewed as an ordinary diff, instead of editing a product-wide catalogue that is not true of every engagement or keeping the question outside the interview loop entirely.
+    owner: yarramate-maintainers
+    status: current
+  - id: compose-question-catalogues
+    kind: applicationFunction
+    name: Compose question catalogues
+    description: Composes the shipped catalogue with the ones a workspace carries into the single catalogue evaluation sees. A wave is declared exactly once and any catalogue may contribute questions to it, and a question id is qualified as catalogue#question carrying no version, so a routine catalogue version bump strands no judgment an adopter has stored against one.
+    owner: yarramate-maintainers
+    status: current
+  - id: workbook-engine
+    kind: compiler-module
+    name: Workbook engine
+    description: Writes and reads the xlsx container by hand, with no dependency. It is held to runtime neutrality - no Node builtins and no compiler at runtime - which is what lets a host generate a workbook inside a Cloudflare Worker. Writing is synchronous so it cannot infect a synchronous store; reading is asynchronous because a workbook a person saved from Excel comes back deflated and inflation is only offered as a stream.
+    owner: yarramate-maintainers
+    status: current
+  - id: interrogation-engine
+    kind: compiler-module
+    name: Interrogation engine
+    description: Evaluates a question catalogue against the compiled graph and reports what is still open, recomputed statelessly on every run. It is the half an adopter embeds rather than authors - the engine is ours and the questions are theirs - which is why it is published as its own runtime-neutral entry and runs inside a consumer's Durable Object on every model write.
+    owner: yarramate-maintainers
     status: current
 relationships:
   - id: contract-manifest-realizes-published-formats
@@ -1881,3 +1933,83 @@ relationships:
     kind: realization
     from: relationship-table
     to: relationship-policy-catalogue
+  - id: cli-provides-import
+    kind: implements
+    from: cli
+    to: import-command
+    status: current
+  - id: export-command-serves-workbook-derivation
+    kind: serving
+    from: export-command
+    to: derive-architecture-workbook
+    description: export xlsx is a derivation mode of the one export verb, not a verb of its own.
+    status: current
+  - id: workbook-derivation-reads-graph
+    kind: access
+    from: derive-architecture-workbook
+    to: semantic-graph
+    mode: read
+    status: current
+  - id: workbook-derivation-produces-workbook
+    kind: access
+    from: derive-architecture-workbook
+    to: architecture-workbook
+    mode: write
+    status: current
+  - id: import-command-serves-workbook-merge
+    kind: serving
+    from: import-command
+    to: merge-edited-workbook
+    status: current
+  - id: workbook-merge-reads-workbook
+    kind: access
+    from: merge-edited-workbook
+    to: architecture-workbook
+    mode: read
+    status: current
+  - id: workbook-merge-produces-operations
+    kind: access
+    from: merge-edited-workbook
+    to: apply-operations
+    mode: write
+    description: The merge emits operations rather than writing YAML, so an import inherits the atomic gate and leaves untouched documents byte-identical.
+    status: current
+  - id: design-command-serves-catalogue-composition
+    kind: serving
+    from: design-command
+    to: compose-question-catalogues
+    status: current
+  - id: catalogue-composition-reads-shipped-catalogue
+    kind: access
+    from: compose-question-catalogues
+    to: question-catalogue
+    mode: read
+    status: current
+  - id: catalogue-composition-reads-workspace-catalogue
+    kind: access
+    from: compose-question-catalogues
+    to: workspace-question-catalogue
+    mode: read
+    status: current
+  - id: workbook-engine-derives-workbook
+    kind: assignment
+    from: workbook-engine
+    to: derive-architecture-workbook
+    status: current
+  - id: workbook-engine-merges-workbook
+    kind: assignment
+    from: workbook-engine
+    to: merge-edited-workbook
+    status: current
+  - id: interrogation-engine-composes-catalogues
+    kind: assignment
+    from: interrogation-engine
+    to: compose-question-catalogues
+    status: current
+  - id: import-command-reads-workbook
+    kind: access
+    from: import-command
+    to: architecture-workbook
+    mode: read
+    description: The command reads the file a reviewer sends back; the merge reads the sheets inside it.
+    status: current

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -929,3 +929,35 @@ observations:
     evidence:
       uri: repo:src/reconciliation.ts
       message: A negative claim held up to failure - evidence evaluation and reconciliation have no write path and no runtime imports that could reach one, so observations cannot silently author intent. The searches that would find such a path come back empty; either one matching is this observation contradicted.
+  - subject: import-command
+    result: confirmed
+    evidence:
+      uri: repo:src/import-command.ts
+  - subject: derive-architecture-workbook
+    result: confirmed
+    evidence:
+      uri: repo:src/workbook.ts
+  - subject: architecture-workbook
+    result: confirmed
+    evidence:
+      uri: repo:src/workbook-xlsx.ts
+  - subject: merge-edited-workbook
+    result: confirmed
+    evidence:
+      uri: repo:src/workbook-merge.ts
+  - subject: workspace-question-catalogue
+    result: confirmed
+    evidence:
+      uri: repo:src/catalogue-sources.ts
+  - subject: compose-question-catalogues
+    result: confirmed
+    evidence:
+      uri: repo:src/interrogate-command.ts
+  - subject: workbook-engine
+    result: confirmed
+    evidence:
+      uri: repo:src/workbook-xlsx.ts
+  - subject: interrogation-engine
+    result: confirmed
+    evidence:
+      uri: repo:src/interrogate-command.ts

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1938,3 +1938,27 @@ mappings:
   - native: changeset-submitted-writes-operations
     external: changesetSubmittedWritesOperations
     type: relationship
+  - native: import-command
+    external: importCommand
+    type: concept
+  - native: derive-architecture-workbook
+    external: deriveArchitectureWorkbook
+    type: concept
+  - native: merge-edited-workbook
+    external: mergeEditedWorkbook
+    type: concept
+  - native: compose-question-catalogues
+    external: composeQuestionCatalogues
+    type: concept
+  - native: workbook-engine
+    external: workbookEngine
+    type: concept
+  - native: interrogation-engine
+    external: interrogationEngine
+    type: concept
+  - native: architecture-workbook
+    external: architectureWorkbook
+    type: concept
+  - native: workspace-question-catalogue
+    external: workspaceQuestionCatalogue
+    type: concept

--- a/test/likec4-cli.test.ts
+++ b/test/likec4-cli.test.ts
@@ -2746,99 +2746,109 @@ mappings:
 
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toBe('')
-      expect(JSON.parse(result.stdout)).toEqual({
-        format: 'yarramate/likec4-diagnostic-result/v1',
-        diagnostics: [
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
-            subject: 'likec4-adapter-provides-export',
-            path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/127',
-            line: 1410,
-            column: 5,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
-            subject: 'likec4-adapter-provides-check',
-            path: '.yarramate/architecture/engine.yaml',
-            pointer: '/relationships/128',
-            line: 1414,
-            column: 5,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-export-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/25/kind',
-            line: 113,
-            column: 11,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-prepare-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/28/kind',
-            line: 125,
-            column: 11,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-project-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/29/kind',
-            line: 129,
-            column: 11,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-project-definition-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/30/kind',
-            line: 133,
-            column: 11,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-project-schema-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/57/kind',
-            line: 246,
-            column: 11,
-          },
-          {
-            severity: 'error',
-            code: 'YMLC104',
-            message:
-              'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
-            subject: 'likec4-generated-project-v2-schema-source',
-            path: '.yarramate/architecture/repository.yaml',
-            pointer: '/concepts/58/kind',
-            line: 250,
-            column: 11,
-          },
-        ],
-      })
+      const payload = JSON.parse(result.stdout) as {
+        format: string
+        diagnostics: {
+          severity: string
+          code: string
+          message: string
+          subject: string
+          path: string
+          pointer: string
+          line: number
+          column: number
+        }[]
+      }
+      expect(payload.format).toBe('yarramate/likec4-diagnostic-result/v1')
+
+      // Asserted on WHICH subject was refused and WHY, not on where it
+      // happens to sit today. This literal used to pin exact line numbers and
+      // relationship indices inside the repository's own self-model, so every
+      // model-maintenance pass broke a LikeC4 test that had not changed
+      // behaviour - the test was measuring the model's layout rather than the
+      // adapter's refusal. Location is still asserted, as the guarantee that
+      // every refusal is locatable at all.
+      expect(
+        payload.diagnostics.map(({ severity, code, message, subject, path }) => ({
+          severity,
+          code,
+          message,
+          subject,
+          path,
+        })),
+      ).toEqual([
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
+          subject: 'likec4-adapter-provides-export',
+          path: '.yarramate/architecture/engine.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic relationship kind "yarramate/development@1.0#implements" resolves to unsupported bundled LikeC4 kind "implements"',
+          subject: 'likec4-adapter-provides-check',
+          path: '.yarramate/architecture/engine.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-export-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-prepare-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-project-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-project-definition-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-project-schema-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+        {
+          severity: 'error',
+          code: 'YMLC104',
+          message:
+            'Semantic concept kind "yarramate/development@1.0#repository-file" resolves to unsupported bundled LikeC4 kind "repository-file"',
+          subject: 'likec4-generated-project-v2-schema-source',
+          path: '.yarramate/architecture/repository.yaml',
+        },
+      ])
+
+      // Every refusal is located, which is the part that must not regress.
+      for (const diagnostic of payload.diagnostics) {
+        expect(diagnostic.line).toBeGreaterThan(0)
+        expect(diagnostic.column).toBeGreaterThan(0)
+        expect(diagnostic.pointer).toMatch(/^\/(concepts|relationships)\/\d+/)
+      }
       expect(existsSync(project)).toBe(false)
     } finally {
       rmSync(parent, { recursive: true, force: true })


### PR DESCRIPTION
The self-model reported **269 concepts / 381 relationships both before and after** the four merges heading into 1.7.0 — which added a published subpath, a manifest category, and two new refusals. The model described none of it.

A release whose self-model is behind its own code is the exact failure this tool exists to prevent, and the case study cites the self-model catching a regression. Shipping it stale would undermine the pitch with evidence.

## Eight subjects, chosen with the rubric

| Subject | What decision it changes |
|---|---|
| `import-command` | the eighth verb; adds no write surface of its own, lands through `apply`'s atomic gate |
| `derive-architecture-workbook` | what an FDE consumes, and why it takes a projection rather than growing a `--state` flag |
| `architecture-workbook` | the artifact, and that it is a **slice** |
| `merge-edited-workbook` | the half with judgment: ancestor, conflict, and a missing row that is never a deletion |
| `workbook-engine` | the module held to runtime neutrality, which is why a Worker can generate one |
| `workspace-question-catalogue` | who may author a question, and when |
| `compose-question-catalogues` | declare-once waves, qualified ids, no version |
| `interrogation-engine` | the half an adopter embeds rather than authors |

## What the rubric kept out

**No subject for `YM921` or `YM915`.** Admission test 4 — the distinction is already carried by `check-command`, and no other diagnostic has a subject of its own.

**No subject for the published subpaths.** `interrogation-entry.ts` was never modelled, and `npm-package` already carries that distinction.

## The interview caught my own work

After the first batch it **reopened**: 3 questions over 6 subjects, every one about what I had just declared.

- three `applicationFunction`s with nobody assigned to perform them
- `import-command` participating in a hop while accessing no data object
- `export-command` and `import-command` flagged as near-duplicates

The second batch answers them — two module subjects, an access edge, and a symmetric `distinctFrom` — and it closed back to **0 open of 51**. That is the loop working on its author, which is the best evidence in this PR that the pass was worth doing.

**One judgment worth your eye:** I declared `distinctFrom` between `export-command` and `import-command`. They are objectively different (opposite directions, different verbs, different files), so I did not treat it as taste — but a distinctness dismissal is a human judgment and your merge is the endorsement.

## Two things found on the way

**The LikeC4 adapter refused the export** with `YMLC102` until every new concept was mapped — and the first run reported only **4 of the 8**. Fixing those revealed the rest. A partial diagnostic list read as a complete one would have looked done.

**`test/likec4-cli.test.ts` pinned line numbers and relationship indices inside the self-model**, so every model-maintenance pass broke a LikeC4 test whose behaviour had not changed. It was measuring the model's layout rather than the adapter's refusal. It now asserts severity, code, message, subject and path exactly, and separately that every refusal is **located at all** — the guarantee that must not regress.

## Gates

| | |
|---|---|
| `check` | clean, **277 concepts / 395 relationships** (from 269 / 381) |
| interview | **0 open of 51** |
| `reconcile` | 236/236 confirmed, 0 contradicted, **0 subjects without evidence** (#142 invariant holds) |
| `pnpm verify` | wiped `dist` and `.yarramate-out`: exit 0, **1872 passed**, 105 files |

The 8 remaining reconcile findings are freshness only (1 stale attestation, 7 unconfirmed), unchanged from before this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)