### PR TITLE
docs: connected expansion follows relationships, not references

### DIFF
--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -92,6 +92,14 @@ works wherever the classification applies.
 
 Two alternatives look right and are not:
 
+*A note on reaching them.* A referenced subject is **not** a one-hop
+neighbour: `relationships: connected` walks relationships, so `ask <subject>`
+and every projection using `connected` leave it out of the slice (#409). It is
+still named in a brief — "Constrained by …" — so it is discoverable and can be
+addressed directly by id; it is named rather than expanded. Worth knowing
+before building a view or a slice that is meant to show a subject together
+with the values restricting it.
+
 - **A constraint subject.** It reads as "this thing is restricted this way",
   and an API layer or an integration style restricts nothing. An ArchiMate
   reader will notice.

--- a/docs/PROJECTIONS.md
+++ b/docs/PROJECTIONS.md
@@ -72,6 +72,25 @@ and its opposite endpoint is added to the result. Expansion is exactly one
 hop: newly added endpoints do not trigger further selection. `none` excludes
 all relationships.
 
+**Expansion follows relationships, and only relationships.** A subject that
+another subject *references* — through `constraints[].ref` or
+`references[].ref` — is not pulled in by `connected`, because a reference is a
+pointer to a shared subject rather than an edge the ArchiMate table governs
+and `check` validates. Widening the expansion to cover both would make the
+neighbourhood of a heavily shared constraint include every concept that
+references it, which is the unbounded result one hop exists to prevent
+(#409).
+
+This is worth knowing when choosing `connected`, because
+`docs/MODEL-FLOOR.md` recommends turning a value that restricts into a
+constraint subject referenced by many, and the shape it recommends is the
+shape this expansion does not walk. A brief still *names* such a subject —
+"Constrained by …" — so a reader learns it exists and can address it
+directly; what they do not get is its kind, description, or its own
+neighbours. A canvas has no prose in which to say the same thing, which is
+why the visual editor's focus (#407) draws structure and not the answers
+hanging off it.
+
 `relationshipKinds` applies after concept selection and before relationship
 mode evaluation. An unavailable qualified relationship kind selects no
 relationships but does not remove otherwise matching concepts or produce a


### PR DESCRIPTION
Closes #409.

#409 decided that a referenced subject is **not** a one-hop neighbour, and recorded two documentation obligations. This is both.

## `docs/PROJECTIONS.md`

States what `connected` walks and what it does not, so an author choosing it knows the boundary rather than discovering it. The tension is stated rather than hidden:

> `docs/MODEL-FLOOR.md` recommends turning a value that restricts into a constraint subject referenced by many, and the shape it recommends is the shape this expansion does not walk.

## `docs/MODEL-FLOOR.md`

Carries the reciprocal note *where it makes that recommendation*, with the reachability that survives: a brief **names** a referenced subject ("Constrained by …"), so it is discoverable and can be addressed by id. Named, not expanded.

## The asymmetry both record

Prose can name what it does not expand. A canvas cannot — a filtered-out node leaves nothing behind. That is what made the decision defensible in the CLI and is why the visual focus (#407, merged) draws structure and not the answers hanging off it.

Docs only. Clean-slate verify exit 0, 1970 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u