### PR TITLE
feat: a wave gate asks about the workspace, and may ask positively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** `has-subject-of-kind`, a workspace-scope condition that holds
+  when the model contains at least one subject of the named kinds. It is the
+  positive twin of `no-subject-of-kind`, with the same `kinds` and the same
+  `kindMatching` default of `descendants`. A wave gate could say "the model
+  has started" and "the model still lacks X" but never "the model now has
+  X", so a phase-ordered interview had every wave open the moment the first
+  concept landed: a consultant with three components modelled was asked who
+  is paged for interfaces that do not exist yet. `opensWhen` requires all
+  conditions to hold and has no `not`, so inverting the negative was not
+  available. ADR 0125 anticipated this shape of arrival; ADR 0134 records
+  it. Requested by an adopter authoring lifecycle waves (#398).
+
+- **Fixed.** A wave gate is refused when it asks about a subject (`YM917`).
+  `opensWhen` is evaluated with no subject, but the schema offered the whole
+  condition vocabulary in that position, and the result split two ways with
+  no diagnostic either way: `has-linkage`, `near-duplicate` and
+  `fills-pattern-slot` left the wave **permanently shut**, while
+  `missing-linkage`, `isolated`, `missing-claim` and `missing-constraint`
+  left the gate **inert**. Both read as a working gate to anyone reviewing
+  the YAML. This is the same invisible failure `YM914` already refuses from
+  a different cause, and only one cause was guarded. The classification is a
+  total map over the condition union rather than a list of names, so a new
+  condition cannot compile until its scope is declared — an allowlist cannot
+  fail for the author who wrote it, and a gate is where a missing entry is
+  silent. Found while verifying #398 against the code (#400, ADR 0134).
+
 ## 1.11.1
 
 - **Fixed.** A profile-declared kind is drawn on the canvas as what it

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -30,7 +30,9 @@ questions. Each question binds:
 
 - a **trigger** — one or more deterministic conditions over the compiled
   graph (all must hold): `missing-claim`, `missing-relationship`,
-  `isolated`, `no-subject-of-kind`, `no-state-defined`,
+  `isolated`, `no-subject-of-kind`, `has-subject-of-kind` (workspace: the
+  positive twin of `no-subject-of-kind`, for a gate that opens once the
+  model HAS something), `no-state-defined`,
   `missing-linkage` (no relationship of given kinds, in a given
   direction, whose counterpart is of a given kind — the linkage-depth
   primitive), `has-linkage` (the positive of `missing-linkage`;
@@ -217,6 +219,40 @@ zero. `ask` prints `not yet — this wave has not opened` rather than an empty
 heading, and a consumer should read `opened` rather than counting. This is
 worth stating because both this repository's own renderer and a consuming
 product's wave rail had the same fault on the day the gate shipped.
+
+### A gate asks about the workspace, never about a subject
+
+A gate is evaluated with **no subject**, so only a workspace-scope condition
+means anything in `opensWhen`. There are five: `has-any-subject`,
+`no-subject-of-kind`, `has-subject-of-kind`, `no-state-defined` and
+`exists-linkage` — the last being a positive existence check, "some concept
+would satisfy `has-linkage`", which is easy to miss and often the one a gate
+wants.
+
+Any other condition is refused (`YM917`). Before the refusal existed they
+loaded silently and split two ways: `has-linkage`, `near-duplicate` and
+`fills-pattern-slot` left the wave **permanently shut**, while
+`missing-linkage`, `isolated`, `missing-claim` and `missing-constraint` left
+the gate **inert**. Both read as a gate to anyone reviewing the YAML, which
+is why this is a refusal rather than a finding, and it is the same invisible
+failure `YM914` refuses when a gate names a kind that resolves nowhere.
+
+A gate that wants "the model now has X" uses `has-subject-of-kind`
+([ADR 0134](adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md)):
+
+```yaml
+waves:
+  - id: design
+    name: Design
+    opensWhen:
+      - condition: has-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationInterface
+```
+
+`opensWhen` requires every condition to hold and has no `not`, so the
+positive and the negative are both needed: a question is closed by an
+absence ending, and a gate opens once the thing is there.
 
 Wave order is load-bearing because of this. A catalogue that sequences
 motivation before implementation is making a claim the engine now honours,

--- a/docs/adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md
+++ b/docs/adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md
@@ -1,0 +1,116 @@
+# A wave gate asks about the workspace, and may ask positively
+
+Status: accepted
+
+ADR 0125 gave a wave an `opensWhen` gate and wrote it in the condition
+vocabulary, so that "a reviewer reads a gate exactly as they read a
+trigger". Two things followed from reusing the vocabulary that the ADR did
+not say, and both surfaced the same week an adopter first authored
+phase-ordered waves.
+
+## The gate is evaluated with no subject, and said so nowhere
+
+`conditionHolds` takes an optional subject, and a gate passes `undefined`:
+a wave is a property of the model, not of any one thing in it. But the
+catalogue schema offered the **whole** condition vocabulary in `opensWhen`,
+and most of the vocabulary asks about a subject.
+
+Authored into a gate, measured against a one-concept workspace, every one
+of these loaded without complaint:
+
+| Gate condition | `opened` | What the author got |
+|---|---|---|
+| `has-linkage`, `near-duplicate`, `fills-pattern-slot` | `false` | a wave that never opens |
+| `missing-linkage`, `isolated`, `missing-claim`, `missing-constraint` | `true` | a gate that does nothing |
+
+The split is what made it invisible. Half leave the wave permanently shut
+and half leave the gate inert, and an author reviewing the YAML sees a gate
+in both cases. The mechanism is a non-null assertion meeting an absent
+subject: `missing-constraint` reads `claimsBySubject.get(subjectId!)`,
+which is `undefined`, so its `.some(...)` is vacuously false and the
+negation is `true`; `has-linkage` guards on `subjectId !== undefined` and
+returns `false`. Neither is wrong where it was written. Both are wrong in
+this position.
+
+**A subject-scope condition in `opensWhen` is refused (`YM917`).** This is
+the same failure `YM914` already refuses from a different cause. `YM914`'s
+reasoning is that a gate naming a kind that resolves nowhere never matches,
+and "that is indistinguishable from a condition that is simply not met" —
+which is precisely this, arrived at by a different route. Only one route
+was guarded.
+
+**Refused at load rather than narrowed in the schema.** The schema could
+express the restriction as a second `oneOf` over the workspace-scope
+conditions, and an editor would then flag it before the engine ran. It
+would also report `must match exactly one schema in oneOf`, naming neither
+the offending condition nor the ones that would work. A diagnostic that
+exists because the author cannot see the problem has to do the seeing.
+
+**The classification is a total map over the union, not a list of names.**
+An allowlist cannot fail for the author who wrote it (CONTRIBUTING.md's
+ninth rule), and a gate is exactly the position where a missing entry is
+silent. `CONDITION_SCOPE` is a `Record<CatalogueCondition['condition'],
+'workspace' | 'subject'>`, so a new condition cannot compile until its
+scope is declared: the typechecker asks the question rather than the table
+remembering the answer. The remedy the diagnostic offers is read off the
+same map, so the advice cannot drift from what the engine accepts.
+
+There are **five** workspace-scope conditions, and it is worth writing the
+number down because the adopter who hit this counted three. `exists-linkage`
+is the fifth, and it is a positive existence check that already reads the
+whole workspace — the existential lift of `has-linkage`, added by hand in
+#206 and easy to miss in a dense list.
+
+## A gate wants the opposite polarity from a question
+
+`no-subject-of-kind` is the right condition for a *question*: "you have no
+stakeholders, who are they?" exists to be closed by the absence ending. A
+*gate* wants the opposite, and `opensWhen` requires every condition to hold
+with no `not`, so inverting was not available.
+
+The consequence was that a wave could say "the model has started"
+(`has-any-subject`) and "the model still lacks X" (`no-subject-of-kind`) but
+never "the model now has X". A phase-ordered interview needs the third:
+without it every wave opens the moment the first concept lands, which is the
+situation #334 fixed for the empty model and left in place one step later. A
+consultant who has modelled three components is asked who is paged for
+interfaces that do not exist yet. The questions are not wrong, they are
+premature, which is the distinction ADR 0125 drew when it put the gate on
+the wave.
+
+**`has-subject-of-kind` is added**, the positive twin of
+`no-subject-of-kind`, with the same `kinds` and the same `kindMatching`
+default of `descendants`. ADR 0125 anticipated exactly this shape of
+arrival: a further condition "can join later without changing the
+mechanism".
+
+It is written as its own existence check rather than as the negation of
+`no-subject-of-kind`, so the empty workspace falls out directly rather than
+by double negative: no subjects of any kind means every gate using it stays
+shut, which is the #334 posture.
+
+## What is deliberately not decided
+
+**No boolean algebra over conditions.** One positive existence check covers
+phase ordering. A `not` operator would raise a question about every other
+condition, and about how a gate reads, that this does not.
+
+**No existential lift.** A gate could instead evaluate a subject-scope
+condition as "some subject satisfies it", which is what `exists-linkage`
+already does relative to `has-linkage`. That is more elegant than a refusal
+and a larger semantic change, and it should be decided on its own rather
+than arrive as a bug fix. The refusal does not foreclose it: a condition
+that is refused today can be given a meaning tomorrow, where one that
+silently returned the wrong answer would have adopters depending on it.
+
+## Consequences
+
+`YM917` is a new refusal, so a catalogue that authored a subject-scope gate
+and appeared to work now fails to load. That is the intent: every such
+catalogue had a wave that never opened or a gate that did nothing, and the
+refusal names which. No catalogue in this repository authored one.
+
+Both schema and evaluator gain `has-subject-of-kind`; it is additive, and no
+existing catalogue changes meaning.
+
+Issues: #398 (the condition), #400 (the gate scope).

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -272,6 +272,34 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -289,6 +289,34 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -248,6 +248,34 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "has-subject-of-kind"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -84,6 +84,23 @@ export type CatalogueCondition =
       readonly kinds: readonly string[]
       readonly kindMatching?: 'exact' | 'descendants'
     }
+  | {
+      /**
+       * The positive twin of `no-subject-of-kind`, and workspace-scope like it
+       * (#398). A gate wants the opposite polarity from a question: a question
+       * exists to be closed by an absence ending, while a gate opens once the
+       * thing is there. `opensWhen` requires every condition to hold and has no
+       * `not`, so inverting was not available and the phase-ordered interview
+       * an adopter was authoring could say "the model still lacks X" but never
+       * "the model now has X".
+       *
+       * ADR 0125 anticipated arrivals in this position: a further condition
+       * "can join later without changing the mechanism".
+       */
+      readonly condition: 'has-subject-of-kind'
+      readonly kinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
   | { readonly condition: 'no-state-defined' }
   | {
       readonly condition: 'missing-linkage'
@@ -494,6 +511,7 @@ const namedKinds = (question: CatalogueQuestion): readonly string[] => {
     switch (condition.condition) {
       case 'missing-relationship':
       case 'no-subject-of-kind':
+      case 'has-subject-of-kind':
       case 'missing-constraint':
         kinds.push(...condition.kinds)
         break
@@ -568,6 +586,56 @@ const linkageHits = (
     )
   })
 }
+
+/**
+ * What a condition needs in order to mean anything: a subject, or only the
+ * workspace (#400).
+ *
+ * A wave gate evaluates with NO subject, and the catalogue schema offered the
+ * whole vocabulary in that position, so a subject-scope condition in
+ * `opensWhen` produced a wave that silently never opened (`has-linkage`,
+ * `near-duplicate`, `fills-pattern-slot`) or a gate that was silently inert
+ * (`missing-linkage`, `isolated`, `missing-claim`, `missing-constraint`) —
+ * measured, both halves. Neither was refused. That is the same failure
+ * `YM914` already refuses from a different cause: a gate nothing can satisfy
+ * is indistinguishable from a gate that is merely unmet.
+ *
+ * This is a `Record` over the union's discriminant rather than a list of the
+ * workspace-scope names, and that is the point. An allowlist cannot fail for
+ * the author who wrote it (CONTRIBUTING.md's ninth rule), so a new condition
+ * must not be able to arrive and be quietly absent from a gate check. Here it
+ * cannot: adding a member to `CatalogueCondition` is a TYPECHECK ERROR until
+ * its scope is declared, so the compiler asks the question rather than this
+ * table remembering the answer.
+ */
+const CONDITION_SCOPE: Record<
+  CatalogueCondition['condition'],
+  'workspace' | 'subject'
+> = {
+  'has-any-subject': 'workspace',
+  'no-subject-of-kind': 'workspace',
+  'has-subject-of-kind': 'workspace',
+  'no-state-defined': 'workspace',
+  'exists-linkage': 'workspace',
+  'missing-claim': 'subject',
+  'missing-relationship': 'subject',
+  isolated: 'subject',
+  'missing-linkage': 'subject',
+  'has-linkage': 'subject',
+  'missing-constraint': 'subject',
+  'missing-flow-content': 'subject',
+  'missing-reference': 'subject',
+  'missing-attestation': 'subject',
+  'near-duplicate': 'subject',
+  'unconstrained-kind': 'subject',
+  'unscoped-succession': 'subject',
+  'unchallenged-evidence': 'workspace',
+  'fills-pattern-slot': 'subject',
+}
+
+export const conditionScope = (
+  condition: CatalogueCondition,
+): 'workspace' | 'subject' => CONDITION_SCOPE[condition.condition]
 
 const conditionHolds = (
   index: GraphIndex,
@@ -689,6 +757,21 @@ const conditionHolds = (
     case 'no-subject-of-kind': {
       const matching = condition.kindMatching ?? 'descendants'
       return ![...index.concepts].some((id) =>
+        kindMatches(
+          index.kindOf.get(id),
+          condition.kinds,
+          matching,
+          profileContext,
+        ),
+      )
+    }
+    case 'has-subject-of-kind': {
+      // Deliberately not `!no-subject-of-kind`: written as its own existence
+      // check so the empty workspace falls out right rather than by double
+      // negative. No subjects of any kind means every gate using it stays
+      // shut, which is the #334 posture.
+      const matching = condition.kindMatching ?? 'descendants'
+      return [...index.concepts].some((id) =>
         kindMatches(
           index.kindOf.get(id),
           condition.kinds,
@@ -1348,6 +1431,51 @@ const undeclaredWaveDiagnostics = (
         ],
   )
 
+/**
+ * `YM917`: a wave gate may only ask about the workspace (#400).
+ *
+ * `opensWhen` is evaluated with no subject, so a subject-scope condition here
+ * cannot mean what it reads as. Half of them then leave the wave permanently
+ * shut and half leave the gate inert, and an author reviewing the YAML sees a
+ * gate either way — the same invisible failure `YM914` refuses when a gate
+ * names a kind that resolves nowhere.
+ *
+ * Refused at load rather than narrowed in the schema on purpose. The schema
+ * could express it as a second `oneOf`, but a `oneOf` miss reports "must match
+ * exactly one schema", which names neither the offending condition nor the
+ * ones that would work — and this diagnostic exists precisely because the
+ * author cannot see the problem.
+ */
+const gateScopeDiagnostics = ({
+  catalogue,
+  locate,
+}: LoadedCatalogueDocument): readonly Diagnostic[] =>
+  catalogue.waves.flatMap((wave, waveIndex) =>
+    (wave.opensWhen ?? []).flatMap((condition, conditionIndex) =>
+      conditionScope(condition) === 'subject'
+        ? [
+            {
+              severity: 'error' as const,
+              code: 'YM917',
+              message:
+                `Condition "${condition.condition}" gates wave "${wave.id}" but asks about a subject, ` +
+                'and a gate is evaluated with none, so the wave would never open or the gate would do ' +
+                `nothing. Gate on the workspace instead: ${workspaceScopeConditions().join(', ')}.`,
+              ...locate(['waves', waveIndex, 'opensWhen', conditionIndex]),
+            },
+          ]
+        : [],
+    ),
+  )
+
+// Read off the scope table rather than restated, so the remedy a diagnostic
+// offers cannot drift from the set the engine actually accepts.
+const workspaceScopeConditions = (): readonly string[] =>
+  Object.entries(CONDITION_SCOPE)
+    .filter(([, scope]) => scope === 'workspace')
+    .map(([condition]) => condition)
+    .sort()
+
 const unresolvableKindDiagnostics = (
   { catalogue, locate }: LoadedCatalogueDocument,
   profileContext?: ResolvedProfileContext,
@@ -1522,6 +1650,7 @@ export function composeCatalogues(
   const declaredWaves = new Set(declaredBy.keys())
   const crossDiagnostics = documents.flatMap((document) => [
     ...undeclaredWaveDiagnostics(document, declaredWaves),
+    ...gateScopeDiagnostics(document),
     ...unresolvableKindDiagnostics(document, profileContext),
     ...unauthorableOfferDiagnostics(document, profileContext),
   ])
@@ -1567,6 +1696,13 @@ export function loadQuestionCatalogue(
   )
   if (waveDiagnostics.length > 0) {
     return { ok: false, diagnostics: waveDiagnostics }
+  }
+  // Before the kind checks, and unlike them it needs no profile context: a
+  // gate that asks about a subject is wrong on its own terms, whether or not
+  // a caller brought a compiled workspace to resolve kinds against.
+  const scopeDiagnostics = gateScopeDiagnostics(loaded.document)
+  if (scopeDiagnostics.length > 0) {
+    return { ok: false, diagnostics: scopeDiagnostics }
   }
   const kindDiagnostics = unresolvableKindDiagnostics(
     loaded.document,

--- a/test/gate-scope.test.ts
+++ b/test/gate-scope.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// Two things that arrived together because an adopter authoring phase-ordered
+// waves needed the first and would silently have been bitten by the second.
+//
+// #398: `has-subject-of-kind`, the positive twin of `no-subject-of-kind`. A
+// question exists to be closed by an absence ending; a GATE wants the opposite
+// polarity, and `opensWhen` has no `not`.
+//
+// #400: a gate is evaluated with NO subject, and the schema offered the whole
+// condition vocabulary in that position. A subject-scope condition there left
+// the wave permanently shut or the gate inert, and nothing said so.
+
+const workspaceOf = (concepts: string) => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:${concepts}
+relationships: []
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+}
+
+const EMPTY = workspaceOf(' []')
+const HAS_ACTOR = workspaceOf(`
+  - id: teller
+    kind: businessActor
+    name: Teller`)
+const HAS_INTERFACE = workspaceOf(`
+  - id: teller
+    kind: businessActor
+    name: Teller
+  - id: payments-api
+    kind: applicationInterface
+    name: Payments API`)
+
+const catalogueSource = (opensWhen: string) => `format: yarramate/question-catalogue/v1
+id: fixture
+version: "1.0"
+profile: yarramate/core@0.1
+presentation:
+  title: Fixture
+  description: A gated wave.
+waves:
+  - id: design
+    name: Design
+    description: Premature until there is something to design.
+${opensWhen}questions:
+  - id: interface-owner-missing
+    wave: design
+    since: "1.0"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#outcome
+    question: Who is paged for this interface?
+    materiality: An interface nobody owns has no one to call.
+    authority: human
+    resolution: Declare an owner.
+`
+
+const load = (opensWhen: string) =>
+  loadQuestionCatalogue({
+    path: 'catalogues/fixture.yaml',
+    source: catalogueSource(opensWhen),
+  })
+
+const loadOrThrow = (opensWhen: string) => {
+  const result = load(opensWhen)
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result.catalogue
+}
+
+const gateOpens = (
+  opensWhen: string,
+  compiled: typeof EMPTY,
+): boolean =>
+  evaluateCatalogue(
+    loadOrThrow(opensWhen),
+    compiled.graph,
+    compiled.profileContext,
+  ).waves.find(({ id }) => id === 'design')!.opened
+
+const HAS_SUBJECT_OF_KIND = `    opensWhen:
+      - condition: has-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationInterface
+`
+
+describe('has-subject-of-kind gates a wave on the model HAVING something', () => {
+  it('stays shut when the workspace holds nothing of the kind', () => {
+    expect(gateOpens(HAS_SUBJECT_OF_KIND, HAS_ACTOR)).toBe(false)
+  })
+
+  it('opens once one subject of the kind exists', () => {
+    expect(gateOpens(HAS_SUBJECT_OF_KIND, HAS_INTERFACE)).toBe(true)
+  })
+
+  // The #334 posture falls out rather than being special-cased: an empty
+  // workspace holds no subject of any kind, so every gate using it is shut.
+  it('stays shut on the empty workspace', () => {
+    expect(gateOpens(HAS_SUBJECT_OF_KIND, EMPTY)).toBe(false)
+  })
+
+  it('resolves through profile lineage by default, like its negative', () => {
+    // `applicationComponent` is the parent of nothing declared here, so this
+    // asserts the default matching is `descendants` and not `exact` by
+    // selecting a CORE kind a subject holds directly.
+    const gate = `    opensWhen:
+      - condition: has-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationInterface
+        kindMatching: exact
+`
+    expect(gateOpens(gate, HAS_INTERFACE)).toBe(true)
+    expect(gateOpens(gate, HAS_ACTOR)).toBe(false)
+  })
+
+  it('is the polarity no existing condition could express', () => {
+    // The point of the issue: the negative gates the wave the wrong way round.
+    const negative = `    opensWhen:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationInterface
+`
+    expect(gateOpens(negative, HAS_INTERFACE)).toBe(false)
+    expect(gateOpens(negative, HAS_ACTOR)).toBe(true)
+  })
+})
+
+// Every subject-scope condition, authored into a gate as a catalogue author
+// would write it. Each one loaded WITHOUT COMPLAINT before this refusal, and
+// the comment records which way each failed, because the split is what made it
+// invisible: a gate that never opens and a gate that does nothing both read as
+// a gate.
+const SUBJECT_SCOPE_GATES: Record<string, string> = {
+  // never opened
+  'has-linkage': `    opensWhen:
+      - condition: has-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+`,
+  'near-duplicate': `    opensWhen:
+      - condition: near-duplicate
+`,
+  'fills-pattern-slot': `    opensWhen:
+      - condition: fills-pattern-slot
+`,
+  // inert
+  'missing-linkage': `    opensWhen:
+      - condition: missing-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: outgoing
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+`,
+  isolated: `    opensWhen:
+      - condition: isolated
+`,
+  'missing-claim': `    opensWhen:
+      - condition: missing-claim
+        predicate: yarramate/ownership/owner
+`,
+  'missing-constraint': `    opensWhen:
+      - condition: missing-constraint
+        kinds:
+          - yarramate/core@0.1#constraint
+`,
+  'missing-flow-content': `    opensWhen:
+      - condition: missing-flow-content
+`,
+  'unconstrained-kind': `    opensWhen:
+      - condition: unconstrained-kind
+`,
+  'unscoped-succession': `    opensWhen:
+      - condition: unscoped-succession
+`,
+  'missing-attestation': `    opensWhen:
+      - condition: missing-attestation
+        topic: security-review
+`,
+  'missing-reference': `    opensWhen:
+      - condition: missing-reference
+        predicate: yarramate/reference/cites
+        direction: outgoing
+`,
+  'missing-relationship': `    opensWhen:
+      - condition: missing-relationship
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: outgoing
+`,
+}
+
+const WORKSPACE_SCOPE_GATES: Record<string, string> = {
+  'has-any-subject': `    opensWhen:
+      - condition: has-any-subject
+`,
+  'no-subject-of-kind': `    opensWhen:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationInterface
+`,
+  'has-subject-of-kind': HAS_SUBJECT_OF_KIND,
+  'no-state-defined': `    opensWhen:
+      - condition: no-state-defined
+`,
+  'exists-linkage': `    opensWhen:
+      - condition: exists-linkage
+        kinds:
+          - yarramate/core@0.1#serving
+        direction: either
+        counterpartKinds:
+          - yarramate/core@0.1#businessActor
+`,
+  'unchallenged-evidence': `    opensWhen:
+      - condition: unchallenged-evidence
+`,
+}
+
+describe('a wave gate may only ask about the workspace (YM917)', () => {
+  for (const [condition, opensWhen] of Object.entries(SUBJECT_SCOPE_GATES)) {
+    it(`refuses ${condition} in opensWhen`, () => {
+      const result = load(opensWhen)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      const refusal = result.diagnostics.find(({ code }) => code === 'YM917')
+      expect(refusal).toBeDefined()
+      // Names the offending condition, and points at it: the author cannot
+      // see this one by reading, so the diagnostic has to do the seeing.
+      expect(refusal!.message).toContain(`"${condition}"`)
+      expect(refusal!.pointer).toBe('/waves/0/opensWhen/0')
+    })
+  }
+
+  for (const [condition, opensWhen] of Object.entries(WORKSPACE_SCOPE_GATES)) {
+    it(`accepts ${condition} in opensWhen`, () => {
+      const result = load(opensWhen)
+      expect(
+        result.ok ? [] : result.diagnostics.filter((d) => d.code === 'YM917'),
+      ).toEqual([])
+    })
+  }
+
+  it('covers every condition the vocabulary has, so none is left unclassified', () => {
+    // The scope table itself is exhaustive by TYPECHECK - a new member of
+    // CatalogueCondition cannot compile until its scope is declared. This
+    // asserts the FIXTURES kept up, which the typechecker cannot do: a
+    // condition added and classified but never authored into a gate here
+    // would leave the refusal unexercised for that condition.
+    const covered = new Set([
+      ...Object.keys(SUBJECT_SCOPE_GATES),
+      ...Object.keys(WORKSPACE_SCOPE_GATES),
+    ])
+    expect(covered.size).toBe(19)
+  })
+
+  it('offers the workspace-scope conditions as the remedy', () => {
+    const result = load(SUBJECT_SCOPE_GATES['isolated']!)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    const message = result.diagnostics.find(
+      ({ code }) => code === 'YM917',
+    )!.message
+    for (const workspaceScope of Object.keys(WORKSPACE_SCOPE_GATES)) {
+      expect(message).toContain(workspaceScope)
+    }
+  })
+
+  it('leaves a wave with no gate alone', () => {
+    const result = load('')
+    expect(result.ok).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #398. Closes #400.

Two changes from one adopter authoring phase-ordered waves: the first was asked for, the second was found while checking the first against the code.

## `has-subject-of-kind` (#398)

The positive twin of `no-subject-of-kind`, same `kinds`, same `descendants` default.

```yaml
opensWhen:
  - condition: has-subject-of-kind
    kinds:
      - yarramate/core@0.1#applicationInterface
```

A gate could say "the model has started" (`has-any-subject`) and "the model still lacks X" (`no-subject-of-kind`) but never "the model now has X". `opensWhen` requires all conditions to hold and has no `not`, so inverting was not available, and every wave opened the moment the first concept landed. A consultant with three components modelled gets asked who is paged for interfaces that do not exist yet: not wrong, premature, which is the distinction ADR 0125 drew when it put the gate on the wave.

ADR 0125 anticipated this shape of arrival, saying a further condition "can join later without changing the mechanism".

Written as its own existence check rather than as `!no-subject-of-kind`, so the empty workspace stays shut by falling out rather than by special case.

## A gate is refused when it asks about a subject (#400, `YM917`)

`opensWhen` is evaluated with **no subject**, and the schema offered the whole condition vocabulary in that position. Measured against a one-concept workspace, all seven loaded without complaint:

| Gate condition | `opened` | What the author got |
|---|---|---|
| `has-linkage`, `near-duplicate`, `fills-pattern-slot` | `false` | wave never opens |
| `missing-linkage`, `isolated`, `missing-claim`, `missing-constraint` | `true` | gate is inert |

The split is what made it invisible: both read as a gate to anyone reviewing the YAML. This is the same failure `YM914` already refuses from a different cause, its own reasoning being that a gate nothing can satisfy "is indistinguishable from a condition that is simply not met". Only one cause was guarded.

**The classification is a total map over the union, not a list of names.** `CONDITION_SCOPE` is a `Record<CatalogueCondition['condition'], 'workspace' | 'subject'>`, so a new condition is a typecheck error until its scope is declared. An allowlist cannot fail for the author who wrote it, and a gate is exactly where a missing entry is silent. The remedy the diagnostic offers is read off the same map, so the advice cannot drift from what the engine accepts.

**Refused at load rather than narrowed in the schema.** A `oneOf` miss reports "must match exactly one schema", naming neither the offending condition nor the ones that would work, and this diagnostic exists precisely because the author cannot see the problem.

## Worth recording separately

There are **five** workspace-scope conditions, not three. `exists-linkage` is the fifth and is a *positive* existence check reading the whole workspace, the existential lift of `has-linkage`. It is documented in a dense list at `docs/INTERROGATION.md:37` and the adopter who hit this counted three, so the docs now name the set in the gate section where a gate author will look.

## Not decided here

An **existential lift**, where a gate would read a subject-scope condition as "some subject satisfies it", which is what `exists-linkage` already does relative to `has-linkage`. More elegant than a refusal and a larger semantic change, so it should be decided on its own rather than arrive as a bug fix. The refusal does not foreclose it: a condition refused today can be given a meaning tomorrow, where one silently returning the wrong answer would already have adopters depending on it.

## Verification

- Clean-slate `pnpm verify`, exit 0: **1952 tests** (110 files), self-check no errors at 353 concepts / 475 relationships.
- New `test/gate-scope.test.ts`, 27 tests, driving the real `loadQuestionCatalogue` and `evaluateCatalogue` seams with authored YAML rather than hand-built condition objects.
- Every one of the 19 conditions is authored into a gate as a fixture, and a test fails if a future condition is classified but never exercised.
- **Four mutations verified to fail**: unwiring the refusal (14 failed), evaluating `has-subject-of-kind` as always false (2), misclassifying `isolated` as workspace-scope (2), dropping the condition name from the message (13).
- Scope classifications were derived from the evaluator body (which cases read `subjectId`) and matched all 19 by hand-check.

## Breaking

`YM917` is a new refusal, so a catalogue that authored a subject-scope gate and appeared to work now fails to load. That is the intent: every such catalogue had a wave that never opened or a gate that did nothing. No catalogue in this repository authored one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
