### PR TITLE
A classification is a grouping, and a threshold is not tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Docs.** `docs/MODEL-FLOOR.md` gained the home for a classification and
+  split a committed threshold from a tuning number, both corrections earned
+  by running the document against a live adopter model of 348 open cards
+  (#386). A classification is a **`grouping` that aggregates its members**,
+  not a constraint subject, which reads as "this thing is restricted this
+  way" and is what the first draft wrongly recommended. Nor is it a
+  specialization to a same-type classifier: that is canonical ArchiMate and
+  the table permits it, but **a same-type classifier is itself an
+  interrogation subject**, and the shipped catalogue names
+  `applicationService` in eighteen selector positions against `grouping` in
+  none, so the change that closes forty-seven cards can open sixty. The
+  refusal of configuration also drew its line in the wrong place: a
+  committed threshold ("must sustain 200 TPS") is a restriction the design
+  must satisfy and survives every capacity change made to meet it, so it is
+  a constraint subject; the vCores chosen to meet it are tuning. The test
+  was always "does it change without the architecture changing", and the
+  examples now defer to the test rather than implying the category.
+
 - **Docs.** `docs/MODEL-FLOOR.md` states, as a contract, which facts a
   model holds and how, which it declines, and where a declined fact belongs
   instead (#386). The floor was never drawn: the foundational extension

--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -28,6 +28,7 @@ and everything below is a consequence of it.
 | These two things relate | a relationship | admissible pairs come from the ArchiMate table (ADR 0097) |
 | This thing is *a kind of* thing | the concept's `kind` | specialize a profile kind with `parent:` |
 | This thing is restricted this way | a **constraint subject**, referenced | one subject, referenced by many concepts |
+| This thing belongs to that set | a **`grouping`** that aggregates it | the home for a classification the `kind` cannot carry |
 | This thing cites that thing | `references[].ref` | resolves to a subject |
 | Someone vouched for this | an `attestation` | records **who** and **when**, never **what** |
 | Someone observed this | an evidence overlay | provider-owned, `evidence.uri` opaque to Core |
@@ -64,6 +65,50 @@ one. The value is checkable (the reference must resolve), queryable (the
 A closed vocabulary of five values becomes five subjects, not a string
 repeated on twenty-seven interfaces.
 
+### A classification is a grouping, not a constraint
+
+The paragraph above is the home for a **restriction**: a rule the subject must
+satisfy. A **classification** is a different fact and takes a different home,
+and confusing the two is the first mistake an adopter makes here.
+
+A subject's own classification is its `kind`. A second axis, which `kind`
+cannot carry because a concept has exactly one, is a `grouping` that
+aggregates its members:
+
+```yaml
+concepts:
+  - id: experience-layer
+    kind: grouping
+    name: Experience layer
+relationships:
+  - id: experience-layer-holds-ocrf
+    kind: aggregation
+    from: experience-layer
+    to: ocrf-experience-api
+```
+
+Aggregation from a `grouping` is permitted to every element kind, so this
+works wherever the classification applies.
+
+Two alternatives look right and are not:
+
+- **A constraint subject.** It reads as "this thing is restricted this way",
+  and an API layer or an integration style restricts nothing. An ArchiMate
+  reader will notice.
+- **Specializing a same-type classifier**, so that twenty-seven services
+  specialize an `applicationService` named "Experience API". This is
+  canonical ArchiMate and the relationship table permits it, but **a
+  same-type classifier is itself an interrogation subject.** The shipped
+  catalogue names `applicationService` in eighteen selector positions and
+  `applicationInterface` in seventeen, so each classifier attracts the whole
+  question set for its type, and a change that closes forty-seven cards can
+  open sixty. `grouping` is named in **no** selector in the shipped
+  catalogue, so a grouping attracts none.
+
+A question about a classification therefore closes on `missing-linkage`,
+asking for an incoming aggregation from a grouping, which records the answer
+rather than the fact that someone answered.
+
 ## What the model does not hold
 
 These are refusals, not gaps awaiting a feature. Each names where the fact
@@ -74,8 +119,9 @@ belongs instead.
 A concept has exactly one `kind`. One classification axis is therefore free,
 and a second is not: an interface classified by both interaction style and
 trigger category cannot express both as kinds without declaring their cross
-product. Where a second axis carries weight, model it as a constraint subject
-the concept references. Where it does not, it belongs in an annex.
+product. Where a second axis carries weight, model it as a `grouping` that
+aggregates its members, per "a classification is a grouping" above. Where it
+does not, it belongs in an annex.
 
 ### A per-instance free value
 
@@ -102,8 +148,16 @@ not mean.
 
 ### Configuration and tuning
 
-Timeouts, retry counts, replica counts, secret store names, host and port.
-These change without the architecture changing, which is the test.
+Replica counts, heap and vCore sizes, secret store names, host and port.
+**These change without the architecture changing, which is the test**, and
+the test rather than the list is what decides.
+
+A committed threshold is on the other side of it. "This interface must
+sustain 200 transactions per second, bursting to 500" is not tuning: it is a
+restriction the design has to satisfy, it survives every capacity change made
+to meet it, and it belongs as a constraint subject. The capacity settings
+chosen to meet it do not. The same register commonly carries both, one column
+apart, and they are different facts.
 
 ## The rule a catalogue must obey
 


### PR DESCRIPTION
Two corrections to `MODEL-FLOOR.md`, earned by an adopter running it against a live model of 348 open cards. **The document survived the test** — one genuinely homeless card out of 348, and that card is a question their catalogue should not have asked. These are the two places it was wrong.

## 1. A classification is a grouping, not a constraint (my error)

The second-axis refusal told adopters to model a classification as a constraint subject. A constraint reads as *"this thing is restricted this way"*, and an API layer or an integration style restricts nothing. An ArchiMate reader notices.

The home is a `grouping` that aggregates its members. Verified permitted to `applicationService`, `applicationInterface`, `applicationComponent`, `dataObject`, `node` and `businessProcess`.

**The alternative worth recording, because it is canonical ArchiMate and the table permits it:** specializing a same-type classifier, so twenty-seven services specialize an `applicationService` named "Experience API". It fails for a reason neither of us predicted:

> a same-type classifier is itself an interrogation subject

Measured in our own catalogue:

| Kind | Selector positions |
|---|---|
| `applicationService` | 18 |
| `applicationInterface` | 17 |
| `grouping` | **0** |

So a same-type classifier attracts the whole question set for its type. On the adopter's model, the change that closes 47 cards opens about 60. A grouping attracts none, and `grouping` is named in **no selector anywhere in the 65-question shipped catalogue**, so that property is general rather than a quirk of their pack.

A classification question then closes on `missing-linkage` (incoming aggregation from a grouping), which records the answer rather than the fact that someone answered — a correct close by the document's own rule.

## 2. A committed threshold is not a tuning number

The configuration refusal drew its line in the wrong place by implying a category from a list of examples.

*"This interface must sustain 200 transactions per second, bursting to 500"* is a restriction the design has to satisfy. It survives every capacity change made to meet it, so it is a constraint subject. The vCores, replicas and heap chosen to meet it are tuning. A capacity register commonly carries both, one column apart, and they are different facts.

The test was always **"does it change without the architecture changing"**. The examples now defer to the test rather than standing in for it.

## What the measurement settled

Reported for the record, since it is what decided #386: of 348 open cards, one is genuinely homeless, and both sides agree that question should not have been asked. Nine of the adopter's eleven domain questions use the wrong condition; one is four questions in a trenchcoat; the two that are correctly `missing-attestation` are both "who" questions where `by` is the whole answer.

That last part is the document's own rule confirming itself on data neither party chose. **#386 stays parked**, and the adopter's own position is that they would not build the attribute mechanism on this evidence either.

`pnpm run verify` green, exit 0: 1924 tests, self-model `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt