### PR TITLE
feat: a vocabulary is closed by its scheme, not its count (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+### A vocabulary is closed by its scheme, not its count
+
+`no-linkage-exists`, the workspace-scope negative of `exists-linkage`: it fires
+while NO concept anywhere satisfies the linkage (#436, ADR 0138). Additive, and
+the interrogation semantics version does not move.
+
+An adopter measured `below-subject-count` on a live engagement within days of
+it shipping and found the count fails in **both** directions. Two throwaway
+values close a vocabulary question dishonestly, because a count cannot tell a
+surveyed estate of two from one plus a throwaway. And a truthful single-value
+estate can **never** close it, because "one is the whole scheme" was not
+recordable, so a correct model carried a permanently open question that only a
+human could clear: 2 of that engagement's 19 open questions.
+
+No value of `atLeast` fixes both, because the count is a proxy for the thing
+the question means. The rule it breaks is `MODEL-FLOOR.md`'s own: whatever the
+interrogation asks about must be recordable as an answer.
+
+The floor also names the answer's home, so this needed no new vocabulary. A
+classification axis is a `grouping` that aggregates its members, so a **scheme**
+aggregating its classes is the statement that these are the classes. Asking for
+that needed only the negative twin of `exists-linkage`, which was the one gap
+in workspace-scope linkage — the same shape `has-subject-of-kind` filled for
+`no-subject-of-kind` in #398.
+
+**`below-subject-count` is not deprecated.** "The model holds fewer than N of
+this kind" is still a legitimate ask, and the adopter's balance stands: two is
+the smallest number that cannot be reached by accident, and it caught real
+incidental vocabulary within days. What changed is which question it is the
+right tool for, and `docs/INTERROGATION.md` now says so beside it.
+
+The shipped catalogue is unaffected: it uses `below-subject-count` zero times,
+and its thirteen workspace `no-subject-of-kind` questions are layer-presence
+questions (#272), not vocabularies.
 ### Adopting a condition has a consumer-side half
 
 Two sections in `docs/INTERROGATION.md`, both earned by an adopter adopting

--- a/docs/INTERROGATION.md
+++ b/docs/INTERROGATION.md
@@ -36,7 +36,10 @@ questions. Each question binds:
   `atLeast` subjects of the given kinds exist, so a **vocabulary**
   question can ask for more than one term; `atLeast` must be at least 2,
   because 1 is `no-subject-of-kind` under a second name and `YM918`
-  refuses it; ADR 0135), `no-state-defined`,
+  refuses it; ADR 0135), `no-linkage-exists` (workspace: the negative of
+  `exists-linkage` — NO concept anywhere satisfies the linkage, which is how a
+  vocabulary question asks for its scheme rather than counting its members;
+  ADR 0138), `no-state-defined`,
   `missing-linkage` (no relationship of given kinds, in a given
   direction, whose counterpart is of a given kind — the linkage-depth
   primitive), `has-linkage` (the positive of `missing-linkage`;
@@ -229,7 +232,7 @@ product's wave rail had the same fault on the day the gate shipped.
 A gate is evaluated with **no subject**, so only a workspace-scope condition
 means anything in `opensWhen`: `has-any-subject`, `no-subject-of-kind`,
 `has-subject-of-kind`, `below-subject-count`, `no-state-defined`,
-`exists-linkage` and `unchallenged-evidence`. `exists-linkage` is a positive
+`exists-linkage`, `no-linkage-exists` and `unchallenged-evidence`. `exists-linkage` is a positive
 existence check, "some concept would satisfy `has-linkage`", which is easy to
 miss and often the one a gate wants.
 
@@ -423,6 +426,57 @@ every kind it matches.
 `missing-attestation` and `missing-claim` are not checked. They name no
 relationship, so there is no table to consult, and inventing one for them
 would be the second encoding this refusal refuses.
+
+## A vocabulary is closed by its scheme, not its count
+
+`below-subject-count` measures a population. **A vocabulary question is not
+asking about a population; it is asking whether anyone surveyed.** Those come
+apart in both directions, and an adopter measured both within days of adopting
+it (#436, ADR 0138):
+
+- **two throwaway values close it dishonestly.** Anyone who wants the question
+  gone adds a second value, and a count cannot tell a surveyed estate of two
+  from one plus a throwaway.
+- **a truthful single-value estate can never close it.** Saying "one is the
+  whole scheme" was not recordable, so a *correct* model carried a permanently
+  open question that only a human could clear.
+
+No value of `atLeast` fixes both, because the count is a proxy. The rule it
+breaks is `docs/MODEL-FLOOR.md`'s: **whatever the interrogation asks about must
+be recordable as an answer.**
+
+The floor also names the answer's home. A classification axis is a `grouping`
+that aggregates its members, so a **scheme** aggregating its classes IS the
+statement that these are the classes and this is the set. Ask for that:
+
+```yaml
+trigger:
+  - condition: no-linkage-exists
+    kinds: ["yarramate/core@0.1#aggregation"]
+    direction: outgoing
+    counterpartKinds: ["acme/consulting@1.0#sensitivity-class"]
+```
+
+| model state | count test | scheme test |
+|---|---|---|
+| nothing declared | open | open |
+| one class, authored incidentally | open | open |
+| two classes, both incidental | **closed** | open |
+| one class, scheme declared | **open** | closed |
+
+Both failures close at once, and neither by tuning a number: the closer is a
+declaration, which a tally cannot reach.
+
+**`below-subject-count` is not deprecated.** "The model holds fewer than N of
+this kind" remains a legitimate thing to ask, and the adopter's own balance is
+worth carrying: two is the smallest number that cannot be reached by accident,
+it caught real incidental vocabulary within days, and they would adopt it
+again. What changed is which question it is the right tool for.
+
+**Model the scheme as a plain `grouping` above classes that are a
+specialization**, not as one more member of the same kind. A scheme of the same
+kind as its members counts as one of them, which closes the count test by
+accident whenever someone models it correctly — the container counting itself.
 
 ## A predicate is not an authoring gesture
 

--- a/docs/adr/0138-a-vocabulary-is-closed-by-its-scheme-not-its-count.md
+++ b/docs/adr/0138-a-vocabulary-is-closed-by-its-scheme-not-its-count.md
@@ -1,6 +1,6 @@
 # A vocabulary is closed by its scheme, not its count
 
-Status: proposed
+Status: accepted
 
 From ApertureX (#436), field evidence on `below-subject-count` after adopting
 it across six vocabulary questions on a live engagement. The condition works:
@@ -161,11 +161,23 @@ authored on an unsurveyed vocabulary.
 semantics to solve a modelling gap, and dismissal is correctly human-only in
 their product.
 
-## Open questions for the maintainer
+## Settled by the maintainer
 
-1. Is the extra scheme subject a fair ask, given `MODEL-FLOOR.md` already says
-   this is how a classification axis should be expressed?
-2. `no-linkage-exists` as the name, matching `exists-linkage` negated.
-3. Whether the guidance change (vocabularies ask for the scheme) belongs in
-   `docs/INTERROGATION.md` beside `below-subject-count`, which would make it
-   the second thing that section says about a condition shipped one day ago.
+The extra scheme subject is a fair ask, `MODEL-FLOOR.md` already prescribing
+the form. The condition is `no-linkage-exists`. The guidance change goes in
+`docs/INTERROGATION.md` beside `below-subject-count`, which is the second thing
+that section says about a condition shipped a day earlier, and that is the
+honest record rather than an embarrassment to manage.
+
+## One thing building it taught
+
+The first fixture used a bare `grouping` for both the scheme and its classes,
+and the scheme then counted as one of its own members — so `below-subject-count`
+CLOSED on a correctly modelled single-class vocabulary, by accident, for the
+wrong reason. It looked like the design working and was the fixture lying.
+
+Modelled the way an adopter actually does it, with the classes as a profile
+specialization and the scheme a plain grouping above them, the row behaves as
+designed. A test that conflates the container with its contents will agree with
+whatever it is asked, which is the same shape of error as counting the
+container in the first place.

--- a/docs/adr/0138-a-vocabulary-is-closed-by-its-scheme-not-its-count.md
+++ b/docs/adr/0138-a-vocabulary-is-closed-by-its-scheme-not-its-count.md
@@ -1,0 +1,171 @@
+# A vocabulary is closed by its scheme, not its count
+
+Status: proposed
+
+From ApertureX (#436), field evidence on `below-subject-count` after adopting
+it across six vocabulary questions on a live engagement. The condition works:
+it caught two pieces of genuinely incidental vocabulary within days. The
+finding is that what it says is one step short of what the question means.
+
+## The two reports, which are one defect
+
+**The count is satisfied by exactly the behaviour it exists to prevent.**
+Anyone who wants the question gone adds a second value, and the trigger cannot
+tell a surveyed estate of two from a surveyed estate of one plus a throwaway.
+
+**When the truth is one, no agent can close it.** A single-plane estate is
+real; saying so is a dismissal, and dismissal is host-side and human-only. So
+a CORRECT model carries a permanently open question. Measured: 2 of 19 open
+questions on the reporting engagement, both against a model that is right.
+
+These look opposite and are the same defect. **A threshold cannot be both
+harder to reach dishonestly and easier to reach honestly**, because the count
+is a proxy: the question means "was this surveyed", and the count measures
+"how many exist". No value of `atLeast` closes the gap between them. The
+reporter named it exactly: *the count is the container, the survey is the
+answer, and counting the container does not reach it.*
+
+## The frame that decides it
+
+This is not a dismissal problem. `docs/MODEL-FLOOR.md` states the rule it
+breaks:
+
+> **Whatever the interrogation asks about must be recordable as an answer.**
+
+The question asks *"which sensitivity classes does this platform recognise?"*.
+For a single-class platform the complete answer is *"one, Confidential, and
+that is the whole scheme."* The model records that Confidential **exists**. It
+cannot record that the scheme is **complete**. Those are different facts and
+only the first is expressible, so the honest answer has nowhere to go.
+
+That reframe settles the fork the issue leaves open. A surveyed marker the
+condition consults is a second encoding of a fact the model should hold, which
+is the risk the reporter named against their own sketch. Letting an agent
+record a dismissal touches authority semantics. Neither is needed: **make the
+answer recordable, and an ordinary condition closes on it.**
+
+## The mechanism, in vocabulary that already exists
+
+`MODEL-FLOOR.md` already prescribes the form: a classification axis is **a
+`grouping` that aggregates its members**. A scheme subject aggregating its
+classes IS the statement "these are the classes, and this is the set". No new
+value type, no new claim, no floor decision.
+
+Verified legal against the ArchiMate table: a `grouping` may aggregate a
+`grouping`, so a scheme may aggregate classes that are themselves grouping
+specializations, which is how the reporting adopter models them.
+
+The vocabulary question then asks for the scheme rather than the tally:
+
+| model state | count test | scheme test |
+|---|---|---|
+| no classes | open | open |
+| one class, authored incidentally | open | open |
+| **two classes, both incidental** | **CLOSED** | **open** |
+| **one class, scheme declared** | **open** | **CLOSED** |
+| two classes, scheme declared | closed | closed |
+
+Both reported problems close at once, and neither by tuning a number. The
+throwaway-second-value escape disappears because the closer is a declaration,
+not a count.
+
+## Validated before proposing, with no engine change
+
+The truth table above is not reasoning. `exists-linkage` is the positive of
+the condition this proposes, and it already ships, so the four states can be
+probed today. Against a probe catalogue triggering on
+`exists-linkage(aggregation -> grouping)`:
+
+| model state | `exists-linkage` |
+|---|---|
+| no classes | quiet |
+| one class, authored incidentally | quiet |
+| two classes, both incidental | quiet |
+| one class + scheme declared | **fires** |
+
+It fires in exactly one of the four, and it is the one where the vocabulary
+question should close. So the negation is correct by construction, and the
+proposed condition is `exists-linkage` inverted rather than new behaviour that
+has to be argued for.
+
+## What is missing: one condition
+
+Workspace-scope linkage has only the positive.
+
+| condition | scope |
+|---|---|
+| `exists-linkage` | workspace |
+| `has-linkage` | subject |
+| `missing-linkage` | subject |
+
+A question is open while its trigger holds, so asking "no scheme aggregates
+any class" needs the **negative twin of `exists-linkage`**, which does not
+exist. This is the same gap `has-subject-of-kind` filled for
+`no-subject-of-kind` in #398, one family over.
+
+```yaml
+trigger:
+  - condition: no-linkage-exists
+    kinds: ["yarramate/core@0.1#aggregation"]
+    direction: outgoing
+    counterpartKinds: ["aperturex/consulting@1.0#sensitivity-class"]
+```
+
+Workspace scope, so it is legal in a wave gate. Same shape as `exists-linkage`
+and the same evaluator, negated.
+
+## What this does NOT do to `below-subject-count`
+
+It does not deprecate it. "The model holds fewer than N of this kind" remains
+a legitimate thing to ask, and the adopter's balance note is worth carrying:
+two remains the smallest number that cannot be reached by accident, the
+condition caught real incidental vocabulary within days, and they would adopt
+it again.
+
+What changes is the guidance. `below-subject-count` measures a population.
+**A vocabulary question is not asking about a population, it is asking whether
+someone surveyed**, and the scheme is where that answer lives.
+
+## Cost, stated plainly
+
+**Adopters author one scheme subject per vocabulary.** Six for the reporting
+adopter. That is more model, and it is the honest more: the scheme is a real
+thing with a name that was previously implicit in a set of loose subjects.
+
+**The first answer gets longer.** Closing a vocabulary from empty now means
+authoring a scheme and a member rather than a member alone. This is the
+sharpest objection to this design and it should be weighed rather than waved
+past.
+
+**The shipped catalogue pays nothing.** `core-enrichment` uses
+`below-subject-count` zero times, and its thirteen workspace
+`no-subject-of-kind` questions are layer-presence questions (#272, ADR 0120),
+not vocabularies: they ask whether a layer exists at all, where one instance
+genuinely is the answer. The reporting adopter drew the same distinction
+unprompted about their own interfaces question. So nothing migrates here, and
+this is additive for adopters.
+
+## Alternatives considered
+
+**Count AND no-scheme, as a two-condition trigger.** Expressible today once
+the new condition exists, and it fixes the honest single-value case while
+leaving the throwaway escape open, because two incidental values still close
+it. Cheaper migration, half the fix.
+
+**A `surveyed` marker the condition consults.** The reporter's first sketch
+and their own stated concern: a second encoding of a fact the model should
+already hold, with the added failure that nothing would stop the marker being
+authored on an unsurveyed vocabulary.
+
+**Letting an agent record a dismissal.** Their second sketch. Moves authority
+semantics to solve a modelling gap, and dismissal is correctly human-only in
+their product.
+
+## Open questions for the maintainer
+
+1. Is the extra scheme subject a fair ask, given `MODEL-FLOOR.md` already says
+   this is how a classification axis should be expressed?
+2. `no-linkage-exists` as the name, matching `exists-linkage` negated.
+3. Whether the guidance change (vocabularies ask for the scheme) belongs in
+   `docs/INTERROGATION.md` beside `below-subject-count`, which would make it
+   the second thing that section says about a condition shipped one day ago.

--- a/schema/yarramate-design-step.schema.json
+++ b/schema/yarramate-design-step.schema.json
@@ -481,6 +481,51 @@
           "additionalProperties": false,
           "required": [
             "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-linkage-exists"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
             "kinds"
           ],
           "properties": {

--- a/schema/yarramate-interrogation-report.schema.json
+++ b/schema/yarramate-interrogation-report.schema.json
@@ -498,6 +498,51 @@
           "additionalProperties": false,
           "required": [
             "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-linkage-exists"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
             "kinds"
           ],
           "properties": {

--- a/schema/yarramate-question-catalogue.schema.json
+++ b/schema/yarramate-question-catalogue.schema.json
@@ -457,6 +457,51 @@
           "additionalProperties": false,
           "required": [
             "condition",
+            "kinds",
+            "direction",
+            "counterpartKinds"
+          ],
+          "properties": {
+            "condition": {
+              "const": "no-linkage-exists"
+            },
+            "kinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "direction": {
+              "enum": [
+                "outgoing",
+                "incoming",
+                "either"
+              ]
+            },
+            "counterpartKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/qualifiedKind"
+              }
+            },
+            "kindMatching": {
+              "enum": [
+                "exact",
+                "descendants"
+              ],
+              "default": "descendants"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition",
             "kinds"
           ],
           "properties": {

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -153,6 +153,36 @@ export type CatalogueCondition =
       readonly kindMatching?: 'exact' | 'descendants'
     }
   | {
+      /**
+       * The negative twin of `exists-linkage`, workspace-scope like it
+       * (#436, ADR 0138). Fires while NO concept in the workspace satisfies
+       * the linkage, so a question can ask "nothing anywhere links this way".
+       *
+       * It exists because a **vocabulary question** was asking the wrong
+       * thing. `below-subject-count` measures a population, and a vocabulary
+       * question means "did anyone survey this" — a proxy that fails in both
+       * directions, measured on a live engagement: two throwaway values close
+       * it dishonestly, while a truthful single-value estate can never close
+       * it at all.
+       *
+       * `MODEL-FLOOR.md` prescribes the answer's home: a classification axis
+       * is a `grouping` that aggregates its members, so a scheme aggregating
+       * its classes IS the statement that these are the classes. Asking "no
+       * scheme aggregates any class" needs this condition; asking how many
+       * classes exist does not reach it.
+       *
+       * Deliberately NOT `!exists-linkage` in the evaluator, for the reason
+       * `has-subject-of-kind` is not `!no-subject-of-kind`: written as its own
+       * check, an empty workspace falls out right rather than by double
+       * negative.
+       */
+      readonly condition: 'no-linkage-exists'
+      readonly kinds: readonly string[]
+      readonly direction: 'incoming' | 'outgoing' | 'either'
+      readonly counterpartKinds: readonly string[]
+      readonly kindMatching?: 'exact' | 'descendants'
+    }
+  | {
       readonly condition: 'missing-constraint'
       readonly kinds: readonly string[]
       readonly kindMatching?: 'exact' | 'descendants'
@@ -548,6 +578,7 @@ const namedKinds = (question: CatalogueQuestion): readonly string[] => {
       case 'missing-linkage':
       case 'has-linkage':
       case 'exists-linkage':
+      case 'no-linkage-exists':
         kinds.push(...condition.kinds, ...condition.counterpartKinds)
         break
       default:
@@ -648,6 +679,7 @@ const CONDITION_SCOPE: Record<
   'below-subject-count': 'workspace',
   'no-state-defined': 'workspace',
   'exists-linkage': 'workspace',
+  'no-linkage-exists': 'workspace',
   'missing-claim': 'subject',
   'missing-relationship': 'subject',
   isolated: 'subject',
@@ -858,6 +890,13 @@ const conditionHolds = (
       )
     case 'exists-linkage':
       return [...index.concepts].some((id) =>
+        linkageHits(index, condition, id, profileContext),
+      )
+    case 'no-linkage-exists':
+      // Its own check rather than `!exists-linkage`, so an empty workspace
+      // falls out right: no concepts means no linkage, which is exactly the
+      // model a vocabulary question is loudest about.
+      return ![...index.concepts].some((id) =>
         linkageHits(index, condition, id, profileContext),
       )
     case 'missing-constraint': {

--- a/test/interrogation-semantics.test.ts
+++ b/test/interrogation-semantics.test.ts
@@ -23,7 +23,7 @@ import {
 // existing question answers.
 
 const EXPECTED_SEMANTICS = '1'
-const EXPECTED_FINGERPRINT = '74ee871f5377fedc'
+const EXPECTED_FINGERPRINT = '1ef7dc086fdde597'
 
 const profile = 'yarramate/core@0.1'
 
@@ -133,6 +133,9 @@ const CONDITION_PROBES: Record<
   // Never fires here, deliberately: no memberships are passed, and "absent
   // memberships stay quiet" is itself a semantic worth pinning (ADR 0131).
   'fills-pattern-slot': ['      - condition: fills-pattern-slot'],
+  // Fires: nothing in the fixture aggregates anything, which is the state a
+  // vocabulary question is loudest about.
+  'no-linkage-exists': ['      - condition: no-linkage-exists', `        kinds: ["${profile}#aggregation"]`, '        direction: outgoing', `        counterpartKinds: ["${profile}#grouping"]`],
 }
 
 const conditionProbes = Object.entries(CONDITION_PROBES) as readonly (readonly [

--- a/test/no-linkage-exists.test.ts
+++ b/test/no-linkage-exists.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  evaluateCatalogue,
+  loadQuestionCatalogue,
+} from '../src/index.js'
+
+// `no-linkage-exists` (#436, ADR 0138): the workspace-scope negative of
+// `exists-linkage`, so a vocabulary question can ask for its SCHEME instead
+// of counting its members.
+//
+// The reported defect, from live use of `below-subject-count`: the count is a
+// proxy that fails in both directions. Two throwaway values close the question
+// dishonestly, and a truthful single-value estate can never close it at all,
+// because saying "one is the whole scheme" was not recordable. That is a
+// MODEL-FLOOR violation — whatever the interrogation asks about must be
+// recordable as an answer — and the floor already names the answer's home: a
+// classification axis is a grouping that aggregates its members.
+
+// Modelled the way the reporting adopter does: the CLASSES are a profile
+// specialization of `grouping`, and the SCHEME is a plain grouping above
+// them. Using bare groupings for both would let the scheme count as one of
+// its own members, which quietly satisfies the count test by doing the right
+// thing and hides the very row this file exists to pin.
+const workspaceOf = (concepts: string, relationships = ' []') => {
+  const result = compileWorkspaceWithProfileContext([
+    {
+      path: 'profile.yaml',
+      source: `format: yarramate/profile/v1
+id: acme/consulting
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: sensitivity-class
+    name: Sensitivity class
+    parent: yarramate/core@0.1#grouping
+relationshipKinds: []
+`,
+    },
+    {
+      path: 'architecture/main.yaml',
+      source: `format: yarramate/v1
+id: main
+profile: acme/consulting@1.0
+concepts:${concepts}
+relationships:${relationships}
+`,
+    },
+  ])
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics))
+  return result
+}
+
+const CLASS = (id: string) => `
+  - id: ${id}
+    kind: sensitivity-class
+    name: ${id}`
+
+const NONE = workspaceOf(' []')
+const ONE_INCIDENTAL = workspaceOf(CLASS('confidential'))
+const TWO_INCIDENTAL = workspaceOf(CLASS('confidential') + CLASS('public'))
+const ONE_WITH_SCHEME = workspaceOf(
+  `
+  - id: scheme
+    kind: grouping
+    name: Sensitivity scheme` + CLASS('confidential'),
+  `
+  - id: scheme-aggregates-confidential
+    kind: aggregation
+    from: scheme
+    to: confidential`,
+)
+
+const catalogueSource = (trigger: string) => `format: yarramate/question-catalogue/v1
+id: fixture
+version: "1.0"
+profile: acme/consulting@1.0
+waves:
+  - id: vocabulary
+    name: Vocabulary
+questions:
+  - id: scheme-undeclared
+    wave: vocabulary
+    since: "1.0"
+    scope: workspace
+    trigger:
+${trigger}
+    question: Which sensitivity classes does this platform recognise?
+    materiality: A vocabulary nobody surveyed is not a vocabulary.
+    authority: human
+    resolution: Declare the scheme and aggregate the classes it recognises.
+`
+
+const load = (trigger: string) =>
+  loadQuestionCatalogue({
+    path: 'catalogues/fixture.yaml',
+    source: catalogueSource(trigger),
+  })
+
+const isOpen = (trigger: string, compiled: typeof NONE): boolean => {
+  const loaded = load(trigger)
+  if (!loaded.ok) throw new Error(JSON.stringify(loaded.diagnostics))
+  return evaluateCatalogue(
+    loaded.catalogue,
+    compiled.graph,
+    compiled.profileContext,
+  )
+    .waves.flatMap(({ questions }) => questions)
+    .find(({ id }) => id.endsWith('scheme-undeclared'))!.open
+}
+
+const SCHEME_TEST = `      - condition: no-linkage-exists
+        kinds:
+          - yarramate/core@0.1#aggregation
+        direction: outgoing
+        counterpartKinds:
+          - acme/consulting@1.0#sensitivity-class
+`
+
+const COUNT_TEST = `      - condition: below-subject-count
+        kinds:
+          - acme/consulting@1.0#sensitivity-class
+        atLeast: 2
+`
+
+// The whole design in one table. Both reported problems are the rows where
+// the two tests disagree, and the scheme test is right in both.
+describe('a vocabulary is closed by its scheme, not its count', () => {
+  it('is open when nothing is declared at all', () => {
+    expect(isOpen(SCHEME_TEST, NONE)).toBe(true)
+  })
+
+  it('is open for one incidental class, as the count test also is', () => {
+    expect(isOpen(SCHEME_TEST, ONE_INCIDENTAL)).toBe(true)
+    expect(isOpen(COUNT_TEST, ONE_INCIDENTAL)).toBe(true)
+  })
+
+  it('STAYS OPEN for two incidental classes, where the count test closes', () => {
+    // Reported problem 1: the count is satisfied by exactly the behaviour it
+    // exists to prevent, because anyone wanting the question gone adds a
+    // second value. The closer here is a declaration, so a tally cannot reach
+    // it.
+    expect(isOpen(COUNT_TEST, TWO_INCIDENTAL)).toBe(false)
+    expect(isOpen(SCHEME_TEST, TWO_INCIDENTAL)).toBe(true)
+  })
+
+  it('CLOSES for one class with a scheme, where the count test cannot', () => {
+    // Reported problem 2, and the operational half: a truthful single-value
+    // estate had no way to say so, so a correct model carried a permanently
+    // open question that only a human could clear. Now an agent can author
+    // the answer.
+    expect(isOpen(COUNT_TEST, ONE_WITH_SCHEME)).toBe(true)
+    expect(isOpen(SCHEME_TEST, ONE_WITH_SCHEME)).toBe(false)
+  })
+})
+
+describe('it is the negative of exists-linkage, and behaves like one', () => {
+  const EXISTS = SCHEME_TEST.replace('no-linkage-exists', 'exists-linkage')
+
+  it('answers the opposite of exists-linkage in every state', () => {
+    for (const [name, model] of [
+      ['none', NONE],
+      ['one incidental', ONE_INCIDENTAL],
+      ['two incidental', TWO_INCIDENTAL],
+      ['one with scheme', ONE_WITH_SCHEME],
+    ] as const) {
+      expect(isOpen(SCHEME_TEST, model), name).toBe(!isOpen(EXISTS, model))
+    }
+  })
+
+  it('honours direction, and the asymmetry is the point', () => {
+    // The scheme aggregates the class, so the linkage runs scheme -> class.
+    // Asked OUTGOING with a `sensitivity-class` counterpart it is found, and
+    // the question closes. Asked INCOMING it looks for something aggregated
+    // BY a sensitivity-class, and the scheme is a plain grouping, so nothing
+    // matches and the question stays open.
+    //
+    // Worth pinning rather than assuming: a catalogue author who writes the
+    // direction the wrong way round gets a question that never closes, not
+    // one that closes wrongly, which is the safer of the two failures and is
+    // the direction `missing-linkage` also fails in.
+    const incoming = SCHEME_TEST.replace(
+      'direction: outgoing',
+      'direction: incoming',
+    )
+    expect(isOpen(incoming, ONE_WITH_SCHEME)).toBe(true)
+    expect(isOpen(SCHEME_TEST, ONE_WITH_SCHEME)).toBe(false)
+  })
+
+  it('honours counterpart kinds', () => {
+    const wrongCounterpart = SCHEME_TEST.replace(
+      '          - acme/consulting@1.0#sensitivity-class\n',
+      '          - yarramate/core@0.1#dataObject\n',
+    )
+    expect(isOpen(wrongCounterpart, ONE_WITH_SCHEME)).toBe(true)
+  })
+})
+
+describe('it is workspace scope, so it may gate a wave', () => {
+  it('is legal in opensWhen', () => {
+    const source = catalogueSource(SCHEME_TEST).replace(
+      '    name: Vocabulary\n',
+      `    name: Vocabulary
+    opensWhen:
+${SCHEME_TEST}`,
+    )
+    expect(
+      loadQuestionCatalogue({ path: 'catalogues/fixture.yaml', source }).ok,
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #436.

## The two reports are one defect

An adopter measured `below-subject-count` on a live engagement days after it shipped. The count fails in **both** directions:

- **two throwaway values close it dishonestly** — a count cannot tell a surveyed estate of two from one plus a throwaway;
- **a truthful single-value estate can never close it** — "one is the whole scheme" was not recordable, so a *correct* model carried a permanently open question only a human could clear. 2 of that engagement's 19 open questions.

No value of `atLeast` fixes both, because the count is a proxy: the question means *was this surveyed*, the count measures *how many exist*.

## The frame decides it

`MODEL-FLOOR.md`'s own rule: **whatever the interrogation asks about must be recordable as an answer.** That rules out both shapes the issue sketched — a surveyed marker is a second encoding, an agent-recorded dismissal moves authority semantics to solve a modelling gap.

The floor also names the answer's home, so **no new vocabulary was needed**: a classification axis is a `grouping` that aggregates its members, so a scheme aggregating its classes *is* the statement. Verified legal: `grouping --aggregation--> grouping` checks clean.

| model state | count test | scheme test |
|---|---|---|
| nothing declared | open | open |
| one class, incidental | open | open |
| two classes, both incidental | **closed** | open |
| one class, scheme declared | **open** | closed |

## Validated before building

`exists-linkage` is this condition's positive and already shipped, so the truth table was probed with **zero engine changes**: it fires in exactly one of four states, the one where the question should close. The negation is correct by construction.

## What building it taught

The first fixture used a bare `grouping` for both scheme and classes, so **the scheme counted as one of its own members** and `below-subject-count` closed on a correctly modelled single-class vocabulary by accident. It looked like the design working and was the fixture lying. Recorded in the ADR: a test that conflates the container with its contents agrees with whatever it is asked, which is the same error as counting the container.

## Scope

`below-subject-count` is **not deprecated** — the guidance changed, and the adopter's balance is carried: two is the smallest number unreachable by accident and it caught real incidental vocabulary within days. The shipped catalogue is unaffected: zero uses, and its thirteen workspace questions are layer-presence, not vocabularies.

| | |
|---|---|
| Clean-slate verify | **real exit code 0** |
| Tests | **2032** across 118 files |
| Mutations | 2 killed |
| Semantics version | unchanged, verified by reproducing the prior fingerprint |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u