### PR TITLE
chore: release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.14.0
 
 ### The interview performs the order it draws (`core-enrichment` 2.0)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 0.15.0
-date-released: 2026-08-06
+version: 1.14.0
+date-released: 2026-08-30
 url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"
 license: MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.14.0**.

| Change | Kind |
|---|---|
| `below-subject-count` (#411, ADR 0135) | feature |
| `core-enrichment` 1.3 → **2.0**, two waves re-gated (#405, ADR 0136) | catalogue major, **adopter-visible** |
| External-locator join direction (#424) | docs, ships in package |
| A condition the engine owns defines its own peers (#399) | docs, ships in package |
| Changelog integrity fix + guard test | fix |

## The adopter-visible part

`core-enrichment` 2.0 gates `application` and `technology` on their subject matter. Waves that opened at the first concept now stay shut longer, and `summary.questions` counts opened waves only, so **reported denominators change and open-question counts can fall for an unchanged model**. A complete interview stays complete; an incomplete one can look nearer to done, which is why it is a major catalogue version. Full migration note in the changelog entry.

## Also de-stales CITATION.cff

It claimed `version: 0.15.0`, dated 2026-08-06 — ten releases behind. The last three release commits touched only `CHANGELOG.md` and `package.json`, so the file a citation reads for the version had been drifting unnoticed. `assets/taglines.txt` is deliberately left alone; its own header records that the version line there is frozen and unmaintained.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2014** across 115 files |
| Reconcile | 313/313 confirmed, 0 unclaimed of 151 |
| `changelog:check` | green, 4 commits since v1.13.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u