### PR TITLE
chore: release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 1.12.0
+
+**Breaking:** `YM917` refuses a wave gate that asks about a subject. A
+catalogue that authored one loaded before and does not now. Every such
+catalogue already had a wave that never opened or a gate that did nothing,
+so nothing that worked stops working; what changes is that the engine now
+says so instead of staying quiet. No catalogue in this repository authored
+one, and the diagnostic names both the offending condition and the
+workspace-scope conditions that would work.
 
 - **Added.** `has-subject-of-kind`, a workspace-scope condition that holds
   when the model contains at least one subject of the named kinds. It is the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release 1.12.0. Two changes, both from one adopter authoring phase-ordered waves: the first was asked for, the second was found while verifying the first against the code.

## Breaking

`YM917` refuses a wave gate that asks about a subject. A catalogue that authored one loaded before and does not now.

Nothing that worked stops working. Every such catalogue already had a wave that **never opened** or a gate that was **inert**, measured both ways, with no diagnostic either way. What changes is that the engine now says so instead of staying quiet, and names both the offending condition and the workspace-scope conditions that would work.

Same shape of break as `YM916` in 1.11.0, and the same minor bump.

## Contents

- **`has-subject-of-kind`** (#398), the positive twin of `no-subject-of-kind`. A gate could say "the model has started" and "the model still lacks X" but never "the model now has X", and `opensWhen` has no `not`.
- **`YM917`** (#400), the gate-scope refusal. Its classification is a total map over the condition union, so a new condition cannot compile until its scope is declared.
- ADR 0134 records both, and records the **existential lift** as considered and deliberately not taken.

## Release gate

- `pnpm install --frozen-lockfile`, then clean-slate `pnpm verify`, **exit 0**: 1952 tests, 110 files.
- Self-model **current, not behind the code**: check no errors (353 concepts / 475 relationships / 4 states), reconcile **312/312 confirmed**, 0 contradicted, **0 unclaimed of 150** artifacts, interview **0 open of 51**. The 8 findings are the same pre-existing attestation freshness notes from 2026-08-13, not drift from this change.
- `npm pack --dry-run`: **272 files, 2.0 MB**. Runtime, normative schemas, `docs/CONSUMING-YARRAMATE.md`, `docs/MODEL-FLOOR.md`, the agent skill, README and LICENSE. No repository source, tests, fixtures, dogfooding inputs or generated output.
- `pnpm` on PATH is 11.7.0, matching `packageManager`.

Publication follows the runbook after merge: annotated tag, publish from a fresh clone detached at the tag so `gitHead` is the tagged commit, then GitHub release and registry verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
