### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.7.0
 
 - **Added.** A workspace can carry its own questions (#345, ADR 0129). A
   `questions:` manifest category resolves like `patterns` and `evidence`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Four changes since 1.6.0, plus the self-model pass that keeps the model level with them.

## What ships

**`yarramate/workbook/import`** publishes the half that *reads* a workbook back (#359). 1.6.0 shipped the writer only, so a host without Node could generate a workbook and had no route from an edited file to something `apply` can take. Its own subpath, because the package declares no `sideEffects` and a generate-only Worker would otherwise carry the whole import half.

**`check` resolves the references in a projection query** (#360, YM921, ADR 0128). A mistyped selector used to write a clean empty artifact and exit 0 from every export kind. Referential, not emptiness — a query whose names all resolve and which selects nothing is still fine, and a projection the manifest does not declare stays portable.

**A workspace carries its own questions** (#361, #362, ADR 0129, closing #345 and #151). `questions:` is a manifest category, additive to the shipped catalogue. A wave is declared exactly once and any catalogue contributes questions to it. Question ids qualify to `catalogue#question` with **no version**, so a routine catalogue bump strands no judgment an adopter has stored against one.

**The self-model declares all of it** (#363): 277 concepts / 395 relationships, from 269 / 381, with the interview back at 0 open of 51.

## The one migration

A consumer matching on question ids sees `core-enrichment#outcome-missing` where it saw `outcome-missing`. Reports, design steps, and host-supplied dismissals alike.

**Breaking for readers, not for constructors.** No published format gained a required field, so nothing that *constructs* these documents breaks. The known adopter has confirmed their migration is a single `UPDATE` with a string concat, and they end with fewer key fields than they started with.

## Release gate

| Step | Result |
|---|---|
| `pnpm --version` vs `packageManager` | 11.7.0, matches |
| `pnpm install --frozen-lockfile` | exit 0 |
| `pnpm run verify`, wiped `dist` + `.yarramate-out` | exit 0, **1872 passed**, 1 skipped, 105 files |
| `npm pack --dry-run` | 266 files, 2.0 MB packed / 7.8 MB unpacked |
| Tarball contents | runtime, schemas, catalogue, skill, README, LICENCE, consumer guide |
| Tarball leakage | none — no `src/`, `test/`, `.yarramate/`, fixtures or research inputs |

**Resolved from the installed tarball**, not the source tree: `yarramate/workbook`, `yarramate/workbook/import`, and `yarramate/interrogation` — including `composeCatalogues`, which is the one call this release asks adopters to make.

The workbook has no JSON schema and is not expected to: it is an xlsx container, not a published document format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)