### PR TITLE
docs: the floor records the attribute mechanism as declined, not pending

### DIFF
--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -214,15 +214,26 @@ fetches, or interprets the URI: URI ownership is the provider's (ADR 0068,
 
 ## Deliberately open
 
-Three of the refusals above are recorded limits rather than settled doctrine,
+Two of the refusals above are recorded limits rather than settled doctrine,
 and are under discussion:
 
-- profile-declared typed values, which would give the second classification
-  axis and the per-instance value a checkable home (#386);
 - declared reference slots, so that what a citation is *for* can be checked
   and asked about (#388);
 - whether an attestation should be able to confirm a declared value rather
-  than only a topic.
+  than only a topic (#397). One of its shapes is #388's slot in another
+  position, so the two are being decided together.
+
+**A general typed-attribute mechanism was examined and declined (#386).** It
+would have given the second classification axis and the per-instance value a
+checkable home, and the measurement went against it: run against a live
+adopter engagement of 348 open cards, this document failed to resolve **one**,
+and that card asked a delivery question in an architecture question's clothes.
+Two corrections from the same measurement are worth carrying, because they
+outlive the decision. An attribute is **single-valued**, so it never rescues
+ordered detail — sixty-eight processor steps are rows, not sixty-eight
+attributes of a flow. And the useful split is **three-way**, not two:
+attribute, attestation, annex, where a fact needing a named human to vouch for
+it is an attestation and not an attribute of anything.
 
 Nothing here is a promise that they stay refused. It is a statement of what is
 true today, written so that the next adopter reads the floor instead of


### PR DESCRIPTION
#386 is closed, and `docs/MODEL-FLOOR.md` still listed it under **Deliberately open** as a limit under discussion.

That document **ships in the package**, so the stale pointer would have reached adopters as an open question when it is a settled one.

## What changed

Two of the three remain open, and #397 is now cross-linked to #388 in the text, because one of #397's shapes is #388's slot in another position and they want deciding together.

The attribute mechanism gets a **paragraph rather than a deletion**, because the measurement that declined it is more useful to an adopter than the decision. Run against a live engagement of 348 open cards, the floor failed to resolve **one**, and that card asked a delivery question in an architecture question's clothes.

Two corrections from that measurement outlive the decision:

- **An attribute is single-valued**, so it never rescues ordered detail. Sixty-eight processor steps are rows, not sixty-eight attributes of a flow.
- **The useful split is three-way**, not two: attribute, attestation, annex. A fact needing a named human to vouch for it is an attestation, not an attribute of anything.

Both are the adopter's own corrections, made against their own ask.

Docs only. Suite green, 1952 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u