### PR TITLE
chore: release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.10.0
 
 - **Added.** A question the model never asked says so (#375, ADR 0132).
   A subject-scoped question whose selector matches no subject now reports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog heading for 1.10.0, a single-feature release: a question the model never asked says so (#375, ADR 0132, shipped in #376). `changelog:check` green; clean-slate verify green at the release version (1897 tests). Tag v1.10.0 goes on the merge commit; npm publish follows from a fresh clone at the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)