### PR TITLE
chore: release 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased
+## 1.13.1
+
+Documentation only, and shipped as a patch for the reason 1.11.1 was: an
+adopter arrives through npm, so guidance that stays in the repository is
+guidance they never see. 1.13.0 added optional workbook cell styles and column
+widths, and the guide in the tarball did not mention them.
 
 - **Docs.** `docs/CONSUMING-YARRAMATE.md` describes the optional workbook cell
   styles and column widths, which shipped in 1.13.0 without an adopter-facing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Documentation only, and a patch for the reason **1.11.1** was one: an adopter arrives through npm, so guidance that stays in the repository is guidance they never see.

## What 1.13.0 is missing

Verified against the installed package rather than assumed:

| Shipped doc | State in 1.13.0 |
|---|---|
| `docs/CONSUMING-YARRAMATE.md` | `columnStyles` appears **zero times** — the feature is in the types, absent from the guide |
| `docs/MODEL-FLOOR.md` | says Core never interprets an annex URI, never says the consequence: the interview can only ask **who vouched** |

## Contents

Two of the five unreleased commits touch files that ship (#422, #415). The other three — the DOGFOODING entry and its two corrections — do not ship and ride along because they are already on main.

No code change, no behaviour change.

## Release gate

- `pnpm install --frozen-lockfile`, then clean-slate `pnpm verify`, **exit 0, 1984 tests**.
- Self-model unchanged and current: 354 concepts / 476 relationships, **0 unclaimed of 151**, 313/313 confirmed, interview **0 open of 51**.
- `npm pack --dry-run`: **273 files, 2.0 MB**.

Publication follows the runbook after merge: annotated tag, publish from a fresh clone detached at the tag, then GitHub release and registry verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u