### PR TITLE
chore: release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.8.0
 
 - **Added.** A catalogue can ask about pattern membership (#346, ADR 0131).
   The new `fills-pattern-slot` trigger condition holds where a subject is
@@ -42,6 +42,11 @@
   The typed API gains `deriveArtifactCoverage` and the `ArtifactCoverage`
   input `reconcileEvidenceReports` now optionally takes, so a host that
   enumerates its own tree can assess coverage without a filesystem.
+
+  Dogfooded in the same release: the self-model's first honest report said
+  72 of 149 in-scope files were unclaimed, and the backlog was worked to
+  zero (#366) — every file bound in by a repository-file concept, a
+  realization to what its code serves, and a confirmed observation.
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog heading for 1.8.0: artifact coverage (#365, ADR 0130) + pattern membership questions (#367, ADR 0131) + the self-model coverage work-down (#366). Clean-slate verify green at the release version (1889 tests); `changelog:check` green; npm pack delta over 1.7.0 is exactly `dist/artifact-coverage.js` + `.d.ts` (268 files). Tag v1.8.0 goes on the merge commit; npm publish follows from a fresh clone at the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)