### PR TITLE
docs: a condition the engine owns defines its own peers (#399)

### DIFF
--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -413,6 +413,62 @@ every kind it matches.
 relationship, so there is no table to consult, and inventing one for them
 would be the second encoding this refusal refuses.
 
+## A condition the engine owns defines its own peers
+
+Comparing a subject against its peers is not new here. `near-duplicate` fires
+when a subject resembles another closely enough to be the same thing under two
+names, so **"what has been said twice" is already a question the vocabulary
+can ask.** A proposal to detect peers that have said something twice
+*differently* (#399) therefore looks like one step from a condition that
+ships, and the step is the whole distance.
+
+Look at what `near-duplicate` takes:
+
+```ts
+{ condition: 'near-duplicate' }
+```
+
+**No parameters.** Its peer relation is universal, any other subject of the
+same kind; its algorithm and thresholds are pinned in ADR 0077; and a
+`yarramate/identity/distinct-from` claim removes a dismissed pair upstream in
+the index, so the condition itself reads as a plain existence check like every
+other. Nothing about it is a catalogue's choice.
+
+A divergence condition as proposed carries a peer selector and a fact
+selector:
+
+```yaml
+- condition: divergent-binding
+  peerVia: ["yarramate/core@0.1#aggregation"]
+  kinds: ["yarramate/policy@0.1#authentication-constraint"]
+```
+
+Those parameters exist because the peer relation is **not** universal.
+Members of one grouping, endpoints of one flow, and subjects of one kind in
+one document are all defensible readings, and which one matters is a property
+of a particular catalogue's modelling style rather than of the graph. A
+condition that has to be told what a peer is is a catalogue's query, and a
+vocabulary of parameterized queries is the query language this design has
+declined every time it has been asked for.
+
+**So the rule: a cross-peer condition belongs in the engine when its peer
+relation holds for every model, and belongs to the host when a catalogue has
+to name it.**
+
+That is a measurement path rather than a refusal. A peer relation is
+discoverable, and the way to discover it is to build the detector host-side
+across more than one catalogue and see what the definition converges to. Two
+independent catalogues that turn out to need the same peer relation have found
+a universal one, which is what `near-duplicate` had before it shipped.
+
+The dismissal half inherits the same test, and it is the half that matters
+more, because a divergence detector with no way to accept a divergence is an
+unclosable question wearing a new hat. `distinct-from` works engine-side
+because distinctness is a judgment about identity, and every model has
+identity. A claim meaning "this divergence is deliberate" would have to name
+the peer relation and the fact it covers, so it cannot be specified before the
+peer relation is.
+
 ## Evaluation model
 
 A question is **open** iff its trigger matches, and **closed** the moment it


### PR DESCRIPTION
Closes #399.

## The question

ApertureX asked for `divergent-binding`: a condition firing when peers disagree about a shared fact, where every peer binds a different `authentication-constraint` and nothing says that is deliberate. They asked for one sentence on whether it is engine-side or consumer-side, and said consumer-side would be a fine answer provided it was **recorded so the next adopter does not re-ask**. Hence a doc section rather than only an issue comment.

## The answer: consumer-side

## Their premise does not hold, and it sharpened the case before it went the other way

> Every condition today is an **absence** predicate. None answers "what has been said twice, differently".

`near-duplicate` answers "what has been said twice, *similarly*". Cross-peer comparison already ships, so the gap is one step wide rather than a missing class. That is a better argument for engine-side than the one the issue made.

## The discriminator is the parameters

`near-duplicate` is `{ condition: 'near-duplicate' }`. **No parameters.** Universal peer relation (any other subject of the same kind), thresholds pinned in ADR 0077, and `distinct-from` removes a dismissed pair upstream in the index so the condition reads as a plain existence check.

`divergent-binding` carries `peerVia` and `kinds`. Those exist because the peer relation is *not* universal, which the issue concedes in its own words: *"What 'peers' means is the hard part and probably yours to decide."* It is not, and that is the answer. A condition that must be told what a peer is is a catalogue's query, and a vocabulary of parameterized queries is the query language this design has declined every time, including in that issue's own "what we are not asking for" section.

**The rule, as recorded:** a cross-peer condition belongs in the engine when its peer relation holds for every model, and belongs to the host when a catalogue has to name it.

## Framed as a measurement path, with a reopen test

Not a refusal. A peer relation is discoverable, and building host-side is how you discover it: ship it against one catalogue, then a second, and **if two independent catalogues need the same peer relation, it is universal**, which is what `near-duplicate` had before it shipped. Same evidence shape that closed #386.

## The dismissal half is the harder one and inherits the test

They were right that a detector with no way to accept a divergence is a nag. It is worse: it is an unclosable question, which `YM914` and `YM916` exist to refuse, so the condition could not ship alone even with the peer relation settled. `distinct-from` works engine-side because identity is universal; a "this divergence is deliberate" claim must name the peer relation and the fact it covers, so it cannot be specified first.

## Verification

Docs only, one new section in `docs/INTERROGATION.md` between the remedy rule and the evaluation model. Clean-slate `rm -rf dist && pnpm verify`, **real exit code 0**, 1984 tests across 112 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
