### PR TITLE
chore: release 1.13.0

### DIFF
--- a/.yarramate/architecture/engine.yaml
+++ b/.yarramate/architecture/engine.yaml
@@ -831,6 +831,11 @@ concepts:
     name: Render ArchiMate kind icons
     description: Draws a 14×14 px single-stroke SVG icon per concept kind in the repository's graph, covering 19 kinds using ArchiMate element glyphs as descriptive notation only, with no trademark or conformance claim. Unknown kinds render nothing. Active only under archimate notation mode; falls back to native rendering when notation is native.
     status: current
+  - id: select-focus-neighbourhood
+    kind: applicationFunction
+    name: Select focus neighbourhood
+    description: Names the subjects a canvas focus narrows to, being the chosen subject and everything one hop from it undirected, or for a relationship its two endpoints. Returns subject ids only and leaves edge selection to the projection it is sent as, so there is one implementation of which edges belong in a slice rather than a second one in the browser. Follows relationships and never references, matching what the connected expansion already does.
+    status: current
   - id: import-command
     kind: applicationService
     name: Import command
@@ -1930,6 +1935,10 @@ relationships:
     kind: assignment
     from: visual-browser
     to: render-archimate-kind-icons
+  - id: visual-browser-selects-focus-neighbourhood
+    kind: assignment
+    from: visual-browser
+    to: select-focus-neighbourhood
   # The data each current service reads or writes. A service's footprint is
   # the consumer-facing claim, distinct from the functions behind it, and it
   # is what the interrogation asks a service in a hop to declare.

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -859,6 +859,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/visual-app/kind-icons.ts
+  - subject: select-focus-neighbourhood
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/focus-neighbourhood.ts
   - subject: visual-request-source
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -1908,6 +1908,9 @@ mappings:
   - native: render-archimate-kind-icons
     external: renderArchimateKindIcons
     type: concept
+  - native: select-focus-neighbourhood
+    external: selectFocusNeighbourhood
+    type: concept
   - native: render-visual-model-reads-kind-catalogue
     external: renderVisualModelReadsKindCatalogue
     type: relationship
@@ -1916,6 +1919,9 @@ mappings:
     type: relationship
   - native: visual-browser-renders-kind-icons
     external: visualBrowserRendersKindIcons
+    type: relationship
+  - native: visual-browser-selects-focus-neighbourhood
+    external: visualBrowserSelectsFocusNeighbourhood
     type: relationship
   - native: visual-badges-source
     external: visualBadgesSource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## Unreleased
+## 1.13.0
+
+**Contains a content-loss fix that was reachable in 1.12.0.** A cell carrying a
+reference and no value — what Excel writes for a formatted empty cell — was
+read against the previous cell's column, and the empty value it wrote is a
+*cleared* value rather than an absent one. An adopter reproduced it end to end
+against the published package: importing a workbook somebody had merely opened
+and saved produced a model write clearing a component's name, presented in
+their preview as an ordinary change a reviewer would confirm. Upgrade if you
+read workbooks.
 
 - **Added.** `yarramate/workbook` takes optional named cell styles and column
   widths (#416, asked for by a workbook consumer). `CellStyle` is a closed set

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release 1.13.0. Three features and a content-loss fix.

## The fix is why this goes now

A cell carrying a **reference and no value** — what Excel writes for a formatted empty cell — was read against the **previous** cell's column. The empty value it wrote is a *cleared* value rather than an absent one.

The ApertureX session reproduced it end to end **against the published 1.12.0 package**:

```
01 Components "orders-app" Name: "Orders application" → ""
```

Importing a workbook somebody had merely opened and saved produced a **model write clearing a component's name**, presented in their preview as an ordinary change a reviewer would confirm. Reachable today, and nothing about the failure said "reader".

## Contents

| | |
|---|---|
| #407 | Canvas focus: narrow to a subject and one hop, clear back to where you were |
| #413 | Editor shell: one-row property fields, the left rail can be put away |
| #416 | Workbook cell styles and column widths, optional and additive |
| — | The reader fix above |

Plus six docs commits, including CONTRIBUTING's fifth rule and the wave-order corrections.

## The self-model pass earned its keep, in three steps

Worth recording because each gate caught the previous fix's omission, and no test suite would have found any of them:

1. **`reconcile`** found `src/visual-app/focus-neighbourhood.ts` unclaimed — one artifact of 151, the #175 shape.
2. Declaring `select-focus-neighbourhood` to claim it left the concept unwired, and **the interview** caught that: *"Who or what performs Select focus neighbourhood?"*
3. Wiring the assignment then broke **the LikeC4 export**, which refuses a projected concept with no adapter mapping.

Final state: 354 concepts / 476 relationships, **0 unclaimed of 151**, 313/313 confirmed, interview **0 open of 51**.

## Release gate

- `pnpm install --frozen-lockfile`, then clean-slate `pnpm verify`, **exit 0, 1984 tests**.
- `npm pack --dry-run`: **273 files, 2.0 MB**, no repository source, tests or fixtures.
- `pnpm` on PATH is 11.7.0, matching `packageManager`.

Publication follows the runbook after merge: annotated tag, publish from a fresh clone detached at the tag so `gitHead` carries the tag's provenance, then GitHub release and registry verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
