### PR TITLE
docs: the model points at the external document, not the reverse (#424)

### DIFF
--- a/docs/MODEL-FLOOR.md
+++ b/docs/MODEL-FLOOR.md
@@ -236,6 +236,42 @@ design. Same reach limit, opposite cause, and the remedies differ: that one is
 fixed by reading the graph instead of the vocabulary, and this one is not
 fixed at all, because there is nothing to read.
 
+### The model points at the external document, not the reverse
+
+The observation above is what makes an annex reachable, and **the direction of
+the join is load-bearing.** The model names the document. The document does
+not name the model.
+
+Inverting it works, and it costs a check. A host document that declares which
+subject it specifies needs nothing from YarraMate, and it keeps the pointer
+beside the thing that changes, which is a real argument. But nothing YarraMate
+reads can then see the link, so a subject whose annex was never written is
+indistinguishable from one that was never meant to have an annex, and a
+document naming a subject that does not exist is never refused.
+
+Pointed outward, both cases are already reported, without resolving or opening
+anything:
+
+- `reconcile` lists `unobservedSubjects`, every current concept no observation
+  covers (ADR 0049). A subject whose annex is missing appears there by
+  construction.
+- A manifest `coverage` scope makes the mirror case visible: an artifact in
+  scope that no observation claims is listed under `unclaimedArtifacts`
+  (ADR 0130), compared as strings against `repo:<path>` locators.
+
+That is the whole of what a model-side check can offer here, and it is worth
+stating as a limit rather than leaving to be discovered: **the pointer's
+presence is checkable; its target's contents are not.**
+
+A locator carried on the subject itself would buy nothing beyond what the
+observation already gives, and it would be a second reference system that
+resolves nothing. That is why none of the compiled mechanisms takes one, and
+each refusal is narrow and correct on its own terms: `references[].ref`
+resolves a workspace-global subject id, `constraints[].expects` is an
+exact-match producer tuple, and `name`, `description` and `aka` are prose Core
+never queries. The opaque locator is real and it is the one on the
+observation.
+
 ## Deliberately open
 
 Two of the refusals above are recorded limits rather than settled doctrine,


### PR DESCRIPTION
Closes #424.

## What the issue asked for, and why the answer is not what it asked for

An adopter wanted to point a subject at an external specification (field-level mapping rows, which ArchiMate has no concept for and `MODEL-FLOOR.md` is right to keep out). Every candidate mechanism refused them, each correctly. They inverted the join so the host document names the subject, and filed asking for a statement that the refusals are deliberate.

**That statement already shipped**, in the section they asked to have it added to. `MODEL-FLOOR.md` § *Where the rest belongs* names the pattern, gives a worked example, and says in those words that no condition can ask about annex contents "and that is the design rather than a gap".

They read 1.13.0 carefully and missed it anyway. That is a finding about the document: the section is titled for the fact rather than the mechanism, and "locator" appears once, mid-paragraph, after a reader has already decided the section is about annexes.

## What this adds

A subsection, **"The model points at the external document, not the reverse"**, carrying the one thing the section did not say.

**The direction of the join is load-bearing, and inverting it costs a check.** Pointing inward puts the only copy of the link outside everything YarraMate reads. Pointing outward gets the presence check for free:

- `reconcile` lists `unobservedSubjects`, every current concept no observation covers (`reconciliation.ts:470`, ADR 0049), so a subject whose annex was never written is reported by construction;
- a manifest `coverage` scope reports the mirror case as `unclaimedArtifacts` (ADR 0130), compared as strings against `repo:<path>`.

Neither resolves or opens anything. The limit is then stated plainly rather than left to be discovered: **the pointer's presence is checkable; its target's contents are not.**

It also carries the adopter's four-mechanism refusal table as the reason a locator on a subject would buy nothing, so the next reader finds the refusals and the destination in one place.

## Corrections made against the issue

Verified rather than relayed, and recorded on #424:

- **`evidence.uri` is the opaque locator**, not a missing convention. Opaque to Core, provider owns resolution (ADR 0068). It is already the shape the issue proposes as hypothetical.
- **`unchallenged-evidence` does read the overlay** (`interrogate-command.ts:157-173`), so "conditions read the graph and cannot see anything else" is false. Their conclusion holds for a sharper reason: the condition is workspace-scope and reduced to `{ result, searched }`, so it can never see a locator or ask per subject.
- **"A subject with no specification is not reported" is false under the documented pattern** — this is the one the inversion cost them.

## Verification

Docs only. Clean-slate `rm -rf dist && pnpm verify`, real exit code 0, **1984 tests across 112 files**. `MODEL-FLOOR.md` ships in the package (`package.json` `files`), so this reaches adopters on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
