### PR TITLE
the connect banner takes a typed target (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Added.** The connect banner takes a typed target (#309). While a
+  connection's target is unchosen, the panel carries a labelled search
+  field: type a name or id, pick a match, and the draft advances exactly as
+  a canvas tap would — same reducer action, same kind list. This restores a
+  keyboard and assistive-technology authoring path for the one mandatory
+  interaction that was canvas-only, and it is also the fast path on a large
+  diagram where finding the target box is pixel hunting. Every form field
+  in the visual app now carries a `name` (Chrome's audit reports zero
+  unnamed fields, from seven).
+
 - **Added.** `MountOptions.catalogue` (and `LocalHostOptions.catalogue`)
   accepts the composed catalogue SET the overlay beneath has taken since
   ADR 0129 (#369, filed from ApertureX adoption): one `{ path, source }` or

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -484,6 +484,7 @@ const DiagramWorkspace = ({
             // and without them a second relationship between the same pair
             // collides with the first and is silently swallowed (#306).
             reservedIds={stagedSubjectIds(state.pendingChangeset.operations)}
+            onTarget={onConnectTarget}
             onStage={onConnectStage}
             onCancel={onConnectCancel}
           />

--- a/src/visual-app/connection-panel.tsx
+++ b/src/visual-app/connection-panel.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import { useState } from 'react'
 import type { CanvasGraph } from '../graph-projection.js'
 import type { YarramateOperation } from '../operations.js'
 import type { RelationshipKind } from '../profile.js'
@@ -7,6 +8,98 @@ import {
   draftRelationship,
 } from '../relationship-drafting.js'
 import type { ConnectionDraft } from './workspace-state.js'
+
+export interface TargetMatch {
+  readonly id: string
+  readonly name: string
+}
+
+/**
+ * Subjects a typed query names as connection targets (#309). The canvas tap
+ * stays the fast path; this is the KEYBOARD path — the one mandatory canvas
+ * interaction was pointer-only, so a screen-reader or keyboard-only reviewer
+ * could not author a relationship at all. Name and id both match,
+ * case-insensitively, because the reviewer knows whichever the rail showed
+ * them; the source is excluded because a self-edge is never what a typed
+ * query means. An empty query matches nothing rather than everything: the
+ * list is an answer to a question, not a roster.
+ */
+export const searchTargets = (
+  graph: CanvasGraph,
+  from: string,
+  query: string,
+  cap = 8,
+): { readonly matches: readonly TargetMatch[]; readonly more: number } => {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return { matches: [], more: 0 }
+  const all = graph.nodes
+    .filter((node) => node.id !== from)
+    .filter(
+      (node) =>
+        node.name.toLowerCase().includes(needle) ||
+        node.id.toLowerCase().includes(needle),
+    )
+    .map((node) => ({ id: node.id, name: node.name }))
+    .sort(
+      (left, right) =>
+        left.name.localeCompare(right.name) || left.id.localeCompare(right.id),
+    )
+  return { matches: all.slice(0, cap), more: Math.max(0, all.length - cap) }
+}
+
+/**
+ * The typed way to name a target (#309). A child component so the hook
+ * lives only where the search exists: `ConnectionPanel` itself stays a
+ * plain function of its props, which is also how its tests call it.
+ */
+const TargetSearch = ({
+  graph,
+  from,
+  onTarget,
+}: {
+  readonly graph: CanvasGraph
+  readonly from: string
+  readonly onTarget: (id: string) => void
+}): React.ReactElement => {
+  const [query, setQuery] = useState('')
+  const { matches, more } = searchTargets(graph, from, query)
+  return (
+    <>
+      <label
+        className="connection-search-label"
+        htmlFor="connection-target-search"
+      >
+        Search targets
+      </label>
+      <input
+        id="connection-target-search"
+        className="connection-search"
+        type="search"
+        autoComplete="off"
+        placeholder="Target name or id"
+        value={query}
+        onChange={(event) => setQuery(event.currentTarget.value)}
+      />
+      {query.trim() === '' ? null : matches.length === 0 ? (
+        <p className="connection-empty">No subject matches.</p>
+      ) : (
+        <ul className="connection-targets">
+          {matches.map((match) => (
+            <li key={match.id}>
+              <button type="button" onClick={() => onTarget(match.id)}>
+                {match.name}
+                <span className="connection-target-id"> {match.id}</span>
+              </button>
+            </li>
+          ))}
+          {more === 0 ? null : (
+            <li className="connection-targets-more">{more} more match</li>
+          )}
+        </ul>
+      )}
+    </>
+  )
+}
 
 /**
  * The connection tool: pick a source, pick a target, pick a kind.
@@ -25,6 +118,7 @@ export const ConnectionPanel = ({
   draft,
   graph,
   reservedIds,
+  onTarget,
   onStage,
   onCancel,
 }: {
@@ -38,6 +132,12 @@ export const ConnectionPanel = ({
    * what is staged, even when the answer is nothing.
    */
   readonly reservedIds: readonly string[]
+  /**
+   * Names the target, exactly as a canvas tap would (#309): same reducer
+   * action, same draft transition. The panel adds the keyboard way in, not
+   * a second connect flow.
+   */
+  readonly onTarget: (id: string) => void
   readonly onStage: (operation: YarramateOperation) => void
   readonly onCancel: () => void
 }): React.ReactElement => {
@@ -49,8 +149,9 @@ export const ConnectionPanel = ({
       <section className="connection-panel" aria-label="Connect subjects">
         <p className="connection-prompt">
           Connecting from <strong>{titleOf(draft.from)}</strong>. Choose a
-          target on the diagram.
+          target on the diagram, or search for one.
         </p>
+        <TargetSearch graph={graph} from={draft.from} onTarget={onTarget} />
         <button type="button" onClick={onCancel}>
           Cancel
         </button>

--- a/src/visual-app/quick-filter.tsx
+++ b/src/visual-app/quick-filter.tsx
@@ -12,6 +12,7 @@ export function QuickFilterBox({ value, onChange }: QuickFilterBoxProps) {
   return (
     <input
       type="search"
+      name="quick-filter"
       className="quick-filter"
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -1202,6 +1202,49 @@ body {
   list-style: none;
 }
 
+.connection-search-label {
+  display: block;
+  margin: 0 0 calc(var(--step) * 0.5);
+  font-family: var(--utility);
+  font-size: 12px;
+  color: var(--quiet);
+}
+
+.connection-search {
+  display: block;
+  width: 100%;
+  margin: 0 0 calc(var(--step) * 1);
+  padding: calc(var(--step) * 0.5) calc(var(--step) * 0.75);
+  border: 1px solid var(--rule-firm);
+  border-radius: 0;
+  background: var(--sheet);
+  color: var(--ink);
+  font-family: var(--utility);
+}
+
+.connection-targets {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--step) * 0.5);
+  margin: 0 0 calc(var(--step) * 1.5);
+  padding: 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.connection-target-id {
+  color: var(--quiet);
+  font-family: var(--utility);
+  font-size: 12px;
+}
+
+.connection-targets-more {
+  color: var(--quiet);
+  font-family: var(--utility);
+  font-size: 12px;
+}
+
 .ledger {
   margin: 0;
   padding: calc(var(--step) * 2) calc(var(--step) * 2.5);

--- a/src/visual-app/subject-form.tsx
+++ b/src/visual-app/subject-form.tsx
@@ -361,6 +361,13 @@ export const overlayRelationshipFields = (
 // ---------------------------------------------------------------------------
 // Shared controls.
 
+
+// Chrome's audit wants every form field to carry an id or name (#309); the
+// name is derived from the visible label so autofill and the a11y tooling
+// see a stable identity without inventing a second vocabulary.
+const fieldNameOf = (label: string): string =>
+  `subject-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+
 const SelectRow = ({
   label,
   value,
@@ -374,7 +381,11 @@ const SelectRow = ({
 }) => (
   <label className="subject-form-field">
     <span className="subject-form-label">{label}</span>
-    <select value={value} onChange={(event) => onCommit(event.target.value)}>
+    <select
+      name={fieldNameOf(label)}
+      value={value}
+      onChange={(event) => onCommit(event.target.value)}
+    >
       {options.map((option) => (
         <option key={option.value} value={option.value}>
           {option.label}
@@ -400,6 +411,7 @@ const TextRow = ({
       <span className="subject-form-label">{label}</span>
       <input
         type="text"
+        name={fieldNameOf(label)}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onBlur={() => onCommit(draft)}

--- a/src/visual-app/view-tree.tsx
+++ b/src/visual-app/view-tree.tsx
@@ -247,6 +247,7 @@ export function ViewTree({
       <div className="view-tree-head">
         <input
           type="search"
+          name="view-tree-filter"
           className="view-tree-filter"
           placeholder="Filter tree"
           aria-label="Filter views and subjects"

--- a/test/connection-panel.test.ts
+++ b/test/connection-panel.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from 'vitest'
 import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
 import { projectGraphForCanvas } from '../src/graph-projection.js'
 import { connectableKinds } from '../src/relationship-drafting.js'
-import { ConnectionPanel } from '../src/visual-app/connection-panel.js'
+import {
+  ConnectionPanel,
+  searchTargets,
+} from '../src/visual-app/connection-panel.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
 import type { YarramateOperation } from '../src/operations.js'
 
@@ -42,6 +45,7 @@ const render = (draft: { from: string; to: string | null }) =>
       draft,
       graph,
       reservedIds: [],
+      onTarget: () => undefined,
       onStage: () => undefined,
       onCancel: () => undefined,
     }),
@@ -107,6 +111,7 @@ describe('ConnectionPanel', () => {
         draft: { from: 'orders', to: 'settle' },
         graph: outside,
         reservedIds: [],
+        onTarget: () => undefined,
         onStage: () => undefined,
         onCancel: () => undefined,
       }),
@@ -151,6 +156,7 @@ describe('ConnectionPanel', () => {
       draft: { from: 'orders', to: 'settle' },
       graph,
       reservedIds: ['orders-assignment-settle'],
+      onTarget: () => undefined,
       onStage: (operation) => staged.push(operation),
       onCancel: () => undefined,
     })
@@ -165,5 +171,71 @@ describe('ConnectionPanel', () => {
       op: 'add-relationship',
       relationship: { id: 'orders-assignment-settle-2' },
     })
+  })
+
+  it('renders a labelled search field while the target is unchosen (#309)', () => {
+    // The keyboard/AT way in: the one mandatory canvas interaction was
+    // pointer-only. The label/id pair is part of the finding, not garnish.
+    const markup = render({ from: 'orders', to: null })
+    expect(markup).toContain('id="connection-target-search"')
+    expect(markup).toContain('for="connection-target-search"')
+    expect(markup).toContain('Search targets')
+    // Once the target is chosen the search has done its work.
+    expect(render({ from: 'orders', to: 'settle' })).not.toContain(
+      'connection-target-search',
+    )
+  })
+})
+
+describe('searchTargets', () => {
+  it('matches name and id, case-insensitively, excluding the source', () => {
+    expect(searchTargets(graph, 'orders', 'SET')).toEqual({
+      matches: [{ id: 'settle', name: 'Settle' }],
+      more: 0,
+    })
+    // "orders" matches the source's own name and id; the source is never a
+    // target, so the honest answer is nothing.
+    expect(searchTargets(graph, 'orders', 'orders')).toEqual({
+      matches: [],
+      more: 0,
+    })
+  })
+
+  it('matches nothing on an empty query rather than everything', () => {
+    expect(searchTargets(graph, 'orders', '')).toEqual({
+      matches: [],
+      more: 0,
+    })
+    expect(searchTargets(graph, 'orders', '   ')).toEqual({
+      matches: [],
+      more: 0,
+    })
+  })
+
+  it('caps the list and says how many more match', () => {
+    const wide = graphOf(`format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: hub
+    kind: applicationComponent
+    name: Hub
+  - id: spoke-a
+    kind: applicationComponent
+    name: Spoke A
+  - id: spoke-b
+    kind: applicationComponent
+    name: Spoke B
+  - id: spoke-c
+    kind: applicationComponent
+    name: Spoke C
+relationships: []
+`)
+    const { matches, more } = searchTargets(wide, 'hub', 'spoke', 2)
+    expect(matches).toEqual([
+      { id: 'spoke-a', name: 'Spoke A' },
+      { id: 'spoke-b', name: 'Spoke B' },
+    ])
+    expect(more).toBe(1)
   })
 })


### PR DESCRIPTION
The near-term ask from #309 (the issue stays open for the longer-term canvas a11y-tree work, which remains gated on a maintainer scoping session).

While a connection's target is unchosen, the panel carries a labelled search field (`searchTargets` is an exported pure function: name+id match, case-insensitive, source excluded, empty query matches nothing, capped with an honest remainder count). Choosing a match dispatches the SAME `connection.targeted` action a canvas tap does — one connect flow, a second way in. The hook lives in a child component so `ConnectionPanel` stays a plain function of its props, which is how its existing tests call it.

Also: every form field in the visual app now carries a `name` (subject-form rows derive it from their visible label; the two filters name themselves). Chrome's "form field element should have an id or name" audit: seven findings to zero.

**Browser-verified end to end** (chrome-devtools, live session): select Orders, Connect, Tab to the labelled field (present in the a11y tree as a searchbox), type "settle", two matches under qualified names, activate Settlement, kind list appears ("Orders to Settlement"), pick assignment, and `add-relationship · orders-assignment-settlement` stages — canvas never touched. Audit re-run on the rebuilt bundle confirms zero unnamed fields.

Verify green, 1894 tests (+4: search-field render, searchTargets values, cap and empty-query semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)