### PR TITLE
fix(compiler): a document that composes to nothing is refused, not crashed on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### A document that composes to nothing is refused, not crashed on
+
+Any workspace source whose YAML composes to `null` crashed the whole compile
+with `TypeError: Cannot read properties of null (reading 'profile')`. Four
+forms reach it: an empty file, a whitespace-only file, a file holding the
+`null` literal, and **a document parked behind `#` comments**, which is the
+one a user reaches without doing anything unusual.
+
+The schema always had the right answer. A bare scalar and a list have always
+been refused with `YM201 ... must be object`, and `null` fails that same check.
+It was simply never reached: the probe that decides whether to inject the
+shipped `yarramate/policy@0.1` profile reads `.profile` off every document
+input, and it runs **before** the gate that rejects a schema-invalid document.
+It read through an `as` cast, which is what kept the typechecker quiet.
+
+What a consumer saw is the part worth naming. `yarramate check` wrote a bare
+`TypeError` to stderr and **nothing at all to stdout**, so `check --json`
+handed a machine reader an empty string and `Unexpected end of JSON input`
+from its own parser, with no code, no path and no line to act on. The exit
+code was already 2, so CI failed honestly throughout.
+
+Reported by an adopter who reached the empty-string form through a manifest
+path with no supplied source, while binding pattern parts. Patterns turned out
+to be incidental: the crash needs only a file, and the fix is in neither the
+pattern nor the operations path.
+
 ## 1.15.0
 
 ### An edge across a nesting boundary no longer collapses the canvas

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -957,9 +957,24 @@ function compileWorkspaceResolved(
     ({ identity }) => identity === shippedPolicyIdentity,
   )
   if (!alreadyDeclaresPolicy) {
+    // This probe runs BEFORE the document gate that rejects a source whose
+    // schema check failed, so it has to hold its own precondition: a source
+    // that composes to anything but a mapping - an empty file, a comment-only
+    // one, a bare scalar - selects no profile at all. It used to read
+    // `.profile` through an `as` cast, which is what hid the null from the
+    // typechecker, and an empty document crashed the whole compile with a
+    // `TypeError` instead of the `YM201 must be object` its schema already
+    // produces. Every other consumer of a parsed entry checks its diagnostics
+    // first (the profile walk above, the pattern walk below); this one could
+    // not, because it runs before that gate exists, so it narrows instead.
     const selected = documentInputs.some(({ entry }) => {
-      const value = entry.value as { readonly profile?: unknown }
-      return value.profile === shippedPolicyIdentity
+      const value: unknown = entry.value
+      return (
+        typeof value === 'object' &&
+        value !== null &&
+        (value as { readonly profile?: unknown }).profile ===
+          shippedPolicyIdentity
+      )
     })
     const extended = pendingProfiles.some(
       ({ value }) => value.extends === shippedPolicyIdentity,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -132,6 +132,37 @@ describe('YarraMate CLI', () => {
     ).toBe(true)
   })
 
+  // The compiler used to throw on any source composing to null, so `check`
+  // reported a bare `TypeError` on stderr and wrote NOTHING to stdout. The
+  // exit code was already 2, so CI failed honestly; what a machine consumer
+  // got was an empty stdout and `Unexpected end of JSON input` from its own
+  // parser, with no code, no path and no line to act on. A crash has to stay
+  // inside the result schema like every other refusal.
+  it('reports a document composing to nothing as a diagnostic, not a crash', () => {
+    const schema = JSON.parse(
+      readFileSync(
+        join(repositoryRoot, 'schema/yarramate-check-result.schema.json'),
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ allErrors: true }).compile(schema)
+    const result = runCli(
+      ['check', 'test/fixtures/invalid/comment-only-document.yaml', '--json'],
+      repositoryRoot,
+    )
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toBe('')
+    const parsed = JSON.parse(result.stdout)
+    expect(validate(parsed), JSON.stringify(validate.errors ?? [])).toBe(true)
+    expect(parsed.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'YM201',
+        path: 'test/fixtures/invalid/comment-only-document.yaml',
+      }),
+    )
+  })
+
   it('emits deterministic machine-readable diagnostics and a failing exit code', () => {
     const result = runCli(
       [

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -2262,6 +2262,38 @@ relationships: []
     expect(compileWorkspace([documentNamed('beta', 'shared-name')]).ok).toBe(true)
   })
 
+  // A source that composes to null used to crash the whole compile with a
+  // `TypeError: Cannot read properties of null (reading 'profile')`, because
+  // the shipped-policy probe read `.profile` off every document input through
+  // an `as` cast before the gate that rejects a schema-invalid document ever
+  // ran. The schema already had the right answer - `must be object`, which is
+  // what a bare scalar has always got - it was simply never reached.
+  //
+  // The four forms are listed from the MECHANISM (any YAML composing to null),
+  // not from the one instance that found it: an adopter hit the empty-string
+  // case through a manifest path with no supplied source, but a user parking a
+  // document behind `#` comments reaches the same crash with no pattern, no
+  // manifest and no adopter anywhere near it.
+  describe.each([
+    ['an empty file', ''],
+    ['a whitespace-only file', '   \n\n'],
+    ['a comment-only file', '# parked until the next engagement\n'],
+    ['a file holding the null literal', 'null\n'],
+  ])('%s', (_label, source) => {
+    it('is refused as a schema violation rather than crashing the compile', () => {
+      const result = compileWorkspace([
+        { path: 'parked.yaml', source },
+        documentNamed('alpha', 'thing'),
+      ])
+      if (result.ok) throw new Error('expected the workspace to be refused')
+      const parked = result.diagnostics.filter(
+        ({ path }) => path === 'parked.yaml',
+      )
+      expect(parked.map(({ code }) => code)).toEqual(['YM201'])
+      expect(parked[0]?.message).toContain('must be object')
+    })
+  })
+
   // A document whose own id repeats would collide on every subject it
   // declares, so the one fault worth acting on is reported alone.
   it('does not pile subject collisions onto a duplicate document id', () => {

--- a/test/fixtures/invalid/comment-only-document.yaml
+++ b/test/fixtures/invalid/comment-only-document.yaml
@@ -1,0 +1,2 @@
+# Parked until the next engagement. A document that composes to nothing is
+# still a document the workspace lists, and must be refused, not crashed on.


### PR DESCRIPTION
## The problem

`compileWorkspace` throws on any source whose YAML composes to `null`:

```
TypeError: Cannot read properties of null (reading 'profile')
    at dist/compiler.js:367
```

Four forms reach it, and the fourth needs nothing unusual of a user:

| source | before | after |
|---|---|---|
| `''` (empty file) | **throws** | `YM201 ... must be object` |
| `'   \n'` (whitespace only) | **throws** | `YM201 ... must be object` |
| `'# parked\n'` (**comment only**) | **throws** | `YM201 ... must be object` |
| `'null\n'` | **throws** | `YM201 ... must be object` |
| `'hello\n'` (scalar) | `YM201 ... must be object` | unchanged |
| `'- a\n'` (list) | `YM201 ... must be object` | unchanged |

The last two rows are why this reads as a hole in a working guard rather than a
missing feature. The schema has always had the right answer for a non-mapping
document; `null` fails the very same check and simply never reached it.

## The contract

`src/compiler.ts:960` is the probe that decides whether to inject the shipped
`yarramate/policy@0.1` profile. It reads `.profile` off every document input,
and it runs **before** the gate at `src/compiler.ts:1507` that rejects a
schema-invalid document. It read through an `as` cast, which is what kept the
typechecker quiet:

```ts
const value = entry.value as { readonly profile?: unknown }
return value.profile === shippedPolicyIdentity
```

Every other consumer of a parsed entry checks `schemaDiagnostics` first (the
profile walk at :917, the pattern walk at :1245). This one cannot, because it
runs before those diagnostics are collected. So it holds its own precondition
instead: a source that composes to anything but a mapping selects no profile.
Narrowing the probe rather than adding `?.` keeps the reason in the code.

Near-miss worth recording: `src/compiler.ts:1489` already defends
`value?.id ?? '<unknown>'` in the same document list, so the null was
anticipated in exactly one place and nowhere else.

## What a consumer saw

This is the half that makes it user-facing rather than internal. With one
comment-only document in a workspace:

- `yarramate check` wrote a bare `TypeError` to **stderr**
- and **nothing at all to stdout** (measured: 0 bytes)
- so `check --json` handed a machine reader an empty string, and its parser
  said `Unexpected end of JSON input` with no code, no path, no line
- exit code was already 2, so CI failed honestly throughout. That is the one
  thing that did work.

## Tests and validation

Both seams, and the fixture set is derived from the **mechanism** (any YAML
composing to null) rather than from the reported instance, per CONTRIBUTING's
seventh rule:

- `test/compiler.test.ts` - all four null-composing forms through
  `compileWorkspace`, asserting exactly one `YM201` against the offending path.
- `test/cli.test.ts` - `check --json` on a new comment-only fixture, asserting
  exit 1, empty stderr, stdout that parses, conformance to
  `yarramate-check-result.schema.json`, and a `YM201` naming the file.

**Mutation check** (CONTRIBUTING rule 5b): reverting the guard to the `as` cast
turns all five red with the original `TypeError`. Confirmed by running it, not
by inspection - my first attempt used `--reporter=basic`, which vitest 4 does
not accept, so the run errored and produced no signal at all. Re-run with a
valid reporter before believing a mutation result.

`rm -rf dist && pnpm verify`, `VERIFY_EXIT=0`, 2046 passed / 119 files.

## Compatibility

None. No schema, no output format and no diagnostic code changes; a workspace
that compiled before compiles identically. The only behaviour that moves is a
crash becoming the diagnostic the schema already specified. Generated output
unchanged.

## Provenance

Reported by the ApertureX adopter session as one of five findings against
pattern binding, reached through a manifest path with no supplied source
(`sourceOf` returns `''`). Patterns turned out to be incidental: the crash
needs only a file, and the fix is in neither the pattern nor the operations
path. Their reproduction is what made that visible, and the reframe came from
opening the code it pointed at.

Filed and prepared by the yarramate maintainer session; Nabeel scoped this
fix and reviews before merge.
