### PR TITLE
the palette is the authoring entry, and its bands collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Changed.** The canvas strip's Add-subject button stands down when the
+  kind palette is offered. The palette is the authoring entry (pick or drag
+  a kind, the same dialog opens with the kind chosen); the button was its
+  predecessor, and the two side by side were a duplicate. It remains as the
+  fallback on a mount whose `sections` omit the palette, so a section-less
+  embed keeps an authoring entry.
+- **Changed.** The kind palette's layer bands are collapsible. Each band
+  header is a real button with `aria-expanded`, every band starts open, and
+  collapsed state is per mount — 62 kinds is a lot of scroll for a reviewer
+  working in one band.
+
 - **Added.** The connect banner takes a typed target (#309). While a
   connection's target is unchosen, the panel carries a labelled search
   field: type a name or id, pick a match, and the draft advances exactly as

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -274,6 +274,7 @@ const DiagramWorkspace = ({
   onApplyFilter,
   onStageView,
   readOnly,
+  paletteReachable,
 }: {
   readonly state: VisualAppState;
   readonly selectedId: string | null;
@@ -344,6 +345,9 @@ const DiagramWorkspace = ({
    * drag still moves a node transiently but writes no layout.
    */
   readonly readOnly: boolean;
+  /** Whether the kind palette section is offered on this mount: when it is,
+   * the canvas strip's Add-subject button stands down. */
+  readonly paletteReachable: boolean;
 }) => {
   // An edge names its endpoints by node id; the reviewer reads titles. The
   // rendering model the renderer itself draws answers that, so nothing here
@@ -413,7 +417,11 @@ const DiagramWorkspace = ({
               value={state.quickFilterText}
               onChange={onQuickFilterChange}
             />
-            {readOnly ? null : (
+            {/* The palette is the authoring entry when it is reachable; this
+              * button is the FALLBACK for a host that mounts without the
+              * palette section (#295's sections opt-in), not a duplicate
+              * beside it. */}
+            {readOnly || paletteReachable ? null : (
               <button
                 type="button"
                 className="subject-draft-open"
@@ -1662,6 +1670,7 @@ export const App = ({
           onApplyFilter={(query) => filter(query, "editor")}
           onStageView={stageViewChange}
           readOnly={readOnly}
+          paletteReachable={offeredSections.includes("palette")}
         />
         {conversationHidden ? (
           // The way back stands where the column stood: a thin strip, not a

--- a/src/visual-app/kind-palette.tsx
+++ b/src/visual-app/kind-palette.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import { useState } from 'react'
 import type { VisualKindOption } from '../adapters/visual/protocol-contract.js'
 import { conceptKinds, layers } from '../profile.js'
 import { ICON_SIZE, kindIconUriOf } from './kind-icons.js'
@@ -73,13 +74,38 @@ export const KindPalette = ({
   /** A kind chosen without the drag - a click, a keyboard - which opens the
    * same dialog a drop does. */
   readonly onPick: (kindLabel: string) => void
-}): React.ReactElement => (
-  <div className="kind-palette">
-    {paletteGroups(kinds).map((group) => (
-      <div className="kind-palette-layer" key={group.layer}>
-        <p className="kind-palette-layer-name">{group.layer}</p>
-        <ul className="kind-palette-rows">
-          {group.kinds.map((option) => {
+}): React.ReactElement => {
+  // Collapsed layer bands, per mount. 62 kinds is a lot of scroll for a
+  // reviewer working in one band; every band starts open so nothing is
+  // hidden until the reviewer hides it, matching the section headers above.
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+  const toggleLayer = (layer: string) =>
+    setCollapsed((current) => {
+      const next = new Set(current)
+      if (next.has(layer)) next.delete(layer)
+      else next.add(layer)
+      return next
+    })
+  return (
+    <div className="kind-palette">
+      {paletteGroups(kinds).map((group) => {
+        const isCollapsed = collapsed.has(group.layer)
+        return (
+          <div className="kind-palette-layer" key={group.layer}>
+            <button
+              type="button"
+              className="kind-palette-layer-name"
+              aria-expanded={!isCollapsed}
+              onClick={() => toggleLayer(group.layer)}
+            >
+              <span className="kind-palette-caret" aria-hidden="true">
+                {isCollapsed ? '▸' : '▾'}
+              </span>
+              {group.layer}
+            </button>
+            {isCollapsed ? null : (
+              <ul className="kind-palette-rows">
+                {group.kinds.map((option) => {
             // The glyph the canvas already draws on a node of this kind; an
             // extension kind borrows its core parent's. No glyph, no image -
             // the label alone still names the kind.
@@ -110,9 +136,12 @@ export const KindPalette = ({
                 </button>
               </li>
             )
-          })}
-        </ul>
-      </div>
-    ))}
-  </div>
-)
+                })}
+              </ul>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/visual-app/styles.css
+++ b/src/visual-app/styles.css
@@ -832,13 +832,24 @@ body {
 /* The layer bands, in the profile's order - the same grouping the model tree
    reads in, so the palette and the rail are one organisation. */
 .kind-palette-layer-name {
+  display: block;
+  width: 100%;
   margin: 0;
   padding: calc(var(--step) * 0.75) calc(var(--step) * 1.5)
     calc(var(--step) * 0.25);
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
   font-family: var(--utility);
   font-size: 11px;
   letter-spacing: 0.08em;
   color: var(--quiet);
+}
+
+.kind-palette-caret {
+  display: inline-block;
+  width: 1em;
 }
 
 .kind-palette-rows {

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -916,7 +916,7 @@ describe('kind palette (#295)', () => {
     const markup = renderSession({ model: kindsModel })
 
     const bands = ['motivation', 'business', 'application'].map((layer) =>
-      markup.indexOf(`class="kind-palette-layer-name">${layer}<`),
+      markup.indexOf(`</span>${layer}</button>`),
     )
     expect(bands.every((at) => at !== -1)).toBe(true)
     expect(bands).toEqual([...bands].sort((a, b) => a - b))
@@ -938,6 +938,24 @@ describe('kind palette (#295)', () => {
 
     expect(markup).not.toContain('stack-section-palette')
     expect(markup).not.toContain('kind-palette-row')
+    // And exactly then the canvas strip keeps its Add-subject button: the
+    // fallback authoring entry for a mount with no palette to pick from.
+    expect(markup).toContain('>Add subject</button>')
+  })
+
+  it('opens every layer band, as a collapsible the keyboard can reach', () => {
+    // Collapsed state is per mount and starts open: nothing is hidden until
+    // the reviewer hides it. Static markup shows the default; the band
+    // header is a real button with aria-expanded, so assistive tech both
+    // reaches it and hears its state.
+    const markup = renderSession({ model: kindsModel })
+
+    const headers = [
+      ...markup.matchAll(/class="kind-palette-layer-name"[^>]*aria-expanded="(\w+)"/g),
+    ]
+    expect(headers).toHaveLength(3)
+    expect(headers.every((header) => header[1] === 'true')).toBe(true)
+    expect(markup).toContain('kind-palette-row')
   })
 
   it('names the drag payload type hosts and tests can rely on', () => {
@@ -1148,7 +1166,10 @@ describe('a read-only mount (#298)', () => {
     const markup = renderSession(activeViewState)
     const inspector = inspectorOf(markup)
 
-    expect(markup).toContain('>Add subject</button>')
+    // The palette is the authoring entry; the canvas strip's Add-subject
+    // button is the fallback for a mount WITHOUT the palette section, so on
+    // the default mount it stands down rather than duplicating the entry.
+    expect(markup).not.toContain('>Add subject</button>')
     expect(markup).toContain('stack-section-palette')
     expect(markup).toContain('stack-section-changes')
     expect(markup).toContain('aria-label="New view"')


### PR DESCRIPTION
Two review findings from Nabeel's session over the live app.

**Why Add subject existed beside the palette**: it predates it (canvas CRUD wave); the palette (#295/#305) opens the same draft dialog with the kind preseeded. It was kept because an embedding host can mount without the palette section — and that stays true: the button now renders exactly when the mount's offered sections do NOT include the palette, so the default app loses the duplicate and a section-less embed keeps its authoring entry. Read-only unchanged (neither shows).

**Collapsible palette bands**: each layer header is now a real `<button aria-expanded>` with a caret, every band starts open, collapsed state is per mount. The hook lives in `KindPalette` itself (no test invokes it as a plain function).

Browser-verified on a live session: Add subject absent on the default mount and present on a `sections: ['properties','changes']` mount (test-pinned); collapsing business dropped 62 visible rows to 49 with `aria-expanded="false"` and caret flip; a palette pick still opens the draft with the kind preselected; the unnamed-field audit stays at zero with the draft dialog open.

Verify green, 1895 tests (+2 render assertions reshaped to the new premise, +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)