### PR TITLE
chore: release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 1.9.0
+
+- **Added.** The gitlab benchmark suite (#288, #372):
+  `docs/research/context-benchmark/tasks/gitlab.yaml`, 8 tasks frozen at
+  authoring, every ground-truth fact verified in a fresh clone at the
+  gallery showcase's pinned commit. Authored under the recorded small-N
+  pooling decision (kafka + gitlab published as N=2).
 
 - **Changed.** The canvas strip's Add-subject button stands down when the
   kind palette is offered. The palette is the authoring entry (pick or drag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog heading for 1.9.0: the #369 mount catalogue-set widening (#370), the #309 typed connect target (#371), the palette as sole authoring entry with collapsible bands (#373), and the gitlab benchmark suite (#372, cited in the section). `changelog:check` green (4 commits checked); clean-slate verify green at the release version (1895 tests); pack unchanged at 268 files. Tag v1.9.0 goes on the merge commit; npm publish follows from a fresh clone at the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)