### PR TITLE
A catalogue question no model could close is refused (YM916, ADR 0133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **Added.** `YM916`: a catalogue question no model could ever close is
+  refused (#382, ADR 0133). A `missing-relationship` trigger naming a
+  (subject kind, relationship kind, direction) triple the ArchiMate table
+  permits no counterpart for asks for a relationship the standard forbids
+  anyone to author — it opens on every matching subject and stays open
+  forever. This is `YM914`'s sibling: `YM914` refuses a question that can
+  never *fire*, `YM916` one that can never be *closed*, and the second is
+  the more invisible of the two, because an open question looks exactly
+  like a model with work left to do. Raised in `composeCatalogues` and
+  `loadQuestionCatalogue`, so `check`, `design`, `ask --open` and any host
+  composing catalogues at runtime all receive it — the defect was reported
+  from a registry consultants edit through a web editor, which no test in
+  any repository can reach. The check reads the same generated relationship
+  table the compiler admits relationships against; a second encoding is the
+  defect it exists to catch. **Breaking for a catalogue carrying this
+  defect**, which will now be refused where it previously loaded; the
+  questions refused were never answerable. Nothing is reported without a
+  compiled workspace, matching `YM914`'s narrowness.
+
 - **Fixed.** A catalogue question that no model could ever answer is now
   refused by the test suite. A `missing-relationship` trigger asks its
   reader to add a relationship; where the ArchiMate table permits no

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -251,6 +251,41 @@ kind maps rather than a declared-kinds list, so a kind inherited through
 `extends` counts: a profile that declares none of its own and inherits every
 one is exactly the case a declared-kinds check would call entirely missing.
 
+## A question must be one some model could answer
+
+A catalogue is refused when a `missing-relationship` trigger names a
+(subject kind, relationship kind, direction) triple the ArchiMate table
+permits no counterpart for (`YM916`, ADR 0133). Seven core kinds have no
+permitted realization source in ArchiMate 3.2, so "nothing realizes this
+driver" opens on every driver, stays open forever, and asks for a
+relationship the standard forbids anyone to author.
+
+This is `YM914`'s sibling. `YM914` refuses a question that can never
+**fire**; `YM916` refuses one that can never be **closed**. Both failures
+are invisible, and this one more so: a question that never fires looks like
+a condition not met, while a question nobody can close looks exactly like a
+model with work left to do. Nothing distinguishes it from honest backlog
+except reading the relationship table by hand.
+
+The check reads the same generated table the compiler admits relationships
+against. That is the point rather than an implementation note: a second
+encoding of ArchiMate's rules is the defect this refusal exists to catch,
+and it is how the consuming product that reported the shape acquired its own
+version of the bug — one fact written down in two places, drifting within a
+day.
+
+Both narrowing rules `YM914` follows apply here unchanged. Without a
+compiled workspace nothing is reported, because an extension kind resolves
+to its core ancestor through the kind lineages and there is none to resolve
+through. A kind that resolves nowhere is `YM914`'s business. And `direction:
+any` is unclosable only when **both** directions are empty, since either one
+satisfies the trigger.
+
+Only `missing-relationship` is checked. It is the one condition naming a
+triple the relationship table can rule on; `missing-attestation` and
+`missing-claim` have no table to consult, and inventing one for them would
+be the second encoding this refusal refuses.
+
 ## Evaluation model
 
 A question is **open** iff its trigger matches, and **closed** the moment it

--- a/docs/adr/0133-a-question-no-model-could-close-is-refused.md
+++ b/docs/adr/0133-a-question-no-model-could-close-is-refused.md
@@ -1,0 +1,80 @@
+# A question no model could close is refused
+
+Status: accepted
+
+`YM914` refuses a catalogue question that names a kind its loaded profile
+does not declare, on the reasoning that "the question can never fire". The
+sibling case was unguarded: a question that can never be CLOSED.
+
+A `missing-relationship` trigger asks its reader to add a relationship. The
+ArchiMate table the compiler admits relationships against decides which
+kinds may hold which relationship to which. Where that table permits no
+counterpart at all for the triple a trigger names, the question reports a
+gap the standard forbids filling. It opens on every matching subject,
+stays open forever, and reads as the model's fault rather than the
+catalogue's.
+
+The failure is invisible, which is what makes it worth a diagnostic rather
+than a report. `YM914`'s failure is invisible because a question that never
+fires looks like a condition not met; this one is invisible because an open
+question is exactly what an unenriched model looks like. Seven core kinds
+have no permitted realization source in ArchiMate 3.2 — `assessment`,
+`driver`, `gap`, `implementationEvent`, `meaning`, `value`, `workPackage` —
+so "nothing realizes this driver" is unanswerable by construction while
+looking like ordinary unfinished work.
+
+Field evidence: an ApertureX session retired a finding of exactly this kind
+on 2026-08-28. It fired on `driver`, and it had drifted from their own
+catalogue within a day of that ArchiMate fact being recorded in two places.
+It surfaced because a consultant looked at the card and found it absurd,
+which is not a detection strategy. That session then measured its own
+catalogues against the rule (12 triples, none dead, production registry
+clean) and argued for the refusal against its own interest, having named
+the upgrade break it creates for them.
+
+Decided:
+
+1. **A new `YM916`, raised where `YM914` is raised.** Composition, not
+   `check`: `YM914` lives inside `composeCatalogues`, and `check` receives
+   it by calling composition like every other caller. One placement
+   therefore covers `check`, `design`, `ask --open`, and any host that
+   composes catalogues at runtime. That last clause is the point — the
+   defect occurred in a registry a consultant edits through a web editor
+   with no product release involved, which no test in any repository can
+   reach.
+2. **The check is derived from the same generated table the compiler
+   admits relationships against.** Not a second encoding of ArchiMate's
+   rules. Re-encoding that table is the precise defect this decision
+   exists to stop, and it is how the reporting consumer's own version of
+   this bug happened.
+3. **Severity is error, matching every other diagnostic.** The questions
+   it refuses were never answerable, so nothing a reader could have acted
+   on is lost. A warning was rejected on the reporter's own argument: a
+   warning for an invisible defect is a warning nobody reads, and the
+   check-result contract has no warning severity to give it.
+4. **No `profileContext`, no check** — `YM914`'s rule, inherited
+   unchanged. An extension kind resolves to its core ancestor through the
+   kind lineages, and without a compiled workspace there is no lineage to
+   resolve it through. Guessing would be the false positive the narrowness
+   exists to avoid.
+5. **`any` closes if either direction admits a counterpart.** The trigger
+   is satisfied by a relationship in either direction, so it is unclosable
+   only when both are empty.
+
+Rejected:
+
+- **Staging by source** — hard error for a catalogue loaded fresh,
+  tolerated for one already attached. It removes the upgrade break for a
+  model mid-engagement, and the reporting consumer offered it. It is also
+  more machinery than the problem carries, and it makes the refusal depend
+  on when a catalogue arrived rather than on whether it is wrong.
+- **A non-error severity.** Larger than this decision: the check-result
+  contract states `severity` as a constant, and changing it reopens a
+  settled question about what `check` reports versus what `--strict`
+  gates. A defect nobody can see is the worst possible first customer for
+  a severity nobody has to act on.
+- **Widening the check to every trigger condition.** Only
+  `missing-relationship` names a triple the relationship table can rule
+  on. `missing-attestation` and `missing-field` have no table to consult,
+  and inventing one for them would be the second encoding this decision
+  refuses.

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -11,6 +11,12 @@ import {
   locateSourcePath,
 } from './source-document.js'
 import { nearDuplicateIndex } from './subject-identity.js'
+import {
+  sourceKindsPermitting,
+  targetKindsPermitting,
+  type CoreConceptKindId,
+} from './relationship-matrix.js'
+import type { RelationshipKind } from './profile.js'
 import catalogueSchema from '../schema/yarramate-question-catalogue.schema.json' with {
   type: 'json',
 }
@@ -1115,6 +1121,119 @@ const unresolvableKinds = (
   })
 }
 
+/** One `missing-relationship` trigger the relationship table can never satisfy. */
+interface UnclosableTrigger {
+  readonly questionId: string
+  readonly subjectKind: string
+  readonly relationshipKind: string
+  readonly direction: string
+  readonly path: readonly (string | number)[]
+}
+
+// The core kind an authored kind resolves to, or undefined when this workspace
+// cannot resolve it at all. Lineage is ancestor-first, so `lineage[0]` is the
+// core identity and an extension inherits its parent's row in the table
+// (ADR 0097); a core kind is its own lineage head.
+const coreKindOf = (
+  kind: string,
+  lineages: ReadonlyMap<string, readonly string[]>,
+): string | undefined => {
+  const lineage = lineages.get(kind)
+  if (lineage === undefined) return undefined
+  const identity = lineage[0] ?? kind
+  return identity.slice(identity.indexOf('#') + 1)
+}
+
+/**
+ * Triples a `missing-relationship` trigger names that no model could satisfy.
+ *
+ * The trigger asks its reader to add a relationship. The ArchiMate table the
+ * compiler admits relationships against decides which kinds may hold which
+ * relationship to which, and where it permits no counterpart at all for the
+ * (subject kind, relationship kind, direction) triple a trigger names, the
+ * question reports a gap the standard forbids filling. It opens on every
+ * matching subject and stays open forever, reading as the model's fault
+ * rather than the catalogue's (ADR 0133).
+ *
+ * The check reads the SAME generated table the compiler does. A second
+ * encoding of ArchiMate's rules is the defect this exists to stop, and it is
+ * how the consuming product that reported the shape got its own version of
+ * this bug: one fact written down twice, drifting within a day.
+ *
+ * Narrow in the same two ways `unresolvableKinds` is narrow. Without a
+ * profile context there is no lineage to resolve an extension kind through,
+ * so nothing is reported rather than guessed; and a kind that resolves
+ * nowhere is `YM914`'s business, not this one.
+ */
+const unclosableTriggers = (
+  catalogue: QuestionCatalogue,
+  profileContext: ResolvedProfileContext,
+): readonly UnclosableTrigger[] => {
+  const found: UnclosableTrigger[] = []
+  for (const [questionIndex, question] of catalogue.questions.entries()) {
+    const subjectKinds = question.subjects?.kinds ?? []
+    if (subjectKinds.length === 0) continue
+    for (const [conditionIndex, condition] of question.trigger.entries()) {
+      const trigger = condition as {
+        condition?: string
+        kinds?: readonly string[]
+        direction?: string
+      }
+      if (trigger.condition !== 'missing-relationship') continue
+      // `any` is satisfied by a relationship in either direction, so the
+      // trigger is unclosable only when both directions are empty.
+      const directions =
+        trigger.direction === 'any'
+          ? (['incoming', 'outgoing'] as const)
+          : ([trigger.direction ?? 'any'] as const)
+      for (const subjectKind of subjectKinds) {
+        const subjectCore = coreKindOf(
+          subjectKind,
+          profileContext.conceptKindLineages,
+        )
+        if (subjectCore === undefined) continue
+        for (const [kindIndex, relationshipKind] of (
+          trigger.kinds ?? []
+        ).entries()) {
+          const relationshipCore = coreKindOf(
+            relationshipKind,
+            profileContext.relationshipKindLineages,
+          )
+          if (relationshipCore === undefined) continue
+          const closable = directions.some((direction) =>
+            (direction === 'incoming'
+              ? sourceKindsPermitting(
+                  relationshipCore as RelationshipKind,
+                  subjectCore as CoreConceptKindId,
+                )
+              : targetKindsPermitting(
+                  relationshipCore as RelationshipKind,
+                  subjectCore as CoreConceptKindId,
+                )
+            ).size > 0,
+          )
+          if (closable) continue
+          found.push({
+            questionId: question.id,
+            subjectKind,
+            relationshipKind,
+            direction: trigger.direction ?? 'any',
+            path: [
+              'questions',
+              questionIndex,
+              'trigger',
+              conditionIndex,
+              'kinds',
+              kindIndex,
+            ],
+          })
+        }
+      }
+    }
+  }
+  return found
+}
+
 /** A catalogue parsed and located, before any cross-catalogue check. */
 interface LoadedCatalogueDocument {
   readonly source: WorkspaceSource
@@ -1198,6 +1317,28 @@ const unresolvableKindDiagnostics = (
           reference.kind.indexOf('#'),
         )}", which this workspace loads, so the question can never fire`,
         ...locate(reference.path),
+      }))
+
+// YM916, the sibling of YM914. YM914 refuses a question that can never FIRE;
+// this refuses one that can never be CLOSED. Both failures are invisible, and
+// this one more so: a question that never fires looks like a condition not
+// met, while a question that cannot be closed looks exactly like an
+// unenriched model, indefinitely (ADR 0133).
+const unclosableTriggerDiagnostics = (
+  { catalogue, locate }: LoadedCatalogueDocument,
+  profileContext?: ResolvedProfileContext,
+): readonly Diagnostic[] =>
+  profileContext === undefined
+    ? []
+    : unclosableTriggers(catalogue, profileContext).map((trigger) => ({
+        severity: 'error' as const,
+        code: 'YM916',
+        message:
+          `Question "${trigger.questionId}" asks for a ${trigger.direction} ` +
+          `"${trigger.relationshipKind}" on "${trigger.subjectKind}", which ` +
+          'the ArchiMate relationship table permits from no kind at all, so ' +
+          'no model could ever close it',
+        ...locate(trigger.path),
       }))
 
 /**
@@ -1331,6 +1472,7 @@ export function composeCatalogues(
   const crossDiagnostics = documents.flatMap((document) => [
     ...undeclaredWaveDiagnostics(document, declaredWaves),
     ...unresolvableKindDiagnostics(document, profileContext),
+    ...unclosableTriggerDiagnostics(document, profileContext),
   ])
   if (crossDiagnostics.length > 0) {
     return { ok: false, diagnostics: crossDiagnostics }
@@ -1381,6 +1523,13 @@ export function loadQuestionCatalogue(
   )
   if (kindDiagnostics.length > 0) {
     return { ok: false, diagnostics: kindDiagnostics }
+  }
+  const triggerDiagnostics = unclosableTriggerDiagnostics(
+    loaded.document,
+    profileContext,
+  )
+  if (triggerDiagnostics.length > 0) {
+    return { ok: false, diagnostics: triggerDiagnostics }
   }
   return { ok: true, catalogue: loaded.document.catalogue }
 }

--- a/test/catalogue-composition.test.ts
+++ b/test/catalogue-composition.test.ts
@@ -235,6 +235,121 @@ describe('composing catalogues', () => {
   })
 })
 
+/**
+ * A driver is one of seven core kinds ArchiMate 3.2 permits NOTHING to
+ * realize, so "nothing realizes this driver" is a question no model could
+ * ever close (ADR 0133). It reads perfectly and opens on every driver
+ * forever.
+ */
+const unclosable = `format: yarramate/question-catalogue/v1
+id: unclosable
+version: "1.0"
+profile: yarramate/core@0.1
+waves:
+  - id: motivation
+    name: Motivation
+questions:
+  - id: driver-unrealized
+    wave: motivation
+    scope: subject
+    subjects:
+      kinds:
+        - yarramate/core@0.1#driver
+    trigger:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#realization
+        direction: incoming
+    question: What realizes {subject.name}?
+    materiality: Unrealized drivers steer nothing.
+    resolution: Add a realization.
+    authority: human
+`
+
+const profileContextOf = () => {
+  const compiled = compileWorkspaceWithProfileContext([
+    { path: 'main.yaml', source: document },
+  ])
+  if (!compiled.ok) throw new Error('fixture does not compile')
+  return compiled.profileContext
+}
+
+describe('a question no model could close', () => {
+  // Two call sites evaluate this, and an unthreaded one fails SILENTLY: the
+  // catalogue composes clean and the question opens forever, which is exactly
+  // the defect. One test per call site, therefore, not one per feature.
+  it('refuses it while composing a set', () => {
+    const composed = composeCatalogues(
+      [sourceOf('domain.yaml', domain), sourceOf('unclosable.yaml', unclosable)],
+      profileContextOf(),
+    )
+    expect(composed.ok).toBe(false)
+    if (composed.ok) return
+    expect(composed.diagnostics.map(({ code }) => code)).toEqual(['YM916'])
+    const [diagnostic] = composed.diagnostics
+    expect(diagnostic!.message).toContain('driver-unrealized')
+    expect(diagnostic!.message).toContain('no model could ever close it')
+    // Located on the offending kind, not on the catalogue as a whole.
+    expect(diagnostic!.path).toBe('unclosable.yaml')
+    expect(diagnostic!.pointer).toBe('/questions/0/trigger/0/kinds/0')
+  })
+
+  it('refuses it when the catalogue stands alone', () => {
+    const composed = composeCatalogues(
+      [sourceOf('unclosable.yaml', unclosable)],
+      profileContextOf(),
+    )
+    expect(composed.ok).toBe(false)
+    if (composed.ok) return
+    expect(composed.diagnostics.map(({ code }) => code)).toEqual(['YM916'])
+  })
+
+  it('says nothing without a profile context, as YM914 does not', () => {
+    // No compiled workspace means no lineage to resolve an extension kind
+    // through, and guessing is the false positive the narrowness avoids.
+    expect(composeCatalogues([sourceOf('unclosable.yaml', unclosable)]).ok).toBe(
+      true,
+    )
+  })
+
+  it('leaves a triple the table permits alone', () => {
+    // The check that decides whether this check survives. A goal CAN be
+    // realized, so the same question shape on a goal is ordinary content and
+    // must compose clean.
+    const composed = composeCatalogues(
+      [
+        sourceOf(
+          'closable.yaml',
+          unclosable
+            .replace('yarramate/core@0.1#driver', 'yarramate/core@0.1#goal')
+            .replace('id: driver-unrealized', 'id: goal-unrealized'),
+        ),
+      ],
+      profileContextOf(),
+    )
+    expect(composed.ok).toBe(true)
+  })
+
+  it('closes on either direction when the trigger says any', () => {
+    // A driver may be the SOURCE of an association even though nothing may
+    // associate into... in fact both directions are permitted for
+    // association, so `any` must not fire. The rule is that `any` is
+    // unclosable only when both directions are empty.
+    const composed = composeCatalogues(
+      [
+        sourceOf(
+          'any.yaml',
+          unclosable
+            .replace('yarramate/core@0.1#realization', 'yarramate/core@0.1#association')
+            .replace('direction: incoming', 'direction: any'),
+        ),
+      ],
+      profileContextOf(),
+    )
+    expect(composed.ok).toBe(true)
+  })
+})
+
 describe('a workspace that carries its own questions', () => {
   let workspace = ''
   const write = (relative: string, source: string) =>

--- a/test/interrogate-command.test.ts
+++ b/test/interrogate-command.test.ts
@@ -385,6 +385,45 @@ describe('ask --open interrogation', () => {
     expect(result.stdout).not.toContain('YM914')
   })
 
+  it('refuses a question no model could ever close (#382, ADR 0133)', () => {
+    writeFileSync(
+      join(workspace, 'catalogue.yaml'),
+      catalogue.replace(
+        '  - id: actor-owner-missing\n' +
+          '    wave: hygiene\n' +
+          '    since: "1.1"\n' +
+          '    scope: subject\n' +
+          '    subjects:\n' +
+          '      kinds: ["yarramate/core@0.1#businessActor"]\n' +
+          '    trigger:\n' +
+          '      - condition: missing-claim\n' +
+          '        predicate: yarramate/ownership/owner\n',
+        '  - id: driver-unrealized\n' +
+          '    wave: hygiene\n' +
+          '    scope: subject\n' +
+          '    subjects:\n' +
+          '      kinds: ["yarramate/core@0.1#driver"]\n' +
+          '    trigger:\n' +
+          '      - condition: missing-relationship\n' +
+          '        kinds: ["yarramate/core@0.1#realization"]\n' +
+          '        direction: incoming\n',
+      ),
+      'utf8',
+    )
+    const result = runCli(
+      ['ask', 'workspace.yaml', '--open', '--catalogue', 'catalogue.yaml'],
+      workspace,
+    )
+    // `--catalogue` reaches loadQuestionCatalogue rather than the composition
+    // path, and an unthreaded call site there fails SILENTLY: the catalogue
+    // loads clean and the question opens on every driver forever, which is
+    // indistinguishable from a model with work left to do.
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('error YM916')
+    expect(result.stdout).toContain('driver-unrealized')
+    expect(result.stdout).toMatch(/^catalogue\.yaml:\d+:\d+ /)
+  })
+
   it('locates a question referencing an undeclared wave', () => {
     writeFileSync(
       join(workspace, 'catalogue.yaml'),

--- a/test/interrogation-api.test.ts
+++ b/test/interrogation-api.test.ts
@@ -178,6 +178,63 @@ describe('interrogation engine as public API', () => {
     expect(questionById(report, 'component-unattested').authority).toBe('human')
   })
 
+  it('refuses a question no model could close, when given a profile context', () => {
+    // `loadQuestionCatalogue` is a published entry on the interrogation
+    // subpath, so it is its own call site: a host embedding the engine reaches
+    // it without going near `composeCatalogues`, and an unthreaded check here
+    // fails SILENTLY - the catalogue loads clean and the question opens on
+    // every driver forever (ADR 0133). Nothing a per-feature test can see.
+    const compilation = compileWorkspaceWithProfileContext([
+      { path: 'architecture/main.yaml', source: document },
+    ])
+    if (!compilation.ok) throw new Error('fixture did not compile')
+    const loaded = loadQuestionCatalogue(
+      {
+        path: 'catalogue.yaml',
+        source: catalogue.replace(
+          '      kinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+            '    trigger:\n' +
+            '      - condition: missing-relationship\n' +
+            '        kinds: ["yarramate/core@0.1#serving"]\n' +
+            '        direction: outgoing\n',
+          '      kinds: ["yarramate/core@0.1#driver"]\n' +
+            '    trigger:\n' +
+            '      - condition: missing-relationship\n' +
+            '        kinds: ["yarramate/core@0.1#realization"]\n' +
+            '        direction: incoming\n',
+        ),
+      },
+      compilation.profileContext,
+    )
+    expect(loaded.ok).toBe(false)
+    if (loaded.ok) return
+    expect(loaded.diagnostics.map(({ code }) => code)).toEqual(['YM916'])
+    expect(loaded.diagnostics[0]!.message).toContain('component-serves-nothing')
+  })
+
+  it('stays silent on the same catalogue when no profile context is given', () => {
+    // Every existing consumer of this entry passes no context, including the
+    // fixture above. The check must be inert for them rather than a refusal
+    // they never asked for.
+    expect(
+      loadQuestionCatalogue({
+        path: 'catalogue.yaml',
+        source: catalogue.replace(
+          'kinds: ["yarramate/core@0.1#applicationComponent"]\n' +
+            '    trigger:\n' +
+            '      - condition: missing-relationship\n' +
+            '        kinds: ["yarramate/core@0.1#serving"]\n' +
+            '        direction: outgoing\n',
+          'kinds: ["yarramate/core@0.1#driver"]\n' +
+            '    trigger:\n' +
+            '      - condition: missing-relationship\n' +
+            '        kinds: ["yarramate/core@0.1#realization"]\n' +
+            '        direction: incoming\n',
+        ),
+      }).ok,
+    ).toBe(true)
+  })
+
   it('renders the report and a single question through the exported renderers', () => {
     expect(renderInterrogationReport(evaluate())).toContain('== Structure ==')
     expect(renderQuestion('Who owns {subject.name}?', 'billing', 'Billing')).toBe(


### PR DESCRIPTION
Closes #382. Decision approved by the maintainer after the consuming product measured its own content and argued for the refusal against its own interest.

## What this refuses

A `missing-relationship` trigger naming a (subject kind, relationship kind, direction) triple the ArchiMate table permits no counterpart for. Seven core kinds have no permitted realization source in ArchiMate 3.2, so `driver-unrealized` asks for a relationship the standard forbids anyone to author. It opens on every driver and stays open forever.

This is `YM914`'s sibling. `YM914` refuses a question that can never **fire**; `YM916` one that can never be **closed**. The second is the more invisible: a question that never fires looks like a condition not met, while a question nobody can close looks exactly like a model with work left to do. Nothing distinguishes it from honest backlog except reading the relationship table by hand, which is how it was found in the field — a consultant looked at a card and thought it absurd.

## Where it is raised, and why that is the whole value

In `composeCatalogues` and `loadQuestionCatalogue`, which is where `YM914` already lives. I filed #382 asking "should `check` gate it" and that was the wrong frame: `check` is not where `YM914` lives either, it just calls composition like every other caller.

One placement therefore covers `check`, `design`, `ask --open`, and **any host composing catalogues at runtime**. That last clause is the point. The defect was reported from a registry that consultants edit through a web editor with no product release involved, so no test in any repository could ever reach it. Their save path already refuses on any diagnostic, so this becomes an authoring-time gate in their editor with no work on their side.

The check reads the same generated relationship table the compiler admits relationships against. A second encoding of ArchiMate's rules is the defect this refusal exists to catch, and it is exactly how the reporting consumer acquired their version of the bug: one fact written down twice, drifting within a day.

## Narrowness, inherited from YM914 unchanged

- **No profile context, no check.** An extension kind resolves to its core ancestor through the kind lineages; without a compiled workspace there is none to resolve through, and guessing is the false positive the narrowness avoids. Every existing caller that passes no context is unaffected, with a test pinning that.
- **A kind that resolves nowhere is `YM914`'s business**, not this one.
- **`direction: any` is unclosable only when both directions are empty**, since either satisfies the trigger. Tested.
- **Only `missing-relationship` is checked.** It is the one condition naming a triple the table can rule on; inventing a table for `missing-attestation` would be the second encoding this refuses.

## Tests: one per call site

An unthreaded call site fails **silently** here — the catalogue loads clean and the question opens forever, which is the defect itself. Per-feature tests cannot see which caller forgot.

Both mutations verified to fail independently. Worth recording that the first draft got this wrong: it covered `composeCatalogues` only, and unthreading `loadQuestionCatalogue` left all 43 tests passing. `loadQuestionCatalogue` is a published entry on the `yarramate/interrogation` subpath, reached by embedding hosts without going near composition, so it is its own call site and now has its own test.

## Compatibility

**Breaking for a catalogue carrying the defect**, which is now refused where it previously loaded. The questions refused were never answerable, so nothing a reader could have acted on is lost.

The one known third-party consumer measured itself before the decision: 12 triples across their built-in catalogue, none dead; their MuleSoft pack contributes zero (all `missing-attestation`); production registry clean. Their own catalogue was clean only because they had fixed this exact class the day before, including taking `driver` off a selector that would otherwise be dead today.

Severity is error because the contract has no other level, and because a warning for an invisible defect is a warning nobody reads. Staging by source (hard error when fresh, tolerated when already attached) was offered by the reporter and rejected in the ADR: it makes the refusal depend on when a catalogue arrived rather than on whether it is wrong.

## Verification

`pnpm run verify` green, exit 0: 1917 tests, self-model `check` clean at 353 concepts / 475 relationships, LikeC4 valid. The shipped catalogue composes unchanged, which is the no-false-positive check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt