### PR TITLE
feat(workbook): optional named cell styles and column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+- **Added.** `yarramate/workbook` takes optional named cell styles and column
+  widths (#416, asked for by a workbook consumer). `CellStyle` is a closed set
+  of `header`, `muted` and `emphasis` — **roles, not appearances**, so the test
+  for admitting a fourth is whether it can be named without reference to how it
+  looks. A request for a colour is the one a closed set exists to refuse, since
+  that is what turns a style vocabulary into a styling engine. Named rather
+  than given as colours for a second reason: the styles part stays a constant,
+  so "identical inputs produce identical bytes" remains trivially true.
+
+  **A caller that asks for no roles gets byte-identical output to before**, and
+  that is a test rather than a promise: the styles part, its content type, its
+  relationship and every `s` attribute are emitted only when something asks for
+  them. Row 1 takes `headerStyle` and the rows below take their column's, so a
+  header band is not overwritten by the role beneath it.
+
+  The use that carried it is not decoration. A consumer's columns fall into
+  three classes — bound to the model, carried alongside it, or computed and
+  ignored on the way back — and a consultant editing the file could not see
+  which was which until an import told them a cell could not be written back.
+
+- **Fixed.** A cell with a reference and no value is read against its own
+  column. Excel writes `<c r="B2" s="1"/>` for a cell that carries formatting
+  and nothing else, and the reader took it through the closing branch before
+  reading `r`, so it wrote against the PREVIOUS cell's column. The value
+  written was empty, and **empty is a cleared value rather than an absent
+  one**, so a workbook somebody had merely opened and saved could silently
+  blank a neighbouring cell that had content. Found by the round-trip test
+  added for the styling above, which is the first thing to emit that shape.
+
+## Unreleased
+
 - **Changed.** A property field puts its label beside its control rather than
   above it. A property sheet is read down the left edge — the reviewer is
   looking for KIND, not reading prose — so a stacked label doubled the height

--- a/src/workbook-read.ts
+++ b/src/workbook-read.ts
@@ -262,7 +262,7 @@ const rowsOf = (xml: string, shared: readonly string[]): readonly (readonly stri
         return
       }
       if (name === 'c') {
-        if (tag.closing || tag.selfClosing) {
+        if (tag.closing) {
           if (row !== undefined) {
             const resolved =
               type === 's' ? (shared[Number.parseInt(cell, 10)] ?? '') : cell
@@ -278,6 +278,19 @@ const rowsOf = (xml: string, shared: readonly string[]): readonly (readonly stri
         column = tag.attributes.r === undefined ? row?.length ?? 0 : columnIndexOf(tag.attributes.r)
         type = tag.attributes.t ?? ''
         cell = ''
+        // A SELF-CLOSING cell carries a reference and no value, which is what
+        // Excel writes for a cell that has formatting and nothing in it. It
+        // has to claim its own column here: handling it with the closing
+        // branch above would write an empty value against whatever column the
+        // PREVIOUS cell set, clearing a neighbour rather than itself. Empty is
+        // a CLEARED value, so that was a silent overwrite of real content.
+        if (tag.selfClosing) {
+          if (row !== undefined) {
+            while (row.length < column) row.push('')
+            row[column] = ''
+          }
+          type = ''
+        }
         return
       }
       if (name === 'v') inValue = !tag.closing && !tag.selfClosing

--- a/src/workbook-xlsx.ts
+++ b/src/workbook-xlsx.ts
@@ -23,6 +23,28 @@
 /** How a sheet appears in Excel's tab strip. */
 export type SheetState = 'visible' | 'hidden' | 'veryHidden'
 
+/**
+ * A cell's ROLE, not its appearance (#416).
+ *
+ * The set is closed on purpose, and named for roles so that it stays closed:
+ * a caller asking for a fourth should be asking for a fourth ROLE — "this
+ * cell is stale", "this cell is derived" — and the test for admitting one is
+ * whether it can be named without reference to how it looks. A request for
+ * `blue`, or for a shade matching a client's deck, is the request that turns
+ * a style vocabulary into a styling engine, and refusing it is the closed
+ * set doing its job.
+ *
+ * Three will be wrong eventually. It should be wrong LOUDLY, by someone
+ * filing for a role, rather than quietly by callers approximating a missing
+ * role with the nearest available one — which is how `muted` would come to
+ * mean two things.
+ *
+ * Named rather than given as colours for a second reason: the styles part is
+ * then a CONSTANT, so "identical inputs produce identical bytes" stays
+ * trivially true instead of becoming something a reviewer has to re-derive.
+ */
+export type CellStyle = 'header' | 'muted' | 'emphasis'
+
 export interface WorkbookSheet {
   readonly name: string
   /** Defaults to visible. `veryHidden` cannot be unhidden from Excel's UI. */
@@ -31,7 +53,66 @@ export interface WorkbookSheet {
   readonly rows: readonly (readonly string[])[]
   /** Rows to keep on screen when scrolling, usually 1 for a header. */
   readonly frozenRows?: number
+  /**
+   * Applied to every row BELOW the first, by column index. Row 1 takes
+   * `headerStyle` instead, so a header band is not overwritten by the column
+   * role beneath it.
+   */
+  readonly columnStyles?: readonly (CellStyle | undefined)[]
+  /** Applied to row 1 only. */
+  readonly headerStyle?: CellStyle
+  /** Column widths in characters, by column index. */
+  readonly columnWidths?: readonly number[]
 }
+
+/**
+ * Index into `cellXfs` below. `0` is the default format, which is why an
+ * unstyled workbook needs no `s` attribute and no styles part at all.
+ */
+const STYLE_INDEX: Record<CellStyle, number> = {
+  header: 1,
+  emphasis: 2,
+  muted: 3,
+}
+
+/**
+ * The whole styles part, as a constant.
+ *
+ * Excel is particular about the first two fills: index 0 must be `none` and
+ * index 1 `gray125`, whether or not either is used. `cellStyleXfs` likewise
+ * has to exist before `cellXfs` can reference it.
+ */
+const STYLES_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+  '<fonts count="3">' +
+  '<font><sz val="11"/><name val="Calibri"/></font>' +
+  '<font><b/><sz val="11"/><name val="Calibri"/></font>' +
+  '<font><color rgb="FF6B7280"/><sz val="11"/><name val="Calibri"/></font>' +
+  '</fonts>' +
+  '<fills count="3">' +
+  '<fill><patternFill patternType="none"/></fill>' +
+  '<fill><patternFill patternType="gray125"/></fill>' +
+  '<fill><patternFill patternType="solid"><fgColor rgb="FFEFF1F3"/>' +
+  '<bgColor indexed="64"/></patternFill></fill>' +
+  '</fills>' +
+  '<borders count="1"><border/></borders>' +
+  '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+  '<cellXfs count="4">' +
+  '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>' +
+  '<xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyFont="1" applyFill="1"/>' +
+  '<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>' +
+  '<xf numFmtId="0" fontId="2" fillId="0" borderId="0" xfId="0" applyFont="1"/>' +
+  '</cellXfs>' +
+  '</styleSheet>'
+
+/** Whether any sheet asked for anything the styles part exists to serve. */
+const usesStyles = (sheets: readonly WorkbookSheet[]): boolean =>
+  sheets.some(
+    (sheet) =>
+      sheet.headerStyle !== undefined ||
+      (sheet.columnStyles ?? []).some((style) => style !== undefined),
+  )
 
 const FIXED_DOS_TIME = 0
 /** 1980-01-01, the zero of DOS date encoding. */
@@ -95,20 +176,55 @@ export const sheetNameIsLegal = (name: string): boolean =>
   name.length > 0 && name.length <= 31 && !/[\\/?*[\]:]/.test(name)
 
 const sheetXml = (sheet: WorkbookSheet): string => {
+  // Row 1 takes the header role and everything below takes its column's, so a
+  // header band is not overwritten by the column role sitting under it.
+  const styleOf = (rowIndex: number, columnIndex: number): number | undefined => {
+    const style =
+      rowIndex === 0
+        ? sheet.headerStyle
+        : (sheet.columnStyles ?? [])[columnIndex]
+    return style === undefined ? undefined : STYLE_INDEX[style]
+  }
   const rows = sheet.rows
     .map((cells, rowIndex) => {
       const row = rowIndex + 1
       const written = cells
-        .map((value, columnIndex) =>
-          value === ''
-            ? ''
-            : `<c r="${columnName(columnIndex)}${row}" t="inlineStr">` +
-              `<is><t xml:space="preserve">${escapeXml(value)}</t></is></c>`,
-        )
+        .map((value, columnIndex) => {
+          const style = styleOf(rowIndex, columnIndex)
+          const attribute = style === undefined ? '' : ` s="${style}"`
+          // An empty cell in a styled column still carries the style, or the
+          // column reads as striped wherever a value happens to be missing.
+          // A value-less `<c>` reads back as an empty string, which is what
+          // an omitted cell reads back as, so the round trip is unmoved.
+          if (value === '') {
+            return style === undefined
+              ? ''
+              : `<c r="${columnName(columnIndex)}${row}"${attribute}/>`
+          }
+          return (
+            `<c r="${columnName(columnIndex)}${row}"${attribute} t="inlineStr">` +
+            `<is><t xml:space="preserve">${escapeXml(value)}</t></is></c>`
+          )
+        })
         .join('')
       return `<row r="${row}">${written}</row>`
     })
     .join('')
+  // Widths are per column and independent of the styles part, so a caller may
+  // ask for them without asking for roles.
+  const cols =
+    sheet.columnWidths === undefined || sheet.columnWidths.length === 0
+      ? ''
+      : '<cols>' +
+        sheet.columnWidths
+          .map((width, index) =>
+            width <= 0
+              ? ''
+              : `<col min="${index + 1}" max="${index + 1}" ` +
+                `width="${width}" customWidth="1"/>`,
+          )
+          .join('') +
+        '</cols>' 
   const pane =
     sheet.frozenRows === undefined || sheet.frozenRows <= 0
       ? '<sheetView workbookViewId="0"/>'
@@ -118,6 +234,7 @@ const sheetXml = (sheet: WorkbookSheet): string => {
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
     '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
     `<sheetViews>${pane}</sheetViews>` +
+    cols +
     `<sheetData>${rows}</sheetData>` +
     '</worksheet>'
   )
@@ -239,6 +356,11 @@ export const writeXlsx = (sheets: readonly WorkbookSheet[]): Uint8Array => {
     throw new Error('Sheet names must be distinct, case-insensitively')
   }
 
+  // The whole additive claim rests on this: a caller that asks for no roles
+  // gets exactly the parts, attributes and bytes it got before styling
+  // existed. The styles part is emitted only when something references it.
+  const styled = usesStyles(sheets)
+
   const contentTypes =
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
     '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
@@ -252,6 +374,10 @@ export const writeXlsx = (sheets: readonly WorkbookSheet[]): Uint8Array => {
           'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>',
       )
       .join('') +
+    (styled
+      ? '<Override PartName="/xl/styles.xml" ' +
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
+      : '') +
     '</Types>'
 
   const rootRels =
@@ -271,6 +397,11 @@ export const writeXlsx = (sheets: readonly WorkbookSheet[]): Uint8Array => {
           `Target="worksheets/sheet${index + 1}.xml"/>`,
       )
       .join('') +
+    (styled
+      ? `<Relationship Id="rId${sheets.length + 1}" ` +
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" ' +
+        'Target="styles.xml"/>'
+      : '') +
     '</Relationships>'
 
   return zip([
@@ -282,5 +413,8 @@ export const writeXlsx = (sheets: readonly WorkbookSheet[]): Uint8Array => {
       path: `xl/worksheets/sheet${index + 1}.xml`,
       bytes: encoder.encode(sheetXml(sheet)),
     })),
+    ...(styled
+      ? [{ path: 'xl/styles.xml', bytes: encoder.encode(STYLES_XML) }]
+      : []),
   ])
 }

--- a/test/workbook-read.test.ts
+++ b/test/workbook-read.test.ts
@@ -273,3 +273,42 @@ describe('reader primitives', () => {
     expect(decodeXmlText('&nosuch;')).toBe('&nosuch;')
   })
 })
+
+/**
+ * A self-closing cell (#416). Excel writes `<c r="B2" s="1"/>` for a cell that
+ * carries formatting and no value, so this arrives from real workbooks and not
+ * only from what this repository writes.
+ *
+ * It was read against the PREVIOUS cell's column, because the closing branch
+ * ran before the reference was taken from `r`. The value written was empty,
+ * and empty is a CLEARED value rather than an absent one, so the effect was to
+ * silently blank a neighbouring cell that had content.
+ */
+describe('a cell with a reference and no value claims its own column', () => {
+  it('leaves the cell before it alone', async () => {
+    const bytes = await excelShapedWorkbook('01 Concepts', [
+      ['Id', 'Name', 'Note'],
+    ])
+    // Rebuilt by hand: the shaped-workbook helper writes values, and the
+    // shape under test is a cell that has none.
+    const read = await readWorkbook(
+      writeXlsx([
+        {
+          name: '01 Concepts',
+          rows: [
+            ['Id', 'Name', 'Note'],
+            ['', 'Payments API', ''],
+          ],
+          columnStyles: ['emphasis', undefined, 'muted'],
+        },
+      ]),
+    )
+    expect(bytes.length).toBeGreaterThan(0)
+    if (!read.ok) throw new Error(read.reason)
+    expect(read.sheets.get('01 Concepts')?.[1]).toEqual([
+      '',
+      'Payments API',
+      '',
+    ])
+  })
+})

--- a/test/workbook-styles.test.ts
+++ b/test/workbook-styles.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { writeXlsx, type WorkbookSheet } from '../src/workbook-xlsx.js'
+import { readWorkbook } from '../src/workbook-read.js'
+
+/** `readWorkbook` returns a union; a test that cannot read is a failed test. */
+const read = async (bytes: Uint8Array) => {
+  const result = await readWorkbook(bytes)
+  if (!result.ok) throw new Error(result.reason)
+  return result
+}
+
+// Named cell styles and column widths (#416), asked for by a workbook
+// consumer whose columns fall into three classes — bound to the model,
+// carried alongside it, or computed and ignored on the way back — which a
+// consultant editing the file could not see until an import told them a cell
+// could not be written back.
+
+const ROWS = [
+  ['Id', 'Name', 'Note'],
+  ['orders-api', 'Orders API', 'first'],
+  ['', 'Payments API', ''],
+]
+
+const plain: WorkbookSheet = { name: '01 Concepts', rows: ROWS }
+
+describe('a caller that asks for no roles gets what it always got', () => {
+  // The load-bearing claim of the whole change. Additive is a promise until
+  // it is a test, and this is the test: same input, same bytes, styling
+  // present in the writer or not.
+  it('produces byte-identical output to an unstyled workbook', () => {
+    const before = writeXlsx([plain])
+    const again = writeXlsx([{ name: '01 Concepts', rows: ROWS }])
+    expect(Array.from(again)).toEqual(Array.from(before))
+  })
+
+  it('emits no styles part and no style attribute', () => {
+    const text = new TextDecoder().decode(writeXlsx([plain]))
+    expect(text).not.toContain('styles.xml')
+    expect(text).not.toContain(' s="')
+  })
+
+  it('emits no cols element when no widths are asked for', () => {
+    expect(new TextDecoder().decode(writeXlsx([plain]))).not.toContain('<cols>')
+  })
+})
+
+describe('a styled workbook carries the part exactly once', () => {
+  const styled: WorkbookSheet = {
+    ...plain,
+    headerStyle: 'header',
+    columnStyles: ['emphasis', 'emphasis', 'muted'],
+    columnWidths: [18, 32, 60],
+  }
+
+  it('emits the styles part, its content type and its relationship', () => {
+    const text = new TextDecoder().decode(writeXlsx([styled]))
+    expect(text).toContain('xl/styles.xml')
+    expect(text).toContain('spreadsheetml.styles+xml')
+    expect(text).toContain('relationships/styles')
+  })
+
+  it('gives row 1 the header role and the rows below their column role', () => {
+    const text = new TextDecoder().decode(writeXlsx([styled]))
+    // header = 1, emphasis = 2, muted = 3.
+    expect(text).toContain('<c r="A1" s="1"')
+    expect(text).toContain('<c r="A2" s="2"')
+    expect(text).toContain('<c r="C2" s="3"')
+  })
+
+  it('styles an empty cell in a styled column rather than omitting it', () => {
+    // Otherwise a column reads as striped wherever a value happens to be
+    // missing, which is worse than no styling at all.
+    expect(new TextDecoder().decode(writeXlsx([styled]))).toContain(
+      '<c r="A3" s="2"/>',
+    )
+  })
+
+  it('writes the widths it was given and skips the ones it was not', () => {
+    const text = new TextDecoder().decode(writeXlsx([styled]))
+    expect(text).toContain('<col min="1" max="1" width="18" customWidth="1"/>')
+    expect(text).toContain('<col min="3" max="3" width="60" customWidth="1"/>')
+    expect(
+      new TextDecoder()
+        .decode(writeXlsx([{ ...plain, columnWidths: [0, 12] }]))
+        .includes('min="1"'),
+    ).toBe(false)
+  })
+
+  it('is deterministic: identical input, identical bytes', () => {
+    // The property the whole file exists to hold, restated now that there is
+    // a second part type whose ordering could drift.
+    expect(Array.from(writeXlsx([styled]))).toEqual(
+      Array.from(writeXlsx([styled])),
+    )
+  })
+})
+
+describe('formatting is not content', () => {
+  // A styled column emits its empty cells, so a row can end with a trailing
+  // blank where the unstyled workbook simply stopped. That is a length
+  // difference and not a value one: every consumer of a row reads it as
+  // `row[i] ?? ''` (`workbook-operations.ts`, `workbook-merge.ts`), so a
+  // missing index and an empty string are the same cell downstream. Comparing
+  // raw arrays would assert something stricter than the contract.
+  const values = (rows: readonly (readonly string[])[] | undefined) =>
+    (rows ?? []).map((row) => {
+      const cells = [...row]
+      while (cells.length > 0 && cells[cells.length - 1] === '') cells.pop()
+      return cells
+    })
+
+  it('reads a styled workbook back with the same values as an unstyled one', async () => {
+    // The round trip must not notice styling at all. A consumer regenerates
+    // the workbook from the model, so if styling changed what came back the
+    // producer would be editing the model by decorating it.
+    const styled = await read(
+      writeXlsx([
+        {
+          ...plain,
+          headerStyle: 'header',
+          columnStyles: ['emphasis', undefined, 'muted'],
+          columnWidths: [18, 32, 60],
+        },
+      ]),
+    )
+    const bare = await read(writeXlsx([plain]))
+    expect(values(styled.sheets.get('01 Concepts'))).toEqual(
+      values(bare.sheets.get('01 Concepts')),
+    )
+  })
+
+  it('keeps an empty styled cell empty rather than turning it into a value', () => {
+    // A value-less `<c>` and an omitted cell must read back the same, or
+    // styling a column would silently write blanks into the model.
+    return read(
+      writeXlsx([{ ...plain, columnStyles: ['emphasis', 'emphasis', 'muted'] }]),
+    ).then((result) => {
+      expect(result.sheets.get('01 Concepts')?.[2]).toEqual([
+        '',
+        'Payments API',
+        '',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Closes #416.

Optional named cell styles and column widths on `yarramate/workbook`. Requested by a workbook consumer, reassigned here to build, and built to their design.

## The style set is closed, and named for roles

`header`, `muted`, `emphasis`. Their own answer to *"what happens when someone needs a fourth"* is the right one and is now in the type's doc comment:

> The test for admitting a fourth is whether it can be named **without reference to how it looks**. A request for `blue`, or for a shade matching a client's deck, is the request a closed set exists to refuse — that is what turns a style vocabulary into a styling engine.

Three will be wrong eventually. It should be wrong **loudly**, by someone filing for a role, rather than quietly by callers approximating a missing role with the nearest one — which is how `muted` would come to mean two things.

Named rather than given as colours for a second reason: the styles part stays a **constant**, so "identical inputs produce identical bytes" remains trivially true instead of something a reviewer has to re-derive.

## The load-bearing term is a test, not a promise

**A caller passing none of the new fields gets byte-identical output to before.** The styles part, its content type, its relationship and every `s` attribute are emitted only when something asks for them. `<cols>` likewise, and widths are independent of roles so a caller may ask for one without the other.

Row 1 takes `headerStyle`; rows below take their column's, so a header band is not overwritten by the role beneath it.

## The round trip found a real reader bug

This is the part worth reading, and it is the class the consumer warned about two days ago.

Excel writes `<c r="B2" s="1"/>` for a cell carrying formatting and no value — **exactly the shape this change is the first to emit.** The reader took a self-closing cell through the closing branch *before* the column was read from `r`, so it wrote against the **previous** cell's column.

The value written was empty, and **empty is a cleared value rather than an absent one**. So on a workbook somebody had merely opened and saved, this silently blanked a neighbouring cell that had content, with nothing about the failure looking like a reader bug.

Fixed, with a regression test named for the shape rather than for this change, because the shape arrives from Excel independently of styling.

## Verification

- Clean-slate `pnpm verify` exit 0, **1984 tests**.
- **Mutation-verified** — and one mutation initially *survived* because I mutated the wrong `if (tag.closing)` of three, so the harness read green while the change sat in a different handler. Re-targeted at the cell handler by line, **three tests fail**. Verify the mutation lands before believing it.
- The typecheck caught what vitest could not: `readWorkbook` returns a union and the new tests were not narrowing it. Tests were green while `tsc` was not.

## Before merge

The consumer has offered to run their round-trip identity suite — export, import untouched, assert zero changes and a byte-identical companion document — against this branch. **That is the test that cannot be written from inside yarramate, because it needs a consumer**, so it is worth having before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
