### PR TITLE
chore: release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.11.0
 
 - **Docs.** `docs/MODEL-FLOOR.md` gained the home for a classification and
   split a committed threshold from a tuning number, both corrections earned

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Nine changes since `v1.10.0`. **Minor, not patch**: `YM916` is a new diagnostic and is breaking for any catalogue carrying the defect it refuses.

## Breaking

**`YM916`** refuses a catalogue question that offers a remedy no model could author. A trigger names the ways its question can be satisfied, and each is an offer; where the ArchiMate relationship table forbids one, the catalogue is refused where it previously loaded.

- The remedies refused were **never authorable**, so nothing a reader could have acted on is lost.
- Nothing is reported without a compiled workspace, matching `YM914`'s narrowness, and every ambiguity resolves toward silence.
- Both conditions naming a relationship are checked: `missing-relationship` against the whole table, `missing-linkage` against the counterpart kinds it names.
- Raised in `composeCatalogues` and `loadQuestionCatalogue`, so `check`, `design`, `ask --open` and any host composing catalogues at runtime receive it from one placement.
- The one known third-party consumer measured itself clean before the decision.

## Not breaking, worth knowing

- **Emitted YAML quotes more than before.** Every string a write emits is measured against both the 1.1 and 1.2 emitters and double-quoted where they disagree, so `"on": "2026-08-27"`, `"no"`, `"0o17"`. Byte-comparing emitted output across versions will differ. Nothing already written is invalid.
- **The workbook routes references by a rule rather than a closed list.** Measured across all 22 self-model projections: zero rows moved.

## Contents

| # | Change |
|---|---|
| #378 | Documents YarraMate writes read the same under every YAML version |
| #381 | Shipped catalogue guarded against unanswerable questions |
| #383 | `YM916` (ADR 0133) |
| #384 | `YM916` reads the offer, and both conditions that name one |
| #385 | A kind the table has never heard of is not a forbidden one |
| #387 | `PROFILES.md` names which ArchiMate mechanism it implements |
| #389 | The workbook routes a reference by a rule, not by a list |
| #390 | `MODEL-FLOOR.md`: the floor as a contract |
| #391 | A classification is a grouping, and a threshold is not tuning |

#384 and #385 correct #383 before release, so nothing wrong reached a consumer.

## Preparation

- `pnpm install --frozen-lockfile` from a clean tree, `pnpm run verify` green, exit 0: **1924 tests**, self-model `check` clean at 353 concepts / 475 relationships, reconcile 312/312, 0 unclaimed of 150, LikeC4 valid.
- `npm pack --dry-run`: 271 files, 2.0 MB packed. Runtime, schemas, catalogues, profiles, consumer guide, agent skill, README, licence. No source, tests, fixtures, dogfooding inputs or generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt