### PR TITLE
docs: what the wave-order rule does not catch, and a third trap

### DIFF
--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -287,11 +287,37 @@ finished". ADR 0120 put the gate on model substance rather than wave
 completion, and that decision stands. `interaction`'s "Hygiene waits" is the
 case that wants the second, and it has no expression here.
 
+**What the check does not do.** It tests for a *contradiction* between a gate
+and a description, not for whether an order exists. Two identically-gated
+waves whose descriptions simply claim nothing pass it, and their boundary is
+still presentational. A pass means "nothing here disagrees", never "the
+sequence is real".
+
 **When choosing a gate, check it against the questions in its own wave.** A
 gate naming the subject its wave exists to elicit never opens for the model
 that needs it: gating `implementation` on a `workPackage` existing means the
 question asking you to declare work packages fires only once you have. The
 gate belongs on what a *prior* wave produces.
+
+**And check what the compiler does with it.** A gate can name a fact that is,
+after compilation, the same fact its wave's headline question triggers on. In
+`core-enrichment`, declaring a `states:` entry mints a `plateau` concept, and
+`implementation-path-missing` fires on there being no `workPackage`,
+`deliverable` or `plateau` — so gating `implementation` on a declared state
+would open the wave at the exact moment its lead question stopped needing to
+be asked. Neither the gate nor the description shows this; only the compiled
+graph does.
+
+**The construction that avoids all of it: each wave elicits the subject the
+next wave gates on.** A catalogue built that way is clean by construction
+rather than by audit, and where a gate does name what its own wave elicits,
+the remedy is positional — move the eliciting question into the wave in front.
+That works for a catalogue ordered by *phase*, where each phase has a
+predecessor whose subject matter can carry the question. It does not work for
+the first wave in each layer of a catalogue ordered by *layer*, which has no
+earlier wave the question would belong to. Such a wave is better left
+ungated, and described as not phase-gated, than given a gate that silences
+it.
 
 ## A kind a catalogue names must exist where it says it does
 

--- a/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
+++ b/docs/adr/0125-a-wave-opens-when-the-model-has-substance.md
@@ -100,6 +100,12 @@ waves:
   therefore be wrong. The author's own description is the evidence, and it is
   checkable by reading.
 
+  **The rule's limit, named by the adopter who wrote it:** it tests for a
+  CONTRADICTION between gate and description, not for whether an order
+  exists. Identically-gated waves whose descriptions claim nothing pass, and
+  their boundary is still presentational. A pass means "nothing here
+  disagrees". It never means "the sequence is real".
+
   **Why nobody saw it**, which is the part worth carrying: when
   `has-any-subject` is the only gate available, every wave after the first
   gets the same one, and a catalogue with six identically-gated waves LOOKS
@@ -117,6 +123,25 @@ waves:
   exists to elicit never opens for the model that needs it: gating
   `implementation` on a `workPackage` would silence the question asking for
   work packages. The gate belongs on what a PRIOR wave produces.
+
+  **A third trap, visible only in the compiled graph.** A gate can name a
+  fact that compilation makes identical to its wave's headline trigger.
+  Declaring a `states:` entry mints a `plateau`, and
+  `implementation-path-missing` fires on the absence of a `workPackage`,
+  `deliverable` or `plateau` — so gating `implementation` on a declared state
+  opens the wave exactly when its lead question has been closed by the same
+  act. Trap one yields a wave that never opens for the model that needs it;
+  this yields one that opens only once it has nothing left to lead with.
+
+  **The construction that avoids all three: each wave elicits the subject the
+  next wave gates on**, which is clean by construction rather than by audit
+  (the adopter's formulation, from auditing their own six-wave lifecycle).
+  Where a gate does name what its own wave elicits, the remedy is POSITIONAL
+  — move the eliciting question into the wave in front. **That remedy is
+  available to a PHASE-ordered catalogue and not to a LAYER-ordered one**,
+  whose first wave in each layer has no predecessor the question would belong
+  to. `implementation` is the case: it has no honest gate, and should stay
+  ungated and say so rather than acquire one that silences it.
 
 `core-enrichment` goes 1.2 to **1.3**, gating every wave after motivation
 on `has-any-subject`. A blank project now opens on three motivation


### PR DESCRIPTION
#404 shipped a rule for identically-gated waves and presented it as "the check". **It is not complete, and running it as if it were gives a false pass.** Three additions.

## 1. The rule's limit (found by the adopter who wrote the rule)

It tests for a **contradiction** between gate and description, not for whether an order exists. Two identically-gated waves whose descriptions simply claim nothing pass it, and their boundary is still presentational.

> A pass means "nothing here disagrees". It never means "the sequence is real".

They found this by auditing their own catalogue: it convicted their `Build` wave correctly, while their `Foundations`/`Analysis` boundary passed despite doing no ordering work, because those descriptions are thin rather than contradictory.

## 2. A third trap, visible only in the compiled graph

Found here while costing #405.

`.yarramate/architecture/evolution.yaml` declares `concepts: []` and four `states:`. The compiled graph nonetheless carries `adapter-foundation` as a concept of kind `plateau`. **A state entry compiles to a plateau.**

And `implementation-path-missing` triggers on:

```yaml
- condition: no-subject-of-kind
  kinds: [workPackage, deliverable, plateau]
```

So gating `implementation` on a declared state would open the wave **at the exact moment its lead question stopped needing to be asked**.

| | Result |
|---|---|
| Trap 1 (gate names what the wave elicits) | a wave that never opens for the model that needs it |
| Trap 3 (gate is the headline trigger, post-compilation) | a wave that opens only once it has nothing left to lead with |

Neither the gate nor the description reveals trap 3. Only the compiled graph does.

## 3. The construction that avoids all three (adopter's formulation)

> Each wave elicits the subject the next wave gates on.

Clean by construction rather than by audit. Where a gate does name what its own wave elicits, the remedy is **positional**: move the eliciting question into the wave in front.

**That remedy is available to a phase-ordered catalogue and not to a layer-ordered one**, whose first wave in each layer has no predecessor the question would belong to. `implementation` is exactly that case, so it has no honest gate and should stay ungated and say so, rather than acquire one that silences it.

## Consequence

`has-state-defined` is **not** the answer for #405 and should not ride along with it. Recorded there in full, with the measurements.

Docs only. Suite green, 1952 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
