### PR TITLE
The canvas draws a profile-declared kind as what it descends from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fixed.** A profile-declared kind is drawn on the canvas as what it
+  descends from. The node's icon resolved through its own label only, and
+  a label with no glyph fell back to nothing, so an adopter's `rest-api`
+  rendered with an empty icon slot. The palette had the two-step already
+  (`label ?? coreLabel`) and edges already carried `coreKindLabel`; the
+  node did not, so the fallback had nothing to reach for.
+  `PROFILE_ALIAS_GLYPH`, a hardcoded map naming **this repository's own
+  two extension kinds**, went with it: it meant the dogfood path had icons
+  and every adopter's did not, which is the shape of defect a rule
+  replaces. Found by an adopter asking, before declaring kinds, whether
+  the mounted editor handles them.
+
 - **Fixed.** `docs/MODEL-FLOOR.md` ships in the package. It was written for
   adopters, and an adopter arrives through npm, so leaving it in the
   repository put it exactly where the people it is for would not find it.

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -291,7 +291,12 @@ function badgeLayersFor(
   showNudges: boolean,
 ): BadgeLayer[] {
   const layers: BadgeLayer[] = []
-  const icon = kindIconUriOf(String(ele.data('kindLabel')))
+  // Label first, then the core kind it descends from - the same two-step
+  // the palette takes. A profile-declared kind is named by its author and
+  // drawn as what it IS.
+  const icon =
+    kindIconUriOf(String(ele.data('kindLabel'))) ??
+    kindIconUriOf(String(ele.data('coreKindLabel')))
   if (icon !== null) {
     layers.push({ image: icon, positionX: '0%', positionY: '0%', size: ICON_SIZE })
   }
@@ -853,6 +858,11 @@ export function graphToElements(
         wrapLabel: withWrapPoints(node.name),
         kind: node.kind,
         kindLabel: node.kindLabel,
+        // The node's resolved core-vocabulary kind, carried for the same
+        // reason an edge already carries it: an extension kind has no glyph
+        // of its own, and the honest fallback is its ancestor's. Without it
+        // the icon slot for `rest-api` is simply empty.
+        coreKindLabel: node.coreKindLabel,
         aspect: node.aspect,
         layer: node.layer,
         status: node.status,

--- a/src/visual-app/kind-icons.ts
+++ b/src/visual-app/kind-icons.ts
@@ -14,16 +14,9 @@ export { ICON_SIZE }
 // each aliases to the parent kind's id rather than duplicating its glyph
 // body - this alias map is local because the notation module has no notion
 // of profile-specific kinds, only the core vocabulary.
-const PROFILE_ALIAS_GLYPH: Record<string, string> = {
-  'compiler-module': 'applicationComponent',
-  'repository-file': 'artifact',
-}
-
 // `kindLabel` is a kind's local id (`kindLabelOf` in `src/kind-label.ts`),
 // not the qualified `<profile>#<id>` identity. Unknown label -> no icon, no
 // crash: the top-right slot simply stays empty.
 export function kindIconUriOf(kindLabel: string): string | null {
-  const aliased = PROFILE_ALIAS_GLYPH[kindLabel]
-  if (aliased !== undefined) return coreKindGlyphDataUriOf(aliased)
   return coreKindGlyphDataUriOf(kindLabel)
 }

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -449,6 +449,54 @@ describe('parallel relationships between the same pair', () => {
     elements.map((element) => [element.data.id, element]),
   )
 
+  it('draws a profile-declared kind with its core ancestor\'s glyph', () => {
+    // The fallback itself, not its input. `badgeLayersFor` is private, so
+    // this reaches it the way the canvas does: through the `node` selector's
+    // `background-image`, which is a function of the element.
+    const stub = (data: Record<string, unknown>) =>
+      ({ data: (key: string) => data[key] }) as never
+    const styleOf = (block: unknown): Record<string, unknown> =>
+      ((block as { style?: Record<string, unknown> }).style ?? {})
+    const styleBlock = buildStylesheet(false, false, false, false).find(
+      (block) => typeof styleOf(block)['background-image'] === 'function',
+    )
+    const backgroundImage = styleOf(styleBlock) [
+      'background-image'
+    ] as (ele: never) => readonly string[]
+
+    const core = backgroundImage(
+      stub({ kindLabel: 'applicationComponent', coreKindLabel: 'applicationComponent' }),
+    )
+    const extension = backgroundImage(
+      stub({ kindLabel: 'rest-api', coreKindLabel: 'applicationComponent' }),
+    )
+    // The extension kind is drawn as what it descends from. (The empty-slot
+    // case for a label nothing resolves is covered in kind-icons.test.ts.)
+    expect(core[0]).toMatch(/^data:image\/svg\+xml;utf8,/)
+    expect(extension[0]).toBe(core[0])
+  })
+
+  it('carries a node\'s core kind, so an extension kind can be drawn as what it is', () => {
+    // A profile-declared kind has no glyph of its own, and the icon falls
+    // back to its core ancestor's - the same two-step the palette takes.
+    // The fallback needs `coreKindLabel` on the element, and until it was
+    // carried here the node had only `kindLabel`, so a `rest-api` rendered
+    // with an empty icon slot. Edges already carried it; nodes did not.
+    const extension = {
+      ...node('mapper'),
+      kind: 'acme/mule@1.0#rest-api',
+      kindLabel: 'rest-api',
+      coreKindLabel: 'applicationComponent',
+    } as unknown as CanvasNode
+    const drawn = graphToElements(
+      { nodes: [extension], edges: [] },
+      [],
+      new Map(),
+    )
+    expect(drawn[0]?.data.kindLabel).toBe('rest-api')
+    expect(drawn[0]?.data.coreKindLabel).toBe('applicationComponent')
+  })
+
   it('keeps every parallel edge as its own element', () => {
     for (const id of ['e1', 'e2', 'e3', 'e4', 'e5']) {
       expect(elementById.get(id), id).toBeDefined()

--- a/test/kind-icons.test.ts
+++ b/test/kind-icons.test.ts
@@ -20,11 +20,9 @@ describe('kind icon URIs', () => {
     'requirement',
     'systemSoftware',
     'technologyFunction',
-    'compiler-module',
-    'repository-file',
   ]
 
-  it('resolves every one of the 19 labels to a non-empty data:image/svg+xml URI', () => {
+  it('resolves every one of the 17 core labels to a non-empty data:image/svg+xml URI', () => {
     for (const label of labels) {
       const uri = kindIconUriOf(label)
       expect(uri).not.toBeNull()
@@ -48,15 +46,15 @@ describe('kind icon URIs', () => {
     expect(kindIconUriOf('notAKind')).toBeNull()
   })
 
-  it('compiler-module returns the same URI as applicationComponent', () => {
-    const comp = kindIconUriOf('applicationComponent')
-    const mod = kindIconUriOf('compiler-module')
-    expect(mod).toEqual(comp)
-  })
-
-  it('repository-file returns the same URI as artifact', () => {
-    const art = kindIconUriOf('artifact')
-    const file = kindIconUriOf('repository-file')
-    expect(file).toEqual(art)
+  it('has no glyph of its own for a profile-declared kind', () => {
+    // This is a label-to-glyph lookup and nothing more. A profile-declared
+    // kind has no glyph, and it is not this function's business to find one:
+    // resolving through the core ancestor needs lineage, which the callers
+    // hold and this does not. It used to carry a two-entry alias map naming
+    // this repository's OWN extension kinds, which meant the dogfood path
+    // had icons and every adopter's did not.
+    expect(kindIconUriOf('compiler-module')).toBeNull()
+    expect(kindIconUriOf('rest-api')).toBeNull()
+    expect(kindIconUriOf('applicationComponent')).not.toBeNull()
   })
 })


### PR DESCRIPTION
Found by an adopter asking, before declaring their first extension kinds, whether the mounted editor handles them. Three of the four surfaces did. The canvas icon did not.

## The defect

A node's icon resolved through its own kind label only. A label with no glyph fell back to nothing, so an adopter's `rest-api` rendered with an **empty icon slot** while every core kind rendered correctly.

Two halves, neither visible alone:

1. **The node element carried `kindLabel` and not `coreKindLabel`**, so a fallback had nothing to reach for. Edges already carried it and already used it for styling.
2. **The icon lookup took one label**, rather than the two-step `kind-palette.tsx` had been doing correctly one file over: label, then the core kind it descends from.

## `PROFILE_ALIAS_GLYPH` went with it

```ts
const PROFILE_ALIAS_GLYPH: Record<string, string> = {
  'compiler-module': 'applicationComponent',
  'repository-file': 'artifact',
}
```

A hardcoded two-entry map naming **this repository's own extension kinds**. It meant the dogfood path had icons and every adopter's did not, which is why the gap survived: the self-model renders `compiler-module` correctly on 10 concepts and `repository-file` on 179, so the canvas looked fine to us.

Same shape as the workbook's `REFERENCE_PREDICATES` (#389): a closed list standing where a rule belongs. The rule was already written next door.

`kindIconUriOf` is now honestly a label-to-glyph lookup with no lineage knowledge, because lineage belongs to the callers that hold it. Its test was updated to state that contract rather than the old workaround.

## What was already correct

Checked all four surfaces the adopter asked about:

| Surface | Handles a profile-declared kind |
|---|---|
| Kind palette | ✅ reads `vocabulary.conceptKinds` from the resolved profile, sent every model frame |
| Add-subject kind picker | ✅ same vocabulary |
| Layer grouping and colour | ✅ via the core kind it descends from |
| **Canvas node icon** | ❌ **fixed here** |

## Verification

Both halves mutation-killed **independently**: dropping `coreKindLabel` from the node data, and dropping the fallback from the lookup. The first attempt tested only the data half and the fallback mutation survived, which is the per-call-site lesson again.

`pnpm run verify` green, exit 0: 1925 tests, self-model `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt