### PR TITLE
docs: wave order is honoured only where gates differ

### DIFF
--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -259,10 +259,39 @@ waves:
 positive and the negative are both needed: a question is closed by an
 absence ending, and a gate opens once the thing is there.
 
-Wave order is load-bearing because of this. A catalogue that sequences
-motivation before implementation is making a claim the engine now honours,
-where before the order was presentational and questions fired in whatever
-order the model happened to trip them.
+Wave order is load-bearing because of this, **but only to the extent that
+gates differ**. Waves carrying the same `opensWhen` open at the same instant,
+however the rail draws them: they are one phase wearing several labels, and
+the engine honours the sequence a catalogue writes only where its gates
+distinguish one wave from the next.
+
+**The check, which needs no engine support: identical gates are a defect
+exactly when a wave's own description names something a prior wave produces.**
+A description that states an *invariant the wave asserts* — "every commitment
+has a delivery mechanism" — claims no sequence, and simultaneous opening is
+correct for it. A description that states a *precondition it depends on* —
+"how declared services are realized" — claims one, and an identical gate
+contradicts it in the same file.
+
+`core-enrichment` is the worked example of getting this wrong. It gates six of
+its seven waves on `has-any-subject` while four of those waves describe a
+precondition: `application` says "how declared services are realized",
+`technology` "where the declared applications actually run", `implementation`
+"how the planned architecture becomes real", and `interaction` ends "Hygiene
+waits" — a wave stating that another is sequenced behind it, while both open
+on the same event.
+
+**One thing the vocabulary cannot express, deliberately.** A gate can say
+"there is something to work on"; it can never say "the previous phase is
+finished". ADR 0120 put the gate on model substance rather than wave
+completion, and that decision stands. `interaction`'s "Hygiene waits" is the
+case that wants the second, and it has no expression here.
+
+**When choosing a gate, check it against the questions in its own wave.** A
+gate naming the subject its wave exists to elicit never opens for the model
+that needs it: gating `implementation` on a `workPackage` existing means the
+question asking you to declare work packages fires only once you have. The
+gate belongs on what a *prior* wave produces.
 
 ## A kind a catalogue names must exist where it says it does
 

--- a/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
+++ b/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
@@ -74,6 +74,50 @@ waves:
   them. The gate makes the sequencing real, which is what a wave was
   always claiming to be.
 
+  **AMENDED 2026-08-29, and the amendment is the more useful half. The
+  sentence above is true only where gates DIFFER, and it was false for the
+  catalogue this decision shipped alongside itself.** `core-enrichment`
+  gates six of its seven waves on the same `has-any-subject`, so exactly one
+  boundary was ever made real — motivation versus everything else — while
+  the rail kept drawing six. Worse, four of those six describe a
+  precondition in their own prose: `application` "how declared services are
+  realized", `technology` "where the declared applications actually run",
+  `implementation` "how the planned architecture becomes real", and
+  `interaction` closing with "Hygiene waits", a wave stating that another is
+  sequenced behind it while both open on the same event. The catalogue
+  contradicts itself three lines apart.
+
+  **The rule, which needs no engine support: identical gates are a defect
+  exactly when a wave's own description names something a prior wave
+  produces.** A description stating an INVARIANT THE WAVE ASSERTS claims no
+  sequence and should open simultaneously; one stating a PRECONDITION IT
+  DEPENDS ON claims a sequence its gate must then honour. Found by the
+  ApertureX adopter, whose own catalogue is clean under this rule for
+  precisely that reason, and whose framing this is.
+
+  **No detector is proposed.** The engine cannot know whether an order was
+  intended, identical gates can be deliberate grouping, and a refusal would
+  therefore be wrong. The author's own description is the evidence, and it is
+  checkable by reading.
+
+  **Why nobody saw it**, which is the part worth carrying: when
+  `has-any-subject` is the only gate available, every wave after the first
+  gets the same one, and a catalogue with six identically-gated waves LOOKS
+  ordered — six names, in sequence, on a rail. The author is structurally
+  last to notice, because the presentation agrees with their intent rather
+  than with the mechanism. CONTRIBUTING.md's ninth rule in a position it had
+  not been put: not an allowlist, but a claim true for nobody, its author
+  included.
+
+  **Two limits worth stating for anyone re-gating a catalogue.** A gate can
+  say "there is something to work on" and can never say "the previous phase
+  is finished" — ADR 0120 put the gate on model substance rather than wave
+  completion, deliberately, and `interaction`'s "Hygiene waits" is the case
+  that wants what does not exist. And a gate naming the subject its own wave
+  exists to elicit never opens for the model that needs it: gating
+  `implementation` on a `workPackage` would silence the question asking for
+  work packages. The gate belongs on what a PRIOR wave produces.
+
 `core-enrichment` goes 1.2 to **1.3**, gating every wave after motivation
 on `has-any-subject`. A blank project now opens on three motivation
 questions — why the system exists, who its stakeholders are, what


### PR DESCRIPTION
ADR 0125 claimed "the gate makes the sequencing real". **That claim was false for the catalogue the ADR shipped alongside itself.**

`core-enrichment` gates six of its seven waves on the same `has-any-subject`, so exactly one boundary was ever made real — motivation versus everything else — while the rail kept drawing six.

And the waves are not neutral labels. Four state a precondition in their own prose:

| Wave | Its own description | Gate |
|---|---|---|
| `interaction` | "… **Hygiene waits.**" | `has-any-subject` |
| `application` | "How **declared services** are realized…" | `has-any-subject` |
| `technology` | "Where the **declared applications** actually run…" | `has-any-subject` |
| `implementation` | "How the **planned architecture** becomes real…" | `has-any-subject` |

The catalogue contradicts itself three lines apart, and `interaction` literally says another wave is sequenced behind it while both open on the same event.

## The rule, which needs no engine support

**Identical gates are a defect exactly when a wave's own description names something a prior wave produces.**

A description stating an *invariant the wave asserts* ("every commitment has a delivery mechanism") claims no sequence, and simultaneous opening is correct. One stating a *precondition it depends on* ("how declared services are realized") claims a sequence its gate must honour.

**No detector is proposed.** The engine cannot know whether an order was intended, identical gates can be deliberate grouping, and a refusal would be wrong. The author's own description is the evidence, and it is checkable by reading.

## Two limits stated for anyone re-gating

- The vocabulary can say "there is something to work on" and **never** "the previous phase is finished". ADR 0120 kept gates on model substance rather than wave completion, deliberately. `interaction`'s "Hygiene waits" is the case that wants what does not exist.
- **A gate naming the subject its own wave exists to elicit never opens for the model that needs it.** Gating `implementation` on a `workPackage` existing would silence the question asking you to declare work packages.

## Why nobody saw it

When `has-any-subject` is the only gate available, every wave after the first gets the same one, and six identically-gated waves **look** ordered — six names, in sequence, on a rail. The author is structurally last to notice, because the presentation agrees with their intent rather than with the mechanism.

CONTRIBUTING.md's ninth rule in a position we had not put it: not an allowlist, but a claim true for nobody, its author included.

## Provenance

Found by the ApertureX adopter in their own unbuilt six-wave lifecycle, where Design and Operate carried the same gate. The generalisation to `core-enrichment`, and the invariant-versus-precondition rule, are theirs. Their own catalogue is clean under it, which is what makes the rule usable rather than merely true.

**Docs only.** Suite green, 1952 tests. The re-gate of `core-enrichment` moves the shipped interview's behaviour and is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
