### PR TITLE
A catalogue question no model could answer is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Fixed.** A catalogue question that no model could ever answer is now
+  refused by the test suite. A `missing-relationship` trigger asks its
+  reader to add a relationship; where the ArchiMate table permits no
+  counterpart for the (subject kind, relationship kind, direction) triple
+  the trigger names, no legitimate model can close it, and the question
+  stays open forever while reading as the model's fault rather than the
+  catalogue's. `YM914` already refuses a question that can never *fire*;
+  a question that can never be *closed* was invisible to every gate,
+  because an open question is exactly what an unenriched model looks
+  like. The check is derived from the same generated table the compiler
+  admits relationships against, so the shipped catalogue cannot drift
+  from it. The catalogue was already clean (40 triples, all closable);
+  this pins it. Reported as a shape rather than a defect by an ApertureX
+  session that had retired a finding of exactly this kind, which fired on
+  `driver` (one of seven core kinds nothing may realize) and had drifted
+  from their own catalogue within a day.
+
 - **Fixed.** Documents YarraMate writes read the same under every YAML
   version (#378). An attestation's `on` key was emitted unquoted, and a
   YAML 1.1 loader (PyYAML's default, and most non-JS loaders') resolves a

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -11,6 +11,15 @@ import { parse as parseYaml } from 'yaml'
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { runCli } from '../src/cli.js'
+import {
+  CORE_CONCEPT_KIND_ORDER,
+  type CoreConceptKindId,
+} from '../src/archimate-relationships.generated.js'
+import {
+  sourceKindsPermitting,
+  targetKindsPermitting,
+} from '../src/relationship-matrix.js'
+import type { RelationshipKind } from '../src/profile.js'
 
 const repositoryRoot = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -47,6 +56,129 @@ projections: []
 adapterMappings: []
 evidence: []
 `
+
+// A `missing-relationship` trigger asks its reader to add a relationship. If
+// the ArchiMate table permits no counterpart for the (subject kind,
+// relationship kind, direction) triple the trigger names, no legitimate model
+// can close it: the question reports a gap the standard forbids filling, and
+// it stays open forever while reading as the model's fault rather than the
+// catalogue's.
+//
+// Nothing else catches this. YM914 already refuses a question whose kind no
+// loaded profile declares, so a question that can never FIRE is a check error;
+// a question that can never be CLOSED is invisible to every gate, because an
+// open question is exactly what an unenriched model looks like. The check here
+// is derived from the same generated table the compiler admits relationships
+// against, so the catalogue cannot drift away from it.
+//
+// Field evidence for the shape: an ApertureX session retired a finding of this
+// exact kind on 2026-08-28. It fired on `driver`, one of the seven core kinds
+// ArchiMate 3.2 permits nothing to realize, and it had drifted from their own
+// catalogue within a day of that fact being written down in two places.
+interface RelationshipTrigger {
+  readonly condition: string
+  readonly kinds?: readonly string[]
+  readonly direction?: string
+}
+
+interface CatalogueQuestion {
+  readonly id: string
+  readonly subjects?: { readonly kinds?: readonly string[] }
+  readonly trigger?: readonly RelationshipTrigger[]
+}
+
+const localKind = (qualified: string): string => qualified.split('#').at(-1) ?? qualified
+
+const unclosableTriples = (
+  questions: readonly CatalogueQuestion[],
+): readonly string[] => {
+  const coreKinds = new Set<string>(CORE_CONCEPT_KIND_ORDER)
+  const unclosable: string[] = []
+  for (const question of questions) {
+    for (const trigger of question.trigger ?? []) {
+      if (trigger.condition !== 'missing-relationship') continue
+      // `any` closes if either direction admits a counterpart.
+      const directions =
+        trigger.direction === 'any' ? ['incoming', 'outgoing'] : [trigger.direction]
+      for (const subject of (question.subjects?.kinds ?? []).map(localKind)) {
+        // An extension kind inherits its core ancestor's row, so a subject
+        // kind outside the core table is not a catalogue defect - it is a
+        // lookup this check cannot make, and it says so by skipping.
+        if (!coreKinds.has(subject)) continue
+        for (const relationship of (trigger.kinds ?? []).map(localKind)) {
+          const closable = directions.some((direction) =>
+            (direction === 'incoming'
+              ? sourceKindsPermitting(
+                  relationship as RelationshipKind,
+                  subject as CoreConceptKindId,
+                )
+              : targetKindsPermitting(
+                  relationship as RelationshipKind,
+                  subject as CoreConceptKindId,
+                )
+            ).size > 0,
+          )
+          if (!closable) {
+            unclosable.push(
+              `${question.id}: nothing may hold ${relationship} ` +
+                `${trigger.direction} ${subject}`,
+            )
+          }
+        }
+      }
+    }
+  }
+  return unclosable
+}
+
+describe('a catalogue question against the ArchiMate relationship table', () => {
+  it('asks nothing of the shipped catalogue that no model could answer', () => {
+    const catalogue = parseYaml(readFileSync(cataloguePath, 'utf8')) as {
+      questions: readonly CatalogueQuestion[]
+    }
+    expect(unclosableTriples(catalogue.questions)).toEqual([])
+  })
+
+  it('names the question when a triple has no permitted counterpart', () => {
+    // The bug this guards, in the shape ApertureX shipped it: a driver is one
+    // of seven core kinds nothing may realize, so "nothing realizes this
+    // driver" is a gap no author can close. Without the negative case the
+    // assertion above passes just as well against a check that finds nothing.
+    expect(
+      unclosableTriples([
+        {
+          id: 'driver-unrealized',
+          subjects: { kinds: ['yarramate/core@0.1#driver'] },
+          trigger: [
+            {
+              condition: 'missing-relationship',
+              kinds: ['yarramate/core@0.1#realization'],
+              direction: 'incoming',
+            },
+          ],
+        },
+      ]),
+    ).toEqual(['driver-unrealized: nothing may hold realization incoming driver'])
+  })
+
+  it('agrees with the table on which kinds nothing may realize', () => {
+    // Pinned so a regenerated table that changed this set is visible as a
+    // change to this list rather than as a silently weakened check.
+    expect(
+      CORE_CONCEPT_KIND_ORDER.filter(
+        (kind) => sourceKindsPermitting('realization', kind).size === 0,
+      ),
+    ).toEqual([
+      'assessment',
+      'driver',
+      'gap',
+      'implementationEvent',
+      'meaning',
+      'value',
+      'workPackage',
+    ])
+  })
+})
 
 describe('core-enrichment 1.0 interaction wave', () => {
   let workspace: string


### PR DESCRIPTION
Acting on a shape flagged by an ApertureX session, not a defect they hit in YarraMate.

## The shape

They retired a compiler-derived finding ("this requirement has nothing realizing it") because it duplicated a question their interrogation catalogue already asked. Two surfaces, one predicate, and the two had drifted within a day: the finding fired on `driver`, one of the core kinds ArchiMate permits nothing to realize, so it reported a gap no legitimate model could close. Their catalogue had been corrected for that a day earlier; the finding rule had not, because only one of the two places encoding that ArchiMate fact got searched.

## The audit

YarraMate does not have the duplicated-predicate half. The relationship table is single-sourced: generated from `vendor/archi/relationships.xml` with a recorded source sha, read by `relationship-matrix.ts`, which is what the compiler admits relationships against and what `ask` reports. Nothing re-encodes it.

The catalogue is also clean today: **40 `missing-relationship` triples, every one closable, every subject kind a core kind** so the whole surface is checkable.

But nothing stopped it drifting. Adding `driver-unrealized` to `catalogues/core-enrichment.yaml` is ApertureX's exact bug, and every existing gate would have passed it.

## Why no gate catches it

`YM914` refuses a question whose kind no loaded profile declares, on the reasoning that "the question can never fire". A question that can never be **closed** is the sibling case and is invisible, because an open question is exactly what an unenriched model looks like. It reads as the model's fault rather than the catalogue's, indefinitely.

## What this adds

A test deriving the check from the same generated table the compiler uses, so the catalogue cannot drift from it. Three assertions: the shipped catalogue has no unclosable triple; the checker names the question when one exists (the `driver-unrealized` case, so the first assertion is not passing against a check that finds nothing); and the seven kinds nothing may realize are pinned, so a regenerated table that changed that set shows up as a visible change rather than as a silently weakened check.

## Verification

- Mutation: injecting `driver-unrealized` into the real shipped catalogue fails the guard, which names it. Restored after.
- `pnpm run verify` green, exit 0: 1909 tests, self-model `check` clean, LikeC4 valid.

## Deliberately not done

A new `YM9xx` diagnostic that would refuse a third-party catalogue with this defect. It is the more useful form, since hosts author their own catalogues, but `severity` is `const: "error"` in the check-result schema with no warning level, so a new code is a hard refusal that could break an existing consumer's `check` on merge. That is a stable-CLI-contract decision and wants an issue first per `CONTRIBUTING.md`. This PR guards the shipped catalogue only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt