### PR TITLE
The workbook routes a reference by a rule, not by a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Fixed.** The workbook routes a ref-valued claim to `05 References` by
+  a rule rather than by a list. Six predicates were named in a closed set
+  that decided sheet placement; the set was correct the day it was written
+  and could only go stale, because a predicate the compiler grows later
+  lands in `07 Other Facts`, round-trips correctly, and reads as though the
+  mapping had not recognised it. That failure already happened once in this
+  file, to a state's `concept/kind`. By the point the routing runs, the
+  column-consumed claims, the relationships, presence and aliases have all
+  gone, so anything still pointing at a subject is a reference in the sense
+  that sheet means. **No data moves**: measured across all 22 projections of
+  the self-model, the rule places exactly what the list placed. A new test
+  guards *placement* rather than losslessness, which is the gap the existing
+  completeness assertion passes through by design, since it counts the
+  overflow sheet as a valid carrier.
+
 - **Docs.** `docs/PROFILES.md` names which ArchiMate customization
   mechanism a YarraMate profile document implements (#386). ArchiMate
   defines two, orthogonally: Specialization derives a type from another and

--- a/src/workbook.ts
+++ b/src/workbook.ts
@@ -56,16 +56,6 @@ const STATE_COLUMNS = [
   ['yarramate/concept/description', 'Description'],
 ] as const
 
-/** Ref-valued predicates that get their own sheet rather than the overflow. */
-const REFERENCE_PREDICATES = new Set([
-  'yarramate/reference/refers-to',
-  'yarramate/lineage/supersedes',
-  'yarramate/lineage/supersedes-respect',
-  'yarramate/identity/distinct-from',
-  'yarramate/constraint/requires',
-  'yarramate/constraint/expects',
-])
-
 const ALIAS_PREDICATE = 'yarramate/concept/alias'
 const PRESENT_IN_PREDICATE = 'yarramate/state/present-in'
 const STATE_TYPE_PREDICATE = 'yarramate/state/type'
@@ -250,7 +240,18 @@ export const buildWorkbookSheets = (
       aliasRows.push([claim.subject, nameOf(claim.subject), valueOf(claim)])
       continue
     }
-    if (REFERENCE_PREDICATES.has(claim.predicate)) {
+    // A rule, not a list. This was six named predicates, and the list was
+    // right on the day it was written and could only go stale: a predicate
+    // the compiler grows later lands in the overflow, round-trips correctly,
+    // and reads as though the mapping had not recognised it. That already
+    // happened once in this file, to `concept/kind` on a state - see the
+    // note on STATE_COLUMNS.
+    //
+    // By here the column-consumed claims, the relationships, presence and
+    // aliases have all gone, so anything left pointing at a subject IS a
+    // reference in the sense this sheet means. `relationshipClaims` above
+    // draws the same distinction the same way.
+    if (isRef(claim)) {
       const target = valueOf(claim)
       referenceRows.push([
         claim.subject,

--- a/test/workbook.test.ts
+++ b/test/workbook.test.ts
@@ -208,6 +208,34 @@ describe('the workbook carries every claim', () => {
     expect(result.claims.length).toBeGreaterThan(20)
   })
 
+  it('routes every ref-valued claim to the references sheet, not the overflow', () => {
+    // The assertion above guards LOSSLESSNESS: every claim is carried
+    // somewhere, and `07 Other Facts` counts as somewhere. It therefore
+    // passes while a fact sits on the wrong sheet, which is exactly how
+    // `concept/kind` on a state was lost to the overflow once already
+    // (see the note on STATE_COLUMNS). This guards PLACEMENT instead.
+    //
+    // Derived from the mechanism rather than from a list of predicates: any
+    // claim whose object points at a subject belongs on the references
+    // sheet, so a predicate the compiler grows later is routed by the rule
+    // rather than by whoever remembers to extend an allowlist.
+    const { result, sheets } = sheetsFor({})
+    const overflow = named(sheets, '07 Other Facts').slice(1)
+    const refValued = new Map(
+      result.claims
+        .filter((claim) => 'ref' in claim.object)
+        .map((claim) => [`${claim.subject} | ${claim.predicate}`, claim]),
+    )
+    const misplaced = overflow
+      .map((row) => `${row[0] ?? ''} | ${row[1] ?? ''}`)
+      .filter((key) => refValued.has(key))
+    expect(misplaced).toEqual([])
+    // Not vacuous: the fixture really does produce ref-valued claims and a
+    // non-empty overflow, so both sides of the assertion have work to do.
+    expect(refValued.size).toBeGreaterThan(0)
+    expect(overflow.length).toBeGreaterThan(0)
+  })
+
   it('gives every relationship a row, with both endpoints named', () => {
     const { result, sheets } = sheetsFor({})
     const rows = named(sheets, '02 Relationships')


### PR DESCRIPTION
A latent trap in a merge-bearing round-trip format, reported by the ApertureX session as worth fixing on its own merits rather than arriving as a side effect of #388. They were right, and it is the same shape that shipped the `patterns` manifest category non-functional.

## The trap

`REFERENCE_PREDICATES` named six predicates and decided **sheet placement** from that set. The set is correct today — I checked before claiming otherwise. What it cannot be is correct tomorrow: a ref-valued predicate the compiler grows later lands in `07 Other Facts`, round-trips correctly, and reads as though the mapping had not recognised it.

That is not hypothetical. The note on `STATE_COLUMNS`, in the same file, records the identical failure already happening:

> Omitting it dropped four kind claims into the overflow sheet, which round-tripped correctly and read as though the mapping had not recognised them.

And the existing completeness test passes straight through it. It asserts every claim is carried *somewhere* and counts `07 Other Facts` as somewhere, so it guards **losslessness** while placement is wrong. That is by design and correct for what it is; it just leaves the other half uncovered.

Placement matters here more than in a read-only export: the workbook is a round-trip format whose `~Baseline` embeds sheet placement and whose three-way merge compares against it (ADR 0127).

## The rule

By the point the routing runs, the column-consumed claims, the relationships, presence and aliases have all gone. Anything still pointing at a subject **is** a reference in the sense that sheet means, so `isRef(claim)` is the rule and it cannot go stale. `relationshipClaims`, one function above, already draws the same distinction the same way.

## No data moves — measured, not argued

Built the workbook across **all 22 projections of the self-model** with the list and with the rule:

| | References rows | Overflow rows |
|---|---|---|
| closed set | 200 | 34 |
| rule | 200 | 34 |

**Zero rows moved.** The only predicate in the overflow is `yarramate/attestation/adequacy`, which is value-valued and stays.

Import turns only `01 Concepts`, `03 States` and `02 Relationships` edits into operations, so both affected sheets are carry-only and produce no operations under either arrangement.

## The test is the more valuable half

New assertion guards **placement**: no ref-valued claim reaches the overflow sheet. Derived from the mechanism rather than from a list, so a predicate the compiler grows later is routed by the rule rather than by whoever remembers to extend an allowlist. It also asserts it is not vacuous — the fixture really does produce both ref-valued claims and a non-empty overflow.

Mutation killed: routing on the single `refers-to` predicate fails it.

## Verification

`pnpm run verify` green, exit 0: 1924 tests, self-model `check` clean, LikeC4 valid.

## Relationship to #388

This makes C2 in #388 cheaper as a side effect, but it stands alone and is deliberately not scoped to that decision. #388 remains open and undecided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt