### PR TITLE
fix(visual): an edge across a nesting boundary is not laid out (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+### An edge across a nesting boundary no longer collapses the canvas
+
+Field-reported by an adopter on a live engagement, where a 66-subject project
+drew two shapes and a stack of superimposed labels (#439, ADR 0139).
+
+Composition maps onto cytoscape's compound `parent`, so a pair that **also**
+carries any other relationship produces an edge from a container to its own
+child, which ELK cannot lay out. The pair rendered and **every unrelated node
+lost its geometry**. Measured on a five-concept model:
+
+| model | painted | drawn box |
+|---|---|---|
+| composition + realization on the pair | 543 | 124 x 64 |
+| the same, realization removed | **10,612** | **832 x 452** |
+| composition + **serving** on the pair | 543 | 124 x 64 |
+
+One edge, a twentyfold difference. The third row is why the fix is keyed to
+nesting rather than to relationship kinds: swapping `serving` for `realization`
+reproduces byte-identically, so **anything drawn between an ancestor and its
+descendant** does it.
+
+Such an edge is now withheld from the **layout**, never from the graph:
+cytoscape draws it between its endpoints wherever they land, so the
+relationship stays on the canvas and the nesting stays too. Leaving the pair
+unnested instead - which is what `resolveNestingParents` does for the two
+nesting anomalies it already knows about - would have thrown away a correct
+nesting to work around a layout limitation.
+
+**This reaches ordinary models.** Both edges are elicited by catalogue
+questions doing their jobs, "which application composes this flow?" and "which
+application implements this?", and the model compiles clean, so the first sign
+was the canvas. The adopter's field model had the pair three times over from
+normal consulting work. This repository's own 358-subject self-model renders
+only because it happens never to pair composition with another edge.
+
+
 ### A vocabulary is closed by its scheme, not its count
 
 `no-linkage-exists`, the workspace-scope negative of `exists-linkage`: it fires

--- a/docs/adr/0139-an-edge-across-a-nesting-boundary-is-not-laid-out.md
+++ b/docs/adr/0139-an-edge-across-a-nesting-boundary-is-not-laid-out.md
@@ -1,0 +1,85 @@
+# An edge across a nesting boundary is not laid out
+
+Status: accepted
+
+From ApertureX (#439), field-reported on a live consulting engagement: the
+canvas drew two shapes and a stack of superimposed labels for a 66-subject
+project. Bisected by the adopter to a four-edge minimal case, reproduced and
+generalised here.
+
+## The defect
+
+Composition maps 1:1 onto cytoscape's compound `parent` field (ADR 0004): the
+container is the relationship's `from`, the nested child its `to`. So a pair
+that **also** carries any other relationship produces an edge from a container
+to its own child, and ELK cannot lay that out. The pair renders; **every
+unrelated node loses its geometry** and stacks at coincident coordinates with
+no shape. `Fit` then zooms IN, because only the surviving fragment
+contributes to the drawn bounding box.
+
+Measured on the five-concept minimal model, 1600x1000 viewport, painted-alpha
+samples at stride 4 over the top canvas layer:
+
+| model | painted | drawn box |
+|---|---|---|
+| composition + realization on the pair | 543 | 124 x 64 |
+| the same, realization removed | **10,612** | **832 x 452** |
+| composition + **serving** on the pair | 543 | 124 x 64 |
+
+**One edge, a twentyfold difference.**
+
+## It is about nesting, not about realization
+
+The third row is why. The field report was composition + realization;
+substituting `serving` reproduces **byte-identically**. Anything drawn between
+an ancestor and its descendant does it, so a fix keyed to relationship kinds
+would have been keyed to the wrong thing.
+
+## Why it reaches real models
+
+Both edges are elicited by catalogue questions doing their jobs: "which
+application composes this flow?" and "which application implements this?". A
+consultant answering both correctly for one interface produces the pair, and
+the adopter's field model had it three times over from ordinary work. **The
+model compiles clean** - the pair is legal, and ADR 0004's rule only forbids
+composition and aggregation over one ordered pair - so the first sign anyone
+gets is the canvas losing every bystander.
+
+This repository's own 358-subject self-model renders only because it happens
+never to pair composition with another edge.
+
+## Decision
+
+An edge whose ends are nested one inside the other is **withheld from the
+layout, never from the graph**. cytoscape draws an edge between its endpoints
+wherever they land, so the relationship stays on the canvas and the nesting
+stays too.
+
+That is the point of this shape. `resolveNestingParents` already handles two
+nesting anomalies - two compositions naming one `to`, and a composition cycle
+- by leaving the affected subjects **unnested**, so the conflicting claims stay
+visible. Doing that here would have been consistent and wrong: those two
+anomalies are modelling mistakes, and this pair is legitimate. Throwing away a
+correct nesting to work around a layout limitation would make the picture
+worse to make the layout easier.
+
+## The rule lives in its own module
+
+`spansNesting` is in `nesting-span.ts` rather than inside `graph-canvas.tsx`,
+following `subject-filter.ts`: the canvas is type-checked with JSX and a test
+that imports it is not, so a pure rule lives where a test can reach it. It
+walks the parent chain in both directions, because a model may declare the
+edge either way and ELK is handed the same degenerate pair regardless.
+
+The walk is bounded by a seen-set. A composition cycle should be unreachable,
+since `resolveNestingParents` refuses to nest one, but the cost of being wrong
+there is a frozen canvas rather than a bad picture.
+
+## Not fixed here
+
+The edge is withheld from layout, so ELK does not route it and cytoscape draws
+it between endpoints that may sit one inside the other. For a container and
+its own child that is a short stub inside the container box. It is honest and
+it is not pretty; a container-to-child relationship may deserve its own
+rendering one day. This ADR buys back every bystander node, which is the part
+that made the canvas unusable.

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import cytoscape from 'cytoscape'
 import type { Core, CollectionReturnValue, ElementDefinition, NodeCollection, NodeSingular } from 'cytoscape'
 import elk from 'cytoscape-elk'
+import { spansNesting } from './nesting-span.js'
 import type {
   CanvasGraph,
   CanvasNode,
@@ -1053,7 +1054,53 @@ function runLayout(
   eles: Core | CollectionReturnValue,
   direction: LayoutDirection,
 ): void {
-  eles.layout(buildLayoutConfig(direction)).run()
+  const collection = 'elements' in eles ? eles.elements() : eles
+  // Withhold ancestor-descendant edges from ELK; see `nestedPairEdges`.
+  // `.difference` returns a collection, so the layout still receives every
+  // node and every ordinary edge - only the degenerate ones are absent, and
+  // they are still drawn between the endpoints the layout places.
+  const degenerate = nestedPairEdges(collection)
+  const forLayout = degenerate.empty()
+    ? collection
+    : collection.difference(degenerate)
+  forLayout.layout(buildLayoutConfig(direction)).run()
+}
+
+/**
+ * Edges whose two ends are nested one inside the other (#439).
+ *
+ * Composition maps onto cytoscape's compound `parent`, so a pair that also
+ * carries any OTHER relationship produces an edge from a container to its own
+ * child. ELK cannot lay that out: measured on a five-concept model, the
+ * container and its child render and **every unrelated node loses its
+ * geometry** - 543 painted samples in a 124x64 box against 10,612 in 832x452
+ * for the same model with the second edge removed. Nothing warns, because the
+ * model is legal and compiles clean.
+ *
+ * It is not about which kind the second edge is. `realization` was the
+ * field report; `serving` on the same pair reproduces byte-identically.
+ * Anything drawn between an ancestor and its descendant does it.
+ *
+ * These edges are withheld from the LAYOUT only, never from the graph.
+ * cytoscape draws an edge between its endpoints wherever they land, so the
+ * relationship stays on the canvas and the nesting stays too - which is the
+ * point, since both claims are legitimate and the alternative was to throw
+ * the nesting away like the anomalies `resolveNestingParents` handles.
+ */
+const nestedPairEdges = (
+  collection: CollectionReturnValue,
+): CollectionReturnValue => {
+  const parentOf = new Map<string, string>()
+  collection.nodes().forEach((node) => {
+    const parent = node.parent()
+    if (parent.length > 0) parentOf.set(node.id(), parent.first().id())
+  })
+  if (parentOf.size === 0) return collection.edges().filter(() => false)
+  return collection
+    .edges()
+    .filter((edge) =>
+      spansNesting(edge.source().id(), edge.target().id(), parentOf),
+    )
 }
 
 

--- a/src/visual-app/nesting-span.ts
+++ b/src/visual-app/nesting-span.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether an edge's two ends are nested one inside the other (#439, ADR 0139).
+ *
+ * Composition maps onto cytoscape's compound `parent`, so a pair that also
+ * carries any OTHER relationship produces an edge from a container to its own
+ * child. ELK cannot lay that out: measured on a five-concept model, the
+ * container and its child render and every unrelated node loses its geometry.
+ *
+ * Its own module rather than a helper inside `graph-canvas.tsx`, following
+ * `subject-filter.ts`: the canvas is type-checked with JSX and a test that
+ * imports it is not, so pure rules live where a test can reach them.
+ */
+export function spansNesting(
+  from: string,
+  to: string,
+  parentOf: ReadonlyMap<string, string>,
+): boolean {
+  const climbs = (start: string, target: string): boolean => {
+    // `resolveNestingParents` already refuses to nest a composition cycle, so
+    // a cycle should be unreachable here. Guarded anyway: the cost of being
+    // wrong is a frozen canvas rather than a bad picture.
+    const seen = new Set<string>()
+    let at = parentOf.get(start)
+    while (at !== undefined && !seen.has(at)) {
+      if (at === target) return true
+      seen.add(at)
+      at = parentOf.get(at)
+    }
+    return false
+  }
+  return climbs(from, to) || climbs(to, from)
+}

--- a/test/nested-pair-edges.test.ts
+++ b/test/nested-pair-edges.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { spansNesting } from '../src/visual-app/nesting-span.js'
+
+// #439, field-reported by an adopter and reproduced here from a five-concept
+// model. Composition maps onto cytoscape's compound `parent`, so a pair that
+// also carries ANY other relationship produces an edge from a container to
+// its own child. ELK cannot lay that out: the container and its child render
+// and every unrelated node loses its geometry.
+//
+// Measured on the minimal case, 1600x1000 viewport, painted-alpha samples at
+// stride 4 over the top canvas layer:
+//
+//   composition + realization   543 painted, 124x64   <- collapse
+//   composition alone        10,612 painted, 832x452  <- healthy
+//   composition + serving       543 painted, 124x64   <- identical collapse
+//
+// The third line is why this is about NESTING and not about realization: any
+// edge between an ancestor and its descendant does it.
+
+const parents = (...pairs: readonly (readonly [string, string])[]) =>
+  new Map(pairs.map(([child, parent]) => [child, parent]))
+
+describe('an edge that spans a nesting boundary', () => {
+  const nested = parents(['orders-api', 'orders-app'])
+
+  it('is found when it runs from container to child', () => {
+    expect(spansNesting('orders-app', 'orders-api', nested)).toBe(true)
+  })
+
+  it('is found when it runs from child to container', () => {
+    // Direction is irrelevant: ELK is handed the same degenerate pair either
+    // way, and a model may legitimately declare the edge in either direction.
+    expect(spansNesting('orders-api', 'orders-app', nested)).toBe(true)
+  })
+
+  it('is found across more than one level', () => {
+    const deep = parents(
+      ['endpoint', 'orders-api'],
+      ['orders-api', 'orders-app'],
+    )
+    expect(spansNesting('orders-app', 'endpoint', deep)).toBe(true)
+  })
+})
+
+describe('an ordinary edge is left alone', () => {
+  const nested = parents(
+    ['orders-api', 'orders-app'],
+    ['billing-api', 'billing-app'],
+  )
+
+  it('between two unrelated top-level subjects', () => {
+    expect(spansNesting('billing-app', 'customers', nested)).toBe(false)
+  })
+
+  it('between siblings under different containers', () => {
+    // The case the fix must not over-reach into: two nested subjects with an
+    // edge between them are ordinary, and withholding it from the layout
+    // would lose real routing.
+    expect(spansNesting('orders-api', 'billing-api', nested)).toBe(false)
+  })
+
+  it('between a container and someone else"s child', () => {
+    expect(spansNesting('orders-app', 'billing-api', nested)).toBe(false)
+  })
+
+  it('when nothing is nested at all', () => {
+    expect(spansNesting('a', 'b', new Map())).toBe(false)
+  })
+})
+
+describe('a cycle in the parent chain terminates', () => {
+  it('does not hang, and reports no spanning', () => {
+    // `resolveNestingParents` already refuses to nest a composition cycle, so
+    // this should be unreachable. It is guarded anyway because the cost of
+    // being wrong is a frozen canvas rather than a bad picture.
+    const cyclic = parents(['a', 'b'], ['b', 'a'])
+    expect(spansNesting('a', 'c', cyclic)).toBe(false)
+  })
+
+  it('still reports a real ancestor inside a cycle', () => {
+    const cyclic = parents(['a', 'b'], ['b', 'a'])
+    expect(spansNesting('a', 'b', cyclic)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #439. Field-reported by the ApertureX adopter, bisected by them to a four-edge case, reproduced independently here and **generalised**.

## The defect

Composition maps 1:1 onto cytoscape's compound `parent` (ADR 0004), so a pair that **also** carries any other relationship produces an edge from a container to its own child. ELK cannot lay that out: the pair renders and **every unrelated node loses its geometry**, stacking at coincident coordinates with no shape. `Fit` then zooms *in*, because only the surviving fragment has drawn geometry.

## Measured, five-concept model

1600x1000 viewport, painted-alpha samples at stride 4 over the top canvas layer:

| model | painted | drawn box |
|---|---|---|
| composition + realization on the pair | 543 | 124 x 64 |
| the same, realization removed | **10,612** | **832 x 452** |
| composition + **serving** on the pair | 543 | 124 x 64 |

**One edge, a twentyfold difference.**

## The third row is what shaped the fix

The field report was composition + realization. Substituting `serving` reproduces **byte-identically**, so this is about **nesting**, not about realization — **anything** drawn between an ancestor and its descendant does it. A fix keyed to relationship kinds would have been keyed to the wrong thing.

## The decision

The edge is withheld from the **layout**, never from the graph. cytoscape draws an edge between its endpoints wherever they land, so the relationship stays on the canvas **and the nesting stays too**.

Leaving the pair unnested — which is what `resolveNestingParents` already does for the two nesting anomalies it knows about — would have been consistent and wrong. Those two are modelling mistakes; this pair is legitimate, and throwing away a correct nesting to work around a layout limitation makes the picture worse to make the layout easier.

## Why it reaches ordinary models

Both edges are elicited by catalogue questions doing their jobs — *"which application composes this flow?"* and *"which application implements this?"* — and **the model compiles clean**, so the canvas is the first sign anyone gets. The adopter's field model had the pair three times from normal consulting work.

This repository's own 358-subject self-model renders only because it happens never to pair composition with another edge.

## Verification

| | |
|---|---|
| Repro | 543 → **10,612** painted, container and child still nested, edge still drawn |
| Self-model default view | **6,607 / 836x452** before and after — unchanged |
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2041** across 119 files |
| Mutations | 3 killed (one-direction-only, never-reports, never-climbs) |

`spansNesting` is in its own module rather than inside `graph-canvas.tsx`, following `subject-filter.ts`: the canvas is type-checked with JSX and a test that imports it is not.

## Not fixed here, and recorded in the ADR

The withheld edge is drawn between endpoints that may sit one inside the other, so a container-to-child relationship is a short stub inside the container box. Honest, not pretty. This buys back every bystander node, which is the part that made the canvas unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u