### PR TITLE
fix(rename): a subject bound into a pattern slot is a reference site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Unreleased
+
+### A rename repoints a subject bound into a pattern slot
+
+`parts` binds a subject into a pattern instance's slot by slot name (ADR
+0123), which makes it a place a subject address lives. It was never
+enumerated as one, so a rename could not move it. `applyOperations` refused
+the whole batch:
+
+```
+YM315 Part "interface" of "greeting-app" names "patron-api",
+      which is not a declared subject
+```
+
+That fails closed, which is the right direction, but a bound part was
+un-renameable over operations entirely.
+
+The reason it went missing is worth more than the fix.
+`test/subject-references.test.ts` exists precisely so this cannot happen: it
+derives every address-typed position from the four JSON Schemas and asserts
+the enumeration accounts for all of them, so that "a new reference field
+cannot be added without landing here too". Its walker descends `properties`,
+`items` and `additionalProperties`. `parts` is spelled with
+**`patternProperties`**, the one form it does not descend, so `parts` shipped
+as an unenumerated reference site **with the completeness test green**.
+
+Measured: the walker derived 14 positions from the document schema, and 15
+once `patternProperties` is walked. The one it gains is exactly
+`concepts/*/parts/*`. Every other address in all four schemas lives in a
+**sequence**; this is the only one that lives in a mapping, which is why three
+forms were enough right up until they were not.
+
+That is CONTRIBUTING's ninth rule one level up, where the closed enumeration
+is of schema FORMS rather than of fields, and its seventh: the walker is
+shaped like the addresses that existed when it was written.
+
+`*` in a reference position now means every element of a collection, which is
+every index of a sequence and every value of an open mapping. The pointer
+segment for a part is the **slot name**, so a diagnostic says
+`/concepts/0/parts/interface` rather than a counted position.
+
+Reported by the ApertureX adopter session.
+
 ## 1.15.0
 
 ### An edge across a nesting boundary no longer collapses the canvas

--- a/src/subject-references.ts
+++ b/src/subject-references.ts
@@ -27,7 +27,13 @@ export type SubjectReferenceForm = 'declaration' | 'reference' | 'qualified'
 
 export interface SubjectReferencePosition {
   readonly group: SubjectReferenceGroup
-  /** Key path from the document root; `*` matches every sequence index. */
+  /**
+   * Key path from the document root; `*` matches every element of a
+   * collection, which is every index of a sequence and every value of a
+   * mapping whose keys are open. Both spell `*` because the schema, not the
+   * position, is what decides which one a path lands on: `items` and
+   * `patternProperties` are the same shape of "and now, each of these".
+   */
   readonly path: readonly string[]
   readonly form: SubjectReferenceForm
 }
@@ -57,6 +63,15 @@ export const SUBJECT_REFERENCE_POSITIONS: readonly SubjectReferencePosition[] =
     {
       group: 'document',
       path: ['concepts', '*', 'constraints', '*', 'ref'],
+      form: 'reference',
+    },
+    // The subjects bound into a pattern instance's slots (ADR 0123). Keyed by
+    // slot name rather than indexed, which is why it went missing: this is the
+    // only address in any of the four schemas that lives in a mapping, and the
+    // completeness walker below derived only sequences.
+    {
+      group: 'document',
+      path: ['concepts', '*', 'parts', '*'],
       form: 'reference',
     },
     {
@@ -225,18 +240,39 @@ const collect = (
   }
   const [segment, ...rest] = path as [string, ...string[]]
   if (segment === '*') {
-    if (!isSeq(node)) return
-    for (const [index, item] of node.items.entries()) {
-      collect(
-        item,
-        rest,
-        `${pointer}/${index}`,
-        form,
-        documentId,
-        source,
-        hits,
-        aliases,
-      )
+    if (isSeq(node)) {
+      for (const [index, item] of node.items.entries()) {
+        collect(
+          item,
+          rest,
+          `${pointer}/${index}`,
+          form,
+          documentId,
+          source,
+          hits,
+          aliases,
+        )
+      }
+      return
+    }
+    // A mapping with open keys, which today is `parts` alone. The pointer
+    // segment is the authored key, so a diagnostic names the SLOT ("/parts/
+    // interface") rather than a position the reader would have to count out.
+    if (isMap(node)) {
+      for (const item of node.items) {
+        const key = isScalar(item.key) ? String(item.key.value) : undefined
+        if (key === undefined) continue
+        collect(
+          item.value,
+          rest,
+          `${pointer}/${key}`,
+          form,
+          documentId,
+          source,
+          hits,
+          aliases,
+        )
+      }
     }
     return
   }

--- a/test/subject-references.test.ts
+++ b/test/subject-references.test.ts
@@ -46,6 +46,7 @@ interface JsonSchemaNode {
   readonly properties?: Readonly<Record<string, JsonSchemaNode>>
   readonly items?: JsonSchemaNode
   readonly additionalProperties?: JsonSchemaNode | boolean
+  readonly patternProperties?: Readonly<Record<string, JsonSchemaNode>>
   readonly allOf?: readonly JsonSchemaNode[]
   readonly oneOf?: readonly JsonSchemaNode[]
   readonly anyOf?: readonly JsonSchemaNode[]
@@ -87,6 +88,17 @@ const addressPositions = (schema: JsonSchemaNode): string[] => {
     walk(node.items, [...path, '*'], seen)
     if (typeof node.additionalProperties === 'object') {
       walk(node.additionalProperties, [...path, '*'], seen)
+    }
+    // A mapping whose KEYS are open is a collection like any other, and
+    // `parts` is spelled that way: `patternProperties` against the slot-name
+    // grammar. Deriving only `properties`, `items` and `additionalProperties`
+    // covered every address that existed when this walker was written - all of
+    // them sequences - so the one form that arrived later was the one form it
+    // could not see, and `concepts/*/parts/*` shipped unenumerated with this
+    // test green. That is CONTRIBUTING's ninth rule one level up: the closed
+    // enumeration here is of SCHEMA FORMS rather than of fields.
+    for (const child of Object.values(node.patternProperties ?? {})) {
+      walk(child, [...path, '*'], seen)
     }
   }
   walk(schema, [], new Set())
@@ -193,6 +205,33 @@ observations:
     expect(hit?.raw).toBe('"checkout~name"')
   })
 
+  // `parts` binds by SLOT NAME, so it is the only address in any of the four
+  // schemas that lives in a mapping rather than a sequence. The walker derived
+  // sequences only, so a bound part was invisible to a rename: `applyOperations`
+  // refused with `YM315 Part "interface" of "greeting-app" names "patron-api",
+  // which is not a declared subject` - failing closed, but leaving a bound part
+  // un-renameable over operations entirely.
+  it('finds a subject bound into a pattern slot, naming the slot', () => {
+    const bound = `format: yarramate/v1
+id: main
+profile: demo/mule@1.0
+concepts:
+  - id: greeting-app
+    kind: mule-http-api
+    name: Greeting
+    parts:
+      interface: patron-api
+      service: patron-service
+relationships: []
+`
+    const scan = scanSubjectReferences(bound, 'document')
+    expect(
+      scan.hits
+        .filter((hit) => hit.address === 'patron-api')
+        .map((hit) => hit.pointer),
+    ).toEqual(['/concepts/0/parts/interface'])
+  })
+
   it('reports an alias at a reference position rather than walking it', () => {
     const aliased = `format: yarramate/v1
 id: main
@@ -239,6 +278,33 @@ describe('rewriteSubjectReferences', () => {
     if (!result.ok) throw new Error(result.aliases.join(', '))
     expect(result.source).toContain('owner: platform-team')
     expect(result.source).toContain('ref: "platform-team"')
+  })
+
+  it('repoints a subject bound into a pattern slot, leaving the slot name', () => {
+    const bound = `format: yarramate/v1
+id: main
+profile: demo/mule@1.0
+concepts:
+  - id: platform
+    kind: businessActor
+    name: Platform
+  - id: greeting-app
+    kind: mule-http-api
+    name: Greeting
+    parts:
+      interface: platform
+      service: untouched
+relationships: []
+`
+    const result = rewriteSubjectReferences(bound, 'document', rename)
+    if (!result.ok) throw new Error(result.aliases.join(', '))
+    expect(result.moved).toEqual([
+      '/concepts/0/id',
+      '/concepts/1/parts/interface',
+    ])
+    // The KEY is a slot name, not an address: only the value moves.
+    expect(result.source).toContain('interface: platform-team')
+    expect(result.source).toContain('service: untouched')
   })
 
   it('carries an aspect suffix through the move', () => {


### PR DESCRIPTION
## The problem

`parts` binds a subject into a pattern instance's slot by slot name (ADR 0123),
which makes it a place a subject address lives. It was never enumerated as one,
so `applyOperations` refused the whole batch rather than move it:

```
YM315 Part "interface" of "greeting-app" names "patron-api",
      which is not a declared subject
```

Failing closed is the right direction. But a bound part was **un-renameable
over operations entirely**, and a rename is the one operation that has to be
total or it leaves a dangling address behind.

## Why it went missing, which is the part worth reading

`test/subject-references.test.ts` exists *precisely* so this cannot happen. It
derives every address-typed position from the four JSON Schemas and asserts
`SUBJECT_REFERENCE_POSITIONS` accounts for all of them, so that, in its own
words, "a new reference field cannot be added without landing here too".

Its walker descends `properties`, `items` and `additionalProperties`. `parts`
is spelled with **`patternProperties`** (document schema, lines 162-166), the
one form it does not descend. So `parts` shipped as an unenumerated reference
site **with the completeness test green**.

Measured, before any fix:

| | positions derived from the document schema |
|---|---|
| shipped walker | 14 |
| walker + `patternProperties` | **15** |
| the one it gains | `concepts/*/parts/*` |

And the reason three forms were enough for so long:

| schema | address positions | in a sequence | in a mapping |
|---|---|---|---|
| document | 15 | 14 | **1** (`parts`) |
| projection | 5 | 5 | 0 |
| evidence | 3 | 3 | 0 |
| adapter-mapping | 1 | 1 | 0 |

**Every other address in all four schemas lives in a sequence.** `parts` is the
only one in a mapping. The walker was shaped like the addresses that existed
when it was written, so its author was structurally the last person able to
notice the gap.

That is CONTRIBUTING's **ninth** rule one level up, where the closed
enumeration is of schema FORMS rather than of fields, and its **seventh**,
deriving a check from the instances already seen. `additionalProperties` is in
the walker but no schema uses it for an address, so even the speculative
coverage missed the form that actually arrived.

## The contract

`*` in a reference position now means **every element of a collection**: every
index of a sequence, and every value of a mapping with open keys. Both spell
`*` because the schema, not the position, decides which one a path lands on,
and the schema-derived side already emits `*` for both `items` and
`additionalProperties`.

Existing positions are unaffected: all fifteen are sequences, and the schemas
guarantee they stay so. A part's pointer segment is the **slot name**, so a
diagnostic reads `/concepts/0/parts/interface` rather than a counted position.

## Tests and validation

Fail-before-fix, in the honest order:

1. Teaching the completeness walker `patternProperties` **fails immediately**,
   naming `concepts/*/parts/*` and nothing else.
2. Enumerating the position and teaching `collect` to descend mappings turns it
   green.

Added: `scanSubjectReferences` finds a bound part and names the slot;
`rewriteSubjectReferences` repoints it while leaving the sibling slot and both
slot **names** untouched.

**Mutation check** (CONTRIBUTING rule 5b): removing the `isMap` branch from
`collect` turns both new tests red.

**End to end** through `applyOperations` on a real bound instance, which is the
call the adopter makes:

```
parts block after rename:
    interface: patron-attendance-api
    service: patron-service        <- untouched
  - id: patron-attendance-api

recompile after rename: OK
memberships: [{"member":"patron-attendance-api","slot":"interface", ...},
              {"member":"patron-service","slot":"service", ...}]
```

`rm -rf dist && pnpm verify`, `VERIFY_EXIT=0`, 2043 passed / 119 files.

Note for the reviewer: `pnpm test` alone was **green** on a version of this
that `tsc` then rejected, because the test's local `JsonSchemaNode` interface
did not declare `patternProperties`. The typecheck earned its place; read
`VERIFY_EXIT`, not the vitest summary.

## Compatibility

Additive. No schema, output format or diagnostic code changes. A rename that
worked before works identically; one that was refused with `YM315` now
completes. Generated output unchanged.

## Related, deliberately NOT in this PR

`parts` is missing from a **second, independent** enumeration: the deletion
referrer scan at `src/apply-command.ts:1006` is hand-rolled over `owner`,
`constraints`, `references`, `from`, `to` and relationship `references`, and
does not read `SUBJECT_REFERENCE_POSITIONS` at all. Measured consequence:

- deleting a subject used as an `owner` gives
  `YM912 Operation 0 deletes "patron-api", which is still referenced by
  "owned-thing" (owner)`
- deleting a subject bound only as a **part** gives
  `YM315 Part "interface" of "greeting-app" names "patron-api", which is not a
  declared subject`

So delete already **fails closed** for a bound part, via the atomic compile
gate rather than the operation-level check. Only the message is worse. That is
a behaviour change rather than a defect fix, and this PR is scoped to the
rename, so it is left for a separate call.

## Provenance

Reported by the ApertureX adopter session as one of five findings against
pattern binding. Their report was that `parts` is a reference site the rename
comment does not list, which is true; the guard blindness underneath it came
from opening the test their reproduction pointed at.

Filed and prepared by the yarramate maintainer session; Nabeel scoped this fix
and reviews before merge.

**Merge note:** this and #445 both add a `## Unreleased` heading to
`CHANGELOG.md`, and a test refuses two of them. Whichever lands second needs
its entry folded under the existing heading.
