### PR TITLE
chore: release 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.11.1
 
 - **Fixed.** A profile-declared kind is drawn on the canvas as what it
   descends from. The node's icon resolved through its own label only, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Three changes since `v1.11.0`. **Patch**: no breaking change, no schema change, no API change.

Cut because it gates real downstream work rather than as a convenience. An adopter has six steps stopped behind it, and the canvas fix is the specific blocker: their next step declares kinds under `applicationComponent`, which on 1.11.0 renders blank icon slots.

## Fixed

**The canvas draws a profile-declared kind as what it descends from.** A node's icon resolved through its own kind label only, so an extension kind with no glyph of its own fell back to nothing and rendered an empty slot. The node element now carries `coreKindLabel` (edges already did) and the lookup takes the two-step the palette already took.

The hardcoded `PROFILE_ALIAS_GLYPH` it replaced named `compiler-module` and `repository-file` — **this repository's own extension kinds** — so the self-model rendered correctly across 189 concepts while every adopter's canvas drew blank.

**`docs/MODEL-FLOOR.md` ships in the package.** It was written for adopters, and an adopter arrives through npm. The one adopter who has read it read it off a working tree that happened to be on the same machine.

## Documentation

`CONTRIBUTING.md` gains the fourth earned rule: **an allowlist cannot fail for the author who wrote it.** Three instances in one week across two codebases, with the distinction that makes it usable — a curated summary may name what it shows, a router or a gate may not. An audit of the remaining literal sets in `src/` found no further instance.

## Preparation

- `pnpm install --frozen-lockfile`, `pnpm run verify` green, exit 0: **1925 tests**, self-model `check` clean at 353 concepts / 475 relationships, LikeC4 valid.
- `npm pack --dry-run`: **272 files** (271 + the floor doc), 2.0 MB packed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXDzTTUwstxea9gGngfjjt