### PR TITLE
Name which ArchiMate mechanism a profile document implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Docs.** `docs/PROFILES.md` names which ArchiMate customization
+  mechanism a YarraMate profile document implements (#386). ArchiMate
+  defines two, orthogonally: Specialization derives a type from another and
+  inherits its permitted relationships, and Profiles attach typed
+  attributes to concepts and relationships. YarraMate implements the first
+  and calls it a profile. It does not implement the second, so declaring a
+  kind buys an identity, a table row, and a selector, and nowhere to say
+  what makes instances of that kind different. A missing capability rather
+  than a conformance defect, recorded because the name collides and a
+  reader who knows ArchiMate reasonably expects attributes. Whether the
+  mechanism should exist is open in #386 and nothing is decided.
+
 - **Added.** `YM916`: a catalogue question that offers a remedy no model
   could author is refused (#382, #384, ADR 0133). A trigger names the ways
   its question can be satisfied, and each is an offer: add this

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -12,6 +12,36 @@ other documents may keep an existing org profile and bind with qualified
 `constraints[].ref`. Re-basing an org profile onto policy is allowed and
 not required.
 
+## What "profile" means here, and what it does not
+
+ArchiMate defines two language customization mechanisms, and they are
+orthogonal. **Specialization** derives a new concept or relationship type
+from an existing one, which inherits the parent's permitted relationships.
+**Profiles** attach a set of typed attributes to concepts and relationships.
+
+A YarraMate profile document implements the first. `parent:` is
+specialization, and everything below follows from it: inherited aspect and
+layer, the inherited row and column in the relationship table, endpoint
+narrowing, and the rigidity rule.
+
+YarraMate does not implement the second. There is no way for a profile to
+declare attributes on a kind, and no way for a concept to carry a value the
+profile defines: `conceptKind` is closed over `{id, name, parent, rigidity,
+layer}` and a concept is closed over its sixteen fields. Declaring a kind
+buys an identity, a table row, and a selector. It does not buy anywhere to
+say what makes instances of that kind different. `rigidity` is not a
+counter-example: it is checked when the profile resolves and then
+discarded, reaching no graph, no claim, and no projection.
+
+This is a missing capability rather than a conformance defect: attributes
+are a customization mechanism, and a model that passes `check` is
+semantically valid ArchiMate either way (ADR 0097). It is called out here
+because the name collides. A reader who knows ArchiMate reads "profiles"
+and reasonably expects attributes, and the word being taken is part of why
+the absence went unrecorded for so long. Whether the mechanism should exist
+is open: see issue #386, which carries the analysis and has decided
+nothing.
+
 ## Smallest profile
 
 ```yaml


### PR DESCRIPTION
Acting on a finding from the #386 investigation that stands whichever way #386 goes.

## The collision

ArchiMate defines two language customization mechanisms, and they are orthogonal:

- **Specialization** derives a concept or relationship type from another, inheriting its permitted relationships.
- **Profiles** attach a set of typed attributes to concepts and relationships.

YarraMate implements the first and names its documents after the second. `docs/PROFILES.md` documented the specialization mechanism without saying which one it was, so a reader who knows ArchiMate arrives expecting attributes and finds specialization.

## Why it is worth a docs change on its own

The word being taken is part of how the absence stayed unrecorded. A search of the five foundational extension ADRs — 0003, 0004, 0006, 0095, 0097 — for any consideration of attributes, properties, or language customization returns **zero mentions across all five**. The only exclusion anywhere in the corpus is one clause in `docs/NATIVE-DOCUMENT.md` naming *arbitrary* properties, which is the #379 generic-bag line, and which frames itself as awaiting a semantic decision rather than as closed.

## What the section says

That `parent:` is specialization and everything downstream follows from it; that there is no way to declare attributes on a kind or carry a profile-defined value on a concept; and that `rigidity` is not a counter-example, being checked at profile resolution and then discarded without reaching a graph, a claim, or a projection.

It is careful to call this a **missing capability, not a conformance defect** — attributes are a customization mechanism, and a model that passes `check` is semantically valid ArchiMate either way (ADR 0097).

## Scope

Documents what is true today and decides nothing. Whether the mechanism should exist is open in #386.

`pnpm run verify` green, exit 0: 1923 tests, self-model `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt