### PR TITLE
perf: build schema validators on first use, not at import (1.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 1.15.2
+
+### Importing the package no longer compiles ten JSON Schemas
+
+Ten JSON Schema validators were constructed and compiled at **module scope**,
+so importing the package paid for every one whether or not a caller ever
+validated anything. Measured on the published 1.15.1 dist:
+
+| entry | Ajv compiles at import | import time | share |
+|---|---|---|---|
+| `yarramate` (barrel) | **10** | 155.2 ms | **80% of import** |
+| `yarramate/interrogation` | **1** | 54.7 ms | 63% of import |
+
+That is not a tidiness concern. Cloudflare Workers budget **startup CPU**
+separately from request CPU and refuse a Worker that exceeds it, so an
+adopter's production deploy was rejected outright (`error 10021`) by work no
+request had asked for. The same Worker had deployed earlier the same day at
+569 ms of startup, which is how close to the edge this had been sitting.
+
+Each site also constructed its **own** `Ajv` instance, so each one compiled the
+2020-12 meta-schema again.
+
+Every validator is now built on first use and reused thereafter:
+
+| entry | before | after |
+|---|---|---|
+| `yarramate` (barrel) | 155.2 ms, 10 compiles | **33.2 ms, 0 compiles** |
+| `yarramate/interrogation` | 54.7 ms, 1 compile | **12.1 ms, 0 compiles** |
+
+A caller now pays only for the schemas it actually touches: compiling a
+workspace builds the document validator and leaves the evidence,
+adapter-mapping, core-contract and operations validators unbuilt.
+
+**No API change and no behaviour change.** The only difference is *when* a
+malformed schema would be reported: at import before, at first use now. The
+schemas ship with the package and are covered by tests, so this fails later
+but still fails.
+
+`test/schema-validation-laziness.test.ts` pins it, asserting that importing
+either entry compiles nothing and that first use then compiles something. It is
+`test/export-purity.test.ts`'s idea applied to time rather than to
+dependencies: the static import graph cannot see a module-scope side effect, so
+this one runs the import and watches. It fails on the next module-scope
+validator anyone adds.
+
+Reported by the ApertureX adopter session, whose measured startup profile
+identified the cause.
+
 ## 1.15.1
 
 ### A document that composes to nothing is refused, not crashed on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {

--- a/src/adapter-mapping.ts
+++ b/src/adapter-mapping.ts
@@ -10,6 +10,7 @@ import {
   locateSourcePath,
   type SourceLocation,
 } from './source-document.js'
+import { lazyValidator } from './schema-validation.js'
 import adapterMappingSchema from '../schema/yarramate-adapter-mapping.schema.json' with {
   type: 'json',
 }
@@ -22,8 +23,8 @@ const ajv2020Module = Ajv2020Module as unknown as {
   default?: typeof Ajv2020Module
 } & typeof Ajv2020Module
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateSchema = new Ajv2020({ allErrors: true }).compile(
-  adapterMappingSchema,
+const validateSchema = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(adapterMappingSchema),
 )
 
 export interface AdapterSubjectMapping {
@@ -69,7 +70,7 @@ export function loadAdapterMapping(
 ): AdapterMappingLoadResult {
   const loaded = loadSourceDocument<AdapterMapping>(
     source,
-    validateSchema,
+    validateSchema(),
     'Adapter mapping',
   )
   if (!loaded.ok) return loaded

--- a/src/apply-command.ts
+++ b/src/apply-command.ts
@@ -62,6 +62,7 @@ import type {
   YarramateApplyResult,
   YarramateOperation,
 } from './operations.js'
+import { lazyValidator } from './schema-validation.js'
 
 // `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
 // `module.exports` and a bundler sees the unwrapped class, and this file is
@@ -72,10 +73,14 @@ const ajv2020Module = Ajv2020Module as unknown as {
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
 // `discriminator` routes a batch entry to the single branch its `op` names, so
 // one malformed operation reports one fault instead of ten near-misses.
-const validateOperations = new Ajv2020({
-  allErrors: true,
-  discriminator: true,
-}).compile(operationsSchema)
+// Keeps its own Ajv instance: `discriminator` changes how a schema compiles,
+// so it cannot share one with the nine that do not set it.
+const validateOperations = lazyValidator(() =>
+  new Ajv2020({
+    allErrors: true,
+    discriminator: true,
+  }).compile(operationsSchema),
+)
 
 // Scalar fields replace; list fields append; `remove` retracts (ADR 0062).
 // An answer enriches what is there and may explicitly take back what it
@@ -551,7 +556,7 @@ export const applyOperations = (
   })
   const loadedOperations = loadSourceDocument<OperationsDocument>(
     operations,
-    validateOperations,
+    validateOperations(),
     'Operations',
   )
   if (!loadedOperations.ok) return failed(loadedOperations.diagnostics)

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -33,6 +33,7 @@ import {
   shippedPolicyIdentity,
   shippedPolicySource,
 } from './shipped-profile.js'
+import { lazyValidator } from './schema-validation.js'
 
 const coreProfile = 'yarramate/core@0.1'
 // `ajv/dist/2020.js` is CJS, and its default-export shape is resolved
@@ -51,9 +52,15 @@ const ajv2020Module = Ajv2020Import as unknown as {
   default?: Ajv2020Ctor
 } & Ajv2020Ctor
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateDocument = new Ajv2020({ allErrors: true }).compile(documentSchema)
-const validateProfile = new Ajv2020({ allErrors: true }).compile(profileSchema)
-const validatePattern = new Ajv2020({ allErrors: true }).compile(patternSchema)
+const validateDocument = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(documentSchema),
+)
+const validateProfile = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(profileSchema),
+)
+const validatePattern = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(patternSchema),
+)
 
 export interface WorkspaceSource {
   readonly path: string
@@ -710,13 +717,13 @@ const parseWorkspaceSource = (
     }
   }
 
-  const valid = parseDiagnostics.length === 0 && validateDocument(value)
+  const valid = parseDiagnostics.length === 0 && validateDocument()(value)
   const schemaDiagnostics: Diagnostic[] =
     parseDiagnostics.length > 0
       ? parseDiagnostics
       : valid
         ? []
-        : (validateDocument.errors ?? []).map((error) => {
+        : (validateDocument().errors ?? []).map((error) => {
             const property =
               error.keyword === 'additionalProperties'
                 ? String(error.params.additionalProperty)
@@ -918,8 +925,8 @@ function compileWorkspaceResolved(
       profileDiagnostics.push(...entry.schemaDiagnostics)
       continue
     }
-    if (!validateProfile(value)) {
-      for (const error of validateProfile.errors ?? []) {
+    if (!validateProfile()(value)) {
+      for (const error of validateProfile().errors ?? []) {
         const property =
           error.keyword === 'additionalProperties'
             ? String(error.params.additionalProperty)
@@ -988,8 +995,8 @@ function compileWorkspaceResolved(
       const value = entry.value as NativeProfile
       if (entry.schemaDiagnostics.length > 0) {
         profileDiagnostics.push(...entry.schemaDiagnostics)
-      } else if (!validateProfile(value)) {
-        for (const error of validateProfile.errors ?? []) {
+      } else if (!validateProfile()(value)) {
+        for (const error of validateProfile().errors ?? []) {
           profileDiagnostics.push({
             severity: 'error',
             code: 'YM201',
@@ -1261,8 +1268,8 @@ function compileWorkspaceResolved(
       patternDiagnostics.push(...entry.schemaDiagnostics)
       continue
     }
-    if (!validatePattern(value)) {
-      for (const error of validatePattern.errors ?? []) {
+    if (!validatePattern()(value)) {
+      for (const error of validatePattern().errors ?? []) {
         const property =
           error.keyword === 'additionalProperties'
             ? String(error.params.additionalProperty)

--- a/src/core-contract.ts
+++ b/src/core-contract.ts
@@ -6,6 +6,7 @@ import {
   loadSourceDocument,
   locateSourcePath,
 } from './source-document.js'
+import { lazyValidator } from './schema-validation.js'
 import coreContractSchema from '../schema/yarramate-core-contract.schema.json' with {
   type: 'json',
 }
@@ -18,8 +19,8 @@ const ajv2020Module = Ajv2020Module as unknown as {
   default?: typeof Ajv2020Module
 } & typeof Ajv2020Module
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateCoreContract = new Ajv2020({ allErrors: true }).compile(
-  coreContractSchema,
+const validateCoreContract = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(coreContractSchema),
 )
 
 export interface CoreContractFormat {
@@ -79,7 +80,7 @@ export function loadCoreContract(
 ): CoreContractLoadResult {
   const loaded = loadSourceDocument<CoreContract>(
     source,
-    validateCoreContract,
+    validateCoreContract(),
     'Core contract',
   )
   if (!loaded.ok) return loaded

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -22,8 +22,9 @@ const ajv2020Module = Ajv2020Module as unknown as {
   default?: typeof Ajv2020Module
 } & typeof Ajv2020Module
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateEvidenceSchema = new Ajv2020({ allErrors: true }).compile(
-  evidenceSchema,
+import { lazyValidator } from './schema-validation.js'
+const validateEvidenceSchema = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(evidenceSchema),
 )
 
 export type EvidenceResult =
@@ -133,7 +134,7 @@ const observationTarget = (observation: EvidenceObservation) =>
 export function loadEvidence(source: WorkspaceSource): EvidenceLoadResult {
   const loaded = loadSourceDocument<EvidenceDocument>(
     source,
-    validateEvidenceSchema,
+    validateEvidenceSchema(),
     'Evidence',
   )
   if (!loaded.ok) return loaded

--- a/src/interrogate-command.ts
+++ b/src/interrogate-command.ts
@@ -31,8 +31,9 @@ const ajv2020Module = Ajv2020Module as unknown as {
   default?: typeof Ajv2020Module
 } & typeof Ajv2020Module
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateCatalogue = new Ajv2020({ allErrors: true }).compile(
-  catalogueSchema,
+import { lazyValidator } from './schema-validation.js'
+const validateCatalogue = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(catalogueSchema),
 )
 
 /**
@@ -1544,7 +1545,7 @@ const loadCatalogueDocument = (
 ): CatalogueDocumentResult => {
   const loaded = loadSourceDocument<QuestionCatalogue>(
     catalogueSource,
-    validateCatalogue,
+    validateCatalogue(),
     'Question catalogue',
   )
   if (!loaded.ok) return { ok: false, diagnostics: loaded.diagnostics }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -30,8 +30,8 @@ const ajv2020Module = Ajv2020Import as unknown as {
   default?: Ajv2020Ctor
 } & Ajv2020Ctor
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateProjection = new Ajv2020({ allErrors: true }).compile(
-  projectionSchema,
+const validateProjection = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(projectionSchema),
 )
 
 export type LifecycleStatus = 'planned' | 'current' | 'retired'
@@ -118,6 +118,7 @@ import type { NestingKind } from './nesting.js'
  */
 export { DEFAULT_DIRECTION, type LayoutDirection } from './layout-direction.js'
 import type { LayoutDirection } from './layout-direction.js'
+import { lazyValidator } from './schema-validation.js'
 
 export type ProjectionQuery = ProjectionDefinition['query']
 
@@ -137,7 +138,7 @@ export type ProjectionLoadResult =
 export function loadProjection(source: WorkspaceSource): ProjectionLoadResult {
   const loaded = loadSourceDocument<ProjectionDefinition>(
     source,
-    validateProjection,
+    validateProjection(),
     'Projection',
   )
   return loaded.ok

--- a/src/schema-validation.ts
+++ b/src/schema-validation.ts
@@ -1,0 +1,36 @@
+import type { ValidateFunction } from 'ajv'
+
+/**
+ * Defers compiling a JSON Schema until something actually validates against
+ * it, then reuses the compiled validator forever.
+ *
+ * Ten validators used to be constructed and compiled at MODULE SCOPE, so
+ * importing the package paid for every one of them whether or not a caller
+ * ever validated anything. Measured on the published 1.15.1 dist: ten
+ * `Ajv.compile` calls costing **123.7ms, 80% of the barrel's entire import
+ * time**, and one more on the `yarramate/interrogation` subpath, which is the
+ * entry we tell Workers consumers to prefer. That is not an abstract cost:
+ * Cloudflare Workers budget STARTUP CPU separately from request CPU and refuse
+ * a Worker that exceeds it, so an adopter's deploy was rejected outright
+ * (error 10021) by work no request had asked for.
+ *
+ * Deferring moves that cost to first use, where the budget is seconds rather
+ * than milliseconds, and a caller pays only for the schemas it actually
+ * touches - a consumer that compiles a workspace no longer pays for the
+ * evidence, adapter-mapping and core-contract validators it never calls.
+ *
+ * The accessor is a function rather than a getter so the deferral is visible
+ * at every call site: `validateDocument()(value)` reads as "get the validator,
+ * then use it", and `validateDocument().errors` cannot accidentally be read
+ * off a validator that was never run. Ajv attaches `errors` to the validator
+ * itself, so the two must come from the same object.
+ *
+ * `test/schema-validation-laziness.test.ts` asserts that importing the package
+ * compiles NOTHING, and fails on the next module-scope validator anyone adds.
+ */
+export const lazyValidator = <T = unknown>(
+  compile: () => ValidateFunction<T>,
+): (() => ValidateFunction<T>) => {
+  let compiled: ValidateFunction<T> | undefined
+  return () => (compiled ??= compile())
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -19,14 +19,15 @@ import workspaceSchema from '../schema/yarramate-workspace.schema.json' with {
 // `.default ?? module`, not a bare `.default`: NodeNext sees the raw CJS
 // `module.exports` and a bundler the unwrapped class. This file resolves a
 // manifest's globs against a real filesystem and so is never bundled, but the
+import { lazyValidator } from './schema-validation.js'
 // two shapes cost one `??` and a reader should not have to work out which of
 // the engine's four Ajv sites is the odd one.
 const ajv2020Module = Ajv2020Module as unknown as {
   default?: typeof Ajv2020Module
 } & typeof Ajv2020Module
 const Ajv2020 = ajv2020Module.default ?? ajv2020Module
-const validateWorkspace = new Ajv2020({ allErrors: true }).compile(
-  workspaceSchema,
+const validateWorkspace = lazyValidator(() =>
+  new Ajv2020({ allErrors: true }).compile(workspaceSchema),
 )
 
 export interface WorkspaceManifest {
@@ -89,7 +90,7 @@ export function loadWorkspaceManifest(
 ): WorkspaceManifestResult {
   const loaded = loadSourceDocument<WorkspaceManifest>(
     source,
-    validateWorkspace,
+    validateWorkspace(),
     'Workspace',
   )
   if (!loaded.ok) return loaded

--- a/test/schema-validation-laziness.test.ts
+++ b/test/schema-validation-laziness.test.ts
@@ -1,0 +1,103 @@
+import Ajv2020Module from 'ajv/dist/2020.js'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Importing this package must compile NO JSON Schemas.
+ *
+ * Ten validators were constructed and compiled at module scope, so an import
+ * paid for every one whether or not the caller validated anything. On the
+ * published 1.15.1 dist that was ten `Ajv.compile` calls costing 123.7ms,
+ * **80% of the barrel's entire import time**, plus one more on the
+ * `yarramate/interrogation` subpath - the entry the consumer guide tells
+ * Workers users to prefer.
+ *
+ * That is not a tidiness concern. Cloudflare Workers budget STARTUP CPU
+ * separately from request CPU (400ms against 30s) and refuse a Worker that
+ * exceeds it, so an adopter's production deploy was rejected outright with
+ * error 10021 by work no request had asked for. The package still deployed at
+ * 1.15.0 with 569ms of startup, which is how close to the edge this had been
+ * sitting.
+ *
+ * This is `test/export-purity.test.ts`'s idea applied to TIME rather than to
+ * dependencies. That test reads the import graph statically and cannot see a
+ * module-scope side effect; this one runs the import and watches. The two
+ * together are what keep the package importable in a constrained runtime, and
+ * this one fails on the next module-scope validator anyone adds.
+ */
+const ajv2020Module = Ajv2020Module as unknown as {
+  default?: typeof Ajv2020Module
+} & typeof Ajv2020Module
+const Ajv2020 = ajv2020Module.default ?? ajv2020Module
+
+const countingCompiles = async (
+  entry: string,
+): Promise<{ atImport: number; afterFirstUse: number }> => {
+  const original = Ajv2020.prototype.compile
+  let compiles = 0
+  // Patched on the prototype rather than by wrapping an instance, because the
+  // point is to catch a validator built by code this test never names.
+  Ajv2020.prototype.compile = function patched(
+    this: unknown,
+    ...args: unknown[]
+  ) {
+    compiles += 1
+    return (original as (...a: unknown[]) => unknown).apply(this, args)
+  } as typeof Ajv2020.prototype.compile
+  try {
+    const loaded = (await import(entry)) as Record<string, unknown>
+    const atImport = compiles
+    // A cache-busting query would defeat the module registry, so first use is
+    // measured on this same instance: whatever it compiles now is what an
+    // import was paying for before.
+    const compileWorkspace = loaded.compileWorkspace as
+      | ((sources: readonly { path: string; source: string }[]) => unknown)
+      | undefined
+    if (compileWorkspace !== undefined) {
+      compileWorkspace([
+        {
+          path: 'minimal.yaml',
+          source: `format: yarramate/v1
+id: minimal
+profile: yarramate/core@0.1
+concepts:
+  - id: thing
+    kind: applicationComponent
+    name: Thing
+relationships: []
+`,
+        },
+      ])
+    }
+    return { atImport, afterFirstUse: compiles }
+  } finally {
+    Ajv2020.prototype.compile = original
+  }
+}
+
+describe('schema validation is deferred until first use', () => {
+  it('compiles no schemas when the package barrel is imported', async () => {
+    const { atImport, afterFirstUse } = await countingCompiles('../src/index.js')
+
+    expect(
+      atImport,
+      'Importing the barrel compiled a JSON Schema. A validator was built at ' +
+        'module scope; wrap it in `lazyValidator` from src/schema-validation.ts.',
+    ).toBe(0)
+    // The other half of the claim, and the half that makes the first
+    // assertion mean something. Without it, deleting every validator would
+    // pass: zero compiles at import is also what a package that validates
+    // nothing looks like (CONTRIBUTING's second rule).
+    expect(
+      afterFirstUse,
+      'Compiling a workspace should build the validators it needs.',
+    ).toBeGreaterThan(0)
+  })
+
+  it('compiles no schemas when the interrogation subpath is imported', async () => {
+    // The entry `docs/CONSUMING-YARRAMATE.md` points Workers consumers at,
+    // and it was paying for the catalogue validator on every import.
+    const { atImport } = await countingCompiles('../src/interrogation-entry.js')
+
+    expect(atImport).toBe(0)
+  })
+})


### PR DESCRIPTION
Cuts **1.15.2**. Combines the fix and the release in one PR because there is a
single change and it is unblocking an adopter's deploys.

## The problem

Ten JSON Schema validators were constructed and compiled at **module scope**,
so importing the package paid for every one whether or not a caller ever
validated anything. Measured on the **published 1.15.1 dist**:

| entry | Ajv compiles at import | import wall | Ajv share |
|---|---|---|---|
| `yarramate` (barrel) | **10** | 155.2 ms | **80%** |
| `yarramate/interrogation` | **1** | 54.7 ms | 63% |

Cloudflare Workers budget **startup CPU** separately from request CPU and
refuse a Worker that exceeds it. An adopter's production deploy was rejected
outright with `error 10021`; the same Worker had deployed earlier that day at
569 ms of startup, which is how close to the edge this had been sitting.

Two things worth noting beyond the report:

- The adopter counted nine sites. There are **ten** — `src/workspace.ts:28`
  was missed.
- `yarramate/interrogation` is the entry we tell **Workers consumers to
  prefer**, and it was paying too. The subpath exists to be import-cheap and
  was not.

## The fix

Every validator is built on first use and reused thereafter, via one shared
`lazyValidator` helper.

| entry | before | after |
|---|---|---|
| `yarramate` (barrel) | 155.2 ms, 10 compiles | **33.2 ms, 0 compiles** |
| `yarramate/interrogation` | 54.7 ms, 1 compile | **12.1 ms, 0 compiles** |

A caller now pays only for what it touches: `compileWorkspace` on a minimal
workspace builds **one** validator and leaves evidence, adapter-mapping,
core-contract and operations unbuilt.

**No API change, no behaviour change.** None of the ten was exported or invoked
at module scope, so deferral is invisible. The only difference is *when* a
malformed schema would be reported — at import before, at first use now. The
schemas ship with the package and are test-covered, so this fails later but
still fails.

`apply-command` keeps its own Ajv instance: `discriminator` changes how a
schema compiles and cannot be shared with the nine that do not set it.

## What is deliberately NOT here

The adopter also asked for the nine `{allErrors: true}` sites to share one Ajv
instance so the meta-schema compiles once. Measured, that is the wrong lever:

```
(a) today, 10 instances at import ......... 81.6 ms
(b) shared instance, still at import ...... 35.0 ms   (57% less)
(c) lazy: import cost ..................... 0.0 ms
```

Sharing reduces a cost that laziness **removes** from the startup path
entirely. Its remaining value is on first use, which is not what Cloudflare
refused. It touches every call site's options and carries real regression
surface, so it belongs in its own change if it is ever worth it. Consolidation
is at least *safe*: no `ajv-formats` anywhere, and all 39 schemas have distinct
`$id`s.

## The guard

`test/schema-validation-laziness.test.ts` spies `Ajv.prototype.compile`,
asserts **zero** compiles on importing either entry, then asserts first use
compiles something. The second assertion is what makes the first mean anything:
zero-at-import is also what a package that validates nothing looks like
(CONTRIBUTING's second rule).

This is `export-purity`'s idea applied to **time** rather than to dependencies.
That test reads the import graph statically and cannot see a module-scope side
effect; this one runs the import and watches.

**Mutation check**: planting one module-scope validator turns it red with a
message naming the fix.

## Tests and validation

`rm -rf dist && pnpm verify`, `npm pack --dry-run` listing **read**: 282 files
(279 plus the new module's `.js`, `.d.ts` and the visual-app-lib type copy). No
`src/`, `test/`, fixtures, `.yarramate/` or `scripts/`.

**One thing the reviewer should know.** Local full-suite runs are currently
flaky on my machine at load ~20: `attestation-staleness` and
`ask-neighbour-cap` time out at 5000 ms with no assertion failure. Both shell
out to `git` via `execFileSync`. I did not assume it was pre-existing — I
stashed this branch and ran the **unmodified tree** under the same load, and it
failed the *same* tests (2 failures against this branch's 1). So the flakiness
is on `main`, not from this change, and all three pass in isolation. **CI on a
clean runner is the arbiter.**

Prepared by the yarramate maintainer session at Nabeel's instruction. He
reviews before merge; publication remains his step.
