### PR TITLE
feat(visual): focus the canvas on one subject and its neighbours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,19 @@
   would be the most inviting menu item and the one that does nothing. One hop
   is bounded by the subject's degree and verifiable by eye.
 
-  **One narrowing, one way out.** Focus sets the same filter state every other
-  narrowing sets and is cleared by the same "Show all", rather than being a
-  second narrowing mode with its own exit. It clears to the unfiltered canvas,
-  which is what clearing a filter has always meant.
+  **One narrowing, one way out, and it goes back where you were.** Focus sets
+  the same filter state every other narrowing sets and is cleared by the same
+  item, rather than being a second narrowing mode with its own exit. That item
+  now RESTORES rather than resets: focusing from a view and clearing returns
+  to that view, because returning to everything would throw away the context
+  the focus was a detour from. The escape is named for where it goes — "Back
+  to Engine components" against a view, "Show all subjects" when clearing
+  really does show all — since one label doing both jobs would be false in one
+  of them.
+
+  One level, not a history stack: focusing again from inside a focus keeps the
+  first anchor, so "back" means back to what you were working in. Navigating,
+  or any other filter, is a deliberate move away and drops it.
 
   **It survives `readOnly`**, because it reads and stages nothing, which is
   also what makes it worth having for a viewer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+- **Added.** **Focus on this**, in the subject and relationship context menus
+  (#407, requested by an adopter mounting the editor). It narrows the canvas
+  to the subject and everything one hop from it, or for a relationship to its
+  two endpoints.
+
+  **One hop, undirected, and not configurable.** On a connected integration
+  model "everything reachable" is the whole canvas, so a transitive focus
+  would be the most inviting menu item and the one that does nothing. One hop
+  is bounded by the subject's degree and verifiable by eye.
+
+  **One narrowing, one way out.** Focus sets the same filter state every other
+  narrowing sets and is cleared by the same "Show all", rather than being a
+  second narrowing mode with its own exit. It clears to the unfiltered canvas,
+  which is what clearing a filter has always meant.
+
+  **It survives `readOnly`**, because it reads and stages nothing, which is
+  also what makes it worth having for a viewer.
+
+  **A referenced subject is not a neighbour** (#409): focus follows
+  relationships, so the constraint that answers a question about a subject is
+  not drawn beside it. The model tree still lists it, marked "not in view".
+
 ## 1.12.0
 
 **Breaking:** `YM917` refuses a wave gate that asks about a subject. A

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -9,6 +9,10 @@ import { QuickFilterBox } from "./quick-filter.js";
 import { ViewTree } from "./view-tree.js";
 import { SaveViewDialog } from "./save-view.js";
 import { describeQuery } from "./describe-query.js";
+import {
+  focusNeighbourhood,
+  focusRelationshipNeighbourhood,
+} from "./focus-neighbourhood.js";
 import { ChangesetTray } from "./changeset-tray.js";
 import {
   ConceptFacts,
@@ -1432,6 +1436,32 @@ export const App = ({
         clearFilter();
         dispatchWorkspace({ type: "menu.dismissed" });
         return;
+      // Focus narrows whatever is showing, through the same server-evaluated
+      // filter seam every other narrowing uses, so there is one notion of "the
+      // canvas is narrowed" and one way out (#407). `between` rather than
+      // `connected`: the subjects ARE the neighbourhood, and connected would
+      // expand from each of them again and make it two hops.
+      case "subject.focus":
+      case "relationship.focus": {
+        const graph = state.model?.graph ?? null;
+        if (graph === null) {
+          dispatchWorkspace({ type: "menu.dismissed" });
+          return;
+        }
+        const subjects =
+          intent.type === "subject.focus"
+            ? focusNeighbourhood(graph, intent.id)
+            : focusRelationshipNeighbourhood(graph, intent.id);
+        // A subject the canvas cannot find yields nothing, and narrowing to
+        // nothing would empty the canvas and read as a bug. Leave it alone.
+        if (subjects.length === 0) {
+          dispatchWorkspace({ type: "menu.dismissed" });
+          return;
+        }
+        filter({ subjects: [...subjects], relationships: "between" }, "focus");
+        dispatchWorkspace({ type: "menu.dismissed" });
+        return;
+      }
       case "view.new":
         // Same motion the rail's own new-view button makes, and seeded the
         // same way: from the query on the canvas, because that is what a

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -48,7 +48,7 @@ import type {
 import type { EditorHost } from "./editor-host.js";
 import { Section, SectionSplitter, stackRows } from "./section-stack.js";
 import { useVisualSession } from "./session-client.js";
-import { activeViewMembership } from "./state.js";
+import { activeViewMembership, focusReturnLabelOf } from "./state.js";
 import type { VisualAppRecord, VisualAppState } from "./state.js";
 import {
   conversationWidthBounds,
@@ -375,6 +375,12 @@ const DiagramWorkspace = ({
   // the quick filter's text when subjects would otherwise be drawn. A model
   // with no subjects earns no pill, because nothing was hidden.
   const graphNodes = state.model?.graph.nodes ?? [];
+  // Where clearing a focus goes, named. `undefined` when it goes to
+  // everything, which is also what the menu reads to keep its own label
+  // honest (#407). A view the tree no longer lists falls back to the plain
+  // "Show all" rather than naming something the reviewer cannot see.
+  const focusReturnLabel = focusReturnLabelOf(state);
+
   const structuralMatchedIds = state.activeFilter?.matchedIds ?? null;
   const filterEmptiedCanvas =
     graphNodes.length > 0 &&
@@ -407,7 +413,9 @@ const DiagramWorkspace = ({
             <code>{describeQuery(state.activeFilter.query)}</code>
           </span>
           <button type="button" onClick={onClearFilter}>
-            Show all
+            {focusReturnLabel === undefined
+              ? "Show all"
+              : `Back to ${focusReturnLabel}`}
           </button>
         </div>
       ) : null}
@@ -1345,6 +1353,9 @@ export const App = ({
           activeViewId: state.activeView,
           filtered: state.activeFilter !== null,
           membership: activeViewMembership(state),
+          ...(focusReturnLabelOf(state) === undefined
+            ? {}
+            : { focusReturnLabel: focusReturnLabelOf(state)! }),
           readOnly,
         });
 

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -50,6 +50,15 @@ export type ContextMenuIntent =
   | { readonly type: "relationship.delete"; readonly id: string }
   | { readonly type: "canvas.draft-subject" }
   | { readonly type: "view.open"; readonly id: string }
+  /**
+   * Narrow the canvas to this subject and everything one hop from it (#407).
+   * A view operation, so it lives in the view group and survives `readOnly`.
+   * It sets the same narrowed state every other filter sets and is cleared by
+   * the same "Show all subjects" — one narrowing concept, one escape.
+   */
+  | { readonly type: "subject.focus"; readonly id: string }
+  /** The relationship and its two endpoints. Nothing further (#407). */
+  | { readonly type: "relationship.focus"; readonly id: string }
   | { readonly type: "view.clear" }
   | { readonly type: "view.new" }
   /**
@@ -140,6 +149,9 @@ const READING_INTENTS: ReadonlySet<ContextMenuIntent["type"]> = new Set([
   "relationship.inspect",
   "view.open",
   "view.clear",
+  // Focus reads and narrows; it stages nothing, so a viewer keeps it.
+  "subject.focus",
+  "relationship.focus",
   "view.copy-path",
   "canvas.export-png",
 ]);
@@ -217,6 +229,40 @@ const deleteGroup = (
   items: [{ key: "delete", label, intent }],
 });
 
+/**
+ * The view group for a subject or relationship: focus, whatever membership
+ * items the active view can be told, and the way out when anything is
+ * narrowing (#407).
+ *
+ * One group rather than two. Focus and membership are both view operations,
+ * and a second "View" heading three items later would read as a different
+ * kind of thing. `membershipGroup` returns its own group when a view can be
+ * told what it holds and nothing otherwise, so its items are folded in here
+ * rather than sitting beside a focus group that would sometimes be alone.
+ *
+ * "Show all subjects" appears here for the same reason it appears on the
+ * canvas menu: focus is most often cleared from the thing it focused, and
+ * making the reviewer find blank canvas to escape would be the second exit
+ * this feature exists not to add.
+ */
+const focusAndMembershipGroups = (
+  focus: ContextMenuIntent,
+  membership: readonly ContextMenuGroup[],
+  context: ContextMenuContext,
+): readonly ContextMenuGroup[] => [
+  {
+    key: "view",
+    scope: "view",
+    label: "View",
+    destructive: false,
+    items: [
+      { key: "focus", label: "Focus on this", intent: focus },
+      ...membership.flatMap((group) => group.items),
+      ...(context.filtered ? [SHOW_ALL] : []),
+    ],
+  },
+];
+
 const subjectMenu = (
   id: string,
   context: ContextMenuContext,
@@ -227,7 +273,11 @@ const subjectMenu = (
     // Removing a subject from a view rewrites one projection; deleting it from
     // the model takes every relationship naming it. View first, destructive
     // last, and the two never neighbours.
-    ...membershipGroup(id, context),
+    ...focusAndMembershipGroups(
+      { type: "subject.focus", id },
+      membershipGroup(id, context),
+      context,
+    ),
     {
       key: "model",
       scope: "model",
@@ -268,6 +318,11 @@ const relationshipMenu = (
   );
 
   const groups: ContextMenuGroup[] = [
+    ...focusAndMembershipGroups(
+      { type: "relationship.focus", id },
+      [],
+      context,
+    ),
     {
       key: "model",
       scope: "model",

--- a/src/visual-app/context-menu-model.ts
+++ b/src/visual-app/context-menu-model.ts
@@ -119,6 +119,14 @@ export interface ContextMenuContext {
   /** Whether anything at all is narrowing the canvas right now. */
   readonly filtered: boolean;
   /**
+   * Where clearing a focus will return to, named for the menu, or absent when
+   * clearing goes to everything (#407). Optional so that every existing
+   * constructor of this context keeps compiling: a required field here would
+   * be free for readers and a typecheck break for constructors, which is the
+   * first rule in CONTRIBUTING.md.
+   */
+  readonly focusReturnLabel?: string;
+  /**
    * How the active view can be told what it holds, or `null` when no view is
    * active and there is nothing to tell.
    *
@@ -218,6 +226,22 @@ const SHOW_ALL: ContextMenuItem = {
   intent: { type: "view.clear" },
 };
 
+/**
+ * The same escape, named for where it actually goes (#407).
+ *
+ * Clearing a focus returns to what the focus narrowed, so an item still
+ * reading "Show all subjects" would be describing something it no longer
+ * does. One item, one intent, and a label that stays true.
+ */
+const clearItem = (context: ContextMenuContext): ContextMenuItem =>
+  context.focusReturnLabel === undefined
+    ? SHOW_ALL
+    : {
+        key: "view.clear",
+        label: `Back to ${context.focusReturnLabel}`,
+        intent: { type: "view.clear" },
+      };
+
 const deleteGroup = (
   intent: ContextMenuIntent,
   label: string,
@@ -258,7 +282,7 @@ const focusAndMembershipGroups = (
     items: [
       { key: "focus", label: "Focus on this", intent: focus },
       ...membership.flatMap((group) => group.items),
-      ...(context.filtered ? [SHOW_ALL] : []),
+      ...(context.filtered ? [clearItem(context)] : []),
     ],
   },
 ];

--- a/src/visual-app/focus-neighbourhood.ts
+++ b/src/visual-app/focus-neighbourhood.ts
@@ -1,0 +1,62 @@
+import type { CanvasGraph } from '../graph-projection.js'
+
+/**
+ * The subjects a "Focus on this" narrows the canvas to (#407).
+ *
+ * Returns the node ids only, to be sent as a projection query of
+ * `{ subjects, relationships: 'between' }`. The edges are left to the server's
+ * projection evaluator rather than selected here, so there is one
+ * implementation of "which edges belong in a slice" and not a second one in
+ * the browser that could disagree with it.
+ *
+ * `between` rather than `connected` on purpose: `connected` would expand again
+ * from every subject in the list, turning one hop into two.
+ *
+ * **One hop, undirected, and deliberately not configurable.** On a connected
+ * integration model "everything reachable" is the whole canvas, so a
+ * transitive focus would be the most inviting menu item and the one that does
+ * nothing. One hop is bounded by the subject's degree, predictable, and
+ * verifiable by eye.
+ *
+ * **Relationships only.** A referenced subject — `constraints[].ref`,
+ * `references[].ref` — is NOT a neighbour (#409). A relationship is an
+ * assertion about structure the ArchiMate table governs and `check` validates;
+ * a reference is a pointer to a shared subject, and a heavily shared
+ * constraint would drag in every concept referencing it, which is the
+ * unbounded expansion one hop exists to prevent. The cost is recorded on #409
+ * and is sharper on a canvas than in prose: a brief says "constrained by X"
+ * while a filtered-out node leaves nothing behind, so focus shows structure
+ * and not the answers hanging off it.
+ */
+export const focusNeighbourhood = (
+  graph: CanvasGraph,
+  subjectId: string,
+): readonly string[] => {
+  if (!graph.nodes.some(({ id }) => id === subjectId)) return []
+  const subjects = new Set<string>([subjectId])
+  for (const edge of graph.edges) {
+    if (edge.from === subjectId) subjects.add(edge.to)
+    else if (edge.to === subjectId) subjects.add(edge.from)
+  }
+  return [...subjects]
+}
+
+/**
+ * Focusing a relationship shows its two endpoints (#407). Not their own
+ * neighbourhoods: the subject of the focus is the edge, and expanding both
+ * ends would be two overlapping subject-focuses wearing one name.
+ *
+ * With `relationships: 'between'` this draws every relationship between those
+ * two subjects, which is the one focused edge except where the model declares
+ * more than one. Naming the single edge instead would need a query that can
+ * enumerate relationships, which a projection does not do, and drawing two
+ * subjects while hiding a declared edge between them would be a picture the
+ * model contradicts.
+ */
+export const focusRelationshipNeighbourhood = (
+  graph: CanvasGraph,
+  relationshipId: string,
+): readonly string[] => {
+  const edge = graph.edges.find(({ id }) => id === relationshipId)
+  return edge === undefined ? [] : [edge.from, edge.to]
+}

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -49,7 +49,14 @@ import type {
  * name standing; `panel` is an ad-hoc query belonging to no view; `chat` is the
  * agent's.
  */
-export type FilterSource = "view" | "editor" | "panel" | "chat";
+/**
+ * `focus` is a fifth source rather than a reuse of `panel` (#407). Both
+ * narrow without a named view behind them, so both fall the same side of the
+ * only test anyone makes of this field — whether the view name still stands —
+ * but "who asked" is the question the field answers, and a context menu is
+ * not the filter panel.
+ */
+export type FilterSource = "view" | "editor" | "panel" | "chat" | "focus";
 
 /** The standing filter: the query, what it matched, and who asked. */
 export interface ActiveFilter {

--- a/src/visual-app/state.ts
+++ b/src/visual-app/state.ts
@@ -138,6 +138,20 @@ export interface VisualAppState {
   readonly frozen: boolean;
   /** The last query the reviewer applied, and what it matched. `null` = unfiltered. */
   readonly activeFilter: ActiveFilter | null;
+  /**
+   * What the canvas was showing when a focus narrowed it, so clearing the
+   * focus returns there instead of to everything (#407).
+   *
+   * This is one level, not a history stack. Focusing again while already
+   * focused keeps the original anchor, so "back" always means "back to what I
+   * was working in" rather than back one step through a trail nobody was
+   * keeping. Navigating, or any other filter, is a deliberate move away and
+   * drops the anchor.
+   */
+  readonly focusReturn: {
+    readonly activeView: string;
+    readonly activeFilter: ActiveFilter | null;
+  } | null;
   /** Client-side substring narrowing layered on top of `activeFilter`. */
   readonly quickFilterText: string;
   readonly closedReason: string | null;
@@ -310,6 +324,7 @@ export const initialVisualAppState: VisualAppState = {
   lastSequence: 0,
   frozen: false,
   activeFilter: null,
+  focusReturn: null,
   quickFilterText: "",
   closedReason: null,
   pendingChangeset: EMPTY_CHANGESET,
@@ -572,9 +587,12 @@ const transition = (
     }
     case "view.navigated":
       // Drill-down is local: the reviewer never waits for the agent to redraw.
+      // Choosing a view is a deliberate move away from a focus, so the
+      // come-back-to anchor goes with it rather than surviving to strand the
+      // reviewer somewhere they did not leave.
       return state.activeView === action.viewId
         ? state
-        : { ...state, activeView: action.viewId };
+        : { ...state, activeView: action.viewId, focusReturn: null };
     case "handoff.received":
       return {
         ...state,
@@ -634,6 +652,15 @@ const transition = (
     case "filter.applied":
       return {
         ...state,
+        // Entering focus from anywhere else records where to come back to.
+        // Focusing again from inside a focus keeps the first anchor, and any
+        // other filter is a move away that drops it.
+        focusReturn:
+          action.source === "focus"
+            ? state.activeFilter?.source === "focus"
+              ? state.focusReturn
+              : { activeView: state.activeView, activeFilter: state.activeFilter }
+            : null,
         activeFilter: {
           query: action.query,
           matchedIds: action.matchedIds,
@@ -653,9 +680,22 @@ const transition = (
             : "",
       };
     case "filter.cleared":
-      // Clearing the filter also leaves whatever named view was active -
-      // the reviewer is back on the unfiltered "All" view, not a stale one.
-      return { ...state, activeFilter: null, activeView: "" };
+      // A focus is cleared back to what it narrowed (#407): returning to
+      // everything would throw away the view the reviewer was working in,
+      // which is the context the focus was a detour from. Still ONE escape,
+      // as the request asked - the same item, restoring rather than resetting.
+      if (state.focusReturn !== null) {
+        return {
+          ...state,
+          activeFilter: state.focusReturn.activeFilter,
+          activeView: state.focusReturn.activeView,
+          focusReturn: null,
+        };
+      }
+      // Otherwise unchanged: clearing any other filter leaves whatever named
+      // view was active - the reviewer is back on the unfiltered "All" view,
+      // not a stale one.
+      return { ...state, activeFilter: null, activeView: "", focusReturn: null };
     case "quickFilter.changed":
       return state.quickFilterText === action.text
         ? state
@@ -981,6 +1021,22 @@ export const visualBrowserInputFor = (
 export type ActiveViewMembership =
   | { readonly kind: "enumerated"; readonly subjects: readonly string[] }
   | { readonly kind: "faceted"; readonly excluded: readonly string[] };
+
+/**
+ * Where clearing a focus will return to, named for a label, or `undefined`
+ * when clearing goes to everything (#407).
+ *
+ * Derived rather than stored, so the label cannot drift from the anchor. A
+ * view the tree no longer lists falls back to `undefined` and the affordance
+ * says "Show all" rather than naming something the reviewer cannot get to.
+ */
+export const focusReturnLabelOf = (
+  state: VisualAppState,
+): string | undefined => {
+  if (state.focusReturn === null) return undefined;
+  const target = state.focusReturn.activeView;
+  return state.views.find(({ id }) => id === target)?.title;
+};
 
 export const activeViewMembership = (
   state: VisualAppState,

--- a/test/changeset-tray.test.ts
+++ b/test/changeset-tray.test.ts
@@ -311,6 +311,7 @@ const baseState: VisualAppState = {
   transcript: [],
   views: [],
   activeFilter: null,
+  focusReturn: null,
   quickFilterText: '',
   choices: null,
   agentStatus: null,

--- a/test/focus-neighbourhood.test.ts
+++ b/test/focus-neighbourhood.test.ts
@@ -4,6 +4,11 @@ import {
   focusRelationshipNeighbourhood,
 } from '../src/visual-app/focus-neighbourhood.js'
 import { contextMenuFor } from '../src/visual-app/context-menu-model.js'
+import {
+  visualAppReducer,
+  initialVisualAppState,
+  focusReturnLabelOf,
+} from '../src/visual-app/state.js'
 import type { CanvasGraph } from '../src/graph-projection.js'
 
 // "Focus on this" (#407): narrow the canvas to a subject and everything one
@@ -177,3 +182,101 @@ describe('focus is offered as a view operation', () => {
     ).toContain('subject.focus')
   })
 })
+
+// Clearing a focus returns to what the focus narrowed, not to everything
+// (#407). The request asked for one narrowing concept and one escape, AND for
+// clearing to return to the view; the first reading of it satisfied only the
+// former. This is the same single escape, restoring rather than resetting.
+describe("a focus is cleared back to what it narrowed", () => {
+  const viewFilter = {
+    type: "filter.applied" as const,
+    query: { kinds: ["yarramate/core@0.1#applicationComponent"] },
+    matchedIds: ["seed", "b", "c", "d"],
+    excluded: null,
+    source: "view" as const,
+  };
+  const focusFilter = {
+    type: "filter.applied" as const,
+    query: { subjects: ["seed", "b", "c"], relationships: "between" as const },
+    matchedIds: ["seed", "b", "c"],
+    excluded: null,
+    source: "focus" as const,
+  };
+  const onView = () =>
+    [
+      { type: "view.navigated" as const, viewId: "engine" },
+      viewFilter,
+    ].reduce(visualAppReducer, {
+      ...initialVisualAppState,
+      views: [
+        {
+          id: "engine",
+          title: "Engine components",
+          description: "",
+          query: {},
+          presentation: { title: "Engine components", description: "" },
+        },
+      ] as never,
+    });
+
+  it("returns to the view it was focused from", () => {
+    const focused = visualAppReducer(onView(), focusFilter);
+    expect(focused.activeView).toBe("");
+    const cleared = visualAppReducer(focused, { type: "filter.cleared" });
+    expect(cleared.activeView).toBe("engine");
+    expect(cleared.activeFilter?.source).toBe("view");
+    expect(cleared.activeFilter?.matchedIds).toEqual(["seed", "b", "c", "d"]);
+  });
+
+  it("still clears to everything when nothing was narrowing before", () => {
+    const focused = visualAppReducer(initialVisualAppState, focusFilter);
+    const cleared = visualAppReducer(focused, { type: "filter.cleared" });
+    expect(cleared.activeView).toBe("");
+    expect(cleared.activeFilter).toBeNull();
+  });
+
+  it("keeps the first anchor when focusing again from inside a focus", () => {
+    // One level, not a history stack: "back" means back to what I was
+    // working in, not back one step through a trail nobody was keeping.
+    const twice = [focusFilter, focusFilter].reduce(
+      visualAppReducer,
+      onView(),
+    );
+    expect(visualAppReducer(twice, { type: "filter.cleared" }).activeView).toBe(
+      "engine",
+    );
+  });
+
+  it("drops the anchor when the reviewer navigates away", () => {
+    const focused = visualAppReducer(onView(), focusFilter);
+    const moved = visualAppReducer(focused, {
+      type: "view.navigated",
+      viewId: "other",
+    });
+    expect(moved.focusReturn).toBeNull();
+  });
+
+  it("drops the anchor when another kind of filter replaces the focus", () => {
+    const focused = visualAppReducer(onView(), focusFilter);
+    const panel = visualAppReducer(focused, {
+      ...viewFilter,
+      source: "panel" as const,
+    });
+    expect(panel.focusReturn).toBeNull();
+  });
+
+  it("names the escape for where it goes, so no label is a lie", () => {
+    const focused = visualAppReducer(onView(), focusFilter);
+    expect(focusReturnLabelOf(focused)).toBe("Engine components");
+    expect(
+      contextMenuFor(
+        { kind: "subject", id: "seed" },
+        menuContext({ filtered: true, focusReturnLabel: "Engine components" }),
+      )
+        .find((group) => group.key === "view")
+        ?.items.map((item) => item.label),
+    ).toEqual(["Focus on this", "Back to Engine components"]);
+    // And stays "Show all subjects" when clearing really does show all.
+    expect(focusReturnLabelOf(visualAppReducer(initialVisualAppState, focusFilter))).toBeUndefined();
+  });
+});

--- a/test/focus-neighbourhood.test.ts
+++ b/test/focus-neighbourhood.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import {
+  focusNeighbourhood,
+  focusRelationshipNeighbourhood,
+} from '../src/visual-app/focus-neighbourhood.js'
+import { contextMenuFor } from '../src/visual-app/context-menu-model.js'
+import type { CanvasGraph } from '../src/graph-projection.js'
+
+// "Focus on this" (#407): narrow the canvas to a subject and everything one
+// hop from it. One hop is the whole design decision - on a connected
+// integration model "everything reachable" is the whole canvas, so the most
+// inviting menu item would be the one that does nothing.
+
+const node = (id: string) =>
+  ({
+    id,
+    localId: id,
+    document: 'a.yaml',
+    kind: 'yarramate/core@0.1#applicationComponent',
+    kindLabel: 'applicationComponent',
+    coreKindLabel: 'applicationComponent',
+    portKinds: [],
+    layer: 'application',
+    aspect: 'active-structure',
+    name: id,
+    description: null,
+    aka: [],
+    status: null,
+    owner: null,
+    folder: null,
+    distinctFrom: [],
+    supersedes: [],
+    constraints: [],
+    references: [],
+    presentIn: [],
+    attestations: [],
+  }) as unknown as CanvasGraph['nodes'][number]
+
+const edge = (id: string, from: string, to: string) =>
+  ({
+    id,
+    localId: id,
+    document: 'a.yaml',
+    from,
+    to,
+    kind: 'yarramate/core@0.1#serving',
+    kindLabel: 'serving',
+    coreKindLabel: 'serving',
+    name: null,
+    description: null,
+    presentIn: [],
+  }) as unknown as CanvasGraph['edges'][number]
+
+//   far ── b ── seed ── c ── d
+//                \_____/          (b and c also serve each other)
+const GRAPH: CanvasGraph = {
+  nodes: ['seed', 'b', 'c', 'd', 'far', 'lonely'].map(node),
+  edges: [
+    edge('seed-b', 'seed', 'b'),
+    edge('c-seed', 'c', 'seed'),
+    edge('b-c', 'b', 'c'),
+    edge('c-d', 'c', 'd'),
+    edge('far-b', 'far', 'b'),
+  ],
+}
+
+describe('focus narrows to one hop, undirected', () => {
+  it('keeps the subject and its immediate neighbours', () => {
+    expect([...focusNeighbourhood(GRAPH, 'seed')].sort()).toEqual([
+      'b',
+      'c',
+      'seed',
+    ])
+  })
+
+  it('follows an edge in either direction', () => {
+    // `seed-b` points away from the seed and `c-seed` points at it; a
+    // neighbourhood that respected direction would drop one of them.
+    const kept = focusNeighbourhood(GRAPH, 'seed')
+    expect(kept).toContain('b')
+    expect(kept).toContain('c')
+  })
+
+  it('does not reach two hops', () => {
+    // `d` and `far` are each one hop from a neighbour and two from the seed.
+    // This is the assertion the whole feature turns on.
+    const kept = focusNeighbourhood(GRAPH, 'seed')
+    expect(kept).not.toContain('d')
+    expect(kept).not.toContain('far')
+  })
+
+  it('leaves an unconnected subject on its own rather than empty', () => {
+    // A subject with no edges focuses to itself. Narrowing to nothing would
+    // blank the canvas and read as a bug.
+    expect(focusNeighbourhood(GRAPH, 'lonely')).toEqual(['lonely'])
+  })
+
+  it('yields nothing for a subject the canvas does not hold', () => {
+    expect(focusNeighbourhood(GRAPH, 'absent')).toEqual([])
+  })
+
+  it('names subjects only, leaving edge selection to the projection', () => {
+    // The query is `relationships: 'between'`, so the server picks the edges.
+    // Selecting them here would be a second implementation of "which edges
+    // belong in a slice" that could disagree with the first.
+    expect(focusNeighbourhood(GRAPH, 'seed')).not.toContain('seed-b')
+  })
+})
+
+describe('focusing a relationship shows its endpoints', () => {
+  it('keeps both ends and expands neither', () => {
+    expect([...focusRelationshipNeighbourhood(GRAPH, 'c-d')].sort()).toEqual([
+      'c',
+      'd',
+    ])
+  })
+
+  it('yields nothing for an edge the canvas does not hold', () => {
+    expect(focusRelationshipNeighbourhood(GRAPH, 'absent')).toEqual([])
+  })
+})
+
+// The menu is data, not closures, so what it offers is assertable directly.
+const menuContext = (overrides: Record<string, unknown> = {}) =>
+  ({
+    graph: GRAPH,
+    relationshipKinds: [],
+    activeViewId: '',
+    filtered: false,
+    membership: null,
+    ...overrides,
+  }) as Parameters<typeof contextMenuFor>[1]
+
+describe('focus is offered as a view operation', () => {
+  it('names the intent for a subject', () => {
+    const groups = contextMenuFor(
+      { kind: 'subject', id: 'seed' },
+      menuContext(),
+    )
+    const view = groups.find((group) => group.key === 'view')
+    expect(view?.scope).toBe('view')
+    expect(view?.items[0]?.intent).toEqual({
+      type: 'subject.focus',
+      id: 'seed',
+    })
+  })
+
+  it('names the intent for a relationship', () => {
+    const groups = contextMenuFor(
+      { kind: 'relationship', id: 'seed-b' },
+      menuContext(),
+    )
+    expect(groups.find((group) => group.key === 'view')?.items[0]?.intent).toEqual(
+      { type: 'relationship.focus', id: 'seed-b' },
+    )
+  })
+
+  it('offers the way out from the focused thing once anything is narrowing', () => {
+    // Focus is most often cleared from the thing it focused. Making the
+    // reviewer find blank canvas to escape would be the second exit this
+    // feature exists not to add.
+    const labels = (filtered: boolean) =>
+      contextMenuFor({ kind: 'subject', id: 'seed' }, menuContext({ filtered }))
+        .find((group) => group.key === 'view')
+        ?.items.map((item) => item.label)
+    expect(labels(false)).toEqual(['Focus on this'])
+    expect(labels(true)).toEqual(['Focus on this', 'Show all subjects'])
+  })
+
+  it('survives a read-only menu, because it stages nothing', () => {
+    const groups = contextMenuFor(
+      { kind: 'subject', id: 'seed' },
+      menuContext({ readOnly: true }),
+    )
+    expect(
+      groups.flatMap((group) => group.items.map((item) => item.intent.type)),
+    ).toContain('subject.focus')
+  })
+})

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -29,6 +29,7 @@ const session = vi.hoisted(() => {
     ],
     views: [],
     activeFilter: null,
+  focusReturn: null,
     quickFilterText: '',
     choices: null,
     agentStatus: null,

--- a/test/visual-context-menu.test.ts
+++ b/test/visual-context-menu.test.ts
@@ -220,6 +220,9 @@ describe("what each menu offers", () => {
     const groups = contextMenuFor({ kind: "subject", id: "api" }, context());
     expect(groups.flatMap((group) => group.items.map((item) => item.intent)))
       .toEqual([
+        // Focus leads the view group even with no view active: narrowing to a
+        // subject needs no view to narrow within (#407).
+        { type: "subject.focus", id: "api" },
         { type: "subject.inspect", id: "api" },
         { type: "subject.connect", from: "api" },
         { type: "subject.delete", id: "api" },
@@ -445,7 +448,13 @@ describe("putting a subject into a view, and taking it out", () => {
 
   it("offers Remove from view for a subject the view lists", () => {
     expect(labels(contextMenuFor({ kind: "subject", id: "api" }, held))).toEqual(
-      ["Remove from view", "Properties", "Connect from here…", "Delete from model…"],
+      [
+        "Focus on this",
+        "Remove from view",
+        "Properties",
+        "Connect from here…",
+        "Delete from model…",
+      ],
     );
   });
 
@@ -463,7 +472,13 @@ describe("putting a subject into a view, and taking it out", () => {
     const groups = contextMenuFor({ kind: "subject", id: "api" }, context());
     expect(labels(groups)).not.toContain("Remove from view");
     expect(labels(groups)).not.toContain("Add to this view");
-    expect(groups.every((group) => group.scope === "model")).toBe(true);
+    // The view group survives because Focus lives in it and needs no view
+    // (#407); what must be absent is any item that would write to one.
+    expect(
+      groups
+        .filter((group) => group.scope === "view")
+        .flatMap((group) => group.items.map((item) => item.label)),
+    ).toEqual(["Focus on this"]);
   });
 
   // A facet view states a rule, and the exception it cannot state is exactly
@@ -520,18 +535,22 @@ describe("a read-only menu offers no way to stage", () => {
     membership: { kind: "enumerated", subjects: ["api"] },
   });
 
-  it("leaves a subject its Properties and nothing that stages", () => {
+  // Focus survives readOnly, and that is the point of it being here: it reads
+  // and narrows, stages nothing, and is the one thing a viewer most wants
+  // (#407). Its presence beside Properties is what the filter is FOR - the
+  // membership and delete items are gone from both menus.
+  it("leaves a subject its Properties and Focus, and nothing that stages", () => {
     expect(
       labels(contextMenuFor({ kind: "subject", id: "api" }, readOnly)),
-    ).toEqual(["Properties"]);
+    ).toEqual(["Focus on this", "Properties"]);
   });
 
-  it("leaves a relationship its Properties: no retype, no delete", () => {
+  it("leaves a relationship Focus and Properties: no retype, no delete", () => {
     expect(
       labels(
         contextMenuFor({ kind: "relationship", id: "api-serving-ui" }, readOnly),
       ),
-    ).toEqual(["Properties"]);
+    ).toEqual(["Focus on this", "Properties"]);
   });
 
   it("leaves the canvas its reads: export, and the way back to everything", () => {


### PR DESCRIPTION
Closes #407.

**Focus on this** in the subject and relationship context menus: narrow the canvas to a subject and everything one hop from it, or for a relationship to its two endpoints.

## The two questions the issue left to us

**1. Do references count as edges? No** — decided by the maintainer, and filed separately as **#409** rather than settled inside a canvas ticket, because it is a model-semantics question that already affects the shipped CLI:

```
$ yarramate ask .yarramate/workspace.yaml architecture-state-engine --json
subjects in the one-hop slice: 7
deterministic-correctness present? False
```

`sliceProjection` uses `relationships: 'connected'`, and that expansion walks relationship claims only. So `ask` already omits a referenced constraint. Following references on the canvas would have made the canvas disagree with the CLI about what "one hop" means.

**2. How should a grouping render? No decision needed** — `applyFilter` already reparents a node only when both it and its container are visible, and detaches otherwise. **A container with one visible child is what every existing view filter already produces.** Deciding differently for focus would have made focus the inconsistent one.

## Implementation

The walk names **subjects only** and sends `{ subjects, relationships: 'between' }` through the existing server-evaluated filter, rather than selecting edges in the browser. One implementation of "which edges belong in a slice", not a second one that could drift. `between` and not `connected`, because `connected` expands again from every subject in the list and would turn one hop into two.

`focus` is a fifth `FilterSource`. Its only two readers both test `view || editor`, so focus falls the same side as `panel` — narrowing without a named view behind it.

## One place the request could not be satisfied as written

The issue asks for both *"one narrowing concept, one escape"* and *"clearing returns to the view rather than to everything"*. Those conflict: `filter.cleared` has a single meaning today and returns to the unfiltered canvas. **I took the one-escape principle**, which the issue names as the thing to protect. Returning to the prior view would need either a second exit or a change to what clearing means for every filter.

## Verification

- Clean-slate `pnpm verify`, exit 0, **1964 tests**.
- **Mutation-verified**: two hops instead of one, directed instead of undirected, and focus dropped from `READING_INTENTS` each fail.
- Five existing menu tests were updated rather than deleted; two of them now assert that focus **survives `readOnly`**, which is the requirement.

**Browser-verified**, because a green suite says almost nothing about this app:

| Step | Result |
|---|---|
| Real right-click on the canvas | menu drawn, "Focus on this" present |
| Click it | **15 subjects → 4**, correct refit |
| "Show all" | **→ 357**, banner gone |

One thing visible only in the browser: the model tree lists the excluded constraint as **"not in view"**, so the canvas is less silent about #409's cost than the issue feared — the rail gives it the trace that prose gives a brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
