### PR TITLE
A kind the table has never heard of is not a forbidden one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,15 @@
   editor, which no test in any repository can reach. **Breaking for a
   catalogue carrying the defect**, which will now be refused where it
   previously loaded; the remedies refused were never authorable. Nothing is
-  reported without a compiled workspace, matching `YM914`'s narrowness.
+  reported without a compiled workspace, matching `YM914`'s narrowness, and
+  every ambiguity resolves toward silence rather than toward blame: an
+  unresolvable kind, a partially unresolvable counterpart list, a
+  both-directions trigger, and a kind the relationship table has no row for
+  are all passed over. That last one is asked explicitly rather than
+  assumed, because every table query answers an absent kind with an empty
+  set, which is indistinguishable from "forbidden" — the empty-set
+  conflation, in the one place where mistaking it turns a gate into a false
+  accuser.
 
 - **Fixed.** A catalogue question that no model could ever answer is now
   refused by the test suite. A `missing-relationship` trigger asks its

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -288,14 +288,26 @@ it is how the consuming product that reported the shape acquired its own
 version of the bug — one fact written down in two places, drifting within a
 day.
 
-Both narrowing rules `YM914` follows apply here unchanged. Without a compiled
-workspace nothing is reported, because an extension kind resolves to its core
-ancestor through the kind lineages and there is none to resolve through. A
-kind that resolves nowhere is `YM914`'s business. A trigger with any
-unresolvable counterpart is skipped whole rather than partially, since a
+**Every ambiguity resolves toward silence.** A gate that accuses wrongly
+implies deleting a working question, so where this one cannot judge, it says
+nothing. That is one rule, and it covers four cases. Without a compiled
+workspace nothing is reported at all, because an extension kind resolves to
+its core ancestor through the kind lineages and there is none to resolve
+through. A kind that resolves nowhere is `YM914`'s business. A trigger with
+any unresolvable counterpart is skipped whole rather than partially, since a
 partial reading could accuse a question a dormant cross-profile kind would
 have answered. And `direction: any` or `either` is dead only when **both**
 directions are, since either one satisfies the trigger.
+
+A kind the relationship table has no row for is the fourth, and it is the one
+that had to be made explicit rather than observed. Every table query answers
+an absent kind with an empty set, which reads identically to "this is
+forbidden" — the empty-set conflation, sitting where mistaking it turns the
+gate into a false accuser on a vocabulary it simply cannot judge. Nothing
+reachable through a profile should hit it, since `parent` is required on every
+declared kind and resolves to a core ancestor; the check asks anyway, because
+that guarantee belongs to another module and a gate should not rest on one
+silently. A test pins the guarantee so the change that broke it would say so.
 
 `kindMatching: descendants` needs no special handling: a descendant shares its
 core ancestor's row and column in the table, so checking the named kind covers

--- a/docs/adr/0133-a-remedy-no-model-could-author-is-refused.md
+++ b/docs/adr/0133-a-remedy-no-model-could-author-is-refused.md
@@ -82,11 +82,17 @@ Decided:
    on is lost. A warning was rejected on the reporter's own argument: a
    warning for an invisible defect is a warning nobody reads, and the
    check-result contract has no warning severity to give it.
-4. **No `profileContext`, no check** — `YM914`'s rule, inherited
-   unchanged. An extension kind resolves to its core ancestor through the
-   kind lineages, and without a compiled workspace there is no lineage to
-   resolve it through. Guessing would be the false positive the narrowness
-   exists to avoid.
+4. **Every ambiguity resolves toward silence.** `YM914`'s narrowness,
+   generalised: a gate that accuses wrongly implies deleting a working
+   question, so a miss is cheaper than a false positive here. No
+   `profileContext`, no check, because an extension kind resolves to its
+   core ancestor through the kind lineages and without a compiled workspace
+   there is none. A kind the table has no row for is passed over too, and
+   that one is asked explicitly rather than assumed: every table query
+   answers an absent kind with an empty set, indistinguishable from
+   "forbidden", and nothing reachable through a profile should hit it
+   because `parent` is required and resolves to a core ancestor. The check
+   asks because that guarantee is another module's to keep.
 5. **`any` and `either` close if either direction admits a counterpart.**
    The trigger is satisfied by a relationship in either direction, so an
    offer is dead only when both are.

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -13,6 +13,8 @@ import {
 import { nearDuplicateIndex } from './subject-identity.js'
 import {
   sourceKindsPermitting,
+  tableKnowsConceptKind,
+  tableKnowsRelationshipKind,
   targetKindsPermitting,
   type CoreConceptKindId,
 } from './relationship-matrix.js'
@@ -1137,7 +1139,13 @@ interface UnauthorableOffer {
 // (ADR 0097); a core kind is its own lineage head. This is also why
 // `kindMatching: descendants` needs no special handling: a descendant shares
 // its ancestor's row and column, so checking the named kind covers them all.
-const coreKindOf = (
+// A kind the table has no row for answers every query with an empty set,
+// which reads exactly like "forbidden". The guards keep the two apart, so a
+// vocabulary the table cannot judge is passed over in silence rather than
+// accused - the direction every ambiguity here resolves in. They are the
+// reason nothing below casts: the typed queries are reached through the
+// check rather than around it.
+const localKindOf = (
   kind: string,
   lineages: ReadonlyMap<string, readonly string[]>,
 ): string | undefined => {
@@ -1145,6 +1153,24 @@ const coreKindOf = (
   if (lineage === undefined) return undefined
   const identity = lineage[0] ?? kind
   return identity.slice(identity.indexOf('#') + 1)
+}
+
+const coreConceptKindOf = (
+  kind: string,
+  lineages: ReadonlyMap<string, readonly string[]>,
+): CoreConceptKindId | undefined => {
+  const local = localKindOf(kind, lineages)
+  return local !== undefined && tableKnowsConceptKind(local) ? local : undefined
+}
+
+const coreRelationshipKindOf = (
+  kind: string,
+  lineages: ReadonlyMap<string, readonly string[]>,
+): RelationshipKind | undefined => {
+  const local = localKindOf(kind, lineages)
+  return local !== undefined && tableKnowsRelationshipKind(local)
+    ? local
+    : undefined
 }
 
 /**
@@ -1185,7 +1211,7 @@ const unauthorableOffers = (
 ): readonly UnauthorableOffer[] => {
   const found: UnauthorableOffer[] = []
   const conceptCore = (kind: string) =>
-    coreKindOf(kind, profileContext.conceptKindLineages)
+    coreConceptKindOf(kind, profileContext.conceptKindLineages)
   for (const [questionIndex, question] of catalogue.questions.entries()) {
     const subjectKinds = question.subjects?.kinds ?? []
     if (subjectKinds.length === 0) continue
@@ -1217,7 +1243,7 @@ const unauthorableOffers = (
         for (const [kindIndex, relationshipKind] of (
           trigger.kinds ?? []
         ).entries()) {
-          const relationship = coreKindOf(
+          const relationship = coreRelationshipKindOf(
             relationshipKind,
             profileContext.relationshipKindLineages,
           )
@@ -1225,18 +1251,12 @@ const unauthorableOffers = (
           const authorable = directions.some((direction) => {
             const opposite =
               direction === 'incoming'
-                ? sourceKindsPermitting(
-                    relationship as RelationshipKind,
-                    subject as CoreConceptKindId,
-                  )
-                : targetKindsPermitting(
-                    relationship as RelationshipKind,
-                    subject as CoreConceptKindId,
-                  )
+                ? sourceKindsPermitting(relationship, subject)
+                : targetKindsPermitting(relationship, subject)
             return counterparts === undefined
               ? opposite.size > 0
-              : counterparts.some((kind) =>
-                  opposite.has(kind as CoreConceptKindId),
+              : counterparts.some(
+                  (kind) => kind !== undefined && opposite.has(kind),
                 )
           })
           if (authorable) continue

--- a/src/relationship-matrix.ts
+++ b/src/relationship-matrix.ts
@@ -101,6 +101,37 @@ export const matrixEndpointAspects = (
   return aspects
 }
 
+/**
+ * Whether the table has a row and column for this kind at all.
+ *
+ * Every query below answers an ABSENT kind with an empty set, which reads
+ * identically to "the table forbids this" - the empty-set conflation, in the
+ * one place where mistaking it turns a gate into a false accuser. A caller
+ * deciding whether something is forbidden must therefore ask this first, so
+ * that "not in the table" resolves toward silence rather than toward blame.
+ *
+ * Nothing reachable through a profile should fail it: `parent` is required on
+ * every declared kind and resolves to a core ancestor, so a lineage head is
+ * always a table kind. The predicates exist because that guarantee is another
+ * module's to keep, and a gate should not rest on one silently.
+ *
+ * They are type guards rather than booleans so that a caller holding a bare
+ * string reaches the typed queries through the check instead of around it by
+ * a cast. The cast is where the hole actually opens: the signatures already
+ * refuse an unknown kind, and asserting past them is what lets an absent kind
+ * arrive and be read as a forbidden one.
+ */
+const CORE_CONCEPT_KINDS = new Set<string>(CORE_CONCEPT_KIND_ORDER)
+const CORE_RELATIONSHIP_KIND_SET = new Set<string>(relationshipKinds)
+
+export const tableKnowsConceptKind = (
+  kind: string,
+): kind is CoreConceptKindId => CORE_CONCEPT_KINDS.has(kind)
+
+export const tableKnowsRelationshipKind = (
+  kind: string,
+): kind is RelationshipKind => CORE_RELATIONSHIP_KIND_SET.has(kind)
+
 /** Kinds that may stand as the source of `kind` into `to`. */
 export const sourceKindsPermitting = (
   kind: RelationshipKind,

--- a/test/archimate-relationships.test.ts
+++ b/test/archimate-relationships.test.ts
@@ -13,8 +13,11 @@ import {
   permittedRelationshipKinds,
   relationshipPermitted,
   sourceKindsPermitting,
+  tableKnowsConceptKind,
+  tableKnowsRelationshipKind,
   targetKindsPermitting,
 } from '../src/relationship-matrix.js'
+import { compileWorkspaceWithProfileContext } from '../src/compiler.js'
 // The generator is plain ESM with no build step; importing it here is what
 // lets the test re-run it against the vendored XML.
 import { generate } from '../scripts/generate-archimate-relationships.mjs'
@@ -185,5 +188,89 @@ describe('the aspect shadow the table casts', () => {
     )
     expect(targetKindsPermitting('realization', 'gap').size).toBeGreaterThan(0)
     expect(targetKindsPermitting('realization', 'gap').has('plateau')).toBe(false)
+  })
+
+  it('keeps "the table forbids this" apart from "the table has never heard of it"', () => {
+    // Both answer with an empty set, and a caller that reads empty as
+    // forbidden turns a gate into a false accuser on a vocabulary it simply
+    // cannot judge. The predicates are what let a caller tell them apart.
+    //
+    // The cast below is the whole point rather than test convenience: the
+    // signature already refuses an unknown kind, so this can only be reached
+    // by asserting past it, which is exactly how a caller holding a bare
+    // string from a lineage map used to reach it. The predicates are type
+    // guards so that route is closed at the type level too.
+    expect(sourceKindsPermitting('realization', 'driver').size).toBe(0)
+    expect(
+      sourceKindsPermitting(
+        'realization',
+        'notAnArchiMateKind' as unknown as Parameters<
+          typeof sourceKindsPermitting
+        >[1],
+      ).size,
+    ).toBe(0)
+    expect(tableKnowsConceptKind('driver')).toBe(true)
+    expect(tableKnowsConceptKind('notAnArchiMateKind')).toBe(false)
+    expect(tableKnowsRelationshipKind('realization')).toBe(true)
+    expect(tableKnowsRelationshipKind('hosting')).toBe(false)
+  })
+
+  it('gives every kind an extension profile can declare a row in the table', () => {
+    // YM916 resolves an authored kind to its core ancestor and then asks the
+    // table about it, so it rests on a guarantee this module does not own:
+    // `parent` is required on every declared kind and resolves to a core
+    // ancestor, making a lineage head always a table kind. If that ever
+    // stopped holding, the gate would start reporting unjudgeable kinds as
+    // forbidden rather than passing over them. Pinned here so the change
+    // that broke it would say so.
+    const compiled = compileWorkspaceWithProfileContext([
+      {
+        path: 'profiles/development.yaml',
+        source: readFileSync(
+          new URL(
+            '../.yarramate/profiles/yarramate-development.yaml',
+            import.meta.url,
+          ),
+          'utf8',
+        ),
+      },
+      {
+        path: 'architecture/main.yaml',
+        source:
+          'format: yarramate/v1\n' +
+          'id: main\n' +
+          'profile: yarramate/development@1.0\n' +
+          'concepts:\n' +
+          '  - id: engine\n' +
+          '    kind: compiler-module\n' +
+          '    name: Engine\n' +
+          '  - id: source\n' +
+          '    kind: repository-file\n' +
+          '    name: src/engine.ts\n' +
+          'relationships:\n' +
+          '  - id: source-implements-engine\n' +
+          '    kind: implements\n' +
+          '    from: source\n' +
+          '    to: engine\n',
+      },
+    ])
+    if (!compiled.ok) throw new Error('self-model profile fixture does not compile')
+    const headOf = (lineage: readonly string[], identity: string): string => {
+      const head = lineage[0] ?? identity
+      return head.slice(head.indexOf('#') + 1)
+    }
+    const strays: string[] = []
+    for (const [identity, lineage] of compiled.profileContext.conceptKindLineages) {
+      if (!tableKnowsConceptKind(headOf(lineage, identity))) strays.push(identity)
+    }
+    for (const [identity, lineage] of compiled.profileContext
+      .relationshipKindLineages) {
+      if (!tableKnowsRelationshipKind(headOf(lineage, identity))) strays.push(identity)
+    }
+    expect(strays).toEqual([])
+    // Not vacuous: the fixture really does load kinds beyond the core set.
+    expect(compiled.profileContext.conceptKindLineages.size).toBeGreaterThan(
+      CORE_CONCEPT_KIND_ORDER.length,
+    )
   })
 })


### PR DESCRIPTION
Still pre-release. Found by generalising the false-accusation rule the ApertureX session framed — **every ambiguity resolves toward silence** — and checking whether YM916 actually honoured it in all the cases that rule names. It did not honour the one that could accuse.

## The hole

Every relationship-table query answers a kind it has no row for with an empty set:

```
sourceKindsPermitting('realization', 'driver')            -> 0   forbidden
sourceKindsPermitting('realization', 'notAnArchiMateKind') -> 0   never heard of it
```

YM916 read empty as forbidden. A kind outside the table would therefore be reported as a dead offer — a **false accusation**, in a gate whose implied remedy is deleting a working question. That is the failure mode the reporter singled out as worse than a miss, and it was the one case of theirs I had not checked.

This is the repository's own empty-set rule ("the honest question is not whether the count is zero but whether anything was asked") sitting inside a gate.

## Reachability, checked rather than assumed

Not reachable today. `parent` is required on every declared kind and resolves to a core ancestor, so a lineage head is always a table kind. Measured across the shipped development profile: 64 concept kinds, 12 relationship kinds, zero strays.

That guarantee belongs to the profile compiler, not to this check, so the check now asks instead of resting on it, and **a test pins the guarantee** so the change that broke it would say so rather than silently converting the gate into an accuser.

## The casts were the hole

The typed queries already refuse an unknown kind — the first attempt at the test failed to compile for exactly that reason. The check was reaching them by asserting past the signature to pass a bare string out of a lineage map.

So the predicates are **type guards**, not booleans. That closes the route at the type level and deletes four casts from `unauthorableOffers`. The one remaining cast is in the test, where demonstrating the runtime behaviour is the point.

## Verification

- Two mutations killed: a predicate that always answers true, and an empty membership set.
- `pnpm run verify` green, exit 0: 1923 tests, self-model `check` clean, LikeC4 valid.

## Note

Four cases now resolve toward silence, documented as one rule rather than four exceptions: no compiled workspace, an unresolvable kind, a partially unresolvable counterpart list, and a kind the table has no row for. Only the last needed code; the other three already held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt