### PR TITLE
chore: release 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 1.14.1
+
+`docs/INTERROGATION.md` now ships in the package. It did not, and 1.14.0 said
+it did.
+
+The catalogue-authoring reference is the one document an adopter writing
+questions needs most, and two things landed in it that were written
+specifically to be found: the rule that a condition the engine owns defines
+its own peers (#399, the recorded answer to an adopter's question, put in a
+document rather than only on the issue precisely so the next adopter would not
+re-ask it), and `below-subject-count`'s entry in the condition list (#411).
+Neither reached anyone arriving through npm.
+
+`package.json` `files` carried only `docs/CONSUMING-YARRAMATE.md` and
+`docs/MODEL-FLOOR.md`, the latter added in #393 for exactly this reason. The
+release notes for 1.14.0 claimed both new documents shipped; one did.
+
+Fixing it exposed the general shape, so four more documents ship with it:
+`NATIVE-DOCUMENT.md`, `SEMANTIC-GRAPH.md`, `EVIDENCE.md` and
+`ARCHITECTURE-STATES.md`. `MODEL-FLOOR.md` already cited the first three by
+path, so a reader with the package was following pointers to files they did
+not have. The shipped set is now closed under reference: following a pointer
+from a document you received never leaves the set. A test asserts that, and
+asserts the shipped list matches the tree, because the previous claim lived
+only in a release note.
+
+These four were already normative references rather than new commitments;
+they were simply unreachable.
+
+Docs-only and shipped as a patch on the same reasoning as 1.11.1 and 1.13.1:
+an adopter arrives through npm, so guidance that stays in the repository is
+guidance they do not have.
+
+
 ## 1.14.0
 
 ### The interview performs the order it draws (`core-enrichment` 2.0)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 1.14.0
+version: 1.14.1
 date-released: 2026-08-30
 url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,12 @@
     "profiles",
     "skills/yarramate-architecture",
     "docs/CONSUMING-YARRAMATE.md",
-    "docs/MODEL-FLOOR.md"
+    "docs/MODEL-FLOOR.md",
+    "docs/INTERROGATION.md",
+    "docs/NATIVE-DOCUMENT.md",
+    "docs/SEMANTIC-GRAPH.md",
+    "docs/EVIDENCE.md",
+    "docs/ARCHITECTURE-STATES.md"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -60,6 +60,23 @@ describe('consumer package contract', () => {
       // through npm. Left in the repository it sat exactly where the people
       // it is for would not find it, which is the condition it exists to end.
       'docs/MODEL-FLOOR.md',
+      // The catalogue-authoring reference, by the same test. 1.14.0 recorded
+      // an adopter's answered question here rather than only on the issue,
+      // on the grounds that a decision living on a closed issue is one the
+      // next adopter re-asks — and then did not ship the file, so it reached
+      // nobody. The release notes claimed it did.
+      'docs/INTERROGATION.md',
+      // The four these three cite BY PATH. A shipped document that names a
+      // document you do not have is worse than one that stays silent: it
+      // tells the reader where to look and the place is not there. None of
+      // these is a new commitment; each was already normative and merely
+      // unreachable. `test/shipped-docs.test.ts` holds the property that
+      // makes this list the right length — the shipped set is closed under
+      // reference — so the next document added here brings whatever it cites.
+      'docs/NATIVE-DOCUMENT.md',
+      'docs/SEMANTIC-GRAPH.md',
+      'docs/EVIDENCE.md',
+      'docs/ARCHITECTURE-STATES.md',
     ])
     expect(packageJson.scripts.prepack).toBe('pnpm build')
     expect(

--- a/test/shipped-docs.test.ts
+++ b/test/shipped-docs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+
+// A shipped document must not point at one that stays in the repository.
+//
+// `docs/INTERROGATION.md` was not in `files` and 1.14.0's notes said it was.
+// Two things had been written into it specifically to be found by adopters:
+// the recorded answer to #399, put in a document rather than only on the
+// issue so the next adopter would not re-ask it, and `below-subject-count`'s
+// entry in the condition list. Neither reached anyone arriving through npm,
+// and nothing said so, because the packaging claim lived in a release note.
+//
+// Fixing that exposed the general shape: `MODEL-FLOOR.md` ships and cited
+// `docs/EVIDENCE.md` and `docs/NATIVE-DOCUMENT.md`, which did not. A reader
+// with the package followed a pointer to a file they did not have.
+
+const files: readonly string[] = JSON.parse(
+  readFileSync('package.json', 'utf8'),
+).files
+
+const shipped = files.filter((entry) => entry.startsWith('docs/'))
+
+const referencesIn = (path: string): readonly string[] => [
+  ...new Set(readFileSync(path, 'utf8').match(/docs\/[A-Z0-9-]+\.md/g) ?? []),
+]
+
+describe('the documentation an adopter receives is self-contained', () => {
+  it('ships the documents it claims to ship', () => {
+    for (const entry of shipped) {
+      expect(existsSync(entry), `${entry} is in files but not in the tree`).toBe(
+        true,
+      )
+    }
+  })
+
+  it('resolves every pointer a shipped document makes', () => {
+    const dangling = shipped.flatMap((entry) =>
+      referencesIn(entry)
+        // A reference to a document that does not exist at all is a broken
+        // link, which is a different defect and not this test's business.
+        .filter((ref) => existsSync(ref) && !files.includes(ref))
+        .map((ref) => `${entry} -> ${ref}`),
+    )
+    expect(
+      dangling,
+      'A shipped document points at one that stays in the repository, so a ' +
+        'reader who installed the package cannot follow it. Either add the ' +
+        'target to `files` in package.json, or stop citing it by path.',
+    ).toEqual([])
+  })
+
+  it('keeps the shipped set closed under reference', () => {
+    // The property the test above enforces one level at a time, stated as
+    // the invariant: following pointers from the shipped set never leaves it.
+    const reachable = new Set(shipped)
+    const queue = [...shipped]
+    while (queue.length > 0) {
+      for (const ref of referencesIn(queue.pop()!)) {
+        if (existsSync(ref) && !reachable.has(ref)) {
+          reachable.add(ref)
+          queue.push(ref)
+        }
+      }
+    }
+    expect([...reachable].sort()).toEqual([...shipped].sort())
+  })
+})


### PR DESCRIPTION
Cuts **1.14.1**. Docs and packaging only.

## The defect

`docs/INTERROGATION.md` was not in `package.json` `files`, and **1.14.0's release notes said it was**. Two things had been written into it specifically to be found by adopters:

- the recorded answer to **#399**, put in a document rather than only on the issue on the explicit grounds that *a decision living on a closed issue is one the next adopter re-asks*;
- **`below-subject-count`**'s entry in the condition list (#411), the condition an adopter asked for.

Neither reached anyone arriving through npm.

## It generalised

`MODEL-FLOOR.md` already shipped and cited `docs/EVIDENCE.md` and `docs/NATIVE-DOCUMENT.md` **by path**, so a reader with the package was following pointers to files they did not have. That is worse than silence: it says where to look and the place is not there.

The shipped set is now **closed under reference**, at seven documents:

| Document | Status |
|---|---|
| `CONSUMING-YARRAMATE.md`, `MODEL-FLOOR.md` | already shipped |
| `INTERROGATION.md` | **new** — the defect |
| `NATIVE-DOCUMENT.md`, `SEMANTIC-GRAPH.md`, `EVIDENCE.md`, `ARCHITECTURE-STATES.md` | **new** — the closure |

The four beyond `INTERROGATION.md` were already normative rather than new commitments; they were merely unreachable. Widening the surface was taken deliberately: `test/package-consumer.test.ts` pins that list and its comment sets the criterion, *written for an adopter, and an adopter arrives through npm*.

## Two tests hold it

- The **pinned list** keeps widening deliberate, and now carries the reasoning for each addition.
- `test/shipped-docs.test.ts` holds the property that makes the list the right **length**: following a pointer out of the shipped set never leaves it, so the next document added brings whatever it cites. Mutation-tested.

The previous claim lived only in a release note, which is exactly why nothing caught it.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2017** across 116 files |
| Tarball | 278 files, 7 documents |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u