### PR TITLE
a question the model never asked says so (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** A question the model never asked says so (#375, ADR 0132).
+  A subject-scoped question whose selector matches no subject now reports
+  `asked: false` beside `open: false`, and renders as `unasked`, never as
+  `closed` — previously never-asked and answered were byte-identical, and
+  a host summing closed questions read an empty model as a satisfied
+  interview (field evidence: a fresh ApertureX project ticked three waves
+  complete with nothing authored). `asked` is absent everywhere else and
+  absent means true, the same additive discipline as `catalogues`: no
+  constructor breaks, existing readers keep their meaning. The
+  interrogation semantics version does not bump — no question's answer
+  changes for an unchanged model; a new distinction is reported where it
+  exists.
+
 ## 1.9.0
 
 - **Added.** The gitlab benchmark suite (#288, #372):

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -254,10 +254,16 @@ one is exactly the case a declared-kinds check would call entirely missing.
 ## Evaluation model
 
 A question is **open** iff its trigger matches, and **closed** the moment it
-no longer does. A question is **not applicable** when any kind it names
-belongs to a profile that no document in the workspace has selected
-(`graph.profiles`). Inapplicable questions are omitted from the report and
-from `summary.questions`; they are not `open: false`. Interview state is
+no longer does. A subject-scoped question whose selector matches no subject
+was **never asked** (#375, ADR 0132): it reports `open: false` with
+`asked: false`, and renders as `unasked`, never as `closed` — a host
+splitting its answered tally must not count it, because completion inferred
+from an empty set is the reading the wave-level "not yet" line already
+refuses. `asked` is absent everywhere else and absent means true, so
+existing readers keep their meaning. A question is **not applicable** when
+any kind it names belongs to a profile that no document in the workspace
+has selected (`graph.profiles`). Inapplicable questions are omitted from
+the report and from `summary.questions`; they are not `open: false`. Interview state is
 recomputed from model plus catalogue on every run and never stored: no
 session files, no second canonical store, nothing to resume. Editing the
 model and re-running yields exactly the still-open questions.

--- a/docs/adr/0132-a-question-the-model-never-asked-says-so.md
+++ b/docs/adr/0132-a-question-the-model-never-asked-says-so.md
@@ -1,0 +1,56 @@
+# A question the model never asked says so
+
+Status: accepted
+
+For a subject-scoped question, evaluation composed subject selection and
+trigger filtering into one expression and reported `matches.length === 0`
+as `open: false`. That one shape conflated three truths: no subject the
+selector names exists (the question was NEVER ASKED), subjects exist and
+every trigger is satisfied (ANSWERED), and subjects exist but none fire.
+A host summing `!open` read all three as answered — and did: a fresh,
+empty ApertureX project reported nine subject-scoped questions "answered"
+across three waves, its wave rail ticked them complete, and an MCP agent
+reading the summary concluded interrogation was done (#375, field evidence
+from a production integration test). The host could not repair it
+downstream without re-running selector semantics outside the engine — the
+drift #289 exists to prevent.
+
+This is the empty-set rule ("the honest question is not whether the count
+is zero but whether anything was asked") landing in the interrogation
+report itself, and the discipline already exists one level up: ADR 0125
+refuses to evaluate a closed wave's questions at all, "rather than
+evaluated and reported closed — the latter would say they had been asked
+and answered". The same line was missing one level down.
+
+Decided:
+
+1. **Evaluation splits selection from trigger filtering.** A selector that
+   matches no subject returns the question marked `asked: false`; a
+   selector that matches subjects whose triggers are all satisfied returns
+   the question closed with `asked` absent.
+2. **`ReportQuestion` gains `asked?: boolean`, absent meaning true** — the
+   additive discipline `catalogues` set (#345): no constructor breaks, and
+   every existing reader keeps its exact meaning. Only the never-asked
+   path writes the field, so a report byte-changes only where the new
+   truth exists.
+3. **The text rendering distinguishes the states too**: a never-asked
+   question renders as `unasked <id> — nothing it selects exists yet`,
+   never as `closed`, for the same reason the wave line says "not yet"
+   (#334): completion must not be inferred from an empty set.
+4. **The semantics version does not bump.** No question's ANSWER changes
+   for an unchanged model — `open` is identical everywhere; a new field
+   appears where a new distinction is reported. Bumping on additions is
+   exactly what the version's own doc comment forbids.
+
+Rejected:
+
+- **A `subjectsConsidered` count.** The boolean is what the filed
+  consumer needs (splitting an answered tally into answered vs
+  never-asked); a count invites reading magnitude into a report that only
+  owes the distinction. Add it when a reader needs the number.
+- **A summary counter for never-asked questions.** A host holding the
+  questions already holds the booleans; a counter would be a second place
+  for the same truth to disagree with the first.
+- **Workspace-scoped questions carrying `asked`.** A workspace-scoped
+  question is always asked — the workspace exists — so the field would be
+  a constant, and a constant field teaches readers to ignore it.

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -133,6 +133,10 @@
         "open": {
           "type": "boolean"
         },
+        "asked": {
+          "type": "boolean",
+          "description": "Whether the question was asked at all (#375, ADR 0132). Absent means true; only a subject-scoped question whose selector matched no subject carries asked: false. Without it, never-asked and answered were byte-identical (open: false), and a host summing closed questions read an empty model as a satisfied interview."
+        },
         "question": {
           "type": "string",
           "minLength": 1

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -210,6 +210,16 @@ export interface ReportQuestion {
   readonly scope: 'workspace' | 'subject'
   readonly authority: 'human' | 'agent' | 'either'
   readonly open: boolean
+  /**
+   * Whether the question was asked at all (#375, ADR 0132). Absent means
+   * true; only a subject-scoped question whose selector matched NO subject
+   * carries `asked: false`. Without it, never-asked and answered were
+   * byte-identical (`open: false`), and a host summing closed questions
+   * read an empty model as a satisfied interview — completion inferred
+   * from an empty set, the exact reading ADR 0125 refuses one level up by
+   * not evaluating a closed wave's questions at all.
+   */
+  readonly asked?: boolean
   readonly question: string
   readonly materiality: string
   readonly resolution: string
@@ -937,11 +947,20 @@ export function evaluateCatalogue(
           }
           return { ...base, open: isOpen }
         }
-        const matches = selectSubjects(
+        // Selection and trigger filtering are separate reads on purpose
+        // (#375, ADR 0132): a selector matching nobody means the question
+        // was never asked, and reporting that as a closed question said it
+        // had been asked and answered — completion inferred from an empty
+        // set, the reading ADR 0125 refuses one level up.
+        const selected = selectSubjects(
           index,
           question.subjects!,
           profileContext,
-        ).filter((id) =>
+        )
+        if (selected.length === 0) {
+          return { ...base, open: false, asked: false }
+        }
+        const matches = selected.filter((id) =>
           question.trigger.every((condition) =>
             conditionHolds(index, condition, id, profileContext, evidence, patternMemberships),
           ),
@@ -1388,6 +1407,15 @@ export function renderInterrogationReport(
       continue
     }
     for (const question of wave.questions) {
+      if (question.asked === false) {
+        // Never asked is not closed (#375): `closed` says answered, and a
+        // selector that matched nobody asked nothing — the question-level
+        // twin of the wave's own "not yet" line above.
+        lines.push(
+          `  unasked ${question.id} — nothing it selects exists yet`,
+        )
+        continue
+      }
       if (!question.open) {
         lines.push(`  closed ${question.id}`)
         continue

--- a/test/never-asked-question.test.ts
+++ b/test/never-asked-question.test.ts
@@ -1,0 +1,162 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runCli } from '../src/cli.js'
+
+const Ajv2020 = Ajv2020Module.default
+
+const reportSchema = JSON.parse(
+  JSON.stringify(
+    await import('../schema/yarramate-interrogation-report.schema.json', {
+      with: { type: 'json' },
+    }).then((module) => module.default),
+  ),
+) as object
+const validateReport = new Ajv2020({ allErrors: true }).compile(reportSchema)
+
+// A question the model never asked says so (#375, ADR 0132). The three
+// states that used to be byte-identical (`open: false`): the selector
+// matched nobody (never asked), subjects existed and every trigger was
+// satisfied (answered), and subjects existed and fired (open). The field
+// evidence was an empty ApertureX project reporting nine subject-scoped
+// questions "answered" and its wave rail ticking them complete.
+
+const catalogue = `format: yarramate/question-catalogue/v1
+id: probe
+version: "0.1"
+profile: yarramate/core@0.1
+waves:
+  - id: probe-wave
+    name: Probe
+questions:
+  - id: svc-doc
+    wave: probe-wave
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#applicationService
+    trigger:
+      - condition: missing-claim
+        predicate: yarramate/concept/description
+    question: What does {subject.name} do?
+    materiality: M
+    resolution: R
+    authority: either
+`
+
+const documentOf = (concepts: string) => `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:${concepts}
+relationships: []
+`
+
+const EMPTY = ' []'
+const SATISFIED = `
+  - id: billing
+    kind: applicationService
+    name: Billing
+    description: Settles the accounts.`
+const FIRING = `
+  - id: billing
+    kind: applicationService
+    name: Billing`
+
+describe('a question the model never asked says so (#375)', () => {
+  let workspace = ''
+  const write = (relative: string, source: string) =>
+    writeFileSync(join(workspace, relative), source, 'utf8')
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'yarramate-never-asked-'))
+    mkdirSync(join(workspace, '.yarramate', 'architecture'), {
+      recursive: true,
+    })
+    mkdirSync(join(workspace, '.yarramate', 'questions'), { recursive: true })
+    write(
+      '.yarramate/workspace.yaml',
+      'format: yarramate/workspace/v1\n' +
+        'id: probe\n' +
+        'documents:\n  - architecture/*.yaml\n' +
+        'profiles: []\n' +
+        'projections: []\n' +
+        'adapterMappings: []\n' +
+        'questions:\n  - questions/*.yaml\n',
+    )
+    write('.yarramate/questions/probe.yaml', catalogue)
+  })
+
+  afterEach(() => rmSync(workspace, { recursive: true, force: true }))
+
+  const probeQuestion = (concepts: string) => {
+    write('.yarramate/architecture/main.yaml', documentOf(concepts))
+    const result = runCli(
+      ['ask', '.yarramate/workspace.yaml', '--open', '--json'],
+      workspace,
+    )
+    expect(result.exitCode).toBe(0)
+    const { report } = JSON.parse(result.stdout) as {
+      report: {
+        waves: {
+          id: string
+          questions: Record<string, unknown>[]
+        }[]
+      }
+    }
+    expect(validateReport(report), JSON.stringify(validateReport.errors)).toBe(
+      true,
+    )
+    const question = report.waves
+      .flatMap(({ questions }) => questions)
+      .find(({ id }) => id === 'probe#svc-doc')
+    expect(question).toBeDefined()
+    return question!
+  }
+
+  it('marks the never-asked state, and only that state', () => {
+    // Selector matches nobody: never asked, and the report says so.
+    const neverAsked = probeQuestion(EMPTY)
+    expect(neverAsked.open).toBe(false)
+    expect(neverAsked.asked).toBe(false)
+
+    // Subjects exist and the trigger is satisfied: answered — and `asked`
+    // is ABSENT, not true, so a report byte-changes only where the new
+    // truth exists and existing readers keep their exact meaning.
+    const satisfied = probeQuestion(SATISFIED)
+    expect(satisfied.open).toBe(false)
+    expect('asked' in satisfied).toBe(false)
+
+    // Subjects exist and fire: open, `asked` absent.
+    const open = probeQuestion(FIRING)
+    expect(open.open).toBe(true)
+    expect('asked' in open).toBe(false)
+    expect(
+      (open.subjects as { id: string }[]).map(({ id }) => id),
+    ).toEqual(['billing'])
+  })
+
+  it('renders never-asked as unasked, never as closed', () => {
+    write('.yarramate/architecture/main.yaml', documentOf(EMPTY))
+    const text = runCli(
+      ['ask', '.yarramate/workspace.yaml', '--open'],
+      workspace,
+    )
+    expect(text.exitCode).toBe(0)
+    expect(text.stdout).toContain(
+      'unasked probe#svc-doc — nothing it selects exists yet',
+    )
+    expect(text.stdout).not.toContain('closed probe#svc-doc')
+
+    // And the satisfied state still reads closed: the two lines must not
+    // collapse back into each other from either side.
+    write('.yarramate/architecture/main.yaml', documentOf(SATISFIED))
+    const satisfied = runCli(
+      ['ask', '.yarramate/workspace.yaml', '--open'],
+      workspace,
+    )
+    expect(satisfied.stdout).toContain('closed probe#svc-doc')
+    expect(satisfied.stdout).not.toContain('unasked probe#svc-doc')
+  })
+})


### PR DESCRIPTION
Closes #375 (ApertureX field evidence: a fresh, empty project reported nine subject-scoped questions "answered" and ticked three waves complete). ADR 0132.

- Evaluation splits subject selection from trigger filtering: a selector matching nobody returns `{ open: false, asked: false }`; a selector whose subjects all satisfy their triggers returns `open: false` with `asked` ABSENT — absent means true, the `catalogues` additive discipline, so no constructor breaks and a report byte-changes only where the new truth exists.
- The text rendering distinguishes too: `unasked <id> — nothing it selects exists yet`, never `closed` — the question-level twin of the wave rail's "not yet" line (#334/ADR 0125, whose discipline this completes one level down).
- The interrogation semantics version does NOT bump: no question's answer changes for an unchanged model, which is exactly the case its own doc comment says not to bump for.
- Schema: optional `asked` boolean on the report question; workspace-scoped questions never carry it (a constant field teaches readers to ignore it — recorded in the ADR's rejections with `subjectsConsidered` and a summary counter).

Verified through the CLI seam on all three states with Ajv validation, plus the renderer both ways (unasked never reads closed, satisfied never reads unasked). Three mutations killed: the split reverted, `asked: false` leaking onto the satisfied path, and the renderer collapsing unasked into closed. Verify green, 1897 tests, zero collateral — no existing test had pinned the conflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)