### PR TITLE
chore: release 1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.15.1
 
 ### A document that composes to nothing is refused, not crashed on
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.15.1**, a patch carrying the two defects fixed since 1.15.0. Both were
in shipped code, and both were found by measurement against an adopter's
reproduction rather than by a field report.

## What ships

**#445 — a document that composes to nothing no longer crashes the compile.**
An empty file, a whitespace-only file, a file holding `null`, and a document
parked behind `#` comments all threw
`TypeError: Cannot read properties of null (reading 'profile')`. The schema
always had the right answer (`YM201 ... must be object`, which a bare scalar
has always got); the shipped-policy probe read `.profile` before the gate that
would have rejected the document. `check --json` wrote **nothing** to stdout on
that path, so a machine reader got `Unexpected end of JSON input` with no code,
path or line.

**#446 — a rename repoints a subject bound into a pattern slot.** `parts` binds
by slot name, which makes it a place a subject address lives; it was never
enumerated as one, so `applyOperations` refused the batch with `YM315` and a
bound part was un-renameable over operations. The completeness guard that
exists to stop exactly this was blind to it: its walker descends `properties`,
`items` and `additionalProperties`, and `parts` is spelled `patternProperties`.
14 positions derived before, 15 after, and the one gained is
`concepts/*/parts/*` — the only address in any of the four schemas that lives
in a mapping rather than a sequence.

## Version choice

Patch. Neither change touches a schema, an output format, a diagnostic code or
a published type. A workspace that compiled before compiles identically; the
only behaviour that moves is a crash becoming the diagnostic the schema already
specified, and a rename that was refused now completing.

## Release preparation, per `docs/RELEASING.md`

| step | result |
|---|---|
| `pnpm` matches `packageManager` | 11.7.0 = 11.7.0 |
| `pnpm install --frozen-lockfile` | clean |
| `rm -rf dist && pnpm verify` | **VERIFY_EXIT=0**, 2048 passed / 119 files |
| `npm pack --dry-run`, **listing read** | 279 files, unchanged from 1.15.0 |
| changelog backstop | every user-visible commit since v1.15.0 has an entry |

Step 4 was done properly rather than skipped, since skipping it is what caused
1.14.1. Audited both directions:

- **absent, as required**: `src/`, `test/`, fixtures, `.yarramate/`,
  `graphify-out/`, `scripts/`, any `*.test.*`, tsconfigs, ADRs
- **present, as required**: `README.md`, `LICENSE`,
  `docs/CONSUMING-YARRAMATE.md`, `dist/cli.js`,
  `skills/yarramate-architecture/SKILL.md`, and the 39 normative schemas

Buckets: 221 `dist`, 39 `schema`, 7 `docs`, 6 `skills`, plus README, LICENSE,
`package.json`, and one each of `profiles`, `catalogues`, `assets`.

## Self-model

Green and unchanged from the 1.15.0 baseline, so nothing regressed:

- `self:check` clean — 355 concepts, 477 relationships, 4 states, no errors
- `self:reconcile` — **314/314 confirmed**, 0 contradicted, 0 unknown,
  0 not-observed, **0 unclaimed of 152 artifacts**
- 8 findings, all attestation *age* (7 unconfirmed, 1 stale). Human sign-offs
  ageing, not code drift, and identical to the 1.15.0 baseline.
- LikeC4 subject mapping **already synchronized**, generated output **fresh**

## No browser pass

Deliberate, and stated so it is a decision rather than an omission. Neither
change touches the visual app: #445 is in `src/compiler.ts`, #446 in
`src/subject-references.ts`, and no bundled UI code path is affected. The
standing rule that a green suite says almost nothing about the canvas applies
to changes that reach it, and these do not.

## Publication

Not performed here — the runbook makes it an explicit external action, and the
last two attempts from this session hit `E401`. After merge I will create the
annotated tag; **the `npm publish --access public` from a fresh clone of the
tag is yours**, and I will verify `gitHead`, the GitHub release and a smoke
test from the public registry once it lands.

Prepared by the yarramate maintainer session at Nabeel's instruction.
