### PR TITLE
docs: an optional feature's absence is silent, and that is the consumer's test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **Docs.** `docs/CONSUMING-YARRAMATE.md` describes the optional workbook cell
+  styles and column widths, which shipped in 1.13.0 without an adopter-facing
+  note in the document adopters actually receive. It also states the hazard
+  that comes with any optional feature: **passing none of the fields produces
+  byte-identical output, and that is exactly what makes the feature's absence
+  undetectable.** If a rename or a bad merge stops the fields reaching the
+  writer, every behavioural assertion stays green while the workbook ships
+  with no roles, because a workbook with no styling is completely valid. The
+  general form reaches past this feature — assert the feature ARRIVED, not
+  only that the result is well-formed, because what degrades gracefully
+  degrades quietly.
+
 ## 1.13.0
 
 **Contains a content-loss fix that was reachable in 1.12.0.** A cell carrying a

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -484,6 +484,42 @@ Anything the mapping does not recognise is carried verbatim on `07 Other
 Facts` rather than dropped, so a workbook stays lossless across a compiler
 that grows new predicates.
 
+**Marking up the sheets.** `WorkbookSheet` takes optional `headerStyle`,
+`columnStyles` and `columnWidths`. The styles are a closed set of **roles**
+rather than appearances — `header`, `muted`, `emphasis` — so the test for
+admitting a fourth is whether it can be named without reference to how it
+looks. A request for a colour is the one a closed set exists to refuse,
+because that is what turns a style vocabulary into a styling engine.
+
+The use worth having is not decoration. Where a workbook's columns differ in
+what they reach — some binding to the model, some carried alongside it, some
+computed and ignored on the way back — an editor cannot see which is which,
+and finds out only when an import reports that a cell could not be written
+back. A role in the file says it while they are typing.
+
+Formatting is not content in either direction. A styled workbook reads back
+exactly as an unstyled one, and an editor's own formatting is ignored on
+import — and then lost on the next export, because the workbook is
+regenerated from the model. That last part is why producer-applied styling is
+the only kind that survives.
+
+**An optional feature's absence is silent, and that is your test to write.**
+Passing none of these fields produces byte-identical output to a release
+before they existed. That property is what makes the feature safe to adopt,
+and it is exactly what makes its absence undetectable: if a rename, a bad
+merge or a refactor stops the fields reaching the writer, every test that
+asserts on *behaviour* stays green while the workbook ships with no roles at
+all, because a workbook with no styling is completely valid.
+
+The general form, which reaches past this feature to any optional thing you
+take from a library: **assert the feature arrived, not only that the result
+is well-formed.** One positive test at the consumer that fails when the
+feature stops arriving — the styles part is in the bytes, the header is
+present, the width was applied. Behavioural assertions cannot catch an
+absence-shaped regression, because the behaviour is well-defined in both
+cases. This is the same reason a `?? ''` default hides a missing column: what
+degrades gracefully degrades quietly.
+
 **Reading one back.** `yarramate import xlsx <workbook.xlsx> <workspace.yaml>`
 merges an edited workbook into the model. An unedited round trip changes
 nothing, byte for byte.

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -514,10 +514,11 @@ worth testing rather than taking.
 
 **An optional feature's absence is silent, and that is your test to write.**
 Passing none of these fields produces byte-identical output to a release
-before they existed — asserted here by a test that writes the same sheet with
-and without the fields, and measured independently at a consumer boundary by
-hashing two real workbooks exported under 1.12.0 and 1.13.0, same SHA-256 and
-same length on both. That property is what makes the feature safe to adopt,
+before they existed. That is asserted here by a test that writes the same
+sheet with and without the fields, and it has been checked the way you can
+check it yourself: call `writeXlsx` with the same plain sheets under the
+published 1.12.0 and 1.13.0 packages and hash the results. They are identical,
+byte for byte, and two people have run it with different fixtures. That property is what makes the feature safe to adopt,
 and it is exactly what makes its absence undetectable: if a rename, a bad
 merge or a refactor stops the fields reaching the writer, every test that
 asserts on *behaviour* stays green while the workbook ships with no roles at

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -497,15 +497,27 @@ computed and ignored on the way back — an editor cannot see which is which,
 and finds out only when an import reports that a cell could not be written
 back. A role in the file says it while they are typing.
 
-Formatting is not content in either direction. A styled workbook reads back
-exactly as an unstyled one, and an editor's own formatting is ignored on
-import — and then lost on the next export, because the workbook is
+**Formatting is not content in either direction, from 1.13.0.** A styled
+workbook reads back exactly as an unstyled one, and an editor's own formatting
+is ignored on import — then lost on the next export, because the workbook is
 regenerated from the model. That last part is why producer-applied styling is
 the only kind that survives.
 
+The version matters here and nowhere else in this section, because this
+sentence is a **guarantee**, and a guarantee's job is to let you decide not to
+write a test. It did not hold in **v1.6.0 through v1.12.0**: a cell carrying
+formatting and no value — which is what Excel writes for a formatted empty
+cell — was read against the previous cell's column, so importing a workbook
+somebody had merely opened and saved could clear a neighbouring value. If you
+are pinned below 1.13.0, that path is the one place this section's promise is
+worth testing rather than taking.
+
 **An optional feature's absence is silent, and that is your test to write.**
 Passing none of these fields produces byte-identical output to a release
-before they existed. That property is what makes the feature safe to adopt,
+before they existed — asserted here by a test that writes the same sheet with
+and without the fields, and measured independently at a consumer boundary by
+hashing two real workbooks exported under 1.12.0 and 1.13.0, same SHA-256 and
+same length on both. That property is what makes the feature safe to adopt,
 and it is exactly what makes its absence undetectable: if a rename, a bad
 merge or a refactor stops the fields reaching the writer, every test that
 asserts on *behaviour* stays green while the workbook ships with no roles at
@@ -515,7 +527,14 @@ The general form, which reaches past this feature to any optional thing you
 take from a library: **assert the feature arrived, not only that the result
 is well-formed.** One positive test at the consumer that fails when the
 feature stops arriving — the styles part is in the bytes, the header is
-present, the width was applied. Behavioural assertions cannot catch an
+present, the width was applied.
+
+**Assert on the artefact, not on the call.** The obvious test is that you
+passed `columnStyles` — inspect the object you handed the writer, or spy on
+the argument — and it is both the easier test to write and the one that
+passes forever while the feature stops arriving, because it asserts your
+intent rather than the result. Read the produced bytes. An absence-shaped
+regression is invisible to any assertion that never opens the output. Behavioural assertions cannot catch an
 absence-shaped regression, because the behaviour is well-defined in both
 cases. This is the same reason a `?? ''` default hides a missing column: what
 degrades gracefully degrades quietly.


### PR DESCRIPTION
Two gaps in the document adopters actually receive.

## The feature shipped without a note in the shipping doc

Optional workbook cell styles and column widths landed in 1.13.0. The `CHANGELOG` had them; `docs/CONSUMING-YARRAMATE.md` — the one in the tarball — did not mention them at all.

Now described, including that the set is a closed set of **roles rather than appearances**, and that the use worth having is not decoration: where a workbook's columns differ in what they reach, an editor cannot see which is which and finds out only when an import reports a cell could not be written back.

## The hazard, which is the part that generalises

Passing none of the fields produces **byte-identical output** to a release before they existed. That property is what makes the feature safe to adopt — and it is exactly what makes its absence undetectable.

> If a rename, a bad merge or a refactor stops the fields reaching the writer, every test that asserts on *behaviour* stays green while the workbook ships with no roles at all, because a workbook with no styling is completely valid.

The general form, and the reason this belongs in the adopter's document rather than a rules file they never see:

> **Assert the feature arrived, not only that the result is well-formed.** One positive test at the consumer that fails when the feature stops arriving. Behavioural assertions cannot catch an absence-shaped regression, because the behaviour is well-defined in both cases.

It is the same reason a `?? ''` default hides a missing column. **What degrades gracefully degrades quietly.**

## Provenance

Named by the ApertureX adopter, who hit it on this exact feature and wrote the positive assertion into their export test before shipping. Every adopter of an optional feature inherits the hazard, and `columnStyles` is only the first one we have published.

Docs only. Clean-slate `pnpm verify` exit 0, 1984 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
