### PR TITLE
chore: release 1.15.0

### DIFF
--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -742,6 +742,10 @@ concepts:
     kind: repository-file
     name: src/visual-app/subject-draft-panel.tsx
     status: current
+  - id: visual-nesting-span-source
+    kind: repository-file
+    name: src/visual-app/nesting-span.ts
+    status: current
   - id: visual-subject-filter-source
     kind: repository-file
     name: src/visual-app/subject-filter.ts
@@ -1546,6 +1550,10 @@ relationships:
   - id: visual-subject-draft-panel-realizes-browser
     kind: realization
     from: visual-subject-draft-panel-source
+    to: visual-browser
+  - id: visual-nesting-span-realizes-browser
+    kind: realization
+    from: visual-nesting-span-source
     to: visual-browser
   - id: visual-subject-filter-realizes-browser
     kind: realization

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -1231,6 +1231,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/visual-app/subject-draft-panel.tsx
+  - subject: visual-nesting-span-source
+    result: confirmed
+    evidence:
+      uri: repo:src/visual-app/nesting-span.ts
   - subject: visual-subject-filter-source
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -2436,3 +2436,78 @@ mappings:
   - native: yaml-emission-realizes-apply
     external: yamlEmissionRealizesApply
     type: relationship
+  - native: catalogue-composition-reads-shipped-catalogue
+    external: catalogueCompositionReadsShippedCatalogue
+    type: relationship
+  - native: catalogue-composition-reads-workspace-catalogue
+    external: catalogueCompositionReadsWorkspaceCatalogue
+    type: relationship
+  - native: cli-provides-import
+    external: cliProvidesImport
+    type: relationship
+  - native: deployment-view-reads-projection-result
+    external: deploymentViewReadsProjectionResult
+    type: relationship
+  - native: design-command-serves-catalogue-composition
+    external: designCommandServesCatalogueComposition
+    type: relationship
+  - native: dynamic-view-reads-projection-result
+    external: dynamicViewReadsProjectionResult
+    type: relationship
+  - native: export-command-serves-workbook-derivation
+    external: exportCommandServesWorkbookDerivation
+    type: relationship
+  - native: graphify-observe-reads-mapping
+    external: graphifyObserveReadsMapping
+    type: relationship
+  - native: graphify-observe-writes-evidence
+    external: graphifyObserveWritesEvidence
+    type: relationship
+  - native: import-command-reads-workbook
+    external: importCommandReadsWorkbook
+    type: relationship
+  - native: import-command-serves-workbook-merge
+    external: importCommandServesWorkbookMerge
+    type: relationship
+  - native: init-command-writes-native-document
+    external: initCommandWritesNativeDocument
+    type: relationship
+  - native: init-command-writes-workspace-manifest
+    external: initCommandWritesWorkspaceManifest
+    type: relationship
+  - native: interrogation-engine-composes-catalogues
+    external: interrogationEngineComposesCatalogues
+    type: relationship
+  - native: reconcile-command-reads-evidence
+    external: reconcileCommandReadsEvidence
+    type: relationship
+  - native: reconcile-command-writes-report
+    external: reconcileCommandWritesReport
+    type: relationship
+  - native: visual-nesting-span-realizes-browser
+    external: visualNestingSpanRealizesBrowser
+    type: relationship
+  - native: visual-nesting-span-source
+    external: visualNestingSpanSource
+    type: concept
+  - native: visual-session-writes-handoff
+    external: visualSessionWritesHandoff
+    type: relationship
+  - native: workbook-derivation-produces-workbook
+    external: workbookDerivationProducesWorkbook
+    type: relationship
+  - native: workbook-derivation-reads-graph
+    external: workbookDerivationReadsGraph
+    type: relationship
+  - native: workbook-engine-derives-workbook
+    external: workbookEngineDerivesWorkbook
+    type: relationship
+  - native: workbook-engine-merges-workbook
+    external: workbookEngineMergesWorkbook
+    type: relationship
+  - native: workbook-merge-produces-operations
+    external: workbookMergeProducesOperations
+    type: relationship
+  - native: workbook-merge-reads-workbook
+    external: workbookMergeReadsWorkbook
+    type: relationship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.15.0
 
 ### An edge across a nesting boundary no longer collapses the canvas
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A tool-neutral semantic architecture engine and guided methodology."
 type: software
 authors:
   - name: YarraMate contributors
-version: 1.14.1
+version: 1.15.0
 date-released: 2026-08-30
 url: "https://yarramate.dev"
 repository-code: "https://github.com/yarrasys/yarramate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.15.0**.

| Change | Kind |
|---|---|
| **Nesting-boundary layout fix** (#439, ADR 0139) | **user-visible fix, adopter waiting** |
| `no-linkage-exists` (#436, ADR 0138) | new condition |
| `missing-claim` skeleton (#430, ADR 0137) | feature |
| Consumer-side half + persuasive prose (#411) | docs |
| Floor settles the reference-slot question (#388, #397) | docs |
| No shipped document links to a file the package lacks | fix |

## The one with urgency

A field-reported canvas fault: composition maps onto cytoscape's compound `parent`, so a pair carrying **any** other relationship produced a container→child edge ELK cannot lay out, and every unrelated node lost its geometry. **543 painted pixels against 10,612** for the same model one edge lighter.

The adopter said explicitly they will not work around it in their model, because the pair is semantically legitimate and their catalogue keeps eliciting it.

## Self-model brought level with the code first

This project's rule, for exactly the failure it exists to prevent. Cutting without it would have shipped a model behind its own code:

- `src/visual-app/nesting-span.ts` was an **unclaimed artifact**;
- syncing the LikeC4 subject mapping surfaced **23 further subjects** unmapped since #363 — latent because none sat in a materialized projection until this one did, which is why the adapter test only failed now.

| | |
|---|---|
| Reconcile | **0 unclaimed of 152**, 314/314 confirmed |
| Interview | **0 open of 52** |

## Verification

| | |
|---|---|
| Clean-slate `rm -rf dist && pnpm verify` | **real exit code 0** |
| Tests | **2041** across 119 files |
| `changelog:check` | green, 6 commits since v1.14.1 |
| Tarball | **inspected before handover** per `docs/RELEASING.md` step 4 — 279 files, seven documents |

That last line is the step whose omission caused 1.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u