### PR TITLE
feat(visual-app): a host can refresh the canvas without discarding staged work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+### A host can refresh the canvas without discarding staged work
+
+`mountEditor` gave a host no way to show new model content except `unmount`
+plus mounting again, which throws away whatever the reviewer had staged — and
+no way to find out whether anything was staged, so a host had to assume the
+worst every time. An adopter shipped a banner and a *Reload the canvas* button,
+then narrowed it with a `pointerdown` proxy that treats any gesture as proof of
+staged work: sound in one direction only, so one stray tap meant banners for
+the rest of the session (#444).
+
+`MountedEditor` gains **`refresh()`**. It re-reads the host's store and follows
+it, keeping the reviewer's staged rows, zoom, selection and filter — only the
+compilation is replaced.
+
+It hands the store no bytes. The host already owns the store and the editor
+reads through it (ADR 0100), so this asks for a re-read rather than opening a
+second way in. Two-thirds of the machinery was already there: a mid-session
+`model` frame has always replaced the compilation while leaving the staged
+changeset alone. What was missing was any way to ask for one, and any way to
+learn that asking would strand staged work.
+
+It answers with an outcome rather than a boolean, because a host must be able
+to explain the result to a person:
+
+| result | meaning |
+|---|---|
+| `{ applied: true }` | the canvas follows the store |
+| `staged-against-changed-documents` | staged work pins content this would replace; nothing delivered, and the named documents are what to show the reviewer |
+| `refused` | the store no longer compiles; the last good model stands, with diagnostics |
+| `not-mounted` | before the shell's first render, or after `unmount` |
+| `not-supported` | a `mountEditorWith` host, which already owns delivery |
+
+**The refusal is the point.** Refreshing over staged work would leave a
+reviewer editing against content nobody can see, to be refused at commit by
+`YMVS312` after more effort had gone in. Re-pinning their operations silently
+would be worse: those pins are the precondition that stops one author
+overwriting another. Refusing at the moment of divergence is the earliest
+honest answer, and it names the documents so the host can say something
+specific instead of showing a blanket banner.
+
+The staleness question is answered host-side, not in the handle: a revision is
+opaque and only the store that minted it may compare two (ADR 0100). The
+handle reports what is staged; the store decides what that means.
+
+Requested by the ApertureX adopter session, who proposed handing documents in
+directly. Asking for a re-read instead keeps the store's ownership intact and
+turned out to be the smaller change.
+
 ## 1.16.0
 
 ### Schema validators are precompiled, so the package never generates code

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -393,6 +393,33 @@ model frame, and ids the model does not name are silently inert. It shares the
 pointer methods' one false window: before the shell's first render, or after
 unmount.
 
+`refresh()` follows a model that moved under an open canvas. An agent writing
+to the same store a reviewer is watching is the case it exists for: before it,
+the only way to show new content was `unmount` plus mounting again, which
+discards whatever the reviewer had staged. A clean refresh keeps their staged
+rows, their zoom, their selection and their filter — only the compilation is
+replaced. It hands the store no bytes: your host already owns the store and the
+editor reads through it, so this asks for a re-read rather than opening a
+second way in.
+
+It answers with what happened, not a boolean, because a host has to be able to
+explain the outcome to a person:
+
+| result | meaning |
+|---|---|
+| `{ applied: true }` | the canvas now follows the store |
+| `staged-against-changed-documents` | staged work pins content this refresh would replace; **nothing was delivered** and the named documents are what to put in front of the reviewer |
+| `refused` | the store's contents no longer compile; the last good model stays on screen and the diagnostics say why |
+| `not-mounted` | before the shell's first render, or after `unmount` |
+| `not-supported` | a `mountEditorWith` host, which already owns delivery and can push a `model` frame itself |
+
+The refusal is deliberate rather than a limitation. Refreshing over staged work
+would leave a reviewer editing against content nobody can see, to be refused at
+commit by `YMVS312` after more effort had gone in; re-pinning their operations
+silently would be worse still, since those pins are the precondition that stops
+one author overwriting another. Refusing at the moment of divergence is the
+earliest honest answer.
+
 `store` is the caller's synchronous `SourceStore`; `workspace` is the caller's
 pre-resolved `ResolvedWorkspace`. The local host compiles, projects, filters,
 commits and saves layouts over that store. A changeset's model and view writes

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -1137,10 +1137,14 @@ export const App = ({
   const pointerContext = useRef<EditorPointerContext>({
     graph: null,
     readOnly,
+    stagedPins: {},
   });
   pointerContext.current = {
     graph: state.model?.graph ?? null,
     readOnly,
+    // Read at call time like the graph is, so a host asking just before a
+    // refresh sees what is staged now rather than at mount (#444).
+    stagedPins: state.pendingChangeset.sourceDigests,
   };
   useEffect(() => {
     onReady?.(

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -127,7 +127,44 @@ const EMPTY_MODEL: VisualRenderedModel = {
   projectionDigests: {},
 }
 
-export const createLocalHost = (options: LocalHostOptions): EditorHost => {
+/**
+ * What a `refresh` did, or why it did nothing (#444).
+ *
+ * A result rather than a boolean, because the caller needs to tell three
+ * different situations apart and act differently on each: it worked, the
+ * workspace will not compile, or the reviewer has staged work against content
+ * that has since moved. `setDecorations` answers with a bare boolean because
+ * decorating is reading and the only failure is a not-there window; refreshing
+ * can fail for reasons a host must be able to explain to a person.
+ */
+export type RefreshOutcome =
+  | { readonly applied: true }
+  | {
+      /**
+       * Staged operations pin content this refresh would replace. Nothing was
+       * delivered and the canvas is unchanged, so the reviewer's work is
+       * exactly where they left it; the named documents are what a host should
+       * put in front of them.
+       */
+      readonly applied: false
+      readonly reason: 'staged-against-changed-documents'
+      readonly documents: readonly string[]
+    }
+  | {
+      /** The store's current contents do not compile; the last good model stands. */
+      readonly applied: false
+      readonly reason: 'refused'
+      readonly diagnostics: readonly VisualDiagnostic[]
+    }
+
+/** A local host, plus the refresh only a store-owning host can perform. */
+export type LocalEditorHost = EditorHost & {
+  readonly refresh: (
+    stagedPins: Readonly<Record<string, string>>,
+  ) => RefreshOutcome
+}
+
+export const createLocalHost = (options: LocalHostOptions): LocalEditorHost => {
   const { store, workspace } = options
   let compiled:
     | {
@@ -385,6 +422,56 @@ export const createLocalHost = (options: LocalHostOptions): EditorHost => {
   })
 
   return {
+    /**
+     * Re-reads the store and pushes the fresh model, keeping staged work
+     * (#444).
+     *
+     * A host whose model moved underneath an open canvas - an agent writing
+     * over MCP while a reviewer watches - previously had only `unmount` plus
+     * `mountEditor` again, which discards everything staged. The delivery half
+     * of the answer already existed: a mid-session `model` frame replaces the
+     * compilation and leaves `pendingChangeset` untouched. What was missing
+     * was any way to ASK for one.
+     *
+     * The staleness question is answered HERE rather than in the handle,
+     * because a revision is opaque and only the store that minted it may
+     * compare two (ADR 0100). The handle reports what is staged; this decides
+     * what that means.
+     *
+     * Refusing rather than refreshing when staged work pins content that
+     * moved is the whole point of the shape. Refreshing anyway would leave
+     * operations staged against bytes nobody can see, to be refused at commit
+     * by `YMVS312` - correct, but only after more work. Re-pinning them
+     * silently would be worse still: it is exactly the unconditional write
+     * the pins exist to prevent.
+     */
+    refresh: (stagedPins: Readonly<Record<string, string>>): RefreshOutcome => {
+      const conflicting = Object.keys(stagedPins)
+        .filter((path) => {
+          const held = store.read(path)
+          // Gone counts as changed: the edit was staged against something that
+          // is no longer there, which is what `YMVS312` says at commit.
+          if (held === undefined) return true
+          return held.revision !== stagedPins[path]
+        })
+        .sort()
+      if (conflicting.length > 0) {
+        return {
+          applied: false,
+          reason: 'staged-against-changed-documents',
+          documents: conflicting,
+        }
+      }
+      const recompiled = recompile()
+      if (!recompiled.ok) {
+        // The canvas keeps the last good model, as it does everywhere else a
+        // recompile fails: a host asking to refresh gets told why rather than
+        // having the graph blanked under its reviewer.
+        return { applied: false, reason: 'refused', diagnostics: recompiled.diagnostics }
+      }
+      deliver?.frame({ kind: 'model', model, views })
+      return { applied: true }
+    },
     open: (events: EditorHostEvents) => {
       deliver = events
       const opened = recompile()

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -1,6 +1,11 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App.js'
-import { createLocalHost, type LocalHostOptions } from './local-host.js'
+import {
+  createLocalHost,
+  type LocalEditorHost,
+  type LocalHostOptions,
+  type RefreshOutcome,
+} from './local-host.js'
 import type { DecorationMap } from './graph-canvas.js'
 import type { EditorHost } from './editor-host.js'
 import {
@@ -113,7 +118,47 @@ export interface MountedEditor {
    * after unmount.
    */
   readonly setDecorations: (decorations: DecorationMap) => boolean
+  /**
+   * Re-reads the host's store and follows it, keeping staged work (#444).
+   *
+   * The answer to a model that moves under an open canvas - an agent writing
+   * while a reviewer watches - where the only previous option was `unmount`
+   * plus mounting again, which discards everything staged. A clean refresh
+   * keeps the reviewer's staged rows, their zoom, their selection and their
+   * filter: only the compilation is replaced.
+   *
+   * It hands the store no bytes. The host already owns the store and the
+   * editor reads through it (ADR 0100), so this asks for a re-read rather
+   * than introducing a second way in.
+   *
+   * Refuses rather than refreshing where staged operations pin content that
+   * moved, naming those documents. That refusal is the point: refreshing
+   * anyway would leave a reviewer editing against bytes nobody can see, to be
+   * refused at commit by `YMVS312` after more work had gone in.
+   *
+   * A mount over a host the caller built (`mountEditorWith`) answers
+   * `not-supported`: such a host already owns delivery and can push a model
+   * frame whenever it likes, which is the same refresh by another route.
+   */
+  readonly refresh: () => MountRefreshOutcome
 }
+
+/** {@link RefreshOutcome}, plus the two ways a handle itself can decline. */
+export type MountRefreshOutcome =
+  | RefreshOutcome
+  | {
+      /** Before the shell's first render, or after `unmount`. */
+      readonly applied: false
+      readonly reason: 'not-mounted'
+    }
+  | {
+      /**
+       * The mount runs over a host the caller built, which owns its own
+       * delivery. Push a `model` frame instead.
+       */
+      readonly applied: false
+      readonly reason: 'not-supported'
+    }
 
 /**
  * The sections a read-only mount defaults to: the reading surfaces. No palette
@@ -184,11 +229,29 @@ export const mountEditorWith = (
       bridge.current?.startConnection(fromSubjectId) ?? false,
     setDecorations: (decorations) =>
       bridge.current?.setDecorations(decorations) ?? false,
+    refresh: () => {
+      const pointer = bridge.current
+      if (pointer === null) return { applied: false, reason: 'not-mounted' }
+      // Only a host that owns a store can re-read one. A caller-built host is
+      // already on the delivering side of the protocol.
+      if (!isLocalHost(host)) return { applied: false, reason: 'not-supported' }
+      // The pins go host-side unread: the handle reports what is staged and
+      // the store that minted those revisions decides what they mean
+      // (ADR 0100).
+      return host.refresh(pointer.stagedPins())
+    },
   }
 }
 
+const isLocalHost = (host: EditorHost): host is LocalEditorHost =>
+  typeof (host as Partial<LocalEditorHost>).refresh === 'function'
+
 export type { EditorHost, EditorHostEvents } from './editor-host.js'
 export type { DecorationMap, DecorationMark } from './graph-canvas.js'
-export type { LocalHostOptions } from './local-host.js'
+export type {
+  LocalEditorHost,
+  LocalHostOptions,
+  RefreshOutcome,
+} from './local-host.js'
 export { createLocalHost } from './local-host.js'
 export { RIGHT_SECTIONS, type RightSectionId } from './workspace-state.js'

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -114,6 +114,15 @@ const nextRelationship = (
 export interface EditorPointerContext {
   readonly graph: CanvasGraph | null;
   readonly readOnly: boolean;
+  /**
+   * What the staged changeset pinned: path -> the revision that path held when
+   * the first edit against it was staged (#444). Empty when nothing is staged.
+   *
+   * The pointer only reports these; it never compares them. A revision is
+   * opaque and only the store that minted it may compare two (ADR 0100), so
+   * the staleness question is answered host-side.
+   */
+  readonly stagedPins: Readonly<Record<string, string>>;
 }
 
 /**
@@ -137,6 +146,12 @@ export interface EditorPointer {
    * method does - a handle before the shell's first render or after disposal.
    */
   readonly setDecorations: (decorations: DecorationMap) => boolean;
+  /**
+   * The staged changeset's pins, for a host about to refresh the canvas
+   * (#444). Reported, never interpreted: the host owns the store that minted
+   * these revisions and is the only party that may compare them (ADR 0100).
+   */
+  readonly stagedPins: () => Readonly<Record<string, string>>;
 }
 
 /**
@@ -184,6 +199,7 @@ export const editorPointerFor = (
     dispatch({ type: "connection.started", from: fromSubjectId });
     return true;
   },
+  stagedPins: () => context().stagedPins,
   setDecorations: (decorations) => {
     // No graph gate and no read-only gate, deliberately (#314, ADR 0119):
     // the marks are held client-side and rendered when a model is on screen,

--- a/test/visual-local-host.test.ts
+++ b/test/visual-local-host.test.ts
@@ -135,7 +135,7 @@ const openHost = (
     session: () => ({ lastSequence: 0, closed: false }),
   })
   const send = (input: VisualBrowserInput) => host.send(input)
-  return { store, frames, send, stop }
+  return { store, host, frames, send, stop }
 }
 
 const input = (
@@ -542,5 +542,121 @@ concepts:
     send(input('filter.query', { query: {} }))
 
     expect(frames).toHaveLength(seen)
+  })
+})
+
+/**
+ * Following a model that moved under an open canvas (#444).
+ *
+ * A host whose store changes while a reviewer watches - an agent writing over
+ * MCP is the case this exists for - previously had only `unmount` plus mounting
+ * again, which discards everything staged. The delivery half already worked: a
+ * mid-session `model` frame replaces the compilation and leaves the staged
+ * changeset alone. What was missing was any way to ask for one, and any way to
+ * find out that asking would strand staged work.
+ */
+describe('local host refresh', () => {
+  const bump = (
+    store: ReturnType<typeof memoryStore>,
+    path: string,
+    source: string,
+  ): void => {
+    const outcome = store.writeAll([
+      { path, source, expected: store.read(path)?.revision ?? null },
+    ])
+    expect(outcome.ok).toBe(true)
+  }
+
+  it('delivers the fresh model when nothing is staged', () => {
+    const { store, host, frames } = openHost()
+    const before = frames.length
+    bump(
+      store,
+      'architecture/main.yaml',
+      document.replace('name: Checkout', 'name: Checkout Service'),
+    )
+
+    expect(host.refresh({})).toEqual({ applied: true })
+    const model = frames.slice(before).find((frame) => frame.kind === 'model')
+    expect(model?.kind).toBe('model')
+    if (model?.kind !== 'model') return
+    expect(model.model.graph.nodes.map(({ name }) => name)).toContain(
+      'Checkout Service',
+    )
+  })
+
+  it('refuses when staged work pins a document that moved, and delivers nothing', () => {
+    const { store, host, frames } = openHost()
+    // What the reviewer's staged edit vouched for: the revision the document
+    // held when they staged it.
+    const staged = {
+      'architecture/main.yaml':
+        store.read('architecture/main.yaml')?.revision ?? '',
+    }
+    bump(
+      store,
+      'architecture/main.yaml',
+      document.replace('name: Ledger', 'name: General Ledger'),
+    )
+    const before = frames.length
+
+    expect(host.refresh(staged)).toEqual({
+      applied: false,
+      reason: 'staged-against-changed-documents',
+      documents: ['architecture/main.yaml'],
+    })
+    // The canvas is untouched, which is the point: the reviewer's staged rows
+    // are exactly where they left them and no frame moved under them.
+    expect(frames.slice(before)).toEqual([])
+  })
+
+  it('refreshes when the pin still matches what the store holds', () => {
+    const { store, host } = openHost()
+    const staged = {
+      'architecture/main.yaml':
+        store.read('architecture/main.yaml')?.revision ?? '',
+    }
+
+    // Nothing moved, so staged work is not stranded and the refresh proceeds.
+    expect(host.refresh(staged)).toEqual({ applied: true })
+  })
+
+  it('counts a document that is gone as changed', () => {
+    const { store, host } = openHost()
+    const staged = {
+      'architecture/main.yaml':
+        store.read('architecture/main.yaml')?.revision ?? '',
+    }
+    store.writeAll([
+      {
+        path: 'architecture/main.yaml',
+        source: null,
+        expected: store.read('architecture/main.yaml')?.revision ?? null,
+      },
+    ])
+
+    // The edit was staged against something no longer there, which is what
+    // `YMVS312` says at commit; saying it here is the same fact, earlier.
+    expect(host.refresh(staged)).toEqual({
+      applied: false,
+      reason: 'staged-against-changed-documents',
+      documents: ['architecture/main.yaml'],
+    })
+  })
+
+  it('reports why rather than blanking the canvas when the store stops compiling', () => {
+    const { store, host, frames } = openHost()
+    bump(store, 'architecture/main.yaml', 'format: yarramate/v1\nid: main\n')
+    const before = frames.length
+
+    const outcome = host.refresh({})
+    expect(outcome.applied).toBe(false)
+    if (outcome.applied) return
+    expect(outcome.reason).toBe('refused')
+    if (outcome.reason !== 'refused') return
+    expect(outcome.diagnostics.length).toBeGreaterThan(0)
+    // No model frame: the last good one stays on screen, the same posture
+    // every other failing recompile takes (#349).
+    expect(frames.slice(before).filter((frame) => frame.kind === 'model')).toEqual([])
   })
 })

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -98,6 +98,80 @@ describe('mountEditorWith', () => {
     expect(editor.openDraft({ kind: 'goal' })).toBe(false)
     expect(editor.startConnection('app.checkout')).toBe(false)
     expect(editor.setDecorations({ 'app.checkout': 'added' })).toBe(false)
+    expect(editor.refresh()).toEqual({
+      applied: false,
+      reason: 'not-mounted',
+    })
+  })
+
+  /**
+   * A caller-built host already owns delivery (#444): it speaks the protocol
+   * and can push a `model` frame whenever it likes, which is the same refresh
+   * by another route. Saying so is better than a bare false, which would read
+   * as "nothing to refresh" and send a host looking for a bug.
+   */
+  it('declines to refresh a host it did not build, and says which it is', () => {
+    const editor = mountEditorWith({} as Element, host, sections)
+    const pointer = {
+      select: vi.fn(() => true),
+      openDraft: vi.fn(() => true),
+      startConnection: vi.fn(() => true),
+      setDecorations: vi.fn(() => true),
+      stagedPins: vi.fn(() => ({})),
+    }
+    onReadyOf(root.render.mock.calls[0]!)(pointer)
+
+    expect(editor.refresh()).toEqual({
+      applied: false,
+      reason: 'not-supported',
+    })
+    // Nothing was asked of the pointer: there is no store behind this host to
+    // compare pins against.
+    expect(pointer.stagedPins).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The pins go across unread. The handle reports what is staged and the store
+   * that minted those revisions decides what they mean (ADR 0100), so this
+   * asserts the handoff rather than any comparison.
+   */
+  it('hands the staged pins to a store-owning host and returns its verdict', () => {
+    const refresh = vi.fn(() => ({ applied: true }) as const)
+    const storeHost = { ...host, refresh }
+    const editor = mountEditorWith({} as Element, storeHost, sections)
+    const pins = { 'architecture/main.yaml': '3' }
+    const pointer = {
+      select: vi.fn(() => true),
+      openDraft: vi.fn(() => true),
+      startConnection: vi.fn(() => true),
+      setDecorations: vi.fn(() => true),
+      stagedPins: vi.fn(() => pins),
+    }
+    onReadyOf(root.render.mock.calls[0]!)(pointer)
+
+    expect(editor.refresh()).toEqual({ applied: true })
+    expect(refresh).toHaveBeenCalledWith(pins)
+  })
+
+  it('passes a refusal back to the host unchanged, naming the documents', () => {
+    const refused = {
+      applied: false,
+      reason: 'staged-against-changed-documents',
+      documents: ['architecture/main.yaml'],
+    } as const
+    const storeHost = { ...host, refresh: vi.fn(() => refused) }
+    const editor = mountEditorWith({} as Element, storeHost, sections)
+    onReadyOf(root.render.mock.calls[0]!)({
+      select: vi.fn(() => true),
+      openDraft: vi.fn(() => true),
+      startConnection: vi.fn(() => true),
+      setDecorations: vi.fn(() => true),
+      stagedPins: vi.fn(() => ({ 'architecture/main.yaml': '1' })),
+    })
+
+    // The named documents are what a host puts in front of a reviewer, so
+    // they have to survive the trip rather than collapse to a boolean.
+    expect(editor.refresh()).toEqual(refused)
   })
 
   it('delegates each method to the pointer the shell hands up (#297)', () => {
@@ -107,6 +181,7 @@ describe('mountEditorWith', () => {
       openDraft: vi.fn(() => true),
       startConnection: vi.fn(() => false),
       setDecorations: vi.fn(() => true),
+      stagedPins: vi.fn(() => ({})),
     }
     onReadyOf(root.render.mock.calls[0]!)(pointer)
 
@@ -131,6 +206,7 @@ describe('mountEditorWith', () => {
       openDraft: vi.fn(() => true),
       startConnection: vi.fn(() => true),
       setDecorations: vi.fn(() => true),
+      stagedPins: vi.fn(() => ({})),
     }
     onReadyOf(root.render.mock.calls[0]!)(pointer)
 
@@ -212,7 +288,7 @@ describe('editorPointerFor', () => {
   }
 
   it('selects a concept exactly as a canvas tap would', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.select('app.checkout')).toBe(true)
     expect(dispatched).toEqual([
@@ -224,7 +300,7 @@ describe('editorPointerFor', () => {
   })
 
   it('selects a relationship with its endpoint titles resolved', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.select('checkout-serves-ledger')).toBe(true)
     expect(dispatched).toEqual([
@@ -242,14 +318,14 @@ describe('editorPointerFor', () => {
   })
 
   it('still selects under a read-only mount, because selecting is reading', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: true })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: true, stagedPins: {} })
 
     expect(pointer.select('app.checkout')).toBe(true)
     expect(dispatched).toHaveLength(1)
   })
 
   it('moves nothing for an id the model does not name', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.select('app.gone')).toBe(false)
     expect(dispatched).toEqual([])
@@ -259,6 +335,7 @@ describe('editorPointerFor', () => {
     const { pointer, dispatched, seeded } = pointerOver({
       graph,
       readOnly: false,
+      stagedPins: {},
     })
 
     expect(pointer.openDraft({ kind: 'goal' })).toBe(true)
@@ -267,7 +344,7 @@ describe('editorPointerFor', () => {
   })
 
   it('opens a plain draft with no kind, clearing any earlier seed (ADR 0116)', () => {
-    const { pointer, seeded } = pointerOver({ graph, readOnly: false })
+    const { pointer, seeded } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.openDraft()).toBe(true)
     expect(seeded).toEqual([undefined])
@@ -277,6 +354,7 @@ describe('editorPointerFor', () => {
     const { pointer, dispatched, seeded } = pointerOver({
       graph,
       readOnly: true,
+      stagedPins: {},
     })
 
     expect(pointer.openDraft({ kind: 'goal' })).toBe(false)
@@ -285,7 +363,7 @@ describe('editorPointerFor', () => {
   })
 
   it('arms the connection tool from a subject, as Connect does', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.startConnection('app.checkout')).toBe(true)
     expect(dispatched).toEqual([
@@ -294,7 +372,7 @@ describe('editorPointerFor', () => {
   })
 
   it('refuses a source that is unknown, or not a concept at all', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: false })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: false, stagedPins: {} })
 
     expect(pointer.startConnection('app.gone')).toBe(false)
     // A relationship has no endpoint to draw from.
@@ -303,7 +381,7 @@ describe('editorPointerFor', () => {
   })
 
   it('refuses to arm the connection tool in a viewer (#298)', () => {
-    const { pointer, dispatched } = pointerOver({ graph, readOnly: true })
+    const { pointer, dispatched } = pointerOver({ graph, readOnly: true, stagedPins: {} })
 
     expect(pointer.startConnection('app.checkout')).toBe(false)
     expect(dispatched).toEqual([])
@@ -316,6 +394,7 @@ describe('editorPointerFor', () => {
     const { pointer, dispatched, decorated } = pointerOver({
       graph,
       readOnly: false,
+      stagedPins: {},
     })
 
     expect(pointer.setDecorations({ 'app.checkout': 'added' })).toBe(true)
@@ -332,13 +411,13 @@ describe('editorPointerFor', () => {
     // the moment a model is on screen - a host hands the map with the mount,
     // not after the first frame. And decorating is reading (#298), so the
     // read-only posture refuses nothing here.
-    const early = pointerOver({ graph: null, readOnly: false })
+    const early = pointerOver({ graph: null, readOnly: false, stagedPins: {} })
     expect(early.pointer.setDecorations({ 'app.checkout': 'removed' })).toBe(
       true,
     )
     expect(early.decorated).toEqual([{ 'app.checkout': 'removed' }])
 
-    const viewer = pointerOver({ graph, readOnly: true })
+    const viewer = pointerOver({ graph, readOnly: true, stagedPins: {} })
     expect(viewer.pointer.setDecorations({})).toBe(true)
     expect(viewer.decorated).toEqual([{}])
   })
@@ -346,7 +425,7 @@ describe('editorPointerFor', () => {
   it('reads the model at call time, so the methods answer for the graph on screen', () => {
     // Before the host's first frame there is nothing to point at; the same
     // pointer starts answering true once the model arrives, with no re-bind.
-    let context: EditorPointerContext = { graph: null, readOnly: false }
+    let context: EditorPointerContext = { graph: null, readOnly: false, stagedPins: {} }
     const dispatched: VisualWorkspaceAction[] = []
     const pointer = editorPointerFor(
       () => context,
@@ -360,7 +439,7 @@ describe('editorPointerFor', () => {
     expect(pointer.startConnection('app.checkout')).toBe(false)
     expect(dispatched).toEqual([])
 
-    context = { graph, readOnly: false }
+    context = { graph, readOnly: false, stagedPins: {} }
     expect(pointer.select('app.checkout')).toBe(true)
     expect(pointer.openDraft()).toBe(true)
     expect(pointer.startConnection('app.checkout')).toBe(true)


### PR DESCRIPTION
Closes #444. `MountedEditor` gains **`refresh()`**: the host's store is re-read
and the canvas follows it, with staged work, zoom, selection and filter intact.

## The shape changed during the build, and that is the interesting part

#444 proposed `setDocuments(documents)`. Building it, **two-thirds of B turned
out to already exist**:

- a mid-session `model` frame has always replaced the compilation while leaving
  `pendingChangeset` untouched — that runs after every commit today
- a `mountEditorWith` host can already push one whenever it likes

What was actually missing was narrow: the local host recompiles at `open()` and
after `commit()` **and nowhere else**, so a `mountEditor` host has no way to say
"my store changed". And nobody computes, at that moment, whether refreshing
would strand staged work.

So this **asks for a re-read** rather than taking documents. Handing bytes
across the mount seam would contradict ADR 0100 — the host owns the store, the
editor reads through it — and duplicate a delivery path that already worked.
The adopter's own constraint was "no new write path"; `setDocuments` would have
been a new *read* path. Nabeel confirmed the change of shape before I built it.

## The outcome, not a boolean

```ts
refresh(): MountRefreshOutcome
```

| result | meaning |
|---|---|
| `{ applied: true }` | the canvas follows the store |
| `staged-against-changed-documents` | staged work pins content this would replace; **nothing delivered**, and the named documents are what to show the reviewer |
| `refused` | the store no longer compiles; last good model stands, with diagnostics |
| `not-mounted` | before the shell's first render, or after `unmount` |
| `not-supported` | a `mountEditorWith` host, which owns its own delivery |

`setDecorations` answers with a bare boolean because decorating is *reading* and
the only failure is a not-there window. Refreshing can fail for reasons a host
has to explain to a person, so it says which.

## Why it refuses rather than refreshing

This is the whole reason B beat A. Refreshing over staged work would leave a
reviewer editing against content nobody can see, to be refused at commit by
`YMVS312` **after more effort had gone in** — which is precisely the lateness
`hasStagedChanges()` would have left in place. Re-pinning their operations
silently would be worse: those pins are the precondition that stops one author
overwriting another.

Refusing at the moment of divergence is the earliest honest answer, and naming
the documents lets a host say something specific instead of showing a blanket
banner.

## Where the comparison lives

Host-side, not in the handle. **A revision is opaque and only the store that
minted it may compare two (ADR 0100)** — so the handle reports what is staged
and the store decides what that means. A document that is gone counts as
changed, which is what `YMVS312` already says at commit.

## Rule 1, firing as designed

`EditorPointerContext` and `EditorPointer` gain a required `stagedPins`, which
broke every construction site in the mount tests — free for readers, a
typecheck break for constructors. Both types are internal (not exported from
`yarramate/visual-app`), so required is right: it makes the next construction
site decide rather than default to silence.

## Tests

Five over the local host:
- a clean refresh delivers the fresh model
- a moved pin refuses **and delivers nothing** — the canvas is untouched, so
  the reviewer's rows are where they left them
- a pin that still matches proceeds
- a document that is gone counts as changed
- a store that stops compiling reports why rather than blanking the canvas

Three over the handle: `not-mounted`, `not-supported` (and the pointer is not
even asked), and the pins handed across unread with the host's verdict returned
unchanged.

**Mutations**: refreshing regardless of pins turns two red; treating a deleted
document as unchanged turns one red.

## Validation

`rm -rf dist && pnpm verify`, **VERIFY_EXIT=0**, 2062 passed / 121 files.
Self-model unchanged and clean: 317/317 confirmed, 0 unclaimed of 155.

Consumer guide carries the outcome table and the reasoning for the refusal.
Left under `## Unreleased` — no version bump, since you have not said to cut.
