### PR TITLE
the mount takes the composed catalogue set the overlay already takes (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** `MountOptions.catalogue` (and `LocalHostOptions.catalogue`)
+  accepts the composed catalogue SET the overlay beneath has taken since
+  ADR 0129 (#369, filed from ApertureX adoption): one `{ path, source }` or
+  an array, evaluated together under the composition rules with each
+  question qualified by its own catalogue. This was the last single-width
+  seam between a host's composed interview and the embedded pane — a pane
+  evaluating fewer catalogues than the host's own question surfaces is a
+  disagreement with no symptom. A single source stays source-compatible;
+  `dismissed` needed nothing, since qualified ids already match across the
+  set.
+
 ## 1.8.0
 
 - **Added.** A catalogue can ask about pattern membership (#346, ADR 0131).

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -328,6 +328,20 @@ sign-off.
 absent rather than failing the mount: the overlay is a garnish on the model,
 and a model frame must not be blocked by it.
 
+`catalogue` also takes the composed SET a workspace carries (#369) — an array
+of `{ path, source }` — evaluated together under the ADR 0129 composition
+rules, each question qualified by its own catalogue. A host attaching
+per-project catalogue packs beside its base interview hands the mount the
+same set its other question surfaces derive from, so the pane and the host's
+own Open-items view ask the same interview over the same files:
+
+```ts
+catalogue: [
+  { path: 'catalogues/consulting.yaml', source: baseText },
+  { path: 'questions/mulesoft-pack.yaml', source: packText },
+],
+```
+
 `dismissed` is what the host has already dealt with. A supplied catalogue
 alone does not cover this — the editor evaluates the catalogue itself and
 cannot know that a reviewer set a question aside, with a reason, recorded

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -83,8 +83,17 @@ export interface LocalHostOptions {
    * already takes: a catalogue that does not load leaves the overlay absent
    * rather than failing the mount, because the overlay is a garnish on the
    * model and a model frame must not be blocked by it.
+   *
+   * One catalogue, or the composed SET a workspace carries (#369). The
+   * overlay beneath has taken the array since ADR 0129 made composition the
+   * qualification point; this option was the last single-width seam between
+   * a host's composed interview and the pane, and a pane evaluating fewer
+   * catalogues than the host's own question surfaces is a disagreement with
+   * no symptom. A single source stays source-compatible.
    */
-  readonly catalogue?: { readonly path: string; readonly source: string }
+  readonly catalogue?:
+    | { readonly path: string; readonly source: string }
+    | readonly { readonly path: string; readonly source: string }[]
   /**
    * Questions this host has already dealt with and does not want asked again
    * (#328).

--- a/test/visual-local-host.test.ts
+++ b/test/visual-local-host.test.ts
@@ -119,9 +119,14 @@ const openHost = (
     'architecture/main.yaml': document,
     'projections/apps.yaml': projection,
   },
+  extra: {
+    readonly catalogue?:
+      | { readonly path: string; readonly source: string }
+      | readonly { readonly path: string; readonly source: string }[]
+  } = {},
 ) => {
   const store = memoryStore(files)
-  const host = createLocalHost({ store, workspace })
+  const host = createLocalHost({ store, workspace, ...extra })
   const frames: VisualServerFrame[] = []
   const stop = host.open({
     frame: (frame) => frames.push(frame),
@@ -170,6 +175,49 @@ describe('an editor over a store, with no server', () => {
     expect(overlay!.workspace.length).toBeGreaterThan(0)
     // This thin fixture leaves subject-scoped questions open somewhere.
     expect(Object.keys(overlay!.subjects).length).toBeGreaterThan(0)
+  })
+
+  it('evaluates the composed catalogue SET a host hands the mount (#369)', () => {
+    // The overlay beneath took the array since ADR 0129; the option was the
+    // last single-width seam, and a pane evaluating fewer catalogues than
+    // the host's Open-items surface is a disagreement with no symptom.
+    const pack = (id: string) =>
+      `format: yarramate/question-catalogue/v1
+id: ${id}
+version: "0.1"
+profile: yarramate/core@0.1
+waves:
+  - id: ${id}-wave
+    name: ${id}
+questions:
+  - id: goal-missing
+    wave: ${id}-wave
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#goal
+    question: Where is the goal, per ${id}?
+    materiality: M
+    resolution: R
+    authority: human
+`
+    const { frames } = openHost(undefined, {
+      catalogue: [
+        { path: 'questions/alpha.yaml', source: pack('alpha') },
+        { path: 'questions/beta.yaml', source: pack('beta') },
+      ],
+    })
+    const ready = frames[0]
+    expect(ready?.kind).toBe('ready')
+    if (ready?.kind !== 'ready') return
+    const overlay = ready.snapshot.model.interrogation
+    expect(overlay).toBeDefined()
+    // Both packs ask, under their own qualified identities: two catalogues
+    // may carry the same local id and remain two questions (ADR 0129).
+    expect(
+      overlay!.workspace.map(({ questionId }) => questionId).sort(),
+    ).toEqual(['alpha#goal-missing', 'beta#goal-missing'])
   })
 
   it('counts a view by its SUBJECTS, not by its match set', () => {


### PR DESCRIPTION
Closes #369 (filed from ApertureX adoption of workspace-carried questions).

`MountOptions.catalogue` and `LocalHostOptions.catalogue` widen from one `{ path, source }` to also accept a readonly array — the composed set `interrogationOverlayOf` has taken since ADR 0129 made composition the qualification point. The pass-through needed no change: the seam beneath already composes, so this was purely the option type plus docs. `dismissed` needed nothing; qualified ids already match across the set. A single source stays source-compatible.

The divergence this closes is the one the overlay's own doc comment warns about: a pane evaluating fewer catalogues than the host's Open-items surface is a disagreement with no symptom.

Verified through the seam: a local host mounted with two catalogue packs shows both questions under their own qualified identities; mutation check (compose only the first catalogue) turns it red. Full verify green, 1890 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)