### PR TITLE
Documents YarraMate writes read the same under every YAML version (#378)

### DIFF
--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -774,6 +774,10 @@ concepts:
     kind: repository-file
     name: src/workbook-read.ts
     status: current
+  - id: yaml-emission-source
+    kind: repository-file
+    name: src/yaml-emission.ts
+    status: current
 relationships:
   - id: backlog-disposition-qualifies-roadmap
     kind: association
@@ -1575,3 +1579,7 @@ relationships:
     kind: realization
     from: workbook-read-source
     to: workbook-engine
+  - id: yaml-emission-realizes-apply
+    kind: realization
+    from: yaml-emission-source
+    to: apply-command

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -1259,6 +1259,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/workbook-read.ts
+  - subject: yaml-emission-source
+    result: confirmed
+    evidence:
+      uri: repo:src/yaml-emission.ts
   - subject: pattern-document
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -2205,6 +2205,9 @@ mappings:
   - native: workbook-read-source
     external: workbookReadSource
     type: concept
+  - native: yaml-emission-source
+    external: yamlEmissionSource
+    type: concept
   - native: pattern-document
     external: patternDocument
     type: concept
@@ -2423,4 +2426,7 @@ mappings:
     type: relationship
   - native: workbook-read-realizes-engine
     external: workbookReadRealizesEngine
+    type: relationship
+  - native: yaml-emission-realizes-apply
+    external: yamlEmissionRealizesApply
     type: relationship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- **Fixed.** Documents YarraMate writes read the same under every YAML
+  version (#378). An attestation's `on` key was emitted unquoted, and a
+  YAML 1.1 loader (PyYAML's default, and most non-JS loaders') resolves a
+  plain `on` to the boolean `true` and a plain `2026-08-27` to a date, so
+  an attestation this toolchain wrote came back to an ApertureX audit
+  script as `{True: date(2026, 8, 27)}`. Nothing in the toolchain misread
+  it: YarraMate reads YAML 1.2, and the surprise landed entirely on
+  whoever read the document with something that was not YarraMate. Rather
+  than quote `on` and wait for its siblings, every string a write emits is
+  now measured against both versions' emitters and double-quoted wherever
+  they disagree, which also covers `y`, `no`, `off`, bare dates,
+  sexagesimals, and (in the other direction, where 1.1 alone would have
+  handed YarraMate's own reader a number) `0o17`. Authored bytes are
+  untouched; only text a write produces changes.
+
 ## 1.10.0
 
 - **Added.** A question the model never asked says so (#375, ADR 0132).

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -515,6 +515,19 @@ referring relationships can leave in one batch (ADR 0069). Retirement
 (`status: retired`) remains the descoping path; delete only when the
 history itself is noise.
 
+Text a write emits is quoted so that it reads the same under every YAML
+version. YarraMate reads YAML 1.2, where a plain `on` is the string `on`.
+YAML 1.1, still PyYAML's default and most non-JS loaders', resolves that
+same plain `on` to the boolean `true` and a plain `2026-08-27` to a date, so
+an attestation written as `on: 2026-08-27` reaches someone's audit script as
+`{True: date(2026, 8, 27)}` rather than the record its author wrote (#378).
+Every string a write produces is therefore measured against both versions
+and double-quoted wherever they disagree (`"on": "2026-08-27"`, `"no"`,
+`"0o17"`), a form both versions read back as the string that was authored.
+Authored bytes are untouched by this, as they are by every other write: the
+rule applies to text YarraMate produces, and a hand-written plain `on:` is
+still read as the string it is.
+
 Two operations — `rename-concept` and `rename-relationship` — move a
 subject's local id. A rename is an identity edit, not a succession: it
 writes no `supersedes` entry and retires nothing, because one subject kept

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -17,7 +17,7 @@ import type { Duplex } from "node:stream";
 import { fileURLToPath } from "node:url";
 import Ajv2020Module from "ajv/dist/2020.js";
 import { WebSocketServer, type RawData, type WebSocket } from "ws";
-import { parse, stringify } from "yaml";
+import { parse } from "yaml";
 import {
   VISUAL_LIMITS,
   VISUAL_PROTOCOL_VERSION,
@@ -96,6 +96,7 @@ import type { PendingWrite, SourceStore } from "../../source-store.js";
 import type { YarramateApplyResult } from "../../operations.js";
 import { DEFAULT_PROJECTION_DIRECTORY } from "./view-identity.js";
 import { createFileSystemStore } from "../../source-store.js";
+import { emitYaml } from "../../yaml-emission.js";
 import {
   loadWorkspaceManifest,
   type ResolvedWorkspace,
@@ -1717,7 +1718,7 @@ export const startVisualServer = async (
           }
           return;
         }
-        const operationsSource = stringify({
+        const operationsSource = emitYaml({
           format: "yarramate/operations/v1",
           operations: event.payload.operations,
         });
@@ -1863,7 +1864,7 @@ export const startVisualServer = async (
         mkdirSync(layoutDir, { recursive: true });
         writeFileSync(
           resolve(options.cwd, path),
-          stringify({
+          emitYaml({
             format: "yarramate/visual-layout/v1",
             projectionId,
             positions,

--- a/src/adapters/visual/workspace-model.ts
+++ b/src/adapters/visual/workspace-model.ts
@@ -1,5 +1,5 @@
-import { stringify } from "yaml";
 import { loadProjection } from "../../projection.js";
+import { emitYaml } from "../../yaml-emission.js";
 import { withDiagnosticSubjects } from "../../compiler.js";
 import type { Diagnostic } from "../../compiler.js";
 import { posixDirectoryOf } from "../../apply-command.js";
@@ -411,7 +411,7 @@ export const planViewWrites = (
       );
       continue;
     }
-    const source = stringify(operation.projection);
+    const source = emitYaml(operation.projection);
     const loaded = loadProjection({ path: operation.path, source });
     if (!loaded.ok) {
       // The composed document is the only source these are about, so they are

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -3,7 +3,6 @@ import {
   isScalar,
   isSeq,
   parseDocument,
-  stringify,
   type Pair,
   type YAMLMap,
   type YAMLSeq,
@@ -17,6 +16,7 @@ import {
   type WorkspaceSource,
 } from './compiler.js'
 import { evaluateEvidence, loadEvidence } from './evidence.js'
+import { emitYaml } from './yaml-emission.js'
 import { loadProjection } from './projection.js'
 import {
   loadSourceDocument,
@@ -116,7 +116,7 @@ const reindent = (text: string, indent: number): string =>
 // line; genuinely multi-line strings become block scalars and are re-indented
 // by the caller.
 const valueText = (value: unknown): string =>
-  stringify(value, { lineWidth: 0 }).trimEnd()
+  emitYaml(value, { lineWidth: 0 }).trimEnd()
 
 const pairFor = (
   map: YAMLMap,
@@ -139,7 +139,7 @@ const sequenceEntries = (
   items: readonly unknown[],
   markerIndent: number,
 ): string => {
-  const rendered = stringify(items, { lineWidth: 0 }).trimEnd()
+  const rendered = emitYaml(items, { lineWidth: 0 }).trimEnd()
   return `${' '.repeat(markerIndent)}${reindent(rendered, markerIndent)}`
 }
 
@@ -327,7 +327,7 @@ const rewriteFlowItem = (
   const [start, valueEnd] = nodeRange(map)
   const fieldIndent = indentAt(source, start)
   const rendered = reindent(
-    stringify(mutated, { lineWidth: 0 }).trimEnd(),
+    emitYaml(mutated, { lineWidth: 0 }).trimEnd(),
     fieldIndent,
   )
   return splice(source, start, valueEnd, rendered)
@@ -403,7 +403,7 @@ const appendListField = (
     ? nodeRange(sequence)
     : nodeRange(pair.value)
   if (isSeq(sequence) && sequence.flow) {
-    const flow = stringify(merged, {
+    const flow = emitYaml(merged, {
       collectionStyle: 'flow',
       lineWidth: 0,
     }).trimEnd()
@@ -467,7 +467,7 @@ const removeCollectionItem = (
       valueEnd,
       remaining.length === 0
         ? '[]'
-        : stringify(remaining, {
+        : emitYaml(remaining, {
             collectionStyle: 'flow',
             lineWidth: 0,
           }).trimEnd(),

--- a/src/import-command.ts
+++ b/src/import-command.ts
@@ -9,10 +9,10 @@ import { buildWorkbookSheets } from './workbook.js'
 import { baselineSheets, mergeWorkbook } from './workbook-merge.js'
 import { operationsFrom, operationsDocument } from './workbook-operations.js'
 import { readWorkbook } from './workbook-read.js'
+import { emitYaml } from './yaml-emission.js'
 import { writeFileSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { stringify } from 'yaml'
 
 /**
  * `yarramate import xlsx <file> <workspace.yaml>` (#355, ADR 0127).
@@ -170,7 +170,7 @@ export async function runImportCommand(
   const operationsPath = join(scratch, 'operations.yaml')
   writeFileSync(
     operationsPath,
-    stringify(operationsDocument(planned.operations)),
+    emitYaml(operationsDocument(planned.operations)),
     'utf8',
   )
   const applied = runApplyCommand([operationsPath, workspacePath], cwd)

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -29,7 +29,7 @@ import {
   serverDiagnostic,
   viewSummaryOf,
 } from '../adapters/visual/workspace-model.js'
-import { stringify } from 'yaml'
+import { emitYaml } from '../yaml-emission.js'
 import { SHIPPED_CATALOGUE } from './shipped-catalogue.js'
 import type { EditorHost, EditorHostEvents } from './editor-host.js'
 
@@ -285,7 +285,7 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
             workspace,
             operations: {
               path: 'changeset.yaml',
-              source: stringify({
+              source: emitYaml({
                 format: 'yarramate/operations/v1',
                 operations,
               }),
@@ -485,7 +485,7 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
           const written = store.writeAll([
             {
               path,
-              source: stringify({
+              source: emitYaml({
                 format: 'yarramate/visual-layout/v1',
                 projectionId,
                 positions,

--- a/src/visual-app/query-panel.tsx
+++ b/src/visual-app/query-panel.tsx
@@ -1,5 +1,5 @@
+import { emitYaml } from "../yaml-emission.js";
 import { useRef, useState } from "react";
-import { stringify } from "yaml";
 import type { CanvasNode } from "../graph-projection.js";
 import type {
   ConceptFacet,
@@ -526,7 +526,7 @@ export function QueryPanel({
               ) : (
                 <>
                   <pre className="query-document">
-                    {stringify(viewDocument(documentInput))}
+                    {emitYaml(viewDocument(documentInput))}
                   </pre>
                   {readOnly ? null : (
                     <div className="query-tab-actions">

--- a/src/yaml-emission.ts
+++ b/src/yaml-emission.ts
@@ -1,0 +1,58 @@
+/**
+ * Emission of YAML that reads the same under every YAML version.
+ *
+ * YarraMate reads its own documents with a YAML 1.2 loader, so the `yaml`
+ * package's default emission is correct for the toolchain. The surprise lands
+ * outside it. YAML 1.1 - still the default of PyYAML and of most non-JS
+ * loaders - resolves a plain `on` to the boolean `true` and a plain
+ * `2026-08-27` to a date, so an attestation this toolchain wrote as
+ * `on: 2026-08-27` reads back as `{True: date(2026, 8, 27)}` in anyone's
+ * migration script, audit pipeline, or client tooling (#378). The asymmetry
+ * is the point: YarraMate writes the document and someone else eats the
+ * version difference.
+ *
+ * Quoting only `on` would fix the reported case and leave its siblings - `y`,
+ * `no`, `off`, every bare date, every sexagesimal `1:30` - to be found one
+ * report at a time. So the check is derived from the mechanism instead: a
+ * string is emitted plain only where the 1.1 and the 1.2 emitters agree on
+ * how to write it. Where they disagree, the string is version-dependent by
+ * construction and gets double quotes, which both versions read back as the
+ * string that was authored.
+ *
+ * The disagreement runs both ways, which is why simply emitting under 1.1 is
+ * not the fix: `0o17` is a plain string to 1.1 and the integer 15 to 1.2, so
+ * a 1.1 emitter would hand YarraMate's own reader a number. Asking both and
+ * quoting on disagreement is the only form that closes each direction.
+ */
+
+import { Document, Scalar, stringify as stringifyYaml, visit } from 'yaml'
+import type { ToStringOptions } from 'yaml'
+
+// True when the two versions would write this string differently, which means
+// the plain form of at least one of them resolves to something other than the
+// string. Each emitter guarantees a round trip under its own version, so
+// agreement is agreement that the shared text is safe under both.
+const versionDependent = (value: string): boolean =>
+  stringifyYaml(value, { version: '1.1' }) !==
+  stringifyYaml(value, { version: '1.2' })
+
+/**
+ * `stringify` from the `yaml` package, with every version-dependent string -
+ * key or value - forced to double quotes. Multi-line strings are untouched:
+ * a block scalar is a string to both versions, so the two emitters agree and
+ * the value keeps its shape.
+ */
+export const emitYaml = (
+  value: unknown,
+  options: ToStringOptions = {},
+): string => {
+  const document = new Document(value)
+  visit(document, {
+    Scalar(_key, node) {
+      if (typeof node.value === 'string' && versionDependent(node.value)) {
+        node.type = Scalar.QUOTE_DOUBLE
+      }
+    },
+  })
+  return document.toString(options)
+}

--- a/test/apply-command.test.ts
+++ b/test/apply-command.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import Ajv2020Module from 'ajv/dist/2020.js'
+import { parse } from 'yaml'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { runCli } from '../src/cli.js'
 
@@ -121,6 +122,27 @@ describe('apply command', () => {
     expect(written).toContain('id: todo-service')
     expect(written).toContain('description: The person managing todo tasks.')
     expect(written).toContain('topic: adequacy')
+    // The document YarraMate writes is read by things that are not YarraMate
+    // (#378). Under a YAML 1.1 loader - PyYAML's default - a plain `on` key
+    // is the boolean true and a plain date is a date, so the attestation an
+    // author wrote comes back as `{True: date(2026, 8, 1)}` in anyone's audit
+    // script. The written key must survive both loaders as the string it is.
+    expect(written).toContain('"on": "2026-08-01"')
+    expect(
+      (parse(written, { version: '1.1' }) as {
+        concepts: readonly {
+          id: string
+          attestations?: readonly Record<string, unknown>[]
+        }[]
+      }).concepts.find((concept) => concept.id === 'user')?.attestations,
+    ).toEqual([
+      {
+        topic: 'adequacy',
+        by: 'reviewer',
+        recordedBy: 'agent-under-test',
+        on: '2026-08-01',
+      },
+    ])
 
     const check = runCli(['check', 'workspace.yaml'], workspace)
     expect(check.exitCode).toBe(0)

--- a/test/yaml-emission.test.ts
+++ b/test/yaml-emission.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+import { emitYaml } from '../src/yaml-emission.js'
+
+// A YAML 1.1 loader is what PyYAML's default is, and what most non-JS
+// loaders are. Reading the emitted text back under both versions is the
+// whole claim this module makes, so the tests read it back under both.
+const bothVersions = (source: string) => ({
+  under11: parse(source, { version: '1.1' }) as unknown,
+  under12: parse(source, { version: '1.2' }) as unknown,
+})
+
+describe('emitYaml', () => {
+  it('quotes the attestation `on` key, which YAML 1.1 reads as the boolean true', () => {
+    const attestation = {
+      topic: 'adequacy',
+      by: 'reviewer',
+      recordedBy: 'agent',
+      on: '2026-08-27',
+    }
+    const source = emitYaml([attestation], { lineWidth: 0 })
+    expect(source).toContain('"on": "2026-08-27"')
+    const { under11, under12 } = bothVersions(source)
+    expect(under11).toEqual([attestation])
+    expect(under12).toEqual([attestation])
+  })
+
+  it('quotes every YAML 1.1 boolean alias an author can write as a value', () => {
+    // `y|yes|n|no|on|off|true|false` in any case: the alias set is 1.1's, and
+    // a concept named "No" is an ordinary thing for an author to write.
+    const aliases = ['y', 'Y', 'yes', 'Yes', 'n', 'N', 'no', 'No', 'on', 'On', 'off', 'OFF']
+    const source = emitYaml({ aka: aliases }, { lineWidth: 0 })
+    const { under11, under12 } = bothVersions(source)
+    expect(under11).toEqual({ aka: aliases })
+    expect(under12).toEqual({ aka: aliases })
+  })
+
+  it('quotes what only YAML 1.2 resolves, so emitting under 1.1 alone is not the fix', () => {
+    // `0o17` is a plain string to 1.1 and the integer 15 to 1.2 - and 1.2 is
+    // what YarraMate's own reader is. The disagreement runs both ways, which
+    // is why the rule asks both emitters rather than picking one.
+    const source = emitYaml({ id: '0o17' }, { lineWidth: 0 })
+    expect(source).toContain('"0o17"')
+    expect(bothVersions(source).under12).toEqual({ id: '0o17' })
+  })
+
+  it('quotes a sexagesimal, which 1.1 reads as a number of seconds', () => {
+    const source = emitYaml({ name: '1:30' }, { lineWidth: 0 })
+    expect(bothVersions(source).under11).toEqual({ name: '1:30' })
+  })
+
+  it('leaves an unambiguous string plain, so a fix for `on` is not churn for everything', () => {
+    const fields = {
+      id: 'todo-service',
+      kind: 'applicationService',
+      name: 'Todo service',
+      status: 'planned',
+    }
+    expect(emitYaml(fields, { lineWidth: 0 })).toBe(
+      'id: todo-service\nkind: applicationService\nname: Todo service\nstatus: planned\n',
+    )
+  })
+
+  it('leaves a multi-line string a block scalar rather than escaping it', () => {
+    // Both versions write a block scalar the same way, so the rule finds no
+    // disagreement and the value keeps its readable shape.
+    const source = emitYaml({ description: 'line one\nline two\n' }, { lineWidth: 0 })
+    expect(source).toBe('description: |\n  line one\n  line two\n')
+  })
+
+  it("honours the stringify options the caller passes", () => {
+    const source = emitYaml([{ id: 'a', on: '2026-08-27' }], {
+      collectionStyle: 'flow',
+      lineWidth: 0,
+    })
+    expect(source.trimEnd()).toBe('[ { id: a, "on": "2026-08-27" } ]')
+  })
+
+  it('reads back identically under both versions for every shape a document carries', () => {
+    const document = {
+      format: 'yarramate/v1',
+      id: 'main',
+      concepts: [
+        {
+          id: 'user',
+          kind: 'businessActor',
+          name: 'No',
+          description: 'A person.\nOn two lines.\n',
+          aka: ['off', '0o17', '2026-08-27', '1:30', '~', '0755'],
+          attestations: [
+            { topic: 'adequacy', by: 'reviewer', recordedBy: 'agent', on: '2026-08-27' },
+          ],
+        },
+      ],
+    }
+    const { under11, under12 } = bothVersions(emitYaml(document, { lineWidth: 0 }))
+    expect(under11).toEqual(document)
+    expect(under12).toEqual(document)
+  })
+})
+
+describe('the writers', () => {
+  // The reported defect was one emitter's output, but every emitter fails the
+  // same way, and the next one written would fail it again. The guard is on
+  // the import rather than on eight outputs: nothing under src/ may reach for
+  // the raw `stringify`, so a new writer inherits the rule by construction.
+  const sourceFiles = (directory: string): readonly string[] =>
+    readdirSync(directory).flatMap((entry) => {
+      const full = join(directory, entry)
+      if (statSync(full).isDirectory()) return sourceFiles(full)
+      return /\.tsx?$/.test(entry) ? [full] : []
+    })
+
+  it('emit YAML through emitYaml, never through the raw stringify', () => {
+    const offenders = sourceFiles(join(process.cwd(), 'src'))
+      .filter((file) => !file.endsWith('yaml-emission.ts'))
+      .filter((file) => {
+        const text = readFileSync(file, 'utf8')
+        return /import\s*\{[^}]*\bstringify\b[^}]*\}\s*from\s*['"]yaml['"]/.test(text)
+      })
+      .map((file) => file.slice(process.cwd().length + 1))
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #378.

## What was wrong

An emitted attestation's `on` key was written unquoted. YarraMate reads YAML 1.2, where that is the string `on`, so nothing in the toolchain misread it. YAML 1.1 is still PyYAML's default and most non-JS loaders', and it resolves a plain `on` to the boolean `true` and a plain `2026-08-27` to a date. The attestation this toolchain wrote came back to an ApertureX audit script as `{True: date(2026, 8, 27)}`. The asymmetry is the whole defect: YarraMate writes the document and someone else eats the version difference.

## The fix

Quoting `on` and nothing else would have left `y`, `no`, `off`, every bare date and every sexagesimal to be found one report at a time, which is what the issue itself flagged as the adjacent risk. So the check is derived from the mechanism: a string is emitted plain only where the 1.1 and the 1.2 emitters agree on how to write it, and gets double quotes wherever they disagree.

That form closes both directions, which is why simply emitting under 1.1 is not the fix. `0o17` is a plain string to 1.1 and the integer `15` to 1.2, so a 1.1-only emitter would hand YarraMate's own reader a number. There is a test for exactly that, and it is the one that fails against the naive alternative.

Multi-line strings are untouched: both versions write a block scalar the same way, so the rule finds no disagreement and the value keeps its readable shape. Authored bytes are untouched as always; only text a write produces changes.

`src/yaml-emission.ts` is the single emitter, and all eight call sites now route through it: `apply-command` (5), `import-command`, the visual `session-server` and `workspace-model`, and the browser `local-host` and `query-panel`.

## Verification

- Reproduced end to end against **PyYAML 6.0.3** (the reporter's loader). Before the fix the emitted key is plain `on:`; after it, `yaml.safe_load` returns `{'topic': 'security', 'by': 'infra-team', 'recordedBy': 'apx-session', 'on': '2026-08-27'}`, exactly the record its author wrote, and `yarramate check` still passes on the same file.
- Three mutations killed: disabling the quoting rule (5 tests fail), swapping it for the naive `version: '1.1'` emission (2 fail, including the `0o17` one), and reintroducing a raw `stringify` import in a writer (the guard names the offending file).
- The guard is on the import rather than on eight outputs, so a new writer inherits the rule by construction rather than by anyone remembering it.
- `pnpm run verify` green, exit 0: 1906 tests, self-model `check` clean at 353 concepts / 475 relationships, reconcile 312/312 confirmed with 0 unclaimed of 150 artifacts, LikeC4 output fresh and valid.

## Notes

No ADR: no native meaning, schema, or CLI contract changes, and every document already written stays valid and reads the same to YarraMate. The rule is recorded in `docs/NATIVE-DOCUMENT.md` under the safe authoring CLI, and the reasoning lives in the module header.

The new module is declared in the self-model by the repository-file idiom (concept, realization, observation, LikeC4 subject mapping), keeping unclaimed artifacts at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt