### PR TITLE
feat: the interview performs the order it draws (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+### The interview performs the order it draws (`core-enrichment` 2.0)
+
+**A major catalogue version, and adopter-visible.** Two waves are re-gated so
+the shipped interview enforces the phase order its own descriptions state
+(#405, ADR 0136):
+
+| Wave | Was | Now |
+|---|---|---|
+| `application` | `has-any-subject` | `has-subject-of-kind: applicationService` |
+| `technology` | `has-any-subject` | `has-subject-of-kind: applicationComponent` |
+
+**Migration.** Waves that opened at the first concept now stay shut longer, and
+`summary.questions` counts opened waves only, so **reported denominators change
+and open-question counts can fall for an unchanged model**. Nothing regresses:
+a complete interview stays complete. What changes is that an incomplete one can
+look nearer to done, which is why this is a major catalogue version rather than
+a minor one. `docs/INTERROGATION.md` gives the rule: minor is additive and
+loosening only; major is for the change class that can silently alter what
+"complete" means.
+
+Both gates are satisfiable from an earlier ungated wave, so no wave goes silent
+for the model that needed it. `no-service-declared` opens `application` from
+`business`; `applicationComponent` is elicited in `interaction`, `business` and
+`application`.
+
+**Two workspace-anchored layer-presence questions are now deferred rather than
+immediate**: `no-event-declared` and `no-artifact-declared`. #272's guarantee
+survives in changed form, silence becoming sequence: the wave reports as
+unopened and the question that opens it is open and waiting, so an absent layer
+is still asked about, in layer order rather than all at once.
+
+`implementation` and `interaction` do **not** change, and both were measured
+rather than argued. `implementation` has no honest gate: every candidate names
+something the wave exists to elicit, and a declared state compiles to a plateau,
+which closes the wave's own lead question, so `has-state-defined` is not built.
+`interaction`'s "Hygiene waits" turned out to be true already, because `design`
+serves questions in wave order and `hygiene` is last.
+
+### Also
+
+- Two `## Unreleased` headings in this file described features that shipped in
+  1.13.0. Cutting a release retitled only the first one, and the entries below
+  it read as pending for two releases. Folded into 1.13.0, where they belong,
+  and a test now refuses a second `## Unreleased` heading so the release step
+  cannot leave one behind again.
+
 ### A vocabulary question may ask for a vocabulary
 
 `below-subject-count`, a workspace-scope condition that fires while FEWER than
@@ -97,8 +143,6 @@ read workbooks.
   blank a neighbouring cell that had content. Found by the round-trip test
   added for the styling above, which is the first thing to emit that shape.
 
-## Unreleased
-
 - **Changed.** A property field puts its label beside its control rather than
   above it. A property sheet is read down the left edge — the reviewer is
   looking for KIND, not reading prose — so a stacked label doubled the height
@@ -131,8 +175,6 @@ read workbooks.
   mode-beside-width, because the rail is a fixed column: there is no dragged
   width to restore. The two sides are independent — hiding one has never been
   a reason to move the other.
-
-## Unreleased
 
 - **Added.** **Focus on this**, in the subject and relationship context menus
   (#407, requested by an adopter mounting the editor). It narrows the canvas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ the shipped interview enforces the phase order its own descriptions state
 
 | Wave | Was | Now |
 |---|---|---|
-| `application` | `has-any-subject` | `has-subject-of-kind: applicationService` |
+| `application` | `has-any-subject` | `has-subject-of-kind`, the three service kinds |
 | `technology` | `has-any-subject` | `has-subject-of-kind: applicationComponent` |
+
+**One question is added**, `no-component-declared` in the ungated `business`
+wave: *"What software actually implements these services?"*. It exists to keep
+the technology conversation reachable, and it is the second half of the
+invariant below.
 
 **Migration.** Waves that opened at the first concept now stay shut longer, and
 `summary.questions` counts opened waves only, so **reported denominators change
@@ -22,10 +27,15 @@ a minor one. `docs/INTERROGATION.md` gives the rule: minor is additive and
 loosening only; major is for the change class that can silently alter what
 "complete" means.
 
-Both gates are satisfiable from an earlier ungated wave, so no wave goes silent
-for the model that needed it. `no-service-declared` opens `application` from
-`business`; `applicationComponent` is elicited in `interaction`, `business` and
-`application`.
+**The invariant that makes this a sequence and not a silence:** the kinds a
+gate names are exactly the kinds an ungated workspace-scope question asks for,
+so each gate opens precisely when its question closes and the interview cannot
+reach zero open while a wave is shut. `no-service-declared` forces
+`application`; `no-component-declared` forces `technology`. A test asserts the
+set equality for every gated wave rather than leaving it to review, because
+review missed it twice: `application` was first gated on `applicationService`
+alone while its question fires only when all three service kinds are absent,
+and `technology` was gated with nothing asking for a component at all.
 
 **Two workspace-anchored layer-presence questions are now deferred rather than
 immediate**: `no-event-declared` and `no-artifact-declared`. #272's guarantee

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -37,11 +37,15 @@ waves:
     description: >-
       How declared services are realized, performed, and fed with
       information. Waits for a declared service, because that is what this
-      wave asks about the realization of.
+      wave asks about the realization of. The kinds here are exactly the ones
+      `no-service-declared` asks for, so this wave opens precisely when that
+      question closes.
     opensWhen:
       - condition: has-subject-of-kind
         kinds:
+          - yarramate/core@0.1#businessService
           - yarramate/core@0.1#applicationService
+          - yarramate/core@0.1#technologyService
   - id: technology
     name: Technology
     description: >-
@@ -928,6 +932,26 @@ questions:
       seven usually carries the whole conversation — and relate each to
       the services or components that realize it with realization.
 
+  - id: no-component-declared
+    wave: business
+    since: "2.0"
+    scope: workspace
+    trigger:
+      - condition: no-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationComponent
+    question: >-
+      What software actually implements these services?
+    askPlain: >-
+      In plain terms: which applications or systems does this run on?
+    materiality: >-
+      A model with services and nothing implementing them cannot say where
+      anything runs, so the whole technology conversation has no subject.
+      This question exists to keep that conversation reachable: the
+      technology wave opens exactly when this question closes (ADR 0136).
+    authority: human
+    resolution: >-
+      Add the application components that implement the declared services.
   - id: no-contract-declared
     wave: business
     since: "1.2"

--- a/catalogues/core-enrichment.yaml
+++ b/catalogues/core-enrichment.yaml
@@ -1,6 +1,6 @@
 format: yarramate/question-catalogue/v1
 id: core-enrichment
-version: "1.3"
+version: "2.0"
 profile: yarramate/core@0.1
 presentation:
   title: Core enrichment interview
@@ -36,21 +36,31 @@ waves:
     name: Application
     description: >-
       How declared services are realized, performed, and fed with
-      information.
+      information. Waits for a declared service, because that is what this
+      wave asks about the realization of.
     opensWhen:
-      - condition: has-any-subject
+      - condition: has-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationService
   - id: technology
     name: Technology
     description: >-
       Where the declared applications actually run and what materializes
-      them.
+      them. Waits for a declared application component, because asking
+      where something runs before anything is declared to run is a question
+      with no subject.
     opensWhen:
-      - condition: has-any-subject
+      - condition: has-subject-of-kind
+        kinds:
+          - yarramate/core@0.1#applicationComponent
   - id: implementation
     name: Implementation
     description: >-
       How the planned architecture becomes real: work, deliverables, and
-      the plateaus between here and there.
+      the plateaus between here and there. NOT phase-gated, deliberately:
+      every candidate gate names something this wave exists to elicit, and
+      a declared state compiles to a plateau, which closes this wave's own
+      lead question. See ADR 0136.
     opensWhen:
       - condition: has-any-subject
   - id: hygiene

--- a/docs/adr/0136-a-wave-opens-when-its-subject-matter-exists.md
+++ b/docs/adr/0136-a-wave-opens-when-its-subject-matter-exists.md
@@ -1,0 +1,101 @@
+# A wave opens when its subject matter exists
+
+Status: accepted
+
+From #405. #404 corrected the documentation to say what was true; this makes
+the original claim true. `core-enrichment` 1.3 → **2.0**.
+
+## The defect
+
+Six of seven waves gated on the same `has-any-subject`, so all six opened the
+instant the first concept landed. Four stated a precondition in their own
+description and enforced none of it.
+
+## Decision
+
+Two waves are re-gated. `has-subject-of-kind` (#398, 1.12.0) expresses both.
+
+| Wave | Gate | Why it is safe |
+|---|---|---|
+| `application` | `applicationService` | elicited by `no-service-declared` in the ungated `business` wave |
+| `technology` | `applicationComponent` | elicited in `interaction`, `business` and `application`, all earlier |
+
+The two remaining waves named in #405 do **not** change, and both reasons were
+found by measurement rather than argument.
+
+## `implementation` has no honest gate
+
+Three routes, all closed.
+
+1. **Gating on what it elicits is trap 1.** `implementation-path-missing` asks
+   the author to declare work packages. Gate on `workPackage` and the question
+   fires only once the author has done the thing it asks for.
+2. **Gating on a declared state is a third trap.**
+   `.yarramate/architecture/evolution.yaml` declares `concepts: []` and four
+   `states:`, and the compiled graph nonetheless carries `adapter-foundation`
+   as a concept of kind `plateau`. **A state entry compiles to a plateau**, and
+   `implementation-path-missing` triggers on
+   `no-subject-of-kind: [workPackage, deliverable, plateau]`. So declaring a
+   state *closes* the wave's headline question, and the gate would open the
+   wave exactly when its lead question no longer needs asking.
+3. **The positional remedy has nowhere to go.** No earlier wave in a
+   layer-ordered catalogue would naturally ask "what work packages does this
+   need?".
+
+So the wave keeps `has-any-subject` and its description now says it is not
+phase-gated, which is the honest form. `has-state-defined` is not built: it
+was proposed only for this wave, and finding 2 disqualifies it.
+
+## `interaction`'s "Hygiene waits" is already true
+
+#405 assumed this sentence overpromised and should be reworded, because wave
+completion cannot be a gate (ADR 0120). Measured, the sentence is not about
+gates: `design` serves **"the first open question in wave order, then
+catalogue order within the wave"**, and `hygiene` is the last wave. So hygiene
+questions are served after interaction questions, which is what the sentence
+says. Nothing to fix, and the prose fix #405 scoped is not part of this change.
+
+## Why 2.0 and not 1.4
+
+`docs/INTERROGATION.md` states the rule: minor versions are **additive**, new
+questions and *loosened* triggers only; major versions "may change or remove
+triggers — the only change class that can silently alter what an existing
+'complete' means".
+
+Tightening a gate is that class. It cannot turn a complete interview
+incomplete, but it can make an incomplete one *look* complete: a model with
+components, data objects and no application service currently gets asked "what
+does this component contribute?" and after this change does not, until a
+service exists. Fewer open questions for an unchanged model is exactly the
+silent alteration the major signal exists for.
+
+## The interaction with #272, which is the part to review
+
+Two workspace-anchored layer-presence questions now sit behind a gate:
+`no-event-declared` (`application`) and `no-artifact-declared`
+(`technology`). Those questions exist because of #272 and ADR 0120, where a
+discovery closed its interview with whole layers silently absent: every
+subject-scoped question matched no subject, so nothing fired and nothing said
+so.
+
+This does not bring that failure back, and the distinction is **silence versus
+sequence**:
+
+- **then**: the question never fired, and the report showed nothing;
+- **now**: the wave reports as unopened, and the question that opens it is
+  itself open and waiting in an earlier ungated wave.
+
+The event layer is still asked about, after the layer it belongs to has a
+subject. `test/absent-layer-catalogue.test.ts` pins both halves rather than
+dropping the old assertion: deferred while the wave is shut, reached as soon
+as a service exists.
+
+It is a real change to what #272 delivered, from "every absent front at once"
+to "every absent front, in layer order", and it is the reason this is a major
+catalogue version.
+
+## Not in scope
+
+A detector for identically-gated waves. The engine cannot know whether an
+order was intended, identical gates can be deliberate grouping, and a refusal
+would be wrong (#404).

--- a/docs/adr/0136-a-wave-opens-when-its-subject-matter-exists.md
+++ b/docs/adr/0136-a-wave-opens-when-its-subject-matter-exists.md
@@ -15,10 +15,40 @@ description and enforced none of it.
 
 Two waves are re-gated. `has-subject-of-kind` (#398, 1.12.0) expresses both.
 
-| Wave | Gate | Why it is safe |
+| Wave | Gate | Forced open by |
 |---|---|---|
-| `application` | `applicationService` | elicited by `no-service-declared` in the ungated `business` wave |
-| `technology` | `applicationComponent` | elicited in `interaction`, `business` and `application`, all earlier |
+| `application` | the three service kinds | `no-service-declared` (`business`, ungated) |
+| `technology` | `applicationComponent` | `no-component-declared` (`business`, ungated, new at 2.0) |
+
+## The invariant, and the review that nearly missed it
+
+A gated wave hides its own layer-presence questions while it is shut. So
+something in an **ungated** wave must force each gate open, or the interview
+can reach zero open questions with a whole layer never asked about, which is
+exactly the #272 defect described below.
+
+The property is **set equality**: the kinds a gate names must be exactly the
+kinds some ungated workspace-scope `no-subject-of-kind` question asks for.
+Then the gate opens precisely when that question closes.
+
+Neither gate had it when this change was first written, and reviewing by
+reading did not find that.
+
+- `application` was gated on `applicationService` alone, while
+  `no-service-declared` fires on `[businessService, applicationService,
+  technologyService]` and therefore closes as soon as **any** of the three
+  exists. A model with one `businessService` closed the question and left the
+  gate shut. The gate now names the same three kinds.
+- `technology` was gated on `applicationComponent` with **nothing** asking for
+  one. A model realizing its services with `applicationFunction` only would
+  never declare a component, so the wave never opened and
+  `no-artifact-declared` never fired. `no-component-declared` is added to the
+  ungated `business` wave to close it.
+
+The first reading of this checked that the gate's kind *appeared in* a forcing
+question's kind list and called it safe. Membership is not equality, and only
+one of the two is checkable by eye. `test/wave-gating.test.ts` now asserts the
+set equality for every gated wave, so the next gate has to satisfy it or fail.
 
 The two remaining waves named in #405 do **not** change, and both reasons were
 found by measurement rather than argument.

--- a/test/absent-layer-catalogue.test.ts
+++ b/test/absent-layer-catalogue.test.ts
@@ -70,13 +70,54 @@ describe('core-enrichment 1.2 asks about absent layers', () => {
     rmSync(workspace, { recursive: true, force: true })
   })
 
-  it('opens every absent front on a model with none of the layers', () => {
+  it('opens every absent front whose wave has opened', () => {
     const ids = openIds(workspace)
     expect(ids).toContain('core-enrichment#no-capability-declared')
-    expect(ids).toContain('core-enrichment#no-event-declared')
     expect(ids).toContain('core-enrichment#no-contract-declared')
     expect(ids).toContain('core-enrichment#no-artifact-declared')
     expect(ids).toContain('core-enrichment#implementation-path-missing')
+  })
+
+  // `no-event-declared` used to be in this list, and its move out is the
+  // sharpest consequence of re-gating `application` on a declared service
+  // (#405, ADR 0136). It is worth stating as its own test rather than as a
+  // deleted line, because #272's guarantee is what is at stake and the
+  // guarantee survives in a changed form.
+  //
+  // #272 fixed a discovery that closed its interview with whole layers
+  // silently absent: subject-scoped questions matched no subject, so nothing
+  // fired and nothing said so. These workspace-anchored questions were the
+  // fix. Gating a wave does NOT bring that failure back, and the difference
+  // is the difference between silence and sequence:
+  //
+  //   - then: the question never fired and the report showed nothing;
+  //   - now: the wave reports as unopened, and the question that opens it
+  //     (`no-service-declared`, in the ungated `business` wave) is itself
+  //     open and waiting.
+  //
+  // So the event layer is still asked about, after the layer it belongs to
+  // has a subject. Both halves are pinned below: deferred here, and reached
+  // as soon as a service exists.
+  it('defers an absent front whose wave has not opened, without losing it', () => {
+    const ids = openIds(workspace)
+    expect(ids).not.toContain('core-enrichment#no-event-declared')
+    // The route to it is open, so this is a sequence and not a silence.
+    expect(ids).toContain('core-enrichment#no-service-declared')
+  })
+
+  it('reaches the deferred front once its wave opens', () => {
+    writeFileSync(
+      join(workspace, 'architecture/main.yaml'),
+      bare.replace(
+        'relationships:',
+        `  - id: ordering
+    kind: applicationService
+    name: Ordering
+relationships:`,
+      ),
+      'utf8',
+    )
+    expect(openIds(workspace)).toContain('core-enrichment#no-event-declared')
   })
 
   it('closes a presence question the moment the layer has a subject', () => {

--- a/test/changelog-shape.test.ts
+++ b/test/changelog-shape.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+// Cutting a release retitles `## Unreleased` to the version being cut. That
+// step assumes there is exactly one, and for two releases there were three:
+// PRs each opened their own heading, the release renamed the first, and the
+// entries below it went on reading as pending after they had shipped. A
+// reader looking for what is in 1.13.0 found its heading, then two
+// "Unreleased" blocks describing 1.13.0's own features.
+//
+// Nothing detected that, because a changelog is prose and prose is not
+// checked. This is the smallest check that would have.
+
+const changelog = readFileSync('CHANGELOG.md', 'utf8')
+const headings = changelog
+  .split('\n')
+  .filter((line) => line.startsWith('## '))
+
+describe('the changelog has one place for pending work', () => {
+  it('carries at most one Unreleased heading', () => {
+    const unreleased = headings.filter(
+      (line) => line.trim() === '## Unreleased',
+    )
+    expect(
+      unreleased.length,
+      'Add entries under the existing "## Unreleased" heading rather than ' +
+        'opening a second one. Cutting a release renames the first, and any ' +
+        'other is left behind describing shipped work as pending.',
+    ).toBeLessThanOrEqual(1)
+  })
+
+  it('puts Unreleased first when it is present', () => {
+    // A pending section below a released one is the same defect wearing a
+    // different hat: it reads as belonging to the release above it.
+    const index = headings.findIndex((line) => line.trim() === '## Unreleased')
+    if (index === -1) return
+    expect(index).toBe(0)
+  })
+
+  it('never repeats a released version heading', () => {
+    const released = headings.filter((line) => line.trim() !== '## Unreleased')
+    expect(released).toEqual([...new Set(released)])
+  })
+})

--- a/test/interaction-catalogue.test.ts
+++ b/test/interaction-catalogue.test.ts
@@ -203,7 +203,7 @@ describe('core-enrichment 1.0 interaction wave', () => {
         id: string
       }[]
     }
-    expect(catalogue.version).toBe('1.3')
+    expect(catalogue.version).toBe('2.0')
     const added = catalogue.questions.filter((question) => question.since === '0.9')
     expect(added.length).toBeGreaterThan(0)
     for (const question of added) {

--- a/test/wave-gating.test.ts
+++ b/test/wave-gating.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// Re-gating `application` and `technology` (#405, ADR 0136), against the
+// SHIPPED catalogue rather than a fixture, because the claim is about what
+// adopters actually run.
+
+const catalogue = (() => {
+  const loaded = loadQuestionCatalogue({
+    path: 'catalogues/core-enrichment.yaml',
+    source: readFileSync('catalogues/core-enrichment.yaml', 'utf8'),
+  })
+  if (!loaded.ok) throw new Error(JSON.stringify(loaded.diagnostics))
+  return loaded.catalogue
+})()
+
+const workspaceOf = (concepts: string) => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:${concepts}
+relationships: []
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+}
+
+const opened = (concepts: string) => {
+  const compiled = workspaceOf(concepts)
+  return new Map(
+    evaluateCatalogue(
+      catalogue,
+      compiled.graph,
+      compiled.profileContext,
+    ).waves.map((wave) => [wave.id, wave.opened]),
+  )
+}
+
+const ACTOR = `
+  - id: teller
+    kind: businessActor
+    name: Teller`
+const SERVICE = `
+  - id: ordering
+    kind: applicationService
+    name: Ordering`
+const COMPONENT = `
+  - id: order-api
+    kind: applicationComponent
+    name: Order API`
+
+describe('the shipped interview performs the order it draws', () => {
+  it('opens neither layered wave on a model with only an actor', () => {
+    const waves = opened(ACTOR)
+    expect(waves.get('application')).toBe(false)
+    expect(waves.get('technology')).toBe(false)
+  })
+
+  it('opens application once a service is declared', () => {
+    const waves = opened(ACTOR + SERVICE)
+    expect(waves.get('application')).toBe(true)
+    expect(waves.get('technology')).toBe(false)
+  })
+
+  it('opens technology once a component is declared', () => {
+    const waves = opened(ACTOR + COMPONENT)
+    expect(waves.get('technology')).toBe(true)
+  })
+
+  it('leaves the ungated waves open from the first concept', () => {
+    // Only two waves moved. `motivation` has no gate at all, and the rest
+    // still open on `has-any-subject`, which is what #405 scoped.
+    const waves = opened(ACTOR)
+    for (const id of ['motivation', 'interaction', 'business', 'hygiene']) {
+      expect(waves.get(id), id).toBe(true)
+    }
+  })
+
+  it('keeps implementation ungated, deliberately', () => {
+    // Every candidate gate names something the wave exists to elicit, and a
+    // declared state compiles to a plateau, which closes the wave's own lead
+    // question `implementation-path-missing`. ADR 0136 records both traps;
+    // this pins the resulting behaviour so a later "tidy-up" has to argue
+    // with a failing test rather than a comment.
+    expect(opened(ACTOR).get('implementation')).toBe(true)
+  })
+})
+
+describe('every gate is satisfiable from an earlier wave', () => {
+  // The rule a gate must pass: it must never name a subject its own wave
+  // exists to elicit, or the wave goes silent for exactly the model that
+  // needed it. Checked here against the shipped catalogue rather than
+  // asserted in prose, because the catalogue is what changes.
+  const questionsOfWave = (wave: string) =>
+    catalogue.questions.filter((question) => question.wave === wave)
+
+  const gatedKinds = (wave: string) =>
+    (catalogue.waves.find(({ id }) => id === wave)?.opensWhen ?? []).flatMap(
+      (condition) => ('kinds' in condition ? condition.kinds : []),
+    )
+
+  it('no gated wave names a kind its own subject selectors elicit', () => {
+    for (const wave of ['application', 'technology']) {
+      const kinds = new Set(gatedKinds(wave))
+      expect(kinds.size, wave).toBeGreaterThan(0)
+      for (const question of questionsOfWave(wave)) {
+        // A workspace-scope `no-subject-of-kind` on the gated kind would be
+        // the pure trap: the wave would open only once its own eliciting
+        // question had been answered.
+        for (const condition of question.trigger) {
+          if (condition.condition !== 'no-subject-of-kind') continue
+          for (const kind of condition.kinds) {
+            expect(kinds.has(kind), `${wave}/${question.id}`).toBe(false)
+          }
+        }
+      }
+    }
+  })
+})

--- a/test/wave-gating.test.ts
+++ b/test/wave-gating.test.ts
@@ -96,6 +96,73 @@ describe('the shipped interview performs the order it draws', () => {
   })
 })
 
+// The invariant that makes a gate a SEQUENCE rather than a SILENCE (#272,
+// ADR 0136). A gated wave hides its layer-presence questions while it is
+// shut, so something in an ungated wave must force it open, or the interview
+// can reach zero open questions with a whole layer never asked about, which
+// is the exact defect #272 was filed for.
+//
+// Written as a test because prose failed at it. Reviewing this change by
+// reading, I checked only that the gate's kind APPEARED in a forcing
+// question's kind list and called it safe. It was not: `no-service-declared`
+// fires on `[businessService, applicationService, technologyService]`, so it
+// closes as soon as ANY of the three exists, while a gate naming only
+// `applicationService` stays shut. Set equality is the property; membership
+// is not, and only one of them is checkable by eye.
+describe('a gated wave cannot hide a layer nobody is asked about', () => {
+  const gatedWaves = catalogue.waves.filter((wave) =>
+    (wave.opensWhen ?? []).some(
+      (condition) => condition.condition === 'has-subject-of-kind',
+    ),
+  )
+
+  const ungatedWaveIds = new Set(
+    catalogue.waves
+      .filter(
+        (wave) =>
+          !(wave.opensWhen ?? []).some(
+            (condition) => condition.condition === 'has-subject-of-kind',
+          ),
+      )
+      .map(({ id }) => id),
+  )
+
+  it('gates the waves this change set out to gate', () => {
+    expect(gatedWaves.map(({ id }) => id).sort()).toEqual([
+      'application',
+      'technology',
+    ])
+  })
+
+  it.each(gatedWaves.map((wave) => wave.id))(
+    'has an ungated question whose kinds exactly match the %s gate',
+    (waveId) => {
+      const wave = catalogue.waves.find(({ id }) => id === waveId)!
+      const gateKinds = (wave.opensWhen ?? []).flatMap((condition) =>
+        condition.condition === 'has-subject-of-kind' ? condition.kinds : [],
+      )
+      const forcing = catalogue.questions.filter(
+        (question) =>
+          ungatedWaveIds.has(question.wave) &&
+          question.scope === 'workspace' &&
+          question.trigger.some(
+            (condition) =>
+              condition.condition === 'no-subject-of-kind' &&
+              condition.kinds.length === gateKinds.length &&
+              condition.kinds.every((kind) => gateKinds.includes(kind)),
+          ),
+      )
+      expect(
+        forcing.map(({ id }) => id),
+        `No ungated workspace question asks for exactly [${gateKinds.join(', ')}]. ` +
+          'Without one, a model can reach zero open questions while this ' +
+          "wave never opens, and the layer-presence questions inside it are " +
+          'never asked (#272).',
+      ).not.toHaveLength(0)
+    },
+  )
+})
+
 describe('every gate is satisfiable from an earlier wave', () => {
   // The rule a gate must pass: it must never name a subject its own wave
   // exists to elicit, or the wave goes silent for exactly the model that


### PR DESCRIPTION
Closes #405. **`core-enrichment` 1.3 → 2.0, adopter-visible.**

## What changed

Six of seven waves gated on the same `has-any-subject`, so all six opened at the first concept while four described a precondition they did not enforce.

| Wave | Gate | Forced open by |
|---|---|---|
| `application` | the three service kinds | `no-service-declared` (`business`, ungated) |
| `technology` | `applicationComponent` | `no-component-declared` (`business`, ungated, **new at 2.0**) |

One question is added, `no-component-declared`: *"What software actually implements these services?"*. It is the second half of the invariant below.

## The invariant, which review got wrong twice

A gated wave hides its own layer-presence questions while shut, so something in an **ungated** wave must force each gate open. Otherwise the interview reaches zero open questions with a whole layer never asked about, which is exactly #272 below.

The property is **set equality**: the kinds a gate names must be exactly the kinds some ungated workspace-scope `no-subject-of-kind` question asks for. Then the gate opens precisely when that question closes.

**Neither gate had it as first written.**

- `application` was gated on `applicationService` alone, while `no-service-declared` fires on `[businessService, applicationService, technologyService]` and therefore closes as soon as **any** of the three exists. One `businessService` closed the question and left the gate shut.
- `technology` was gated on `applicationComponent` with **nothing** asking for one. A model realizing its services with `applicationFunction` only would never declare a component, so the wave never opened.

The first review checked that the gate's kind *appeared in* a forcing question's list and called it safe. **Membership is not equality**, and only one of the two is checkable by eye. `test/wave-gating.test.ts` now asserts the set equality for every gated wave, mutation-tested both ways, so the next gate has to satisfy it or fail.

## Two waves #405 scoped do NOT change, both by measurement

**`implementation` has no honest gate.** Gating on what it elicits is trap 1. A declared state compiles to a **plateau**, and `implementation-path-missing` triggers on `no-subject-of-kind: [workPackage, deliverable, plateau]`, so gating on a state would open the wave exactly when its lead question no longer needs asking. And no earlier layer-ordered wave would naturally ask for work packages. Its description now says it is not phase-gated. **`has-state-defined` is therefore not built.**

**`interaction`'s "Hygiene waits" is already true.** #405 assumed the prose overpromised, since wave completion cannot gate (ADR 0120). But the sentence is not about gates: `design` serves *"the first open question in wave order, then catalogue order within the wave"*, and `hygiene` is the last wave. Nothing to fix.

## Why major, not minor

`docs/INTERROGATION.md`: minor versions are additive, "new questions and **loosened** triggers only"; major is for the class that "can silently alter what an existing 'complete' means".

Tightening a gate is that class. It cannot make a complete interview incomplete, but a model with components, data objects and no application service currently gets asked "what does this component contribute?" and after this does not.

## The part to review

Two workspace-anchored layer-presence questions now sit behind gates: `no-event-declared` and `no-artifact-declared`. Those exist because of **#272 / ADR 0120**, where a discovery closed its interview with whole layers silently absent.

This is **silence becoming sequence**, not that failure returning:

| | then (#272's defect) | now |
|---|---|---|
| Question | never fired | deferred |
| Report | showed nothing | wave shows as unopened |
| Route to it | none | the forcing question open and waiting |

The old assertion was **not deleted**. It is split into three tests pinning both halves: deferred while the wave is shut, and reached the moment a service exists. ADR 0136 records this as the reviewable decision.

The maintainer chose to close the hole rather than drop a gate, so both gates ship with a forcing question apiece.

## Found while writing the changelog entry

**Two `## Unreleased` headings described features that shipped in 1.13.0**, confirmed by `git tag --contains` on `14b43e3` (focus) and `5a1e6c1` (property fields). PRs each opened their own heading and cutting a release retitles only the first, so for two releases a reader looking for 1.13.0 found its heading followed by two "Unreleased" blocks describing 1.13.0's own features.

Folded into 1.13.0, and `test/changelog-shape.test.ts` now refuses a second `## Unreleased`, requires it to come first, and refuses a repeated version heading. Mutation-tested. Nothing caught this because a changelog is prose and prose is not checked.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2014** across 115 files |
| Self-model | unaffected: 7/7 waves open, 52 questions (+1), 0 open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
