### PR TITLE
chore: release 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.17.0
 
 ### A host can refresh the canvas without discarding staged work
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.17.0**, carrying #456: `MountedEditor.refresh()`.

## Version choice

A **minor**. New public API on the mount surface — the handle gains one method
and two exported types — with no breaking change: every existing method behaves
identically, and a host that never calls `refresh()` sees nothing new.

## Release preparation, per `docs/RELEASING.md`

| step | result |
|---|---|
| `pnpm` matches `packageManager` | 11.7.0 = 11.7.0 |
| `pnpm install --frozen-lockfile` | clean |
| `rm -rf dist && pnpm verify` | **VERIFY_EXIT=0**, 2062 passed / 121 files |
| `npm pack --dry-run`, **listing read** | 288 files, unchanged from 1.16.0 |
| changelog backstop | every user-visible commit since v1.16.0 has an entry |

Listing audited both directions — absent: `src/`, `test/`, fixtures,
`.yarramate/`, `scripts/`, any `*.test.*`; present: `README.md`, `LICENSE`,
`docs/CONSUMING-YARRAMATE.md`, `dist/cli.js`, `dist/visual-app-lib/editor.js`.

## Self-model

Green and unchanged — the feature added no source files, so nothing new to
declare:

- `self:check` clean — 358 concepts, 480 relationships, 4 states
- `self:reconcile` — **317/317 confirmed**, 0 contradicted, **0 unclaimed of
  155 artifacts**
- LikeC4 subject mapping **already synchronized**
- `pnpm generate:validators` regenerates to **zero diff** — the freshness check
  that would catch a schema edited without regenerating

That pre-flight has caught something in three of the last four releases (an
undeclared module twice, four drifted mappings once). Clean this time.

## No browser pass

Stated as a decision rather than an omission. `refresh()` is reachable only
through the `mountEditor` handle by a host that owns a store; it changes no
rendering, no canvas code and no UI affordance. The path it delivers through —
a mid-session `model` frame — is the one every commit already takes and is
covered by the local-host tests. The standing rule that a green suite says
nothing about the canvas applies to changes that reach it, and this does not.

Nabeel's cytoscape 3.34.2 canvas check on 1.16.0 stands as the most recent
first-hand look, and nothing has touched the canvas since.

## Publication

Not performed here — the runbook makes it an explicit external action, and it
needs Nabeel's OTP. After merge I create the annotated tag; the
`npm publish --access public --otp <code>` from a fresh clone of the tag is
his, and I verify `gitHead`, the GitHub release and a registry smoke test once
it lands.
