### PR TITLE
docs/MODEL-FLOOR.md ships in the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Fixed.** `docs/MODEL-FLOOR.md` ships in the package. It was written for
+  adopters, and an adopter arrives through npm, so leaving it in the
+  repository put it exactly where the people it is for would not find it.
+  The one adopter who has read it read it off a working tree that happened
+  to be on the same machine, which is the condition the document exists to
+  end. Additive: one file, 10 kB on a 2.0 MB package.
+
 ## 1.11.0
 
 - **Docs.** `docs/MODEL-FLOOR.md` gained the home for a classification and

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "catalogues",
     "profiles",
     "skills/yarramate-architecture",
-    "docs/CONSUMING-YARRAMATE.md"
+    "docs/CONSUMING-YARRAMATE.md",
+    "docs/MODEL-FLOOR.md"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -55,6 +55,11 @@ describe('consumer package contract', () => {
       'profiles',
       'skills/yarramate-architecture',
       'docs/CONSUMING-YARRAMATE.md',
+      // The floor belongs in the package for the same reason the consumer
+      // guide does: it is written for an adopter, and an adopter arrives
+      // through npm. Left in the repository it sat exactly where the people
+      // it is for would not find it, which is the condition it exists to end.
+      'docs/MODEL-FLOOR.md',
     ])
     expect(packageJson.scripts.prepack).toBe('pnpm build')
     expect(


### PR DESCRIPTION
One line in `files`. The floor document was written for adopters and left where adopters are not.

## The evidence

An adopter who arrives through npm gets the runtime, schemas, catalogues, profiles, the agent skill and `CONSUMING-YARRAMATE.md`. No statement of what a model holds, what it declines, or where a declined fact belongs.

The one adopter who has read `MODEL-FLOOR.md` read it off a working tree that happened to be on the same machine. Their words:

> An adopter who arrives through npm gets the package and no floor, which is the exact condition the document was written to end.

That condition is finding the floor by building into it, which is what produced three issues in a week.

## The objection, checked and dissolved

`MODEL-FLOOR.md` carries two relative references to docs that are not in the tarball (`docs/EVIDENCE.md`, `docs/NATIVE-DOCUMENT.md`). That looked like a reason to hold.

It is not: the **already-shipped** `docs/CONSUMING-YARRAMATE.md` links to seven `adr/…` paths that are equally absent. Dangling relative links to unshipped docs are the existing accepted state for the consumer doc that already ships, so this introduces no new class of problem.

## Cost

Additive, one file, 10 kB against a 2.0 MB package. No API, schema or behaviour change.

`pnpm run verify` green, exit 0: 1924 tests, self-model `check` clean.

## Note on release

Rides `## Unreleased`. Whether it justifies a 1.11.1 on its own is a separate call, since the change only reaches anyone at the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt