### PR TITLE
docs: there are six workspace-scope conditions, not five

### DIFF
--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -223,11 +223,16 @@ product's wave rail had the same fault on the day the gate shipped.
 ### A gate asks about the workspace, never about a subject
 
 A gate is evaluated with **no subject**, so only a workspace-scope condition
-means anything in `opensWhen`. There are five: `has-any-subject`,
-`no-subject-of-kind`, `has-subject-of-kind`, `no-state-defined` and
-`exists-linkage` — the last being a positive existence check, "some concept
-would satisfy `has-linkage`", which is easy to miss and often the one a gate
-wants.
+means anything in `opensWhen`. There are six: `has-any-subject`,
+`no-subject-of-kind`, `has-subject-of-kind`, `no-state-defined`,
+`exists-linkage` and `unchallenged-evidence`. `exists-linkage` is a positive
+existence check, "some concept would satisfy `has-linkage`", which is easy to
+miss and often the one a gate wants.
+
+**Do not trust this sentence over the engine.** The set is derived from the
+condition union in code, and `YM917`'s own message lists it; a count written
+in prose is the thing that goes stale, and this one did — it shipped saying
+five and omitting `unchallenged-evidence`.
 
 Any other condition is refused (`YM917`). Before the refusal existed they
 loaded silently and split two ways: `has-linkage`, `near-duplicate` and

--- a/docs/adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md
+++ b/docs/adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md
@@ -2,6 +2,15 @@
 
 Status: accepted
 
+Amended immediately after release (1.12.0). This ADR argued that a list of
+names goes stale and that the classification must therefore be a total map the
+typechecker enforces — and then restated the list in prose and got it wrong,
+saying **five** workspace-scope conditions and omitting `unchallenged-evidence`.
+The code was right throughout, because `YM917`'s message is read off the map;
+only the prose was wrong, and `docs/INTERROGATION.md` carried the same error.
+Corrected to six. The rule earned another instance the day it was written,
+which is rule 8: writing about a silent failure mode is when you produce it.
+
 ADR 0125 gave a wave an `opensWhen` gate and wrote it in the condition
 vocabulary, so that "a reviewer reads a gate exactly as they read a
 trigger". Two things followed from reusing the vocabulary that the ADR did
@@ -55,9 +64,9 @@ scope is declared: the typechecker asks the question rather than the table
 remembering the answer. The remedy the diagnostic offers is read off the
 same map, so the advice cannot drift from what the engine accepts.
 
-There are **five** workspace-scope conditions, and it is worth writing the
+There are **six** workspace-scope conditions, and it is worth writing the
 number down because the adopter who hit this counted three. `exists-linkage`
-is the fifth, and it is a positive existence check that already reads the
+is one of them, and it is a positive existence check that already reads the
 whole workspace — the existential lift of `has-linkage`, added by hand in
 #206 and easy to miss in a dense list.
 


### PR DESCRIPTION
ADR 0134 argued that a list of names goes stale, which is exactly why the gate's scope classification is a total map the typechecker enforces rather than an allowlist. It then restated the list in prose and got it wrong: **five**, with `unchallenged-evidence` missing. `docs/INTERROGATION.md` carried the same error.

**The code was right throughout.** `YM917`'s message is read off the map, so the engine has been telling adopters the correct six all along:

```
error YM917 Condition "isolated" gates wave "design" but asks about a subject ...
Gate on the workspace instead: exists-linkage, has-any-subject, has-subject-of-kind,
no-state-defined, no-subject-of-kind, unchallenged-evidence.
```

Six. Caught by reading that line during the post-publish smoke test against the public registry, which is the one place the engine's claim and my prose sat side by side.

`docs/INTERROGATION.md` now **defers to the engine explicitly** rather than competing with it, since a count in prose is precisely the thing that goes stale. ADR 0134 carries an amendment note in the house style.

**Not a patch release.** `docs/INTERROGATION.md` does not ship in the npm package (only `CONSUMING-YARRAMATE.md` and `MODEL-FLOOR.md` do), so no adopter received the wrong number through npm, and the diagnostic they would actually hit was always correct.

Rule 8 earned another instance on the day it was written: writing about a silent failure mode is when you produce it. Suite green, 1952 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
