### PR TITLE
docs: an annex is unreachable by any condition, and that is the design

### DIFF
--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -220,6 +220,22 @@ locator against the subject, with the provider named. Core never resolves,
 fetches, or interprets the URI: URI ownership is the provider's (ADR 0068,
 `docs/EVIDENCE.md`).
 
+**So no condition can ask about what is inside it, and that is the design
+rather than a gap.** An annex is not compiled, so nothing about its contents
+reaches the graph the interrogation runs over. A catalogue therefore cannot
+ask "are the field mappings recorded"; it can only ask **who confirmed that
+they are**, which is what `missing-attestation` is for. An attestation names a
+person and a date, and where the substance lives outside the graph that is the
+only honest instrument left — a condition claiming to check annex contents
+would be claiming to check something Core never read.
+
+This is the adopter-facing half of CONTRIBUTING.md's fifth rule, arrived at
+from the other side. There a check could not see what a declaration compiles
+to, by accident. Here it cannot see what was deliberately never compiled, by
+design. Same reach limit, opposite cause, and the remedies differ: that one is
+fixed by reading the graph instead of the vocabulary, and this one is not
+fixed at all, because there is nothing to read.
+
 ## Deliberately open
 
 Two of the refusals above are recorded limits rather than settled doctrine,


### PR DESCRIPTION
`docs/MODEL-FLOOR.md` tells adopters where a refused fact belongs and says Core never resolves or interprets the URI. **It never says the consequence**, which is the part an adopter actually needs.

## What was missing

No condition can ask about an annex's contents. A catalogue therefore cannot ask *"are the field mappings recorded"* — only **who confirmed that they are**.

`missing-attestation` is the honest instrument where the substance lives outside the graph. A condition claiming to check annex contents would be claiming to check something Core never read.

## Why it belongs here rather than in CONTRIBUTING

This is the **adopter-facing half of CONTRIBUTING's fifth rule** (#414), arrived at from the other side:

| | Cause | Remedy |
|---|---|---|
| Fifth rule | a check cannot see what a declaration **compiles to** — by accident | read the graph instead of the vocabulary |
| This note | a check cannot see what was **deliberately never compiled** — by design | none; there is nothing to read |

Same reach limit, opposite cause, different remedies. And `MODEL-FLOOR.md` **ships in the package**, where CONTRIBUTING does not — so this is where the adopters it is for will actually find it.

## Provenance

Raised by an adopter who had already shipped exactly this shape: per-field mappings in a workspace document deliberately left out of the compile, and they reached attestation as the only remaining instrument without being told to. That is the rule working in the field before it was written down.

Docs only. Clean-slate verify exit 0, 1973 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u