### PR TITLE
feat: a missing-claim question offers the field it is missing (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### A missing-claim question offers the field it is missing
+
+`design` now prints an `update-concept` skeleton for a `missing-claim` trigger
+on `yarramate/ownership/owner`, `yarramate/concept/description` or
+`yarramate/lifecycle/status` (#430, ADR 0137). Every other predicate prints
+nothing, exactly as before.
+
+Filed by an adopter who **declined to use `missing-claim` because of this**.
+Their answer-shape mapping covered five conditions and this was the sixth, so a
+question using it rendered as prose, and their pack asserts no card degrades to
+prose. They left ownership unelicited rather than ship one card that behaved
+differently. The shipped catalogue had the same gap from the inside: four of
+its questions use `missing-claim` and none printed a skeleton.
+
+`missing-claim` matches a **raw predicate**, and a predicate is not an
+authoring gesture: an attestation predicate is written by adding an
+attestation, a reference predicate by adding a reference, and a profile may
+mint predicates the engine has never heard of. So it cannot map in general.
+Three predicates name a concept field that `update-concept` writes directly,
+which makes them unambiguous, and those three are every `missing-claim` the
+shipped catalogue uses. A test keeps the mapping level with the catalogue.
+
+`docs/INTERROGATION.md` now states this where a catalogue author meets it,
+including that **the engine takes no position on which predicates a host should
+render as editable** — the trigger carries the predicate and the host decides.
+That was the adopter's own hesitation about asking for a `set-field` answer
+shape, and it was right; ADR 0110 excluded a normalized remedy vocabulary for
+the same reason.
+
+
 ## 1.14.1
 
 `docs/INTERROGATION.md` now ships in the package. It did not, and 1.14.0 said

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -424,6 +424,41 @@ every kind it matches.
 relationship, so there is no table to consult, and inventing one for them
 would be the second encoding this refusal refuses.
 
+## A predicate is not an authoring gesture
+
+`missing-claim` matches a **raw predicate**, and every other condition names a
+structure. That difference decides what a consumer can offer for it.
+
+A trigger travels verbatim into the report and the design step (ADR 0110), and
+a host maps it onto its own affordance. Most conditions map cleanly:
+`no-subject-of-kind` is a concept to add, `missing-relationship` an edge to
+draw. `missing-claim` does not, in general, because a predicate is not a
+gesture — `yarramate/attestation/adequacy` is written by adding an attestation,
+`yarramate/reference/refers-to` by adding a reference, and a profile may mint
+predicates this engine has never heard of.
+
+So a card built from `missing-claim` can come back with no affordance, which is
+how an adopter found this (#430): their mapping covered five conditions, this
+was the sixth, and their pack asserts no card degrades to prose.
+
+**The predicate is the shape.** It is on the trigger, and the host decides what
+control to draw for it and which predicates it is willing to draw at all. The
+engine takes no position on which predicates are user-editable fields, because
+it cannot know a host's editor.
+
+`design` maps three, and prints an `update-concept` skeleton for them:
+
+| Predicate | Field |
+|---|---|
+| `yarramate/ownership/owner` | `owner` |
+| `yarramate/concept/description` | `description` |
+| `yarramate/lifecycle/status` | `status` |
+
+Each names a field `update-concept` writes directly, so each is unambiguous.
+Any other predicate prints nothing, which is ADR 0110's rule holding: a wrong
+skeleton is never offered. Those three are every `missing-claim` the shipped
+catalogue uses, and a test keeps that true (ADR 0137).
+
 ## A condition the engine owns defines its own peers
 
 Comparing a subject against its peers is not new here. `near-duplicate` fires

--- a/docs/adr/0137-a-predicate-is-not-an-authoring-gesture.md
+++ b/docs/adr/0137-a-predicate-is-not-an-authoring-gesture.md
@@ -1,0 +1,75 @@
+# A predicate is not an authoring gesture
+
+Status: accepted
+
+From ApertureX (#430), filed after they decided **not** to use `missing-claim`
+because of this.
+
+## The report
+
+Their answer-shape mapping, the consumer half of ADR 0110, turns a trigger
+into a one-click affordance and covered five conditions:
+
+```
+no-subject-of-kind                     -> add-concept
+missing-relationship / missing-linkage -> add-relationship
+missing-constraint                     -> add-constraint
+missing-attestation                    -> record-attestation
+```
+
+`missing-claim` mapped to nothing, so a question using it rendered as prose:
+the card states the problem and the consultant goes and finds the editor. Their
+pack has a test asserting **no card degrades to prose** across 42 questions, so
+adopting it meant either breaking that guarantee or shipping the one card that
+behaves differently from every other. They shipped neither, and the ownership
+column stayed workbook-filled while the interview never asked who owns a
+component.
+
+## Why it mapped to nothing, which is the part worth stating
+
+`missing-claim` matches a **raw predicate**, and a predicate is not an
+authoring gesture. `yarramate/attestation/adequacy` is written by adding an
+attestation. `yarramate/reference/refers-to` by adding a reference.
+`yarramate/constraint/requires` by adding a constraint binding. And a profile
+may mint predicates this engine has never heard of.
+
+So the condition cannot map onto one operation **in general**, and ADR 0110's
+rule is that a skeleton is printed only where the mapping is unambiguous,
+because a wrong skeleton is never offered.
+
+## Decision
+
+Three predicates map, and only three: `yarramate/ownership/owner`,
+`yarramate/concept/description` and `yarramate/lifecycle/status`. Each names a
+field on a concept that `update-concept` writes directly, so each is
+unambiguous. Everything else prints nothing, exactly as before.
+
+This is the **"one new mapping case" ADR 0110 anticipated**, not the normalized
+remedy DSL it excluded. No second vocabulary is introduced, nothing is added to
+the report envelope, and the trigger still travels verbatim.
+
+Those three happen to be **every `missing-claim` the shipped catalogue uses**:
+`owner-missing`, `information-unowned`, `concept-undescribed` and
+`status-missing`. The gap the adopter met from outside, the CLI had from
+inside, on four of its own questions.
+
+## What is NOT decided
+
+**The engine takes no position on which predicates a HOST should render as
+editable.** That was the adopter's own hesitation about their option 1 and it
+is right: the trigger carries the predicate, and a host decides what control to
+draw. This change is the CLI rendering its own affordance, the same as its
+other two cases, and it does not reach into a consumer's mapping.
+
+An adopter wanting the same coverage reads the predicate off the trigger, which
+ADR 0110 already puts there, and maps it to their own field control. What they
+were missing was the statement that `missing-claim` is a predicate match rather
+than a gesture, so the mapping is theirs to make and to bound.
+
+## Keeping it honest
+
+A test asserts the mapping covers every `missing-claim` predicate the shipped
+catalogue uses. The catalogue is the thing that changes; a question arriving on
+an unmapped predicate now fails a test, so the author extends the mapping or
+accepts prose deliberately, rather than an adopter discovering it from a
+shapeless card.

--- a/src/design-command.ts
+++ b/src/design-command.ts
@@ -137,6 +137,47 @@ const localKind = (qualified: string): string => {
   return hash === -1 ? qualified : qualified.slice(hash + 1)
 }
 
+/**
+ * The `missing-claim` predicates that name a CONCEPT FIELD, and the field
+ * each one is written through (#430).
+ *
+ * `missing-claim` matches a raw predicate, and a predicate is not an
+ * authoring gesture: `yarramate/attestation/adequacy` is written by adding an
+ * attestation, `yarramate/reference/refers-to` by adding a reference, and a
+ * profile may mint predicates this engine has never heard of. So the
+ * condition cannot map to one operation in general, which is why an adopter
+ * wiring it up got a card with no affordance and filed #430.
+ *
+ * It maps for these three, and only these three, because each is a named
+ * field on a concept that `update-concept` writes directly. They are Core's
+ * own, closed, and they are every `missing-claim` the shipped catalogue uses
+ * — `owner-missing`, `information-unowned`, `concept-undescribed` and
+ * `status-missing`. Anything else returns no skeleton, which is ADR 0110's
+ * rule holding: a wrong skeleton is never offered.
+ *
+ * This is the "one new mapping case" ADR 0110 anticipated, not a remedy DSL.
+ * The engine still takes no position on which predicates a HOST should render
+ * as editable; the trigger carries the predicate and the host decides. This
+ * is the CLI rendering its own affordance, the same as the other two cases.
+ */
+const CONCEPT_FIELD_PREDICATES: Record<
+  string,
+  { readonly name: string; readonly placeholder: string }
+> = {
+  'yarramate/ownership/owner': {
+    name: 'owner',
+    placeholder: '<owning-subject-id>',
+  },
+  'yarramate/concept/description': {
+    name: 'description',
+    placeholder: '<one line>',
+  },
+  'yarramate/lifecycle/status': {
+    name: 'status',
+    placeholder: '<planned|current|retired>',
+  },
+}
+
 const skeletonHeader = (
   documentAddress: string,
   op: string,
@@ -192,6 +233,16 @@ const renderSkeleton = (
       `        kind: ${kinds[0]}${alternatives}`,
       `        from: ${from}${swap}`,
       `        to: ${to}`,
+    ]
+  }
+  if (condition.condition === 'missing-claim' && step.subject !== undefined) {
+    const field = CONCEPT_FIELD_PREDICATES[condition.predicate]
+    if (field === undefined) return []
+    return [
+      ...skeletonHeader(documentAddress, 'update-concept'),
+      '      concept:',
+      `        id: ${step.subject.id.split('#').pop()}`,
+      `        ${field.name}: ${field.placeholder}`,
     ]
   }
   return []

--- a/test/missing-claim-skeleton.test.ts
+++ b/test/missing-claim-skeleton.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runCli } from '../src/cli.js'
+
+// #430, from an adopter who DECLINED to use `missing-claim` because of this.
+//
+// Their answer-shape mapping (the consumer half of ADR 0110) turns a trigger
+// into a one-click affordance and covered five conditions. `missing-claim`
+// mapped to nothing, so a question using it rendered as prose, and their pack
+// asserts no card degrades to prose across 42 questions. Rather than break
+// that guarantee they left ownership unelicited.
+//
+// The shipped catalogue had the same gap from the other side: four of its
+// questions use `missing-claim` and `design` printed no skeleton for any.
+
+let workspace: string
+
+const catalogueFor = (predicate: string) => `format: yarramate/question-catalogue/v1
+id: probe
+version: "1.0"
+profile: yarramate/core@0.1
+waves:
+  - id: only
+    name: Only
+questions:
+  - id: field-missing
+    wave: only
+    since: "1.0"
+    scope: subject
+    subjects:
+      kinds: [yarramate/core@0.1#applicationComponent]
+    trigger:
+      - condition: missing-claim
+        predicate: ${predicate}
+    question: What is missing on {subject.name}?
+    materiality: Probe.
+    authority: human
+    resolution: Fill it in.
+`
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'yarramate-missing-claim-'))
+  mkdirSync(join(workspace, 'architecture'))
+  writeFileSync(
+    join(workspace, 'architecture/main.yaml'),
+    `format: yarramate/v1
+id: main
+profile: yarramate/core@0.1
+concepts:
+  - id: ordering
+    kind: applicationComponent
+    name: Ordering
+relationships: []
+`,
+    'utf8',
+  )
+  writeFileSync(
+    join(workspace, 'workspace.yaml'),
+    `format: yarramate/workspace/v1
+id: fixture
+documents:
+  - architecture/main.yaml
+profiles: []
+adapterMappings: []
+projections: []
+`,
+    'utf8',
+  )
+})
+
+afterEach(() => rmSync(workspace, { recursive: true, force: true }))
+
+const designWith = (predicate: string) => {
+  writeFileSync(
+    join(workspace, 'cat.yaml'),
+    catalogueFor(predicate),
+    'utf8',
+  )
+  const result = runCli(
+    ['design', 'workspace.yaml', '--catalogue', 'cat.yaml'],
+    workspace,
+  )
+  expect(result.exitCode).toBe(0)
+  return result.stdout
+}
+
+describe('a missing-claim question offers the field it is missing', () => {
+  it('writes the owner through update-concept, naming the subject', () => {
+    const out = designWith('yarramate/ownership/owner')
+    expect(out).toContain('- op: update-concept')
+    expect(out).toContain('id: ordering')
+    expect(out).toContain('owner: <owning-subject-id>')
+  })
+
+  it('writes a description', () => {
+    expect(designWith('yarramate/concept/description')).toContain(
+      'description: <one line>',
+    )
+  })
+
+  it('offers the status vocabulary rather than a bare placeholder', () => {
+    // The three values are the whole answer, so printing `<one line>` here
+    // would send the reader to the schema for something the skeleton knows.
+    expect(designWith('yarramate/lifecycle/status')).toContain(
+      'status: <planned|current|retired>',
+    )
+  })
+
+  it('offers nothing for a predicate that is not a concept field', () => {
+    // ADR 0110's rule, and the reason this mapping is a table rather than a
+    // guess: an attestation predicate is written by adding an attestation,
+    // not by setting a field, so a skeleton here would be wrong. Silence is
+    // the correct output.
+    const out = designWith('yarramate/attestation/adequacy')
+    expect(out).not.toContain('Prefilled skeleton')
+  })
+
+  it('offers nothing for a predicate the engine has never heard of', () => {
+    const out = designWith('acme/delivery/sprint')
+    expect(out).not.toContain('Prefilled skeleton')
+  })
+})
+
+describe('the mapping keeps up with the catalogue', () => {
+  it('covers every missing-claim predicate the shipped catalogue uses', () => {
+    // The catalogue is the thing that changes. A question arriving on a
+    // predicate the mapping does not know should fail here, so the author
+    // extends the mapping or accepts prose deliberately, rather than an
+    // adopter discovering it from a shapeless card as in #430.
+    const used = [
+      ...readFileSync('catalogues/core-enrichment.yaml', 'utf8').matchAll(
+        /condition: missing-claim\s*\n\s*predicate: (\S+)/g,
+      ),
+    ].map((match) => match[1]!)
+    expect(used.length).toBeGreaterThan(0)
+    for (const predicate of [...new Set(used)]) {
+      expect(designWith(predicate), predicate).toContain('Prefilled skeleton')
+    }
+  })
+})


### PR DESCRIPTION
Closes #430.

## The report

An adopter **declined to use `missing-claim` because of this**. Their answer-shape mapping (the consumer half of ADR 0110) covers five conditions; this was the sixth, so a question using it rendered as prose. Their pack asserts no card degrades to prose across 42 questions, so they left ownership unelicited and the column workbook-filled.

The shipped catalogue had the same gap from the inside: **four** of its questions use `missing-claim` — `owner-missing`, `information-unowned`, `concept-undescribed`, `status-missing` — and `design` printed a skeleton for none of them.

## Why it mapped to nothing

`missing-claim` matches a **raw predicate**, and a predicate is not an authoring gesture. `yarramate/attestation/adequacy` is written by adding an attestation, `yarramate/reference/refers-to` by adding a reference, and a profile may mint predicates this engine has never heard of. So it cannot map onto one operation in general, and ADR 0110's rule is that a wrong skeleton is never offered.

## What changed

Three predicates map, because each names a concept field `update-concept` writes directly:

| Predicate | Field |
|---|---|
| `yarramate/ownership/owner` | `owner` |
| `yarramate/concept/description` | `description` |
| `yarramate/lifecycle/status` | `status`, offered as `<planned\|current\|retired>` |

Everything else prints nothing, exactly as before. This is the **"one new mapping case" ADR 0110 anticipated**, not the normalized remedy DSL it excluded: no second vocabulary, nothing added to the envelope, the trigger still travels verbatim.

Those three are every `missing-claim` the shipped catalogue uses.

## Their option 1 is declined, for their own reason

A `set-field` answer shape would make **the engine take a position on which predicates a host renders as editable**. That was their own stated hesitation and it is right. The trigger carries the predicate, and the host decides what control to draw and which predicates it will draw at all.

What they were missing was the statement, not the feature. `docs/INTERROGATION.md` now says it where a catalogue author meets it — and that file ships in the package as of 1.14.1, so it will actually reach them.

## Keeping it honest

A test asserts the mapping covers every `missing-claim` predicate in the shipped catalogue. The catalogue is what changes, so a question arriving on an unmapped predicate fails a test and the author extends the mapping or accepts prose deliberately, rather than an adopter discovering it from a shapeless card.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2023** across 117 files |
| Mutations | 4 killed; a no-op control survives, confirming the harness discriminates |

Verified end to end against the real CLI, including that an attestation predicate and an unknown profile predicate both print nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u