### PR TITLE
docs: the reader defect was three days old, not years

### DIFF
--- a/docs/DOGFOODING.md
+++ b/docs/DOGFOODING.md
@@ -84,8 +84,21 @@ empty cell. No test could have produced it, because nothing here produced it.
 
 What surfaced it was building a feature that emitted the shape for the first
 time: styling a column means styling its empty cells, so the new writer wrote
-one, and the round-trip test failed on the cell beside it. The defect was
-years-old and reachable from any workbook a person had opened and saved.
+one, and the round-trip test failed on the cell beside it.
+
+The defect was present in the reader's **first commit** (`9f99b84`,
+2026-08-27) and shipped in **eight releases over three days**, v1.6.0 through
+v1.12.0. It was reachable that whole time from any workbook a person had
+opened and saved.
+
+Three days rather than three years is the useful number, because it removes
+the comfortable reading. This was not old code nobody had looked at: it was
+written correct-looking, reviewed, tested and shipped eight times in
+seventy-two hours, and not one of those releases could have surfaced it.
+Elapsed time was never what protected it, and neither was usage. The
+condition for surfacing it was somebody emitting a shape nobody had emitted
+yet — so a bug that survived three days for this reason would have survived
+three years for the same one.
 
 So the remedy to "a suite cannot see what nothing produces" is not to wait for
 a consumer to trip over it. It is to **build the shape you have never


### PR DESCRIPTION
#420 called the workbook reader defect **"years-old"**. I had no basis for that — the repository's first commit is 2026-07-27, so nothing in it can be years old. I wrote a plausible-sounding fact without checking it, and the adopter caught it and verified before asking.

## Verified here

| | |
|---|---|
| Repository first commit | 2026-07-27 (34 days) |
| `src/workbook-read.ts` added | 2026-08-27, `9f99b84` |
| The flaw at that commit | line 265, `if (tag.closing \|\| tag.selfClosing)` — the exact pre-fix shape |
| Releases carrying it | **eight**: v1.6.0 → v1.12.0, across three days |
| Fixed | v1.13.0 |

## Three days is the better fact

This is why it is worth a commit rather than a quiet edit, and the reasoning is the adopter's.

**"Years-old" invites the comfortable reading** — old code, nobody's fault, the kind of thing that accumulates. The truth is more uncomfortable and makes the paragraph's own argument harder:

> The reader was written correct-looking, reviewed, tested and shipped **eight times in seventy-two hours**, and not one of those releases could have surfaced it.

Elapsed time was never what protected it, and neither was usage. The condition for surfacing it was somebody emitting a shape nobody had emitted yet — so a bug that survived three days for this reason would have survived three years for the same one.

Saying "years-old" attributed to neglect what was actually a structural blind spot.

Docs only. Suite green, 1984 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u