### PR TITLE
reconcile reports the artifacts no observation claims (#175)

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -713,6 +713,11 @@ concepts:
     name: Detect stale attestations
     description: "Reports a sign-off as stale when the attested subject's name or description changed in a commit dated after the attestation, so a reviewer learns which sign-offs no longer cover the wording they read. It is a reconcile finding only: it never reopens an evaluator verdict and never gates check --strict, because gating would reward backdating. Outside a git checkout it emits a note rather than silence, keeping \"not assessed\" distinguishable from \"clean\"."
     status: current
+  - id: assess-artifact-coverage
+    kind: applicationFunction
+    name: Assess artifact coverage
+    description: "Reports every artifact a declared coverage scope selects that no observation's repository locator claims, as a set difference over paths. The scope is opt-in in the workspace manifest and resolves against the git repository the manifest lives in, so the report is honest about what it was asked to look at; the counters appear exactly when coverage was assessed, keeping \"never looked\" distinguishable from \"everything claimed\". An unclaimed artifact is absence and never a finding, because no provider looked and disagreed, and it never gates check --strict."
+    status: current
   - id: subject-identity
     kind: compiler-module
     name: Subject identity resolver
@@ -1663,10 +1668,28 @@ relationships:
     kind: assignment
     from: evidence-evaluator
     to: detect-stale-attestations
+  - id: evidence-evaluator-assesses-artifact-coverage
+    kind: assignment
+    from: evidence-evaluator
+    to: assess-artifact-coverage
   - id: reconcile-command-serves-stale-attestations
     kind: serving
     from: reconcile-command
     to: detect-stale-attestations
+  - id: reconcile-command-serves-artifact-coverage
+    kind: serving
+    from: reconcile-command
+    to: assess-artifact-coverage
+  - id: artifact-coverage-reads-workspace-manifest
+    kind: access
+    from: assess-artifact-coverage
+    to: workspace-manifest
+    mode: read
+  - id: artifact-coverage-writes-report
+    kind: access
+    from: assess-artifact-coverage
+    to: reconciliation-report
+    mode: write
   - id: stale-attestation-detection-reads-graph
     kind: access
     from: detect-stale-attestations

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -285,6 +285,11 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/attestation-staleness.ts
+  - subject: assess-artifact-coverage
+    result: confirmed
+    evidence:
+      uri: repo:src/artifact-coverage.ts
+      message: deriveArtifactCoverage enumerates the declared scope from the manifest's git toplevel; the set difference itself is assessArtifactCoverage in src/reconciliation.ts
   - subject: diagnostic-result
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1533,9 +1533,21 @@ mappings:
   - native: detect-near-duplicate-subjects
     external: detectNearDuplicateSubjects
     type: concept
+  - native: artifact-coverage-reads-workspace-manifest
+    external: artifactCoverageReadsWorkspaceManifest
+    type: relationship
+  - native: artifact-coverage-writes-report
+    external: artifactCoverageWritesReport
+    type: relationship
+  - native: assess-artifact-coverage
+    external: assessArtifactCoverage
+    type: concept
   - native: detect-stale-attestations
     external: detectStaleAttestations
     type: concept
+  - native: evidence-evaluator-assesses-artifact-coverage
+    external: evidenceEvaluatorAssessesArtifactCoverage
+    type: relationship
   - native: evidence-evaluator-detects-stale-attestations
     external: evidenceEvaluatorDetectsStaleAttestations
     type: relationship
@@ -1553,6 +1565,9 @@ mappings:
     type: relationship
   - native: near-duplicate-detection-reads-graph
     external: nearDuplicateDetectionReadsGraph
+    type: relationship
+  - native: reconcile-command-serves-artifact-coverage
+    external: reconcileCommandServesArtifactCoverage
     type: relationship
   - native: reconcile-command-serves-stale-attestations
     external: reconcileCommandServesStaleAttestations

--- a/.yarramate/workspace.yaml
+++ b/.yarramate/workspace.yaml
@@ -12,3 +12,10 @@ evidence:
   - evidence/*.yaml
 contracts:
   - contracts/*.yaml
+# The artifacts this model intends to cover (#175, ADR 0130). reconcile
+# reports every file here that no evidence observation claims; the number
+# is expected to be nonzero and to shrink as the model catches up.
+coverage:
+  - src/**/*.ts
+  - src/**/*.tsx
+  - schema/*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## 1.7.0
+## Unreleased
+
+- **Added.** Reconcile reports the artifacts no observation claims (#175,
+  ADR 0130). A workspace manifest may declare an optional `coverage` list of
+  glob patterns; `reconcile` resolves them against the root of the git
+  repository the manifest lives in — tracked files plus untracked files git
+  does not ignore — and reports every selected file no observation's
+  `repo:<path>` locator claims (fragments stripped, a directory claiming
+  everything beneath it). `summary.artifactsInScope` and
+  `summary.unclaimedArtifacts` appear exactly when coverage was assessed, a
+  positive count lists paths in a top-level `unclaimedArtifacts` array beside
+  a `coverageScope` echo, and a report that never looked says why in `notes`
+  instead of staying silent. Never a finding, never `check --strict`: the
+  same line ADR 0049 drew for unobserved subjects. This closes the
+  recurrence the issue measured three times — a day of shipped features and
+  a model that acquired nothing, with every gate green, because nothing
+  asked.
+
+  The typed API gains `deriveArtifactCoverage` and the `ArtifactCoverage`
+  input `reconcileEvidenceReports` now optionally takes, so a host that
+  enumerates its own tree can assess coverage without a filesystem.
+
+
 
 - **Added.** A workspace can carry its own questions (#345, ADR 0129). A
   `questions:` manifest category resolves like `patterns` and `evidence`, and

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -34,7 +34,10 @@ not by itself fail Core validation, and confirmation is not approval.
 
 The `evidence.uri` value is opaque to YarraMate Core. Its provider owns URI
 resolution and external validity. An optional non-empty message may explain
-the observation; arbitrary provider metadata is not accepted.
+the observation; arbitrary provider metadata is not accepted. One syntactic
+reading is the exception (ADR 0130): artifact coverage, below, compares
+`repo:<path>` locators against a declared scope as strings — still without
+resolving, opening, or validating anything a locator points at.
 
 ## Value observations
 
@@ -208,6 +211,39 @@ the report says so instead of letting the gap pass as verified.
 
 A finding is advisory evidence, not a proposed replacement claim, validation
 error, CI verdict, or authorization to modify the native model.
+
+## Artifact coverage
+
+Unobserved subjects answer only half of the coverage question: they report
+declared intent no observation supports, and nothing reported code the model
+never mentions at all (#175, ADR 0130). A workspace manifest may therefore
+declare a `coverage` list of glob patterns naming the artifacts the model
+intends to cover:
+
+```yaml
+coverage:
+  - src/**/*.ts
+  - schema/*.json
+```
+
+`reconcile` — only `reconcile` — resolves the patterns against the root of
+the git repository the manifest lives in. An artifact is any selected file
+git can see there: tracked, or untracked and not ignored. An observation
+claims an artifact when its locator is `repo:<path>`, with any `#fragment`
+stripped; a locator naming a directory claims everything beneath it; a
+locator in any other scheme claims nothing. The summary counts
+`artifactsInScope` and `unclaimedArtifacts` exactly when coverage was
+assessed, and a positive count lists the paths in a top-level
+`unclaimedArtifacts` array, sorted, beside a `coverageScope` echo of the
+declared patterns.
+
+When coverage was not assessed — no scope declared, or no git repository —
+the report says why in `notes` rather than staying silent, and a declared
+pattern that selects no artifact gets a note naming it: a dead glob is
+indistinguishable from a typo. An unclaimed artifact is absence, never
+accusation: no finding is fabricated, and `check --strict` does not read
+the list — the same line unobserved subjects and unobserved expectations
+hold.
 
 ## Stale attestations
 

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -22,6 +22,8 @@ evidence:
   - evidence/*.yaml
 contracts:
   - contracts/*.yaml
+coverage:
+  - src/**/*.ts
 ```
 
 `questions` carries question catalogues the workspace itself declares, ADDITIVE
@@ -29,6 +31,15 @@ to the shipped catalogue (#345, ADR 0129). It is how a question true of one
 engagement and nowhere else gets versioned with the model, reviewed as a diff,
 and asked by the same interview loop as everything else. See
 [docs/INTERROGATION.md](INTERROGATION.md).
+
+`coverage` is not a document category: nothing it names is loaded or
+compiled, and it is the one field that does not resolve relative to the
+manifest directory. It declares the artifacts the model intends to cover,
+and `reconcile` — only `reconcile` — resolves the patterns against the root
+of the git repository the manifest lives in and reports every selected file
+no evidence observation claims (#175, ADR 0130). Load-time validation covers
+pattern safety alone, with the same `YM701` every other category uses. See
+[docs/EVIDENCE.md](EVIDENCE.md).
 
 Patterns are relative to the directory containing the manifest and use
 forward-slash paths. Resolution:
@@ -42,7 +53,10 @@ forward-slash paths. Resolution:
 
 Empty categories are written as `[]`. A manifest never searches parent
 directories, reads an environment override, contacts a registry, or infers a
-source category from a filename.
+source category from a filename. Manifest resolution keeps that rule even
+now that `coverage` exists: the coverage patterns resolve to nothing at
+load, and `reconcile` alone interprets them against the repository root
+(ADR 0130).
 
 ## CLI use
 

--- a/docs/adr/0130-reconcile-reports-the-artifacts-no-observation-claims.md
+++ b/docs/adr/0130-reconcile-reports-the-artifacts-no-observation-claims.md
@@ -1,0 +1,98 @@
+# Reconcile reports the artifacts no observation claims
+
+Status: accepted
+
+Three times in three weeks, a day of shipped features moved the model not at
+all while every gate stayed green (#175). The blind spot is structural, not
+disciplinary: the catalogue asks about declared subjects, reconcile compares
+declared claims against observed evidence, and a change that declares nothing
+touches neither. ADR 0049 closed the subject side of this gap — a `current`
+concept no observation reaches is counted and listed. The artifact side had
+no reciprocal: nothing could say which files in the repository no observation
+so much as mentions.
+
+Decided: the workspace manifest may declare an optional `coverage` list of
+glob patterns, and `reconcile` — only `reconcile` — assesses it. The patterns
+resolve against the root of the git repository the manifest lives in, and an
+artifact is any file git can see there: tracked, or untracked and not
+ignored. An observation claims an artifact when its evidence locator is
+`repo:<path>`, with any `#fragment` stripped; a locator naming a directory
+claims everything beneath it; a locator in any other scheme claims nothing.
+The report mirrors ADR 0049: `summary.artifactsInScope` and
+`summary.unclaimedArtifacts` appear exactly when coverage was assessed, and a
+positive count lists the paths in a top-level `unclaimedArtifacts` array,
+sorted, beside a `coverageScope` echo of the declared patterns so the report
+is honest about what it was asked to look at.
+
+Unclaimed is absence, never accusation: no finding is fabricated, and the
+list does not participate in `check --strict` — a coverage signal is not a
+contradiction, the same line staleness (ADR 0074) and unobserved
+expectations (ADR 0075) already hold.
+
+When coverage was not assessed, the report says so in `notes` rather than
+staying silent: a manifest with no `coverage` scope, and a workspace outside
+any git repository, each name their reason — the ADR 0074 parallel the issue
+asked for. The counters appear exactly when the scope was assessed, so a
+report without them is one that never looked, not one that found nothing. A
+declared pattern that selects no artifact gets its own note naming the
+pattern: a dead glob is indistinguishable from a typo, and silently
+contributing nothing is how a mistyped pattern would report full coverage
+(the ADR 0128 lesson, resolved with a note rather than a refusal because a
+coverage scope is a lens, not load-bearing input — YM702 refuses an
+unmatched *document* pattern because without documents there is no
+workspace).
+
+Three recorded decisions sit in this feature's path, and each keeps its
+line rather than being reversed:
+
+1. **"The `evidence.uri` value is opaque to YarraMate Core"**
+   (docs/EVIDENCE.md). Resolution and external validity stay entirely with
+   the provider: Core still never opens, fetches, or validates what a
+   locator points at. Coverage performs a syntactic string comparison
+   against the one scheme the product's own documentation has always used
+   for repository paths — `repo:` appears in every EVIDENCE.md example and
+   ADR 0068 names it outright. A workspace whose providers use other
+   schemes simply reports everything unclaimed, which is true: no
+   observation names those files as repository paths.
+2. **"The engine stays out of the indexing business: no repository
+   scanning"** (ADR 0068). What that refused was inference — a code index,
+   inferred links, rank. Coverage infers nothing: it enumerates files only
+   inside a scope the maintainer declared, reads no file contents, and
+   reports only absence. Scanning-to-understand stays out;
+   counting-to-report-absence is the same honesty ADR 0068 itself promised
+   when it called evidence coverage "the visible limiting reagent".
+3. **"A manifest never searches parent directories"** (docs/WORKSPACES.md).
+   Manifest *resolution* still doesn't: `coverage` is not a document
+   category, resolves to no files at load, and is never compiled. It is a
+   declaration that `reconcile`, the verb already coupled to the
+   repository's reality frame through git (ADR 0074), interprets against
+   the repository root. Load-time validation covers only pattern safety —
+   absolute paths, backslashes, and `..` traversal are refused with the
+   same YM701 every other category uses.
+
+The enumeration is bounded by git twice over: the root comes from
+`rev-parse --show-toplevel` on the manifest's directory, and glob matches
+are intersected with `git ls-files --cached --others --exclude-standard`,
+so a symlink escaping the repository or a build tree git ignores cannot
+enter the artifact set however broad the glob.
+
+Rejected:
+
+- **Tracked files only.** The recurrence this feature exists to catch is
+  precisely a fresh file nobody has declared, and during development that
+  file is often not yet committed. Filtering to the index would blind the
+  report to exactly the newest artifacts.
+- **Anchoring on the process cwd.** That is the #216 bug shape: the same
+  command reporting different coverage depending on where it was invoked.
+  The git toplevel of the manifest's directory is stable and matches what
+  `repo:` locators have always meant in practice.
+- **A declarable root for a tree the workspace does not live in.** An audit
+  workspace modelling an external repository cannot declare a scope over
+  it. Deferred with a gate: build a `root` when a real workspace models a
+  tree it does not live in and asks for coverage over it — it needs a
+  deliberate relaxation of the `..` guard and nothing shipped needs it
+  today.
+- **The RELEASING.md checklist line.** Three releases shipped on
+  2026-08-26 and a checklist question would have been answered "fine"
+  three times; this recurred twice with maintainers who knew. Discipline
+  is the thing that failed; the fix is a number that moves.

--- a/schema/yarramate-reconciliation-report.schema.json
+++ b/schema/yarramate-reconciliation-report.schema.json
@@ -38,7 +38,17 @@
       "staleAttestations": { "type": "integer", "minimum": 0 },
         "unconfirmedAttestations": { "type": "integer", "minimum": 0 },
         "expectationsCompared": { "type": "integer", "minimum": 0 },
-        "expectationsWithoutObservation": { "type": "integer", "minimum": 0 }
+        "expectationsWithoutObservation": { "type": "integer", "minimum": 0 },
+        "artifactsInScope": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Files the declared coverage scope selected (ADR 0130). Present exactly when coverage was assessed, so a report without it is one that never looked, not one that found nothing."
+        },
+        "unclaimedArtifacts": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Artifacts in scope that no observation's repo: locator claims (ADR 0130). Present exactly when coverage was assessed."
+        }
       }
     },
     "findings": {
@@ -52,6 +62,16 @@
     "unobservedExpectations": {
       "type": "array",
       "items": { "$ref": "#/$defs/unobservedExpectation" }
+    },
+    "coverageScope": {
+      "description": "The coverage patterns as the manifest declared them, echoed so the report is honest about what it was asked to look at (ADR 0130). Present exactly when coverage was assessed.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "unclaimedArtifacts": {
+      "description": "Repository-relative paths of in-scope artifacts no observation claims, sorted (ADR 0130). Absence, never accusation: no finding is fabricated and check --strict does not read this. Present when the count is positive.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
     },
     "notes": {
       "type": "array",

--- a/schema/yarramate-workspace.schema.json
+++ b/schema/yarramate-workspace.schema.json
@@ -44,6 +44,10 @@
     },
     "contracts": {
       "$ref": "#/$defs/patterns"
+    },
+    "coverage": {
+      "description": "Glob patterns naming the artifacts the model intends to cover (#175, ADR 0130). NOT a document category: nothing here is loaded or compiled. reconcile resolves the patterns against the root of the git repository the manifest lives in and reports every selected file no evidence observation claims. Opt-in; absent means coverage is not assessed and the reconciliation report says so.",
+      "$ref": "#/$defs/patterns"
     }
   },
   "$defs": {

--- a/src/artifact-coverage.ts
+++ b/src/artifact-coverage.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process'
+import { globSync } from 'node:fs'
+import { sep } from 'node:path'
+
+// Artifact coverage derives from git (ADR 0130), so it belongs to
+// reconcile, the verb that reports observed reality. The manifest declares
+// the scope; this module enumerates it; the pure reconciliation takes the
+// result as data, so a host with no filesystem can pass its own.
+
+export interface CoverageScopePattern {
+  readonly pattern: string
+  /** Repository-relative files the pattern selected, sorted. */
+  readonly artifacts: readonly string[]
+}
+
+export type ArtifactCoverage =
+  | { readonly assessed: false; readonly reason: string }
+  | {
+      readonly assessed: true
+      readonly scope: readonly CoverageScopePattern[]
+    }
+
+const runGit = (cwd: string, args: readonly string[]) =>
+  spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' })
+
+export function deriveArtifactCoverage(
+  manifestDirectory: string,
+  patterns: readonly string[] | undefined,
+): ArtifactCoverage {
+  if (patterns === undefined) {
+    return {
+      assessed: false,
+      reason: 'the workspace manifest declares no coverage scope',
+    }
+  }
+  // The root is the git toplevel of the manifest's directory, never the
+  // process cwd: the same command must report the same coverage wherever it
+  // was invoked (the #216 bug shape), and the repository boundary is git's
+  // to draw, not a directory-layout guess.
+  const toplevel = runGit(manifestDirectory, [
+    'rev-parse',
+    '--show-toplevel',
+  ])
+  if (toplevel.status !== 0) {
+    return {
+      assessed: false,
+      reason: 'the workspace does not live in a git repository',
+    }
+  }
+  const root = toplevel.stdout.trim()
+  // An artifact is any file git can see: tracked, or untracked and not
+  // ignored. Tracked-only would blind the report to exactly the newest
+  // files — the recurrence this feature exists to catch (ADR 0130).
+  const listed = runGit(root, [
+    'ls-files',
+    '-z',
+    '--cached',
+    '--others',
+    '--exclude-standard',
+  ])
+  if (listed.status !== 0) {
+    return {
+      assessed: false,
+      reason: `git ls-files failed: ${(listed.stderr ?? '').trim()}`,
+    }
+  }
+  const visible = new Set(
+    (listed.stdout ?? '').split('\0').filter((path) => path.length > 0),
+  )
+  // Glob matches are intersected with git's view, so a symlink escaping the
+  // repository or a build tree git ignores cannot enter the artifact set
+  // however broad the glob. The intersection also drops directories: git
+  // lists files only.
+  return {
+    assessed: true,
+    scope: patterns.map((pattern) => ({
+      pattern,
+      artifacts: globSync(pattern, { cwd: root })
+        .map((path) => path.split(sep).join('/'))
+        .filter((path) => visible.has(path))
+        .sort((left, right) => left.localeCompare(right)),
+    })),
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
   evaluateEvidenceWorkspace,
   loadEvidence,
 } from './evidence.js'
+import { deriveArtifactCoverage } from './artifact-coverage.js'
 import { deriveAttestationStaleness } from './attestation-staleness.js'
 import { reconcileEvidenceReports } from './reconciliation.js'
 import { loadWorkspaceManifest } from './workspace.js'
@@ -120,6 +121,13 @@ const runReconciliation = (
         documentId: documentIdByPath.get(path) ?? path,
       })),
     )
+    // Coverage anchors on the manifest's own directory, not the process
+    // cwd, so the same command reports the same coverage wherever it was
+    // invoked (ADR 0130).
+    const coverage = deriveArtifactCoverage(
+      dirname(resolve(cwd, workspacePath)),
+      loadedWorkspace.manifest.coverage,
+    )
     return {
       exitCode: 0,
       stdout: `${JSON.stringify(
@@ -128,6 +136,7 @@ const runReconciliation = (
           evaluation.reports,
           compilation.graph,
           staleness,
+          coverage,
         ),
         null,
         2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,11 @@ export {
 } from './reconciliation.js'
 export { deriveAttestationStaleness } from './attestation-staleness.js'
 export {
+  deriveArtifactCoverage,
+  type ArtifactCoverage,
+  type CoverageScopePattern,
+} from './artifact-coverage.js'
+export {
   buildRtm,
   renderRtmMarkdown,
   type RequirementsTraceabilityMatrix,

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -9,6 +9,7 @@ import type {
   EvidenceReport,
   EvidenceResult,
 } from './evidence.js'
+import type { ArtifactCoverage } from './artifact-coverage.js'
 
 export interface AssertedRelationship {
   readonly from: string
@@ -128,10 +129,29 @@ export interface ReconciliationReport {
     readonly unconfirmedAttestations?: number
     readonly expectationsCompared: number
     readonly expectationsWithoutObservation: number
+    /**
+     * Files the declared coverage scope selected, and the ones no
+     * observation's `repo:` locator claims (ADR 0130). Both appear exactly
+     * when coverage was assessed, so a report without them is one that
+     * never looked, not one that found nothing.
+     */
+    readonly artifactsInScope?: number
+    readonly unclaimedArtifacts?: number
   }
   readonly findings: readonly ReconciliationFinding[]
   readonly unobservedSubjects?: readonly string[]
   readonly unobservedExpectations?: readonly UnobservedExpectation[]
+  /**
+   * The coverage patterns as the manifest declared them, echoed so the
+   * report is honest about what it was asked to look at (ADR 0130).
+   */
+  readonly coverageScope?: readonly string[]
+  /**
+   * In-scope artifacts no observation claims, sorted. Absence, never
+   * accusation: no finding is fabricated and `check --strict` never reads
+   * this (ADR 0130), the line ADR 0049 drew for unobserved subjects.
+   */
+  readonly unclaimedArtifacts?: readonly string[]
   readonly notes?: readonly string[]
 }
 
@@ -320,6 +340,87 @@ const unobservedCurrentConcepts = (
     .sort((left, right) => left.localeCompare(right))
 }
 
+// An observation claims an artifact when its locator is `repo:<path>`,
+// read syntactically: any `#fragment` stripped, a directory claiming
+// everything beneath it, any other scheme claiming nothing. Resolution
+// and external validity stay with the provider (ADR 0130) — nothing here
+// opens a file or checks one exists.
+const claimedArtifactPaths = (
+  reports: readonly EvidenceReport[],
+): ReadonlySet<string> => {
+  const claimed = new Set<string>()
+  for (const report of reports) {
+    for (const observation of report.observations) {
+      const uri = observation.evidence.uri
+      if (!uri.startsWith('repo:')) continue
+      const located = uri.slice('repo:'.length)
+      const fragment = located.indexOf('#')
+      const path = (fragment === -1 ? located : located.slice(0, fragment))
+        .replace(/\/+$/, '')
+      if (path.length > 0) claimed.add(path)
+    }
+  }
+  return claimed
+}
+
+const isClaimed = (
+  claimed: ReadonlySet<string>,
+  artifact: string,
+): boolean => {
+  if (claimed.has(artifact)) return true
+  for (const path of claimed) {
+    if (artifact.startsWith(`${path}/`)) return true
+  }
+  return false
+}
+
+interface CoverageOutcome {
+  readonly scope?: readonly string[]
+  readonly artifacts?: number
+  readonly unclaimed?: readonly string[]
+  readonly notes: readonly string[]
+}
+
+const assessArtifactCoverage = (
+  coverage: ArtifactCoverage | undefined,
+  reports: readonly EvidenceReport[],
+): CoverageOutcome => {
+  // An absent argument is a caller that never looked (the strict gate);
+  // an unassessed derivation is a reconcile that looked and could not,
+  // and says why (ADR 0130, the ADR 0074 parallel).
+  if (coverage === undefined) return { notes: [] }
+  if (!coverage.assessed) {
+    return {
+      notes: [`Artifact coverage was not assessed: ${coverage.reason}.`],
+    }
+  }
+  const notes: string[] = []
+  if (coverage.scope.length === 0) {
+    notes.push(
+      'The workspace manifest declares an empty coverage scope, so no artifacts were assessed.',
+    )
+  }
+  // A dead glob is indistinguishable from a typo, and silently
+  // contributing nothing is how a mistyped pattern would report full
+  // coverage. A note, not a refusal: a coverage scope is a lens, not
+  // load-bearing input (ADR 0130).
+  for (const { pattern, artifacts } of coverage.scope) {
+    if (artifacts.length === 0) {
+      notes.push(`Coverage pattern "${pattern}" matched no artifacts.`)
+    }
+  }
+  const artifacts = [
+    ...new Set(coverage.scope.flatMap(({ artifacts }) => artifacts)),
+  ].sort((left, right) => left.localeCompare(right))
+  const claimed = claimedArtifactPaths(reports)
+  return {
+    scope: coverage.scope.map(({ pattern }) => pattern),
+    artifacts: artifacts.length,
+    unclaimed: artifacts.filter((artifact) => !isClaimed(claimed, artifact)),
+    notes,
+  }
+}
+
 // A judgment a machine transcribed is not the act the authority
 // performed. The recorder is in the model, so the difference is
 // derivable here: an authority who wrote the record in their own hand
@@ -360,11 +461,13 @@ export function reconcileEvidenceReports(
   reports: readonly EvidenceReport[],
   graph?: SemanticGraph,
   staleness?: AttestationStaleness,
+  coverage?: ArtifactCoverage,
 ): ReconciliationReport {
   const assertedByClaim = assertedRelationshipsByClaim(graph)
   const unobservedSubjects = unobservedCurrentConcepts(graph, reports)
   const expectations = compareExpectations(graph, reports)
   const unconfirmed = unconfirmedAttestations(graph)
+  const assessedCoverage = assessArtifactCoverage(coverage, reports)
   const summary = {
     evidenceDocuments: reports.length,
     observations: 0,
@@ -389,6 +492,15 @@ export function reconcileEvidenceReports(
       : { unconfirmedAttestations: unconfirmed.length }),
     expectationsCompared: expectations.compared,
     expectationsWithoutObservation: expectations.unobserved.length,
+    // Coverage counters appear exactly when the scope was assessed
+    // (ADR 0130): a report without them never looked; a report carrying
+    // zero looked and found everything claimed.
+    ...(assessedCoverage.artifacts === undefined
+      ? {}
+      : {
+          artifactsInScope: assessedCoverage.artifacts,
+          unclaimedArtifacts: assessedCoverage.unclaimed?.length ?? 0,
+        }),
   }
   const findings: ReconciliationFinding[] = [
     ...(staleness?.findings ?? []),
@@ -462,7 +574,11 @@ export function reconcileEvidenceReports(
     ),
   )
   summary.findings = findings.length
-  const notes = [...(staleness?.notes ?? []), ...absenceNotes]
+  const notes = [
+    ...(staleness?.notes ?? []),
+    ...absenceNotes,
+    ...assessedCoverage.notes,
+  ]
   return {
     format: 'yarramate/reconciliation-report/v1',
     workspace,
@@ -472,6 +588,13 @@ export function reconcileEvidenceReports(
     ...(expectations.unobserved.length === 0
       ? {}
       : { unobservedExpectations: expectations.unobserved }),
+    ...(assessedCoverage.scope === undefined
+      ? {}
+      : { coverageScope: assessedCoverage.scope }),
+    ...(assessedCoverage.unclaimed === undefined ||
+    assessedCoverage.unclaimed.length === 0
+      ? {}
+      : { unclaimedArtifacts: assessedCoverage.unclaimed }),
     ...(notes.length === 0 ? {} : { notes }),
   }
 }

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -355,8 +355,11 @@ const claimedArtifactPaths = (
       if (!uri.startsWith('repo:')) continue
       const located = uri.slice('repo:'.length)
       const fragment = located.indexOf('#')
-      const path = (fragment === -1 ? located : located.slice(0, fragment))
-        .replace(/\/+$/, '')
+      // Trailing slashes are stripped with a loop, not a regex: an
+      // anchored /\/+$/ is polynomial on a locator of many slashes, and
+      // locators are library input.
+      let path = fragment === -1 ? located : located.slice(0, fragment)
+      while (path.endsWith('/')) path = path.slice(0, -1)
       if (path.length > 0) claimed.add(path)
     }
   }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -40,6 +40,14 @@ export interface WorkspaceManifest {
   readonly questions?: readonly string[]
   readonly evidence?: readonly string[]
   readonly contracts?: readonly string[]
+  /**
+   * Glob patterns naming the artifacts the model intends to cover (#175,
+   * ADR 0130). Not a document category: nothing here is loaded or compiled,
+   * so it never joins ResolvedWorkspace. reconcile resolves the patterns
+   * against the root of the git repository the manifest lives in and reports
+   * every selected file no evidence observation claims.
+   */
+  readonly coverage?: readonly string[]
 }
 
 export interface ResolvedWorkspace {
@@ -91,6 +99,22 @@ export function loadWorkspaceManifest(
   const realBase = realpathSync(base)
   const resolutionDiagnostics: Diagnostic[] = []
   const categoryByPath = new Map<string, string>()
+  const positionOf = (field: string, index: number) => {
+    const node = yaml.getIn([field, index], true)
+    const offset =
+      typeof node === 'object' &&
+      node !== null &&
+      'range' in node &&
+      Array.isArray(node.range)
+        ? node.range[0]
+        : 0
+    return lineCounter.linePos(offset)
+  }
+  const unsafePattern = (pattern: string): boolean =>
+    isAbsolute(pattern) ||
+    /^[A-Za-z]:[\\/]/.test(pattern) ||
+    pattern.includes('\\') ||
+    pattern.split('/').includes('..')
   const expand = (
     field:
       | 'documents'
@@ -107,21 +131,8 @@ export function loadWorkspaceManifest(
     [
       ...new Set(
         patterns.flatMap((pattern, index) => {
-          const node = yaml.getIn([field, index], true)
-          const offset =
-            typeof node === 'object' &&
-            node !== null &&
-            'range' in node &&
-            Array.isArray(node.range)
-              ? node.range[0]
-              : 0
-          const position = lineCounter.linePos(offset)
-          const unsafe =
-            isAbsolute(pattern) ||
-            /^[A-Za-z]:[\\/]/.test(pattern) ||
-            pattern.includes('\\') ||
-            pattern.split('/').includes('..')
-          if (unsafe) {
+          const position = positionOf(field, index)
+          if (unsafePattern(pattern)) {
             resolutionDiagnostics.push({
               severity: 'error',
               code: 'YM701',
@@ -207,6 +218,24 @@ export function loadWorkspaceManifest(
       'Core contract',
       value.contracts ?? [],
     ),
+  }
+  // Coverage patterns resolve to nothing here: they are not a document
+  // category, and reconcile interprets them against the repository root
+  // (ADR 0130). Load-time validation covers only pattern safety, with the
+  // same guard every resolving category gets — but relative to the
+  // repository, so escaping it is what YM701 refuses.
+  for (const [index, pattern] of (value.coverage ?? []).entries()) {
+    if (!unsafePattern(pattern)) continue
+    const position = positionOf('coverage', index)
+    resolutionDiagnostics.push({
+      severity: 'error',
+      code: 'YM701',
+      message: `Workspace coverage pattern "${pattern}" must be a relative path beneath the repository root`,
+      path: source.path,
+      pointer: `/coverage/${index}`,
+      line: position.line,
+      column: position.col,
+    })
   }
   if (resolutionDiagnostics.length > 0) {
     return {

--- a/test/artifact-coverage.test.ts
+++ b/test/artifact-coverage.test.ts
@@ -1,0 +1,282 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+// The barrel import is the point (the composeCatalogues lesson): the one
+// call a host makes to assess its own tree must be reachable from the
+// published entry, not only from the module that defines it.
+import { deriveArtifactCoverage } from '../src/index.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const reconciliationSchema = JSON.parse(
+  JSON.stringify(
+    await import('../schema/yarramate-reconciliation-report.schema.json', {
+      with: { type: 'json' },
+    }).then((module) => module.default),
+  ),
+) as object
+
+const validateReport = new Ajv2020({ allErrors: true }).compile(
+  reconciliationSchema,
+)
+
+// Coverage is assessed against what git can see, so the assessed fixtures
+// run `git init` — deliberately with no commit: an untracked file is
+// exactly the newest-artifact shape the feature exists to catch, and it
+// must count (ADR 0130).
+const writeFixture = (options: {
+  readonly coverage?: string
+  readonly git: boolean
+}) => {
+  const parent = mkdtempSync(join(tmpdir(), 'yarramate-coverage-'))
+  mkdirSync(join(parent, '.yarramate', 'architecture'), { recursive: true })
+  mkdirSync(join(parent, '.yarramate', 'evidence'), { recursive: true })
+  mkdirSync(join(parent, 'src', 'legacy'), { recursive: true })
+  mkdirSync(join(parent, 'src', 'generated'), { recursive: true })
+  writeFileSync(
+    join(parent, '.yarramate', 'workspace.yaml'),
+    'format: yarramate/workspace/v1\n' +
+      'id: shop\n' +
+      'documents:\n' +
+      '  - architecture/*.yaml\n' +
+      'profiles: []\n' +
+      'projections: []\n' +
+      'adapterMappings: []\n' +
+      'evidence:\n' +
+      '  - evidence/*.yaml\n' +
+      (options.coverage ?? ''),
+  )
+  writeFileSync(
+    join(parent, '.yarramate', 'architecture', 'shop.yaml'),
+    'format: yarramate/v1\n' +
+      'id: shop\n' +
+      'profile: yarramate/core@0.1\n' +
+      'concepts:\n' +
+      '  - id: api-service\n' +
+      '    kind: applicationService\n' +
+      '    name: Api\n' +
+      '    status: current\n' +
+      '  - id: legacy-store\n' +
+      '    kind: dataObject\n' +
+      '    name: Legacy store\n' +
+      '    status: current\n' +
+      'relationships: []\n',
+  )
+  // One locator carries a fragment and one names a directory: stripping
+  // the fragment and claiming beneath the directory are each load-bearing
+  // for the expected unclaimed set below.
+  writeFileSync(
+    join(parent, '.yarramate', 'evidence', 'repository.yaml'),
+    'format: yarramate/evidence/v1\n' +
+      'id: shop-repository\n' +
+      'version: "1.0"\n' +
+      'provider: repository-inspection\n' +
+      'observations:\n' +
+      '  - subject: api-service\n' +
+      '    result: confirmed\n' +
+      '    evidence:\n' +
+      '      uri: repo:src/api.ts#L1\n' +
+      '  - subject: legacy-store\n' +
+      '    result: confirmed\n' +
+      '    evidence:\n' +
+      '      uri: repo:src/legacy\n',
+  )
+  writeFileSync(join(parent, 'src', 'api.ts'), 'export const api = 1\n')
+  writeFileSync(
+    join(parent, 'src', 'legacy', 'old.ts'),
+    'export const old = 1\n',
+  )
+  writeFileSync(
+    join(parent, 'src', 'orphan.ts'),
+    'export const orphan = 1\n',
+  )
+  writeFileSync(
+    join(parent, 'src', 'generated', 'gen.ts'),
+    'export const gen = 1\n',
+  )
+  writeFileSync(join(parent, '.gitignore'), 'src/generated/\n')
+  if (options.git) {
+    const initialized = spawnSync('git', ['init'], {
+      cwd: parent,
+      encoding: 'utf8',
+    })
+    expect(initialized.status).toBe(0)
+  }
+  return parent
+}
+
+const declaredScope =
+  'coverage:\n' + '  - src/**/*.ts\n' + '  - missing/**/*.ts\n'
+
+describe('artifact coverage in reconciliation', () => {
+  it('lists in-scope artifacts no observation claims', () => {
+    const parent = writeFixture({ coverage: declaredScope, git: true })
+    try {
+      const result = runCli(
+        ['reconcile', '.yarramate/workspace.yaml'],
+        parent,
+      )
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).toBe('')
+      const report = JSON.parse(result.stdout)
+      // Three artifacts, not four: src/generated/gen.ts sits inside the
+      // glob and is asserted out of scope because git ignores it — the
+      // intersection is what bounds a broad glob (ADR 0130).
+      expect(report.summary.artifactsInScope).toBe(3)
+      expect(report.summary.unclaimedArtifacts).toBe(1)
+      expect(report.unclaimedArtifacts).toEqual(['src/orphan.ts'])
+      expect(report.coverageScope).toEqual([
+        'src/**/*.ts',
+        'missing/**/*.ts',
+      ])
+      expect(report.notes).toContain(
+        'Coverage pattern "missing/**/*.ts" matched no artifacts.',
+      )
+      expect(validateReport(report)).toBe(true)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('reports the same coverage wherever the command is invoked', () => {
+    const parent = writeFixture({ coverage: declaredScope, git: true })
+    try {
+      const fromRoot = JSON.parse(
+        runCli(['reconcile', '.yarramate/workspace.yaml'], parent).stdout,
+      )
+      // The #216 bug shape is coverage that changes with the invocation
+      // directory; the anchor is the manifest's git toplevel instead.
+      const fromSubdirectory = JSON.parse(
+        runCli(
+          ['reconcile', join('..', '.yarramate', 'workspace.yaml')],
+          join(parent, 'src'),
+        ).stdout,
+      )
+      expect(fromSubdirectory.summary.artifactsInScope).toBe(
+        fromRoot.summary.artifactsInScope,
+      )
+      expect(fromSubdirectory.unclaimedArtifacts).toEqual(
+        fromRoot.unclaimedArtifacts,
+      )
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('says coverage was not assessed when no scope is declared', () => {
+    const parent = writeFixture({ git: true })
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', '.yarramate/workspace.yaml'], parent).stdout,
+      )
+      expect(report.notes).toContain(
+        'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
+      )
+      // The counters appear exactly when coverage was assessed: absent
+      // means never looked, and must not read as zero unclaimed.
+      expect('artifactsInScope' in report.summary).toBe(false)
+      expect('unclaimedArtifacts' in report.summary).toBe(false)
+      expect('coverageScope' in report).toBe(false)
+      expect('unclaimedArtifacts' in report).toBe(false)
+      expect(validateReport(report)).toBe(true)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('says coverage was not assessed outside a git repository', () => {
+    const parent = writeFixture({ coverage: declaredScope, git: false })
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', '.yarramate/workspace.yaml'], parent).stdout,
+      )
+      expect(report.notes).toContain(
+        'Artifact coverage was not assessed: the workspace does not live in a git repository.',
+      )
+      expect('artifactsInScope' in report.summary).toBe(false)
+      expect(validateReport(report)).toBe(true)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('assesses a declared empty scope honestly', () => {
+    const parent = writeFixture({ coverage: 'coverage: []\n', git: true })
+    try {
+      const report = JSON.parse(
+        runCli(['reconcile', '.yarramate/workspace.yaml'], parent).stdout,
+      )
+      expect(report.summary.artifactsInScope).toBe(0)
+      expect(report.summary.unclaimedArtifacts).toBe(0)
+      expect(report.coverageScope).toEqual([])
+      expect('unclaimedArtifacts' in report).toBe(false)
+      expect(report.notes).toContain(
+        'The workspace manifest declares an empty coverage scope, so no artifacts were assessed.',
+      )
+      expect(validateReport(report)).toBe(true)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses a coverage pattern that escapes the repository', () => {
+    const parent = writeFixture({
+      coverage: 'coverage:\n  - ../escape/*.ts\n',
+      git: true,
+    })
+    try {
+      const result = runCli(
+        ['reconcile', '.yarramate/workspace.yaml'],
+        parent,
+      )
+      expect(result.exitCode).toBe(1)
+      const output = JSON.parse(result.stdout)
+      expect(output.diagnostics).toEqual([
+        expect.objectContaining({
+          code: 'YM701',
+          pointer: '/coverage/0',
+          message:
+            'Workspace coverage pattern "../escape/*.ts" must be a relative path beneath the repository root',
+        }),
+      ])
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('exposes the derivation through the package barrel', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'yarramate-coverage-api-'))
+    try {
+      expect(deriveArtifactCoverage(parent, undefined)).toEqual({
+        assessed: false,
+        reason: 'the workspace manifest declares no coverage scope',
+      })
+      expect(deriveArtifactCoverage(parent, ['src/**/*.ts'])).toEqual({
+        assessed: false,
+        reason: 'the workspace does not live in a git repository',
+      })
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('never fails check --strict on unclaimed artifacts', () => {
+    const parent = writeFixture({ coverage: declaredScope, git: true })
+    try {
+      // The same workspace reconcile reports one unclaimed artifact for;
+      // a coverage signal is not a contradiction (ADR 0130).
+      const result = runCli(
+        ['check', '.yarramate/workspace.yaml', '--strict'],
+        parent,
+      )
+      expect(result.exitCode).toBe(0)
+    } finally {
+      rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/attestation-staleness.test.ts
+++ b/test/attestation-staleness.test.ts
@@ -196,7 +196,10 @@ describe('stale attestations', () => {
     )
     expect(finding.evidence.message).toContain('the description changed in commit')
     expect(report.summary.staleAttestations).toBe(1)
-    expect(report.notes).toBeUndefined()
+    // The only note is coverage's: staleness itself was assessed cleanly.
+    expect(report.notes).toEqual([
+      'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
+    ])
   })
 
   it('stays silent when the sign-off came after the change', () => {
@@ -325,6 +328,8 @@ describe('stale attestations', () => {
     expect(report.summary.staleAttestations).toBe(0)
     expect(report.notes).toEqual([
       'Attestation staleness was not assessed: the workspace is not inside a git repository.',
+    
+      'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
     ])
   })
 
@@ -355,6 +360,8 @@ describe('stale attestations', () => {
     expect(staleFindings(report)).toEqual([])
     expect(report.notes).toEqual([
       'Attestation staleness was not assessed for architecture/extra.yaml: the file has no committed history.',
+    
+      'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
     ])
   })
 
@@ -369,6 +376,8 @@ describe('stale attestations', () => {
     expect(staleFindings(report)).toEqual([])
     expect(report.notes).toEqual([
       'Attestation "signed-off" on refund-rule predates the earliest committed history of architecture/policy.yaml; staleness was not assessed.',
+    
+      'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
     ])
   })
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -552,6 +552,9 @@ describe('YarraMate CLI', () => {
         expectationsWithoutObservation: 0,
       },
       unobservedSubjects: ['order-service'],
+      notes: [
+        'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
+      ],
       findings: [
         {
           target: {
@@ -645,6 +648,9 @@ describe('YarraMate CLI', () => {
         expectationsCompared: 0,
         expectationsWithoutObservation: 0,
       },
+      notes: [
+        'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
+      ],
       findings: [
         {
           target: {

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -336,11 +336,10 @@ evidence:
         { id: 'delivery-api', type: 'concept' },
         { id: 'delivery-data', type: 'concept' },
       ])
-      expect(
-        JSON.parse(
-          run(['reconcile', '.yarramate/workspace.yaml']),
-        ),
-      ).toMatchObject({
+      const reconciliationReport = JSON.parse(
+        run(['reconcile', '.yarramate/workspace.yaml']),
+      )
+      expect(reconciliationReport).toMatchObject({
         format: 'yarramate/reconciliation-report/v1',
         workspace: 'consumer',
         summary: {
@@ -351,6 +350,11 @@ evidence:
         },
         findings: [],
       })
+      // A report that never assessed artifact coverage says so (ADR 0130),
+      // and this asserts it through the packed CLI, not the source tree.
+      expect(reconciliationReport.notes).toContain(
+        'Artifact coverage was not assessed: the workspace manifest declares no coverage scope.',
+      )
       expect(
         JSON.parse(
           run([


### PR DESCRIPTION
Closes #175. ADR 0130.

Three times in three weeks a day of shipped features moved the model not at
all while every gate stayed green. The blind spot is structural: the
catalogue asks about declared subjects, reconcile compares declared claims,
and a change that declares nothing touches neither. ADR 0049 closed the
subject side; this is the reciprocal — **which artifacts in scope are
claimed by nothing?**

## What ships

- The workspace manifest takes an optional `coverage` list of glob
  patterns. Not a document category: nothing is loaded or compiled, and
  load-time validation covers only pattern safety (the same `YM701`).
- `reconcile` — only `reconcile` — resolves the patterns against the root
  of the git repository the manifest lives in (never the process cwd: that
  is the #216 bug shape). An artifact is any selected file git can see:
  tracked, or untracked and not ignored, because the recurrence this
  catches is precisely a fresh file nobody declared yet.
- An observation claims an artifact when its locator is `repo:<path>`,
  read syntactically — `#fragment` stripped, a directory claiming
  everything beneath it, any other scheme claiming nothing. Core still
  never resolves, opens, or validates what a locator points at.
- The report mirrors ADR 0049: `summary.artifactsInScope` and
  `summary.unclaimedArtifacts` appear exactly when coverage was assessed,
  a positive count lists paths in a top-level `unclaimedArtifacts` array
  beside a `coverageScope` echo, and a report that never looked says why
  in `notes`. A dead glob gets a note naming it. Never a finding, never
  `check --strict`.
- Typed API: `deriveArtifactCoverage`, plus an optional `ArtifactCoverage`
  input on `reconcileEvidenceReports`, so a host that enumerates its own
  tree can assess coverage without a filesystem.

## Three recorded decisions, lines held rather than reversed

1. *"evidence.uri is opaque to Core"* (EVIDENCE.md) — resolution and
   external validity stay with the provider; coverage is a string
   comparison against the one scheme the docs have always used. The
   opacity paragraph now names the carve-out.
2. *"No repository scanning"* (ADR 0068) — what that refused was
   inference. Coverage enumerates only inside a declared scope, reads no
   contents, reports only absence.
3. *"A manifest never searches parent directories"* (WORKSPACES.md) —
   manifest resolution still doesn't; `coverage` resolves to nothing at
   load and reconcile interprets it against the repository.

## Verified

- Through the seam: every assertion drives the real CLI on git-initialized
  fixtures; the packed-consumer test pins the not-assessed note through
  the published CLI; the barrel test calls `deriveArtifactCoverage` off
  the package entry (the `composeCatalogues` lesson).
- Mutation-proven: disabling fragment stripping, directory claiming, the
  git intersection, and untracked-file inclusion each turned the headline
  test red.
- Invocation-independent: the same report from the repo root and from a
  subdirectory, asserted.

## Dogfooded on the self-model, and the number is the point

`.yarramate/workspace.yaml` now declares `src/**/*.ts`, `src/**/*.tsx`,
`schema/*.json`. First honest report: **149 artifacts in scope, 72
unclaimed** — the entire visual app (30 files), the workbook read half
shipped last week, 15 schemas. That list is the measured backlog #175
predicted, now visible in every reconcile instead of recurring silently.

And the acid test: the model acquired *this* feature in the same PR
(`assess-artifact-coverage`, performed by the evidence evaluator, served
by the reconcile command, evidence claiming `src/artifact-coverage.ts`) —
the interview opened `behavior-unassigned` on the new function mid-build
and the assignment closed it. Shipping this without the model mentioning
it would have been the fourth recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
