### PR TITLE
chore: declare the schema-validation module in the self-model

### DIFF
--- a/.yarramate/architecture/repository.yaml
+++ b/.yarramate/architecture/repository.yaml
@@ -626,6 +626,10 @@ concepts:
     kind: repository-file
     name: src/relationship-drafting.ts
     status: current
+  - id: schema-validation-source
+    kind: repository-file
+    name: src/schema-validation.ts
+    status: current
   - id: shipped-profile-source
     kind: repository-file
     name: src/shipped-profile.ts
@@ -1435,6 +1439,10 @@ relationships:
     kind: realization
     from: relationship-drafting-source
     to: apply-operations
+  - id: schema-validation-realizes-document-validation
+    kind: realization
+    from: schema-validation-source
+    to: validate-document-structure
   - id: shipped-profile-realizes-catalogue
     kind: realization
     from: shipped-profile-source

--- a/.yarramate/evidence/repository.yaml
+++ b/.yarramate/evidence/repository.yaml
@@ -1115,6 +1115,10 @@ observations:
     result: confirmed
     evidence:
       uri: repo:src/relationship-drafting.ts
+  - subject: schema-validation-source
+    result: confirmed
+    evidence:
+      uri: repo:src/schema-validation.ts
   - subject: shipped-profile-source
     result: confirmed
     evidence:

--- a/.yarramate/integrations/likec4/subject-mapping.yaml
+++ b/.yarramate/integrations/likec4/subject-mapping.yaml
@@ -2511,3 +2511,9 @@ mappings:
   - native: workbook-merge-reads-workbook
     external: workbookMergeReadsWorkbook
     type: relationship
+  - native: schema-validation-realizes-document-validation
+    external: schemaValidationRealizesDocumentValidation
+    type: relationship
+  - native: schema-validation-source
+    external: schemaValidationSource
+    type: concept


### PR DESCRIPTION
Release pre-flight for 1.15.2 found the self-model a step behind the code.

`src/schema-validation.ts` shipped in #452 without a declaration, so
`self:reconcile` reported **`unclaimedArtifacts: 1`** against a scope that had
grown 152 → 153. The self-model is this project's own headline claim, so a
release whose model lags its code undermines the pitch.

## Changes

- `schema-validation-source`, a `repository-file`, realizing
  `validate-document-structure` — the behaviour whose validators it defers.
- The confirming observation in the evidence overlay.
- **Two LikeC4 subject mappings** that `map --sync` reported as drifted. That
  command belongs in the release pre-flight and earned its place again.

## After

| check | result |
|---|---|
| `self:check` | clean — 356 concepts, 478 relationships, 4 states |
| `self:reconcile` | **315/315 confirmed**, 0 contradicted, **0 unclaimed of 153** |
| LikeC4 mapping | synchronized |
| suite | **2050 passed / 120 files** |

## A note on local flakiness, and a fix worth considering separately

Full-suite runs on my machine intermittently fail with `Test timed out in
5000ms` and **no assertion failure**. Up to six files at once, always the same
set, and every one shells out to `git` via `execFileSync`:
`artifact-coverage`, `ask-neighbour-cap`, `attestation-staleness`,
`changed-slices`, `check-changelog`, `likec4-cli`.

It is not this change and it is not #452. I established that by stashing #452
and running the **unmodified tree** under the same load, which failed the same
tests. And this run pins it further:

```
pnpm verify (default workers, load ~19) ... 1–7 failures, all timeouts
npx vitest run --maxWorkers=4 (load ~17) ... 120 files, 2050 passed
```

**Capping workers fixes it deterministically at the same load**, so the cause
is worker contention over git subprocesses rather than absolute machine load.
That suggests a real remedy — a higher `testTimeout` for the git-spawning
files, or a worker cap in `vitest.config.ts` — but it is a change to the test
harness rather than to the release, so it is deliberately not here. Happy to
file it.

Prepared by the yarramate maintainer session. This is the last piece before
tagging v1.15.2.
