### PR TITLE
State the floor as a contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Docs.** `docs/MODEL-FLOOR.md` states, as a contract, which facts a
+  model holds and how, which it declines, and where a declined fact belongs
+  instead (#386). The floor was never drawn: the foundational extension
+  records consider arbitrary properties nowhere, and an adopter therefore
+  found the edges one at a time by building something that did not fit,
+  filing three issues in a week that a written floor would have turned into
+  one question or none. It names the homes, including the one adopters
+  miss (**a value that carries architectural weight becomes a subject other
+  subjects point at**, with the shipped policy profile as the worked
+  example); the refusals, each with where the fact goes instead; and the
+  rule a catalogue must obey, that **whatever the interrogation asks about
+  must be recordable as an answer**. That last one has a sharp case:
+  `missing-attestation` closes on a claim recording who vouched and when,
+  and carries no value by construction, so it is right for "has this been
+  reviewed?" and wrong for "what is the deployment model?", where closing
+  it discards what was confirmed and the card reads worked. The three
+  refusals still under discussion are marked as such.
+
 - **Fixed.** The workbook routes a ref-valued claim to `05 References` by
   a rule rather than by a list. Six predicates were named in a closed set
   that decided sheet placement; the set was correct the day it was written

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ When an Issue already exists, link it from the pull request.
 Read these sources before changing semantics:
 
 - `docs/PRODUCT-CONTRACT.md`
+- `docs/MODEL-FLOOR.md`
 - `docs/GLOSSARY.md`
 - `docs/ROADMAP.md`
 - the relevant decision records under `docs/adr/`

--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -1,0 +1,175 @@
+# What a model states, and what it does not
+
+This document is a contract rather than a description. It says which facts a
+YarraMate model can hold, which it deliberately will not, and where the second
+kind belongs instead.
+
+It exists because the floor was never drawn. A search of the foundational
+extension records (ADRs 0003, 0004, 0006, 0095, 0097) finds no consideration
+of arbitrary properties or of ArchiMate's attribute mechanism, and
+`docs/NATIVE-DOCUMENT.md` carries one deferral clause about *arbitrary*
+properties and nothing more. An adopter probing the edges therefore finds them
+one at a time, by building something and discovering it does not fit. Three
+issues were filed in one week that a written floor would have turned into one
+question or none (#379, #386, #388).
+
+## The rule everything else follows from
+
+**Every value in a native record is defined syntax that compiles to a claim.**
+There is no generic metadata bag (ADR 0003), and there is no place to put a
+fact the compiler does not understand. That is the whole of the discipline,
+and everything below is a consequence of it.
+
+## Where a fact lives
+
+| The fact | Its home | Notes |
+| --- | --- | --- |
+| This thing exists | a concept | |
+| These two things relate | a relationship | admissible pairs come from the ArchiMate table (ADR 0097) |
+| This thing is *a kind of* thing | the concept's `kind` | specialize a profile kind with `parent:` |
+| This thing is restricted this way | a **constraint subject**, referenced | one subject, referenced by many concepts |
+| This thing cites that thing | `references[].ref` | resolves to a subject |
+| Someone vouched for this | an `attestation` | records **who** and **when**, never **what** |
+| Someone observed this | an evidence overlay | provider-owned, `evidence.uri` opaque to Core |
+| This is true in that phase | `presentIn` | the **time** axis only: baseline, transition, target |
+
+### A value that matters becomes a subject
+
+This is the least obvious entry and the one adopters miss, so it is worth
+stating outright. Where a value carries architectural weight, it is modelled
+as a subject that other subjects point at, not as a property repeated on each
+of them.
+
+The shipped policy profile is the worked example. `core-enrichment` asks "what
+is the default authentication mechanism for interactions in this
+architecture?", and the answer is authored as an `authentication-constraint`
+concept named for the mechanism:
+
+```yaml
+concepts:
+  - id: oauth2
+    kind: authentication-constraint
+    name: OAuth2 client credentials
+  - id: orders-api
+    kind: applicationInterface
+    name: Orders API
+    constraints:
+      - id: authn
+        ref: oauth2
+```
+
+One subject holds the value; every interface that uses it points at the same
+one. The value is checkable (the reference must resolve), queryable (the
+`missing-constraint` condition asks about it), and shared rather than copied.
+A closed vocabulary of five values becomes five subjects, not a string
+repeated on twenty-seven interfaces.
+
+## What the model does not hold
+
+These are refusals, not gaps awaiting a feature. Each names where the fact
+belongs instead.
+
+### A second, orthogonal classification
+
+A concept has exactly one `kind`. One classification axis is therefore free,
+and a second is not: an interface classified by both interaction style and
+trigger category cannot express both as kinds without declaring their cross
+product. Where a second axis carries weight, model it as a constraint subject
+the concept references. Where it does not, it belongs in an annex.
+
+### A per-instance free value
+
+An endpoint's path, an operation verb, a tuning number. Nothing holds these
+but `description`, and description prose is opaque to Core by design: it is
+narrative, never queried, never validated. A fact you need a machine to read
+back is not a description.
+
+### Ordered detail beneath a subject
+
+A model holds subjects and edges. It does not hold rows under a subject:
+processor sequences, message samples, field-level mappings, entity attribute
+tables. Modelling them as concepts is technically possible and is a mistake,
+because **every concept is an interrogation subject**, so a hundred rows of
+implementation detail become a hundred subjects a selector matches and the
+architecture interview becomes unusable.
+
+### An environment axis
+
+`presentIn` is time, not place: baseline, transition, target. A deployment
+topology per environment has no axis, and the closest available expression
+(marking a production node `status: planned`) states something the author does
+not mean.
+
+### Configuration and tuning
+
+Timeouts, retry counts, replica counts, secret store names, host and port.
+These change without the architecture changing, which is the test.
+
+## The rule a catalogue must obey
+
+**Whatever the interrogation asks about must be recordable as an answer.**
+
+A model may decline to hold processor steps precisely because nothing asks
+about them. It may not decline a fact its own catalogue asks for by name and
+then calls answered. Depth is a modelling choice; a question whose answer has
+nowhere to go is a defect at any depth.
+
+The sharp case is `missing-attestation`. It closes on
+`yarramate/attestation/<topic>`, a claim that records **who** vouched and
+**when**, and by construction carries no value. That is exactly right for a
+question of the form *"has this been reviewed?"*. The shipped catalogue's two
+attestation questions both ask that, and who-and-when is the whole answer.
+
+It is exactly wrong for a question of the form *"what is the deployment
+model?"*. Closing it records that a confirmation happened and discards what
+was confirmed. The card reads worked, the substance is gone, and nothing
+anywhere reports a problem. A question whose answer is a value must be asked
+with a condition that closes on that value's home: `missing-constraint` where
+the value is a restriction, `missing-relationship` or `missing-linkage` where
+it is structural, `no-subject-of-kind` where it is a vocabulary the workspace
+should declare.
+
+Read the question text back before choosing a condition. If it begins "what"
+or "which", `missing-attestation` is the wrong close.
+
+## Where the rest belongs
+
+Facts this model declines are not homeless. They belong in a host document
+alongside the workspace, joined to the model by subject id.
+
+Such a document is not declared in the workspace manifest, which selects
+compiler inputs rather than inventorying a directory. To make it discoverable
+from the model, record it as an evidence observation under a provider of your
+own naming, with an opaque `evidence.uri` the host resolves:
+
+```yaml
+format: yarramate/evidence/v1
+provider: acme-lld
+observations:
+  - subject: order-flow
+    result: confirmed
+    key: processors
+    evidence:
+      uri: acme:annex/order-flow.processors.yaml
+```
+
+`yarramate ask <workspace.yaml> --where order-flow --json` then returns that
+locator against the subject, with the provider named. Core never resolves,
+fetches, or interprets the URI: URI ownership is the provider's (ADR 0068,
+`docs/EVIDENCE.md`).
+
+## Deliberately open
+
+Three of the refusals above are recorded limits rather than settled doctrine,
+and are under discussion:
+
+- profile-declared typed values, which would give the second classification
+  axis and the per-instance value a checkable home (#386);
+- declared reference slots, so that what a citation is *for* can be checked
+  and asked about (#388);
+- whether an attestation should be able to confirm a declared value rather
+  than only a topic.
+
+Nothing here is a promise that they stay refused. It is a statement of what is
+true today, written so that the next adopter reads the floor instead of
+finding it.

--- a/docs/NATIVE-DOCUMENT.md
+++ b/docs/NATIVE-DOCUMENT.md
@@ -572,3 +572,11 @@ This foundation does not define arbitrary properties, automatic profile or
 repository discovery, remote registries, inferred claims, adapter execution
 or round-tripping, constraint-policy execution, or governance workflow. These
 require separate semantic decisions or later adapter and conformance work.
+
+`docs/MODEL-FLOOR.md` states the whole of it as a contract: which facts a
+model holds and how, which it declines, and where a declined fact belongs
+instead. Read it before concluding that something has no home, because the
+homes are not all obvious. A value that carries architectural weight, for
+instance, is modelled as a subject other subjects point at rather than as a
+property repeated on each of them, and the shipped policy profile is the
+worked example.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Case study: the model is the handover](CASE-STUDY-CROSS-HARNESS.md)
 - [Product contract](PRODUCT-CONTRACT.md)
+- [What a model states, and what it does not](MODEL-FLOOR.md)
 - [Product journeys](PRODUCT-JOURNEYS.md)
 - [Reviewing model and profile growth](MODEL-REVIEW.md)
 - [Consuming YarraMate](CONSUMING-YARRAMATE.md)


### PR DESCRIPTION
The recommendation from an adopter's structural review, and the one thing a pre-release core owes an adopter that is not a feature.

## Why

The floor was never drawn. The foundational extension records (ADRs 0003, 0004, 0006, 0095, 0097) consider arbitrary properties nowhere, and `NATIVE-DOCUMENT.md` carried a single deferral clause. An adopter probing the edges therefore found them one at a time, by building something and discovering it did not fit: three issues in a week (#379, #386, #388) that a written floor would have turned into one question or none. Their words, and they are right: *"If that document had existed on Monday I would have built the annex without asking, and been right."*

## What it says

**The homes a fact can have**, as a table. The entry adopters miss is stated outright: **a value carrying architectural weight becomes a subject other subjects point at**, not a property repeated on each of them. The shipped policy profile is the worked example, and `core-enrichment` already asks its authentication question that way. A closed vocabulary of five values is five subjects, not a string on twenty-seven interfaces. I compiled it to be sure it works as documented.

**The refusals**, each with a destination rather than a silence: a second orthogonal classification (a concept has exactly one `kind`, so one axis is free and a second is not); a per-instance free value (`description` is opaque by design, so a fact a machine must read back is not a description); ordered rows beneath a subject (every concept is an interrogation subject, so detail modelled as concepts makes the interview unusable); an environment axis (`presentIn` is time, not place); and configuration.

**The rule a catalogue must obey**, which is the adopter's formulation and better than the depth argument it replaces:

> Whatever the interrogation asks about must be recordable as an answer.

Depth is a modelling choice. A question whose answer has nowhere to go is a defect at any depth, and this test does not depend on anyone agreeing where the floor sits.

## The sharp case, measured

`missing-attestation` closes on `yarramate/attestation/<topic>`, a claim recording **who** vouched and **when**, carrying no value by construction.

Both shipped attestation questions ask *"Has an accountable reviewer accepted this?"* and *"Has the design been reviewed?"*. Who-and-when **is** the answer, and the shape is exactly right.

Asked as *"what is the deployment model?"*, closing it records that a confirmation happened and discards what was confirmed. The card reads worked, the substance is gone, nothing reports a problem. That is not a defect in the condition; it is a mismatch between a condition and a question shape, and nothing warned anyone. The document now does, with the guidance to read the question text back before choosing a condition.

For context on scale: our catalogue is 2 attestation conditions of 75. The adopter's is 14 of 25, and 79% of their field cards.

## Scope

States what is true today. The three refusals under live discussion (#386 declared values, #388 declared reference slots, whether an attestation should confirm a declared value) are marked as open rather than settled, so this decides nothing.

Linked from `docs/README.md`, `CONTRIBUTING.md`'s "start with the product contract" list, and the deliberate-exclusions clause in `NATIVE-DOCUMENT.md` that previously stood alone.

`pnpm run verify` green, exit 0: 1924 tests, self-model `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt