### PR TITLE
feat: a vocabulary question may ask for a vocabulary (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## Unreleased
+
+### A vocabulary question may ask for a vocabulary
+
+`below-subject-count`, a workspace-scope condition that fires while FEWER than
+`atLeast` subjects of the named kinds exist (#411, ADR 0135). Additive: nothing
+today can express it, so no existing catalogue changes meaning, and the
+interrogation semantics version does not move.
+
+`no-subject-of-kind` is satisfied by ONE instance, so a question asking a
+workspace to declare its vocabulary — which sensitivity classes, which
+integration styles, which API-led layers — closed on the first term, and a
+one-term vocabulary was indistinguishable from a complete one. An adopter
+measured two live cases: a class authored incidentally to answer a different
+question closed the vocabulary question four versions before it was ever asked,
+and an `integration-style` vocabulary closed after one entry with nothing in
+the estate that could ever disagree with it.
+
+`atLeast` must be at least 2. `YM918` refuses `atLeast: 1` and names
+`no-subject-of-kind`, because an author who wrote it wanted the condition that
+already exists rather than making an arithmetic mistake; the schema refuses 0
+structurally, since a count could never fall below it.
+
+`kindMatching` defaults to `descendants` as everywhere else, which matters
+here: a classification kind is typically a `grouping` specialization, and a
+catalogue naming the core kind has to count it.
+
+### Also
+
+- The interrogation semantics backstop claimed to exercise every condition the
+  engine understands and missed two, because it checked its own list against
+  itself. The probes are now typechecker-enforced, so a new condition cannot
+  arrive without one (`CONTRIBUTING.md`'s ninth rule; same technique as
+  ADR 0134's `CONDITION_SCOPE`).
+- `docs/INTERROGATION.md` no longer states how many workspace-scope conditions
+  there are. The count shipped wrong once, was corrected, and went stale again
+  the next time one arrived.
+
 ## 1.13.1
 
 Documentation only, and shipped as a patch for the reason 1.11.1 was: an

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -32,7 +32,11 @@ questions. Each question binds:
   graph (all must hold): `missing-claim`, `missing-relationship`,
   `isolated`, `no-subject-of-kind`, `has-subject-of-kind` (workspace: the
   positive twin of `no-subject-of-kind`, for a gate that opens once the
-  model HAS something), `no-state-defined`,
+  model HAS something), `below-subject-count` (workspace: fewer than
+  `atLeast` subjects of the given kinds exist, so a **vocabulary**
+  question can ask for more than one term; `atLeast` must be at least 2,
+  because 1 is `no-subject-of-kind` under a second name and `YM918`
+  refuses it; ADR 0135), `no-state-defined`,
   `missing-linkage` (no relationship of given kinds, in a given
   direction, whose counterpart is of a given kind — the linkage-depth
   primitive), `has-linkage` (the positive of `missing-linkage`;
@@ -223,16 +227,23 @@ product's wave rail had the same fault on the day the gate shipped.
 ### A gate asks about the workspace, never about a subject
 
 A gate is evaluated with **no subject**, so only a workspace-scope condition
-means anything in `opensWhen`. There are six: `has-any-subject`,
-`no-subject-of-kind`, `has-subject-of-kind`, `no-state-defined`,
+means anything in `opensWhen`: `has-any-subject`, `no-subject-of-kind`,
+`has-subject-of-kind`, `below-subject-count`, `no-state-defined`,
 `exists-linkage` and `unchallenged-evidence`. `exists-linkage` is a positive
 existence check, "some concept would satisfy `has-linkage`", which is easy to
 miss and often the one a gate wants.
 
 **Do not trust this sentence over the engine.** The set is derived from the
-condition union in code, and `YM917`'s own message lists it; a count written
-in prose is the thing that goes stale, and this one did — it shipped saying
-five and omitting `unchallenged-evidence`.
+condition union in code, and `YM917`'s own message lists it, so ask the
+diagnostic rather than this paragraph.
+
+This sentence used to carry a count, and the count is gone deliberately. It
+shipped saying "five" while omitting `unchallenged-evidence`; that was
+corrected to "six"; and it went stale again the next time a workspace-scope
+condition arrived. A number in prose beside a list in code is a second
+encoding of the same fact with nothing holding the two together, which is
+`CONTRIBUTING.md`'s ninth rule in the smallest possible instance. The list
+stays because it is useful, and a reader who needs the count can count it.
 
 Any other condition is refused (`YM917`). Before the refusal existed they
 loaded silently and split two ways: `has-linkage`, `near-duplicate` and

--- a/docs/adr/0135-a-vocabulary-question-may-ask-for-a-vocabulary.md
+++ b/docs/adr/0135-a-vocabulary-question-may-ask-for-a-vocabulary.md
@@ -1,0 +1,103 @@
+# A vocabulary question may ask for a vocabulary
+
+Status: accepted
+
+From ApertureX (#411), against 1.12.0, with two field cases from a live
+MuleSoft engagement rather than a hypothetical.
+
+## The defect
+
+A **vocabulary question** asks a workspace to declare the terms that later
+per-subject questions resolve against: which API-led layers exist, which data
+sensitivity classes, which integration styles. The only condition able to ask
+was `no-subject-of-kind`, which is satisfied by **one** instance. So the
+question closed the moment any single term existed, and a one-term vocabulary
+was indistinguishable from a complete one.
+
+Both reported cases are worth keeping, because they fail differently.
+
+**Born satisfied by incidental content.** A consultant authored one
+`sensitivity-class` ("Confidential") at model v4 to answer a per-object
+classification question. The vocabulary question was attached four versions
+later and had already been satisfied by that single class. It never appeared.
+The cost surfaced seven versions on, when a second data object arrived and
+could only point at "Confidential", which a human recognised as wrong.
+
+**The same shape with no forcing function.** `integration-style` closed after
+one style. Every interface on that engagement genuinely is request-reply, so
+nothing will ever point at the vocabulary and disagree. The single entry sits
+there looking declared indefinitely. This is the worse case: the first
+self-corrected by accident and this one cannot.
+
+## Why the catalogue could not fix it
+
+The obvious remedy is to reword only the vocabulary questions that lack a
+per-subject consumer able to challenge them. The adopter measured that across
+both their catalogues: **all five vocabularies have a consumer, including both
+that failed.** The rule selects nothing.
+
+The actual discriminator is whether the estate contains two things needing
+different classifications, which is a property of the engagement rather than
+of the catalogue. It is invisible at authoring time, at compose time, and at
+the moment the question fires, because the model then usually holds nothing to
+classify yet. So there is no catalogue-side rule, and the adopter's fallback
+was to reword all five questions to stop over-claiming: "Has this platform
+declared its API-led layers?" rather than "Which API-led layers does this
+platform use?". Honest, and a worse question.
+
+## Decision
+
+`below-subject-count`, workspace-scope, fires while fewer than `atLeast`
+subjects of the named kinds exist. `no-subject-of-kind` is its `atLeast: 1`
+case, so the existing condition is the degenerate form of this one.
+
+`kindMatching` behaves as everywhere else, `descendants` by default. This is
+load-bearing rather than incidental: the adopter's `sensitivity-class` is a
+`grouping` specialization, and a catalogue naming the core kind has to count
+the specialization.
+
+The answer shape is the `add-concept` that `no-subject-of-kind` already
+produces, so nothing downstream learns a new remedy. Nothing today can express
+this, so no existing catalogue changes meaning and the addition is not
+breaking. Per ADR 0106 the interrogation semantics version does not move: a
+new condition changes no existing question's answer, and that was verified by
+reproducing the previous fingerprint from the unchanged probes.
+
+## `atLeast` must be at least 2, and the refusal says why
+
+`YM918` refuses a smaller threshold, in two layers.
+
+`atLeast: 0` is refused **structurally** by the schema (`minimum: 1`): a count
+can never fall below zero, so the question could never fire, which is
+`YM914`'s defect arriving through arithmetic. The engine's guard is `< 2`
+rather than `=== 1` so a host composing a catalogue programmatically cannot
+slip past the schema layer.
+
+`atLeast: 1` is well-formed and means something the vocabulary already says,
+which no schema can know. `YM918` names `no-subject-of-kind` rather than
+stating a bound, because an author who wrote `atLeast: 1` did not make an
+arithmetic mistake. They wanted the condition that already exists.
+
+## What this is not
+
+A general numeric comparison vocabulary. A kind's population against a floor
+is the whole need. The narrow condition is the same trade that kept
+`has-subject-of-kind` a twin rather than a predicate, and it is the trade
+recorded one issue over in "a condition the engine owns defines its own
+peers": a vocabulary of parameterised comparisons is a query language, and
+this design declines those. `atLeast` is a threshold on a count the engine
+already computes, not a selector the catalogue gets to define.
+
+## The backstop this exposed
+
+`test/interrogation-semantics.test.ts` claimed to exercise "every condition the
+engine understands" and missed two, `has-subject-of-kind` and
+`fills-pattern-slot`, because it compared its own list against itself. Both had
+arrived after it was written.
+
+The probes are now a `Record<CatalogueCondition['condition'], …>`, the same
+technique ADR 0134 applied to `CONDITION_SCOPE`: a new member of the union is
+a compile error until it is given a probe, so the backstop cannot fall behind
+the engine it backstops. This is `CONTRIBUTING.md`'s ninth rule, and the
+failure was the rule's own prediction: an allowlist cannot fail for the author
+who wrote it.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -300,6 +300,40 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds",
+            "atLeast"
+          ],
+          "properties": {
+            "condition": {
+              "const": "below-subject-count"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "atLeast": {
+              "description": "The floor the kind's population must reach. At least 2: atLeast 1 is no-subject-of-kind under another name, and the engine refuses it (YM918).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -317,6 +317,40 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds",
+            "atLeast"
+          ],
+          "properties": {
+            "condition": {
+              "const": "below-subject-count"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "atLeast": {
+              "description": "The floor the kind's population must reach. At least 2: atLeast 1 is no-subject-of-kind under another name, and the engine refuses it (YM918).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -276,6 +276,40 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "condition",
+            "kinds",
+            "atLeast"
+          ],
+          "properties": {
+            "condition": {
+              "const": "below-subject-count"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "atLeast": {
+              "description": "The floor the kind's population must reach. At least 2: atLeast 1 is no-subject-of-kind under another name, and the engine refuses it (YM918).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
             "condition"
           ],
           "properties": {

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -101,6 +101,35 @@ export type CatalogueCondition =
       readonly kinds: readonly string[]
       readonly kindMatching?: 'exact' | 'descendants'
     }
+  | {
+      /**
+       * The cardinality member of the same family, workspace-scope like the
+       * other two (#411). Fires while FEWER than `atLeast` subjects of the
+       * named kinds exist, so `no-subject-of-kind` is its `atLeast: 1` case.
+       *
+       * It exists because a **vocabulary question** — "which data sensitivity
+       * classes does this platform recognise?" — had no way to say it wanted
+       * more than one term. `no-subject-of-kind` closes on the first
+       * instance, so a one-term vocabulary was indistinguishable from a
+       * complete one, and an adopter measured two live cases where a class
+       * authored incidentally to answer a different question closed the
+       * vocabulary question before it was ever asked.
+       *
+       * `atLeast` is required and must be at least 2 (`YM918`): 1 is
+       * `no-subject-of-kind` spelled a second way, and 0 is a condition that
+       * can never fire, which is what `YM914` exists to refuse.
+       *
+       * Deliberately NOT a general numeric comparison. A kind's population
+       * against a floor is the whole need, and the narrow condition is the
+       * same trade that kept `has-subject-of-kind` a twin rather than a
+       * predicate: a vocabulary of parameterised comparisons is a query
+       * language, which this design declines.
+       */
+      readonly condition: 'below-subject-count'
+      readonly kinds: readonly string[]
+      readonly atLeast: number
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
   | { readonly condition: 'no-state-defined' }
   | {
       readonly condition: 'missing-linkage'
@@ -512,6 +541,7 @@ const namedKinds = (question: CatalogueQuestion): readonly string[] => {
       case 'missing-relationship':
       case 'no-subject-of-kind':
       case 'has-subject-of-kind':
+      case 'below-subject-count':
       case 'missing-constraint':
         kinds.push(...condition.kinds)
         break
@@ -615,6 +645,7 @@ const CONDITION_SCOPE: Record<
   'has-any-subject': 'workspace',
   'no-subject-of-kind': 'workspace',
   'has-subject-of-kind': 'workspace',
+  'below-subject-count': 'workspace',
   'no-state-defined': 'workspace',
   'exists-linkage': 'workspace',
   'missing-claim': 'subject',
@@ -779,6 +810,33 @@ const conditionHolds = (
           profileContext,
         ),
       )
+    }
+    case 'below-subject-count': {
+      // Counts, then compares. Written as its own count rather than as
+      // `!has-subject-of-kind` plus arithmetic so the degenerate reading
+      // stays visible: at `atLeast: 1` this IS `no-subject-of-kind`, which
+      // is why the loader refuses that spelling rather than quietly
+      // accepting two names for one condition.
+      //
+      // Stops at the threshold instead of counting the whole workspace: the
+      // answer is a comparison, not a tally, and a model with ten thousand
+      // subjects of a kind should cost the same as one with two.
+      const matching = condition.kindMatching ?? 'descendants'
+      let seen = 0
+      for (const id of index.concepts) {
+        if (
+          kindMatches(
+            index.kindOf.get(id),
+            condition.kinds,
+            matching,
+            profileContext,
+          )
+        ) {
+          seen += 1
+          if (seen >= condition.atLeast) return false
+        }
+      }
+      return true
     }
     case 'no-state-defined':
       return !index.hasStates
@@ -1125,6 +1183,70 @@ interface CatalogueKindReference {
  * wave never opens and carries no questions at all - one typo silently
  * retiring a wave (#351).
  */
+/**
+ * Every condition the catalogue holds, gate and trigger alike, with the path
+ * that locates it. `kindReferencesOf` walks the same two places for kinds;
+ * this walks them for the conditions themselves, so a check about a
+ * condition's own shape does not have to re-derive where conditions live.
+ */
+const conditionsOf = (
+  catalogue: QuestionCatalogue,
+): readonly { condition: CatalogueCondition; path: (string | number)[] }[] => {
+  const found: { condition: CatalogueCondition; path: (string | number)[] }[] =
+    []
+  catalogue.waves.forEach((wave, waveIndex) => {
+    ;(wave.opensWhen ?? []).forEach((condition, conditionIndex) => {
+      found.push({
+        condition,
+        path: ['waves', waveIndex, 'opensWhen', conditionIndex],
+      })
+    })
+  })
+  catalogue.questions.forEach((question, questionIndex) => {
+    question.trigger.forEach((condition, conditionIndex) => {
+      found.push({
+        condition,
+        path: ['questions', questionIndex, 'trigger', conditionIndex],
+      })
+    })
+  })
+  return found
+}
+
+/**
+ * `YM918`: `below-subject-count` must ask for at least two (#411).
+ *
+ * `atLeast: 1` is `no-subject-of-kind` under a second name, and this design
+ * refuses second spellings of one meaning wherever it finds them. `atLeast: 0`
+ * is worse: the count can never be below zero, so the question can never fire,
+ * which is what `YM914` refuses from a different cause.
+ *
+ * The message names `no-subject-of-kind` rather than stating a bound, because
+ * an author who wrote `atLeast: 1` did not make an arithmetic mistake. They
+ * wanted the condition that already exists.
+ */
+const subjectCountFloorDiagnostics = ({
+  catalogue,
+  locate,
+}: LoadedCatalogueDocument): readonly Diagnostic[] =>
+  conditionsOf(catalogue).flatMap(({ condition, path }) =>
+    condition.condition === 'below-subject-count' && condition.atLeast < 2
+      ? [
+          {
+            severity: 'error' as const,
+            code: 'YM918',
+            message:
+              `Condition "below-subject-count" asks for atLeast ${condition.atLeast}, ` +
+              (condition.atLeast === 1
+                ? 'which is what "no-subject-of-kind" already asks. Use that condition instead.'
+                : 'so a count could never fall below it and the question could never fire. ' +
+                  'Ask for at least 2, or use "no-subject-of-kind" for the presence case.'),
+            ...locate([...path, 'atLeast']),
+          },
+        ]
+      : [],
+  )
+
 const kindReferencesOf = (
   catalogue: QuestionCatalogue,
 ): readonly CatalogueKindReference[] => {
@@ -1651,6 +1773,7 @@ export function composeCatalogues(
   const crossDiagnostics = documents.flatMap((document) => [
     ...undeclaredWaveDiagnostics(document, declaredWaves),
     ...gateScopeDiagnostics(document),
+    ...subjectCountFloorDiagnostics(document),
     ...unresolvableKindDiagnostics(document, profileContext),
     ...unauthorableOfferDiagnostics(document, profileContext),
   ])
@@ -1703,6 +1826,12 @@ export function loadQuestionCatalogue(
   const scopeDiagnostics = gateScopeDiagnostics(loaded.document)
   if (scopeDiagnostics.length > 0) {
     return { ok: false, diagnostics: scopeDiagnostics }
+  }
+  // Beside the scope check and for the same reason: a threshold below 2 is
+  // wrong on the condition's own terms, with no profile context needed.
+  const floorDiagnostics = subjectCountFloorDiagnostics(loaded.document)
+  if (floorDiagnostics.length > 0) {
+    return { ok: false, diagnostics: floorDiagnostics }
   }
   const kindDiagnostics = unresolvableKindDiagnostics(
     loaded.document,

--- a/test/below-subject-count.test.ts
+++ b/test/below-subject-count.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  composeCatalogues,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// `below-subject-count` (#411): a vocabulary question needs to ask for a
+// VOCABULARY, and `no-subject-of-kind` closes on the first term.
+//
+// The adopter's two field cases are the whole motivation, and they differ in
+// the way that matters. In the first, one `sensitivity-class` was authored
+// incidentally to answer a per-object question, which closed the "which
+// classes does this platform recognise?" question four versions before it was
+// ever asked; it self-corrected seven versions later only because a second
+// object arrived and a human noticed it could point at nothing right. In the
+// second, `integration-style` closed after one style and nothing will ever
+// disagree with it, so a one-term vocabulary sits there looking declared
+// forever. The first case was luck. The second has no forcing function, and
+// that is what this condition is for.
+
+const workspaceOf = (concepts: string) => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:${concepts}
+relationships: []
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+}
+
+const grouping = (id: string) => `
+  - id: ${id}
+    kind: grouping
+    name: ${id}`
+
+const NONE = workspaceOf(' []')
+const ONE = workspaceOf(grouping('confidential'))
+const TWO = workspaceOf(grouping('confidential') + grouping('public'))
+const THREE = workspaceOf(
+  grouping('confidential') + grouping('public') + grouping('internal'),
+)
+
+const catalogueSource = (trigger: string) => `format: yarramate/question-catalogue/v1
+id: fixture
+version: "1.0"
+profile: yarramate/core@0.1
+presentation:
+  title: Fixture
+  description: A vocabulary question.
+waves:
+  - id: vocabulary
+    name: Vocabulary
+questions:
+  - id: classes-undeclared
+    wave: vocabulary
+    since: "1.0"
+    scope: workspace
+    trigger:
+${trigger}
+    question: Which sensitivity classes does this platform recognise?
+    materiality: A one-term vocabulary is indistinguishable from a complete one.
+    authority: human
+    resolution: Declare the classes this platform recognises.
+`
+
+const load = (trigger: string) =>
+  loadQuestionCatalogue({
+    path: 'catalogues/fixture.yaml',
+    source: catalogueSource(trigger),
+  })
+
+const loadOrThrow = (trigger: string) => {
+  const result = load(trigger)
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result.catalogue
+}
+
+const isOpen = (trigger: string, compiled: typeof NONE): boolean =>
+  evaluateCatalogue(
+    loadOrThrow(trigger),
+    compiled.graph,
+    compiled.profileContext,
+  )
+    .waves.flatMap(({ questions }) => questions)
+    .find(({ id }) => id.endsWith('classes-undeclared'))!.open
+
+const atLeast = (n: number, kind = 'grouping') => `      - condition: below-subject-count
+        kinds:
+          - yarramate/core@0.1#${kind}
+        atLeast: ${n}
+`
+
+describe('a vocabulary question stays open until the vocabulary has terms', () => {
+  it('is open when the model holds none', () => {
+    expect(isOpen(atLeast(2), NONE)).toBe(true)
+  })
+
+  it('is STILL open at one, which is the whole point', () => {
+    // `no-subject-of-kind` closes here. That is the defect: the single class
+    // a consultant authored to answer a different question satisfies the
+    // vocabulary question, and it never appears.
+    expect(isOpen(atLeast(2), ONE)).toBe(true)
+  })
+
+  it('closes once the floor is reached', () => {
+    expect(isOpen(atLeast(2), TWO)).toBe(false)
+  })
+
+  it('stays closed above the floor', () => {
+    expect(isOpen(atLeast(2), THREE)).toBe(false)
+  })
+
+  it('honours a floor higher than two', () => {
+    expect(isOpen(atLeast(3), TWO)).toBe(true)
+    expect(isOpen(atLeast(3), THREE)).toBe(false)
+  })
+})
+
+// The adopter's `sensitivity-class` is a `grouping` SPECIALIZATION, so the
+// counting has to reach through profile lineage. Plain groupings would not
+// test that at all: a fixture has to hold a declared child kind, or "counts
+// descendants" is a claim about a case the test never builds.
+const SPECIALIZED = (() => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'profile.yaml',
+      source: `format: yarramate/profile/v1
+id: acme/consulting
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: sensitivity-class
+    name: Sensitivity class
+    parent: yarramate/core@0.1#grouping
+relationshipKinds: []
+`,
+    },
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: acme/consulting@1.0
+concepts:
+  - id: confidential
+    kind: sensitivity-class
+    name: Confidential
+  - id: public
+    kind: sensitivity-class
+    name: Public
+relationships: []
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+})()
+
+describe('counting follows the same kind rules as the rest of the family', () => {
+  it('counts a profile-declared specialization by default', () => {
+    // Two `sensitivity-class` subjects, counted against the core `grouping`
+    // the catalogue names. Flip the default to `exact` and this fires,
+    // because neither subject IS a grouping.
+    expect(isOpen(atLeast(2), SPECIALIZED)).toBe(false)
+    expect(isOpen(atLeast(3), SPECIALIZED)).toBe(true)
+  })
+
+  it('counts only the named kind under kindMatching: exact', () => {
+    const exact = `      - condition: below-subject-count
+        kinds:
+          - yarramate/core@0.1#grouping
+        atLeast: 2
+        kindMatching: exact
+`
+    expect(isOpen(exact, SPECIALIZED)).toBe(true)
+  })
+
+  it('counts nothing of another kind', () => {
+    const ACTORS = workspaceOf(`
+  - id: teller
+    kind: businessActor
+    name: Teller
+  - id: clerk
+    kind: businessActor
+    name: Clerk`)
+    expect(isOpen(atLeast(2), ACTORS)).toBe(true)
+  })
+})
+
+describe('the degenerate spellings are refused rather than accepted quietly', () => {
+  // Two names for one condition is the thing this design refuses wherever it
+  // finds it, and a threshold nothing could fall below is `YM914`'s defect
+  // arriving through arithmetic.
+  const diagnostics = (n: number) => {
+    const result = load(atLeast(n))
+    if (result.ok) throw new Error(`atLeast: ${n} was accepted`)
+    return result.diagnostics
+  }
+
+  it('refuses atLeast 1 and names the condition that already says it', () => {
+    const [first] = diagnostics(1)
+    expect(first?.code).toBe('YM918')
+    expect(first?.message).toContain('no-subject-of-kind')
+  })
+
+  it('refuses atLeast 0 structurally, before the semantic check sees it', () => {
+    // Two layers on purpose. A floor below 1 is nonsense about counting, so
+    // the schema refuses it (`minimum: 1`) and reports a shape error. A floor
+    // of exactly 1 is well-formed and means something the vocabulary already
+    // says, which no schema can know, so `YM918` refuses that one and names
+    // the condition the author actually wanted.
+    expect(diagnostics(0)[0]?.code).not.toBe('YM918')
+    expect(load(atLeast(0)).ok).toBe(false)
+  })
+
+  it('still refuses atLeast 0 from a host that never saw the schema', () => {
+    // `loadQuestionCatalogue` is not the only door: the engine's guard is
+    // `< 2`, not `=== 1`, so a programmatically composed catalogue cannot
+    // slip a never-firing question past the schema layer.
+    const result = loadQuestionCatalogue({
+      path: 'catalogues/fixture.yaml',
+      source: catalogueSource(atLeast(1)),
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('accepts the smallest threshold that means something new', () => {
+    expect(load(atLeast(2)).ok).toBe(true)
+  })
+})
+
+describe('it is a workspace condition, so it may gate a wave', () => {
+  // The adopter asked for this explicitly: "open once at least two runtime
+  // planes exist" is coherent. Scope is declared in CONDITION_SCOPE, and
+  // YM917 would refuse it in a gate if it were subject-scope.
+  const gated = (compiled: typeof NONE) =>
+    evaluateCatalogue(
+      loadOrThrow(atLeast(2)),
+      compiled.graph,
+      compiled.profileContext,
+    ).waves.find(({ id }) => id === 'vocabulary')!.opened
+
+  it('is legal in opensWhen and is not refused as subject-scope', () => {
+    const source = catalogueSource(atLeast(2)).replace(
+      '    name: Vocabulary\n',
+      `    name: Vocabulary
+    opensWhen:
+      - condition: below-subject-count
+        kinds:
+          - yarramate/core@0.1#grouping
+        atLeast: 2
+`,
+    )
+    const result = loadQuestionCatalogue({
+      path: 'catalogues/fixture.yaml',
+      source,
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('leaves an ungated wave open', () => {
+    expect(gated(NONE)).toBe(true)
+  })
+})
+
+describe('the refusal reaches the composition path too', () => {
+  // Two doors into the engine, and a check wired into only one is a check
+  // that silently is not there. A workspace contributing its own questions
+  // (`questions:` in the manifest, ADR 0129) composes rather than loads, so
+  // a threshold refused on one path and accepted on the other would let an
+  // adopter author exactly the question this condition exists to prevent.
+  const compose = (trigger: string) =>
+    composeCatalogues([
+      { path: 'catalogues/fixture.yaml', source: catalogueSource(trigger) },
+    ])
+
+  it('refuses atLeast 1 when the catalogue arrives by composition', () => {
+    const result = compose(atLeast(1))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.diagnostics[0]?.code).toBe('YM918')
+    expect(result.diagnostics[0]?.message).toContain('no-subject-of-kind')
+  })
+
+  it('composes a legal threshold', () => {
+    expect(compose(atLeast(2)).ok).toBe(true)
+  })
+})

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import {
+  type CatalogueCondition,
   INTERROGATION_SEMANTICS_VERSION,
   compileWorkspaceWithProfileContext,
   evaluateCatalogue,
@@ -22,7 +23,7 @@ import {
 // existing question answers.
 
 const EXPECTED_SEMANTICS = '1'
-const EXPECTED_FINGERPRINT = 'c1d51437c346fb07'
+const EXPECTED_FINGERPRINT = '74ee871f5377fedc'
 
 const profile = 'yarramate/core@0.1'
 
@@ -92,25 +93,52 @@ const document = [
 // One question per condition the engine understands. Several never fire
 // against this fixture, and that is the point: a condition that starts firing
 // when it did not before is exactly the drift this catches.
-const conditions: readonly (readonly [string, readonly string[]])[] = [
-  ['missing-claim', ['      - condition: missing-claim', '        predicate: yarramate/ownership/owner']],
-  ['missing-relationship', ['      - condition: missing-relationship', `        kinds: ["${profile}#serving"]`, '        direction: outgoing']],
-  ['isolated', ['      - condition: isolated']],
-  ['no-subject-of-kind', ['      - condition: no-subject-of-kind', `        kinds: ["${profile}#goal"]`]],
-  ['no-state-defined', ['      - condition: no-state-defined']],
-  ['missing-linkage', ['      - condition: missing-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`]],
-  ['has-linkage', ['      - condition: has-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`]],
-  ['exists-linkage', ['      - condition: exists-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationService"]`]],
-  ['missing-constraint', ['      - condition: missing-constraint', `        kinds: ["${profile}#applicationComponent"]`]],
-  ['missing-flow-content', ['      - condition: missing-flow-content']],
-  ['missing-reference', ['      - condition: missing-reference', '        predicate: yarramate/reference/spec', '        direction: outgoing']],
-  ['missing-attestation', ['      - condition: missing-attestation', '        topic: adequacy']],
-  ['near-duplicate', ['      - condition: near-duplicate']],
-  ['unconstrained-kind', ['      - condition: unconstrained-kind']],
-  ['unscoped-succession', ['      - condition: unscoped-succession']],
-  ['unchallenged-evidence', ['      - condition: unchallenged-evidence']],
-  ['has-any-subject', ['      - condition: has-any-subject']],
-]
+// A RECORD over the union's discriminant, not a list, and that is the point.
+//
+// This was a list, and it silently missed two conditions (`has-subject-of-kind`
+// and `fills-pattern-slot`) while the test above claimed to exercise every one
+// the engine understands. The claim was checked against the list itself, so it
+// compared the list to the list and passed. That is CONTRIBUTING.md's ninth
+// rule exactly: an allowlist cannot fail for the author who wrote it, and the
+// author who adds a condition is the one who would have to remember.
+//
+// As a `Record` the typechecker asks instead. A new member of
+// `CatalogueCondition` is a compile error here until it is given a probe, so
+// the backstop cannot fall behind the engine it backstops. Same technique as
+// `CONDITION_SCOPE` in the engine (ADR 0134).
+const CONDITION_PROBES: Record<
+  CatalogueCondition['condition'],
+  readonly string[]
+> = {
+  'missing-claim': ['      - condition: missing-claim', '        predicate: yarramate/ownership/owner'],
+  'missing-relationship': ['      - condition: missing-relationship', `        kinds: ["${profile}#serving"]`, '        direction: outgoing'],
+  'isolated': ['      - condition: isolated'],
+  'no-subject-of-kind': ['      - condition: no-subject-of-kind', `        kinds: ["${profile}#goal"]`],
+  'no-state-defined': ['      - condition: no-state-defined'],
+  'missing-linkage': ['      - condition: missing-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`],
+  'has-linkage': ['      - condition: has-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationFunction"]`],
+  'exists-linkage': ['      - condition: exists-linkage', `        kinds: ["${profile}#applicationComponent"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#applicationService"]`],
+  'missing-constraint': ['      - condition: missing-constraint', `        kinds: ["${profile}#applicationComponent"]`],
+  'missing-flow-content': ['      - condition: missing-flow-content'],
+  'missing-reference': ['      - condition: missing-reference', '        predicate: yarramate/reference/spec', '        direction: outgoing'],
+  'missing-attestation': ['      - condition: missing-attestation', '        topic: adequacy'],
+  'near-duplicate': ['      - condition: near-duplicate'],
+  'unconstrained-kind': ['      - condition: unconstrained-kind'],
+  'unscoped-succession': ['      - condition: unscoped-succession'],
+  'unchallenged-evidence': ['      - condition: unchallenged-evidence'],
+  'has-any-subject': ['      - condition: has-any-subject'],
+  'has-subject-of-kind': ['      - condition: has-subject-of-kind', `        kinds: ["${profile}#applicationComponent"]`],
+  // Fires: the fixture holds one applicationService and the floor is two.
+  'below-subject-count': ['      - condition: below-subject-count', `        kinds: ["${profile}#applicationService"]`, '        atLeast: 2'],
+  // Never fires here, deliberately: no memberships are passed, and "absent
+  // memberships stay quiet" is itself a semantic worth pinning (ADR 0131).
+  'fills-pattern-slot': ['      - condition: fills-pattern-slot'],
+}
+
+const conditionProbes = Object.entries(CONDITION_PROBES) as readonly (readonly [
+  CatalogueCondition['condition'],
+  readonly string[],
+])[]
 
 // The overlay the unchallenged-evidence probe reads: one confirmed
 // observation and no recorded search, so the condition fires. Every other
@@ -127,7 +155,7 @@ const catalogue = [
   '  - id: all',
   '    name: All conditions',
   'questions:',
-  ...conditions.flatMap(([name, trigger]) => [
+  ...conditionProbes.flatMap(([name, trigger]) => [
     `  - id: cond-${name}`,
     '    wave: all',
     '    scope: subject',
@@ -179,9 +207,13 @@ const answers = () => {
 }
 
 describe('interrogation semantics are versioned and pinned', () => {
-  it('exercises every condition the engine understands', () => {
+  it('answers every condition the engine understands', () => {
+    // That the PROBES cover the union is the typechecker's job, above; a
+    // missing member of `CatalogueCondition` will not compile. What this adds
+    // is that every probe reached an answer, so a question cannot be silently
+    // dropped between the catalogue and the report.
     const seen = answers().map(({ id }) => id.replace('cond-', ''))
-    expect(seen.sort()).toEqual(conditions.map(([name]) => name).sort())
+    expect(seen.sort()).toEqual(conditionProbes.map(([name]) => name).sort())
   })
 
   it('has not changed what an existing question answers', () => {


### PR DESCRIPTION
Closes #411.

## The defect

A **vocabulary question** asks a workspace to declare the terms that later per-subject questions resolve against: which API-led layers exist, which sensitivity classes, which integration styles. The only condition able to ask was `no-subject-of-kind`, which is satisfied by **one** instance. So the question closed on the first term, and a one-term vocabulary was indistinguishable from a complete one.

The adopter's two field cases fail differently, and both are in ADR 0135:

- **Born satisfied by incidental content.** One `sensitivity-class` authored at model v4 to answer a per-object question closed the vocabulary question attached four versions later. It never appeared. The cost surfaced seven versions on, when a second data object could only point at "Confidential", which a human recognised as wrong.
- **The same shape with no forcing function.** `integration-style` closed after one style, and every interface on that engagement genuinely is request-reply, so nothing will ever disagree. The first case self-corrected by accident; this one cannot.

**There is no catalogue-side fix, and they measured that** rather than asserting it: the obvious rule is to reword only vocabularies lacking a consumer able to challenge them, and **all five of theirs have a consumer, including both that failed.** The discriminator is a property of the engagement, invisible when the question fires.

## The change

`below-subject-count`, workspace-scope, fires while fewer than `atLeast` subjects of the named kinds exist. `no-subject-of-kind` is its `atLeast: 1` case. Additive, so no existing catalogue changes meaning. `kindMatching` defaults to `descendants` as everywhere else, which is load-bearing here: a classification kind is typically a `grouping` specialization.

**`atLeast` must be at least 2, refused in two layers for two different reasons.** `0` is refused structurally by the schema, since a count can never fall below zero (`YM914`'s defect through arithmetic). `1` is well-formed and means what the vocabulary already says, which no schema can know, so **`YM918` names `no-subject-of-kind`** instead of stating a bound: an author who wrote `atLeast: 1` did not make an arithmetic mistake. The engine guards `< 2` rather than `=== 1` so a programmatically composed catalogue cannot bypass the schema layer, and the refusal is wired into **both** load paths with a test on each.

Semantics version unchanged per ADR 0106, and **verified rather than assumed**: removing the three new probes reproduces the previous fingerprint `c1d51437c346fb07` exactly, so no existing question answers differently.

## Two things found on the way

**The semantics backstop had a hole.** `test/interrogation-semantics.test.ts` claimed to exercise "every condition the engine understands" and missed **two**, `has-subject-of-kind` and `fills-pattern-slot`, both added after it was written. Its check compared its own list against itself and passed. The probes are now `Record<CatalogueCondition['condition'], …>`, the technique ADR 0134 applied to `CONDITION_SCOPE`: a new union member is a compile error until it has a probe. This is `CONTRIBUTING.md`'s ninth rule, and the failure was the rule's own prediction.

**A count in prose went stale again.** `docs/INTERROGATION.md` said there are six workspace-scope conditions, directly above a paragraph warning that this number goes stale and recording that it shipped saying five. This change made it wrong a third time, so the number is gone rather than incremented.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2000** across 113 files (+16) |
| Mutations killed | **6 of 6** |

Mutation coverage: `>=` → `>`, threshold ignored, `< 2` → `< 1`, `descendants` → `exact` default, and each of the two wiring sites removed independently. The `descendants` mutation initially **survived**, because the test named "counts descendants" used plain groupings and had no descendant to count; it was rebuilt against a real profile-declared `sensitivity-class` child of `grouping`, which is the adopter's actual shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
