### PR TITLE
docs: no link a reader with the package cannot follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### No link a reader with the package cannot follow
+
+Nine markdown links in shipped documents pointed at `adr/` files that do not
+ship, seven in `CONSUMING-YARRAMATE.md` and two in `INTERROGATION.md`. They are
+now prose references, and `test/shipped-docs.test.ts` refuses a new one.
+
+Shipping the ADR closure instead would have been 26 more files out of 137, and
+each shipped file is a contract. The adopter who reported this class put the
+reason for prose better than the size argument does: **prose that says
+"recorded in ADR 0136" is honest, and a link that 404s is a promise the package
+cannot keep.** So the conversion is the fix rather than a workaround for one.
+
+This is the same defect the 1.14.1 guard was written for, one level down. That
+guard compared bare `docs/NAME.md` mentions and said nothing about links, so it
+missed nine instances of exactly what it existed to catch.
+
+
 ### The reference-slot question is settled, and the floor says so
 
 `docs/MODEL-FLOOR.md` closed two open questions rather than continuing to list

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -227,7 +227,7 @@ These subpaths are Workers/browser-safe: no Node built-ins, no `ws`, and no
 visual session server. The local `yarramate-visual` runtime remains the
 optional loopback conversation product and is not required for projection.
 `presentation.notation: 'archimate'` is still a rendering mode only
-([ADR 0087](adr/0087-archimate-notation-is-a-rendering-mode-not-a-vocabulary.md));
+(ADR 0087);
 the notation module is the rendering vocabulary for that mode; the element
 vocabulary and relationship table themselves are implemented in the core
 profile (ADR 0097).
@@ -262,14 +262,14 @@ const report = { workspace: id, ...evaluateCatalogue(catalogue, graph, profileCo
 
 The report carries `semantics`, the version of condition evaluation, which
 changes only when an existing question's answer can change for an unchanged
-model ([ADR 0106](adr/0106-a-report-says-which-engine-answered.md)). A consumer
+model (ADR 0106). A consumer
 that **persists** answers should store it beside them: equal means a flipped
 answer is about the model and belongs in front of a user, different means the
 engine moved and the right response is to re-baseline silently rather than
 reopen someone's queue.
 
 Every question also carries `trigger`, the catalogue conditions that opened
-it, verbatim ([ADR 0110](adr/0110-an-open-question-carries-its-answer-shape.md)).
+it, verbatim (ADR 0110).
 That is the question's machine-readable answer shape: a host building an
 answering affordance — a concept form with the kind preselected from
 `no-subject-of-kind`, a relationship editor with one endpoint fixed by
@@ -354,7 +354,7 @@ untouched and `ask --open` still reports the question, because the interview is
 not the editor's to settle.
 
 Pass `readOnly: true` to mount a viewer over the same surface — for a frozen
-published snapshot, say ([ADR 0117](adr/0117-a-mounted-editor-can-refuse-the-pen.md)).
+published snapshot, say (ADR 0117).
 The reviewer still selects, filters, navigates views and reads questions and
 properties (as values, not forms), but every affordance that stages or commits
 is absent rather than disabled: no Add subject, no palette or changes
@@ -365,7 +365,7 @@ with a store that refuses writes; the two defenses are independent.
 `mountEditorWith` takes the same flag as its trailing parameter.
 
 The returned handle can also point at the canvas
-([ADR 0118](adr/0118-the-host-can-point-at-the-canvas.md)):
+(ADR 0118):
 `select(subjectId)` selects a concept or relationship exactly as a canvas tap
 would, which also scopes the Open questions section to it;
 `openDraft({ kind })` opens the Add-subject dialog with the kind preselected
@@ -380,7 +380,7 @@ anything they lead to still stages through the changeset and commits through
 the same validated batch.
 
 The viewer also accepts per-subject marks
-([ADR 0119](adr/0119-the-viewer-accepts-the-hosts-marks.md)): pass
+(ADR 0119): pass
 `decorations: { [subjectId]: 'added' | 'removed' | 'changed' }` — concepts and
 relationships alike — and the canvas renders them as visual treatments (added
 an eucalyptus border, removed a quiet dashed one, changed ochre; a fault still
@@ -399,7 +399,7 @@ commits and saves layouts over that store. A changeset's model and view writes
 land together in one compare-and-swap batch; the caller therefore owns
 persistence. An asynchronous product fetches into a synchronous in-memory
 store before mounting and flushes writes itself, per
-[ADR 0100](adr/0100-sources-come-from-a-store-and-a-batch-lands-by-compare-and-swap.md).
+ADR 0100.
 
 The stylesheet ships beside the bundle and is not imported by it, so a host
 attaches it one of two ways. A bundler takes the `import` above; because that

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -191,7 +191,7 @@ calling `evaluateCatalogue` directly should compose first for the same reason.
 ## Waves open when the model has substance
 
 A wave may declare `opensWhen`, conditions that must all hold before it opens
-([ADR 0125](adr/0125-a-wave-opens-when-the-model-has-substance.md)):
+(ADR 0125):
 
 ```yaml
 waves:
@@ -254,7 +254,7 @@ is why this is a refusal rather than a finding, and it is the same invisible
 failure `YM914` refuses when a gate names a kind that resolves nowhere.
 
 A gate that wants "the model now has X" uses `has-subject-of-kind`
-([ADR 0134](adr/0134-a-wave-gate-asks-about-the-workspace-and-may-ask-positively.md)):
+(ADR 0134):
 
 ```yaml
 waves:

--- a/test/shipped-docs.test.ts
+++ b/test/shipped-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 
 // A shipped document must not point at one that stays in the repository.
 //
@@ -46,6 +47,33 @@ describe('the documentation an adopter receives is self-contained', () => {
       'A shipped document points at one that stays in the repository, so a ' +
         'reader who installed the package cannot follow it. Either add the ' +
         'target to `files` in package.json, or stop citing it by path.',
+    ).toEqual([])
+  })
+
+  it('makes no link a reader with the package cannot follow', () => {
+    // The hole in the two checks above, found by re-reading them after an
+    // adopter reported this class from the other side. They compare bare
+    // `docs/NAME.md` mentions; they say nothing about markdown LINKS, and
+    // nine `[ADR 0110](adr/....md)` links pointed at files that do not ship.
+    //
+    // The adopter's framing is the one worth keeping: prose that says
+    // "recorded in ADR 0136" is honest, and a link that 404s is a promise the
+    // package cannot keep. So a shipped document cites an unshipped one by
+    // NAME or not at all, never by href.
+    const dangling = shipped.flatMap((entry) => {
+      const links = [
+        ...readFileSync(entry, 'utf8').matchAll(/\]\((?!https?:|#|mailto:)([^)]+)\)/g),
+      ].map((match) => match[1]!)
+      return links
+        .map((href) => join(dirname(entry), href.split('#')[0]!))
+        .filter((target) => target.endsWith('.md') && !files.includes(target))
+        .map((target) => `${entry} -> ${target}`)
+    })
+    expect(
+      dangling,
+      'A shipped document links to a file the package does not contain, so a ' +
+        'reader who installed it follows the link to nothing. Cite it by name ' +
+        '("ADR 0136") instead, or add the target to `files` in package.json.',
     ).toEqual([])
   })
 


### PR DESCRIPTION
Nine markdown links in shipped documents pointed at `adr/` files that do not ship — seven in `CONSUMING-YARRAMATE.md`, two in `INTERROGATION.md`. A reader who installed the package followed them to nothing.

## This is the 1.14.1 defect one level down, inside the guard written for it

`test/shipped-docs.test.ts` shipped in 1.14.1 to stop exactly this. It compared bare `docs/NAME.md` mentions and **said nothing about markdown links**, so it missed nine instances of what it existed to catch.

Found by re-reading it after the adopter who first reported the packaging class mentioned the same thing from their side.

## Prose, not more files

Shipping the ADR closure would have been **26 files out of 137**, and each shipped file becomes a contract. The adopter's framing beats the file-count argument:

> Prose that says "recorded in ADR 0136" is honest, and a link that 404s is a promise the package cannot keep.

So the conversion is the fix, not a workaround for one. Every link was already `[ADR NNNN](adr/…)`, so each becomes `ADR NNNN` with no loss of information.

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2024** across 117 files |
| Mutation | restoring one link fails the new check |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u