### PR TITLE
fix(compiler): mint one claim per triple, with ownership deciding the id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### One relationship, one claim, when two pattern wires name it
+
+Two wires could name the same triple, and both minted, so one relationship
+became two relationship claims in the graph. Any consumer counting or diffing
+relationships saw one edge twice: `check` totals, `export graph`, the workbook,
+a canvas drawing two edges between one pair. Both claims carried
+`origin: 'declared'`, so nothing downstream could tell them apart (#460,
+observed by the ApertureX adopter session against 1.16.0 and 1.17.0).
+
+The wiring loop asked whether an **authored** relationship already said it, and
+whether the derived id was already a declared subject, but never whether a
+**previously minted wire** had said it. An authored edge satisfies both wires,
+which is why a workspace that writes the relationship down never met this and
+one that left it to expansion did.
+
+Now one claim per triple, with **ownership** deciding which id survives: an edge
+with an owner carries its owner's wiring id, and an edge with only guests
+carries the id of its triple. A wire whose `from` is `self` owns the edge
+because the edge leaves that instance; a wire whose `from` is a slot is a guest
+naming somebody else's edge, and defers.
+
+**No id changes for a workspace that compiles today.** Every existing edge
+either has an owner or is a group of one, and a group of one is not a collision:
+a wire between two slots of one pattern keeps its ADR 0123 id untouched. The
+triple-derived id appears only where two or more guests name one triple and the
+owner's wire is absent, which happens when the owning instance is greenfield and
+an unbound slot wires nothing. See ADR 0141.
+
 ### A pattern can become a questionnaire
 
 A pattern declares the shape a kind promises, and an instance that has not

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -105,6 +105,18 @@ every instance on the next compile.
   exactly what a wiring edge says, nothing is minted: the authored one
   satisfies the wiring. A model can adopt a pattern without touching a
   line and delete the redundant relationships afterwards.
+- **One relationship, one claim, when two wires name it** (ADR 0141). Two
+  patterns can wire the same triple — an app wiring `mapping access
+  payload` and the mapping wiring `self access source`, both landing on
+  one data object — and only one claim is minted. Which id survives is
+  decided by OWNERSHIP: a wire whose `from` is `self` owns the edge,
+  because the edge leaves that instance, and keeps its derived id above.
+  A wire whose `from` is a slot is a guest naming somebody else's edge,
+  and defers. Where every wire is a guest, which happens when the owning
+  instance is greenfield and so its own wire never fires, the id comes
+  from the triple instead: `{from}-{kind}-{to}`. A wire nothing competes
+  with is not a collision and is untouched, including a wire between two
+  slots of one pattern, which has no `self` endpoint but no rival either.
 - **The pattern owns the pairs it wires.** Any other authored
   relationship between a wired pair — reversed, or a different kind — is
   a compile error. Edges from a part to anything *else* are free.

--- a/docs/adr/0141-an-edge-with-an-owner-carries-its-owners-wiring-id.md
+++ b/docs/adr/0141-an-edge-with-an-owner-carries-its-owners-wiring-id.md
@@ -1,0 +1,110 @@
+# An edge with an owner carries its owner's wiring id
+
+Status: accepted
+
+Two wires can name one triple. Before this, both minted, so one relationship
+became two relationship claims (#460, observed by the ApertureX adopter session
+in their own pack test, against released 1.16.0 and 1.17.0):
+
+```
+id: app-mapping-access-payload   subject: map-x  →  access  →  shared-payload   origin: declared
+id: map-x-access-source          subject: map-x  →  access  →  shared-payload   origin: declared
+```
+
+The shape is an app pattern whose `mapping` slot takes an instance of a mapping
+pattern with parts of its own: the app wires `mapping --access--> payload`, the
+mapping wires `self --access--> source`, and one document binds both to the same
+data object.
+
+Nothing caught it because the wiring loop asked two questions before minting and
+neither covers this. Does an **authored** relationship already say it
+(`authoredByPair`), in which case the wire is satisfied and mints nothing; and
+is the derived id already a **declared subject** (`declaredIds`), which is
+`YM420`. It never asked whether a **previously minted wire** had said it, and
+the two ids differ by construction, so `YM420` could not fire either. An
+authored edge satisfies *both* wires, which is why a workspace that writes the
+relationship down never meets this and one that leaves it to expansion does.
+
+## Decided
+
+**One claim per triple, and OWNERSHIP decides which id survives.**
+
+> An edge with an owner carries its owner's wiring id; an edge with only guests
+> carries the id of its triple.
+
+- A wire whose `from` is `self` **owns** the edge, because the edge leaves that
+  instance. It mints, and its ADR 0123 id survives unchanged.
+- A wire whose `from` is a slot is a **guest** naming an edge that leaves
+  somebody else, and defers.
+- Where every wire in a collision is a guest, the owner's wire is absent —
+  typically its instance is greenfield and an unbound slot wires nothing — so
+  there is no ADR 0123 id to prefer, and the id comes from the triple:
+  `{from}-{kind}-{to}`.
+
+**A group of one is not a collision, and this exception is the load-bearing
+half.** A wire between two SLOTS of one pattern (`component --composition-->
+interface`) has no `self` endpoint and therefore no owner, but nothing competes
+with it. Its ADR 0123 id survives untouched. Without this, ownership would
+rename every slot-to-slot edge in every workspace — including ADR 0123's own
+worked examples, `contact-system-api-component-composition-interface` — which is
+precisely the migration ownership exists to avoid. This was not reasoned out in
+advance: applying the rule without it renamed
+`sys-api-component-composition-interface` in the existing suite, which is how it
+was found.
+
+**Nothing that compiles today changes id.** Every existing edge is either a
+group of one or has an owner.
+
+## Why ownership rather than the alternatives
+
+- **Refusing the collision** (a new diagnostic saying two patterns wire the same
+  pair) was refused. Two wires naming one triple are two patterns **agreeing**,
+  and agreement is already treated as one fact when it is authored, since an
+  authored edge satisfies every wire that names it. `YM418` is what exists for
+  the case where statements *disagree*. Refusal would also make a legal
+  composition of two independently-authored patterns an authoring error, at
+  exactly the shape the reporting adopter now ships into every new project.
+- **Deriving every minted id from the triple** was refused. It is stable and
+  order-independent, but it rewrites the ADR 0123 contract and moves every
+  minted wiring id in every workspace. That is a migration priced as a dedup.
+- **Keeping today's ids and picking the survivor by sorting** was refused. It
+  fixes ordering but not stability: adding or removing a further guest could
+  change which id survives. Ownership plus a triple-derived fallback is stable
+  under both.
+
+## Consequences
+
+- **The no-owner fallback carries real traffic and is not a corner.** Two apps
+  sharing one *greenfield* mapping produce two guest wires and no owner at all,
+  because the mapping has bound nothing and an unbound slot wires nothing. That
+  is the adoption state ADR 0140 exists to surface, so the fallback needed to be
+  a first-class rule rather than a footnote.
+- **Two id derivations now coexist in one id space**, one built from slot names
+  and one from subject ids, selected by whether an owner exists. A reader
+  holding an id can no longer tell how it was derived without knowing the
+  pattern topology.
+- **They can collide.** A data object whose id is literally `source` gives the
+  guest-only triple `(map-x, access, source)` and so the triple-derived id
+  `map-x-access-source`, which is also the ADR 0123 id of an owner wire whose
+  slot is named `source` bound to a different subject. Same id, different
+  triples. It lands on the existing `declaredIds` check and is refused as
+  `YM420`, so it fails loudly rather than silently, which is the right
+  direction. `YM420`'s message says the id "is already a declared subject",
+  which is not quite what happened; left as is rather than widened on
+  speculation, since the case is constructible but has not been observed.
+- **Two owners on one triple cannot occur.** `self` differs per instance, and
+  within one instance `YM315` already refuses two slots naming one subject. The
+  implementation sorts the owners anyway rather than trusting that from a
+  distance.
+- Minting moved from inside the per-instance loop to a pass over the collected
+  candidates, because whether a wire mints depends on wires belonging to other
+  instances. Claim ORDER is unaffected downstream: `claims` is sorted by id
+  before emission.
+
+## Provenance
+
+Observed and pinned by the ApertureX session, reproduced here before filing.
+The ownership rule and its wording are theirs, arrived at after two earlier
+proposals were withdrawn under review. The group-of-one exception and the
+no-owner reachability are this session's, both found by measurement rather than
+argument.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3113,6 +3113,26 @@ function compileWorkspaceResolved(
       else group.push(entry)
     }
 
+    /**
+     * Every wire that wants to mint, keyed by the TRIPLE it names (#460).
+     * Collected across all instances before any is minted, because two wires
+     * belonging to different instances can name one triple and only one claim
+     * may survive.
+     */
+    const wireCandidates = new Map<
+      string,
+      {
+        readonly instance: string
+        readonly pattern: ResolvedPattern
+        readonly wire: ResolvedPattern['wiring'][number]
+        readonly from: string
+        readonly to: string
+        readonly where: GraphSource
+        readonly owner: boolean
+        readonly wireId: string
+      }[]
+    >()
+
     for (const { instance, pattern, bindings, sourceOf } of patternInstances) {
       const boundTo = new Map<string, string>()
       for (const [slot, target] of bindings) {
@@ -3218,37 +3238,91 @@ function compileWorkspaceResolved(
           })
         }
         if (satisfied) continue
-        const wireId = [
+        // Collected rather than minted, because whether this wire mints
+        // depends on wires belonging to OTHER instances (#460). Two wires can
+        // name one triple, and before this they both minted: two relationship
+        // claims for one relationship.
+        const key = `${from}\u0000${wire.kindIdentity}\u0000${to}`
+        const candidate = {
           instance,
-          ...(wire.from === 'self' ? [] : [wire.from]),
-          wire.coreKind,
-          wire.to,
-        ].join('-')
-        if (declaredIds.has(wireId)) {
-          diagnostics.push({
-            severity: 'error',
-            code: 'YM420',
-            message:
-              `The pattern for "${pattern.kindIdentity}" derives the wiring id ` +
-              `"${wireId}" for "${instance}", which is already a declared subject`,
-            path: where.path,
-            pointer: where.pointer,
-            line: where.line,
-            column: where.column,
-          })
-          continue
+          pattern,
+          wire,
+          from,
+          to,
+          where,
+          owner: wire.from === 'self',
+          wireId: [
+            instance,
+            ...(wire.from === 'self' ? [] : [wire.from]),
+            wire.coreKind,
+            wire.to,
+          ].join('-'),
         }
-        declaredIds.add(wireId)
-        subjects.push({ id: wireId, type: 'relationship' })
-        claims.push({
-          id: wireId,
-          subject: from,
-          predicate: wire.kindIdentity,
-          object: { ref: to },
-          origin: 'declared',
-          source: where,
-        })
+        const group = wireCandidates.get(key)
+        if (group === undefined) wireCandidates.set(key, [candidate])
+        else group.push(candidate)
       }
+    }
+
+    // One claim per triple, whichever wires named it (#460, ADR 0141).
+    //
+    // OWNERSHIP decides the id, not walk order. A wire whose `from` is `self`
+    // owns the edge, because the edge leaves that instance; a wire whose
+    // `from` is a slot is a guest naming somebody else's edge, and defers. So
+    // an edge with an owner keeps the ADR 0123 id it has always had, and
+    // nothing moves for a workspace that compiles today.
+    //
+    // Where every wire is a guest the owner's wire is absent — typically its
+    // instance is greenfield, and an unbound slot wires nothing — so there is
+    // no ADR 0123 id to prefer and the id comes from the TRIPLE instead. That
+    // is stable under adding or removing further guests, which sorting a
+    // winner out of the guests would not be.
+    for (const [, group] of [...wireCandidates].sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      const owners = group
+        .filter(({ owner }) => owner)
+        // Two owners on one triple cannot happen: `self` differs per instance,
+        // and within one instance YM315 already refuses two slots naming one
+        // subject. Sorted anyway rather than trusting that from a distance.
+        .sort((left, right) => left.wireId.localeCompare(right.wireId))
+      const winner = owners[0] ?? group[0]
+      if (winner === undefined) continue
+      // A group of ONE is not a collision and keeps its ADR 0123 id, always.
+      // This is the case that matters most, because a wire between two SLOTS
+      // of one pattern (`component --composition--> interface`) has no `self`
+      // endpoint and so no owner, yet nothing is competing with it. Deriving
+      // its id from the triple would rename every such edge in every
+      // workspace, which is exactly the migration ownership exists to avoid;
+      // ADR 0123's own worked example is one of them.
+      const wireId =
+        group.length === 1 || owners.length > 0
+          ? winner.wireId
+          : [winner.from, winner.wire.coreKind, winner.to].join('-')
+      if (declaredIds.has(wireId)) {
+        diagnostics.push({
+          severity: 'error',
+          code: 'YM420',
+          message:
+            `The pattern for "${winner.pattern.kindIdentity}" derives the wiring id ` +
+            `"${wireId}" for "${winner.instance}", which is already a declared subject`,
+          path: winner.where.path,
+          pointer: winner.where.pointer,
+          line: winner.where.line,
+          column: winner.where.column,
+        })
+        continue
+      }
+      declaredIds.add(wireId)
+      subjects.push({ id: wireId, type: 'relationship' })
+      claims.push({
+        id: wireId,
+        subject: winner.from,
+        predicate: winner.wire.kindIdentity,
+        object: { ref: winner.to },
+        origin: 'declared',
+        source: winner.where,
+      })
     }
   }
 

--- a/test/duplicate-wiring.test.ts
+++ b/test/duplicate-wiring.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compileWorkspaceWithProfileContext,
+  type WorkspaceSource,
+} from '../src/index.js'
+
+// #460: two wires naming one triple both minted, so one relationship became two
+// relationship claims. Reported by the ApertureX session against 1.16.0 and
+// 1.17.0, from their own pack test.
+//
+// The rule under test (ADR 0141): an edge with an owner carries its owner's
+// wiring id; an edge with only guests carries the id of its triple. A wire
+// whose `from` is `self` owns the edge because the edge leaves that instance; a
+// wire whose `from` is a slot is a guest naming somebody else's edge.
+//
+// The assertion that matters most is the one about ids that must NOT move:
+// almost every wire in existence is a group of one, and a group of one is not a
+// collision.
+
+const profile = `format: yarramate/profile/v1
+id: aperturex/consulting
+version: "1.0"
+extends: yarramate/core@0.1
+conceptKinds:
+  - id: app-kind
+    name: App
+    parent: yarramate/core@0.1#applicationComponent
+  - id: mapping-kind
+    name: Mapping
+    parent: yarramate/core@0.1#applicationFunction
+relationshipKinds: []
+`
+
+// The app wires `mapping --access--> payload`, a GUEST wire: its `from` is a
+// slot, so it names an edge leaving the mapping rather than leaving the app.
+// The mapping wires `self --access--> source`, which is the OWNER of the same
+// edge whenever both land on one object.
+const patterns = `format: yarramate/pattern/v1
+id: consulting
+version: "1.0"
+patterns:
+  - kind: aperturex/consulting@1.0#app-kind
+    parts:
+      mapping:
+        kind: aperturex/consulting@1.0#mapping-kind
+      payload:
+        kind: yarramate/core@0.1#dataObject
+    wiring:
+      - from: self
+        kind: yarramate/core@0.1#assignment
+        to: mapping
+      - from: mapping
+        kind: yarramate/core@0.1#access
+        to: payload
+  - kind: aperturex/consulting@1.0#mapping-kind
+    parts:
+      source:
+        kind: yarramate/core@0.1#dataObject
+    wiring:
+      - from: self
+        kind: yarramate/core@0.1#access
+        to: source
+`
+
+const sourcesFor = (document: string): readonly WorkspaceSource[] => [
+  { path: 'profiles/consulting.yaml', source: profile },
+  { path: 'patterns/consulting.yaml', source: patterns },
+  { path: 'architecture/main.yaml', source: document },
+]
+
+const accessEdges = (document: string) => {
+  const result = compileWorkspaceWithProfileContext(sourcesFor(document))
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.diagnostics.map((d) => d.code).join())
+  return result.graph.claims
+    .filter(
+      (claim) =>
+        claim.predicate === 'yarramate/core@0.1#access' &&
+        'ref' in claim.object &&
+        claim.object.ref === 'shared-payload',
+    )
+    .map((claim) => claim.id)
+    .sort()
+}
+
+describe('#460: two wires naming one triple mint one claim', () => {
+  it('mints once where an owner and a guest name the same triple', () => {
+    // The reported shape. Before this, both wires minted:
+    // `app-mapping-access-payload` AND `map-x-access-source`.
+    expect(
+      accessEdges(`format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+  - id: app
+    kind: app-kind
+    name: App
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships: []
+`),
+    ).toEqual(['map-x-access-source'])
+  })
+
+  it('keeps the OWNER id, so nothing moves for a workspace that compiles today', () => {
+    // The surviving id is the mapping's own ADR 0123 id, unchanged from what
+    // it would be with no app in the workspace at all. Asserted as an equality
+    // between the two workspaces rather than as a literal, so the claim "the
+    // guest changes nothing" is what is actually tested.
+    const withoutGuest = accessEdges(`format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+relationships: []
+`)
+    // The guest is declared FIRST on purpose, so it is the wire collected
+    // first. An implementation that took whichever wire it met first would
+    // answer `app-mapping-access-payload` here and pass a fixture that put the
+    // owner first.
+    const withGuest = accessEdges(`format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: app
+    kind: app-kind
+    name: App
+    parts:
+      mapping: map-x
+      payload: shared-payload
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+relationships: []
+`)
+    expect(withoutGuest).toEqual(['map-x-access-source'])
+    expect(withGuest).toEqual(withoutGuest)
+  })
+
+  it('falls back to the triple where every wire is a guest', () => {
+    // Two apps sharing one GREENFIELD mapping. The owner's wire never fires,
+    // because `map-x` binds nothing and an unbound slot wires nothing, so
+    // there is no ADR 0123 id to prefer and no basis to pick between the two
+    // guests. Measured on 1.17.0 this produced two claims.
+    expect(
+      accessEdges(`format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+  - id: app1
+    kind: app-kind
+    name: App one
+    parts:
+      mapping: map-x
+      payload: shared-payload
+  - id: app2
+    kind: app-kind
+    name: App two
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships: []
+`),
+    ).toEqual(['map-x-access-shared-payload'])
+  })
+
+  it('holds that id steady as further guests arrive', () => {
+    // The property that sank picking a winner by sorting the guests: a third
+    // app whose id sorts before the others must not move the surviving id.
+    const two = `format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+  - id: app1
+    kind: app-kind
+    name: App one
+    parts:
+      mapping: map-x
+      payload: shared-payload
+  - id: app2
+    kind: app-kind
+    name: App two
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships: []
+`
+    const three = two.replace(
+      'relationships: []',
+      `  - id: aaa-app
+    kind: app-kind
+    name: Earlier app
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships: []`,
+    )
+    expect(accessEdges(three)).toEqual(accessEdges(two))
+  })
+
+  it('does not depend on the order the instances are written in', () => {
+    const appFirst = `format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: app
+    kind: app-kind
+    name: App
+    parts:
+      mapping: map-x
+      payload: shared-payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+relationships: []
+`
+    const mappingFirst = `format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+  - id: app
+    kind: app-kind
+    name: App
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships: []
+`
+    expect(accessEdges(appFirst)).toEqual(accessEdges(mappingFirst))
+    expect(accessEdges(appFirst)).toEqual(['map-x-access-source'])
+  })
+
+  it('still lets an authored edge satisfy both wires and mint nothing', () => {
+    // The adopter's own control case, which is why their reference project
+    // never met the defect: an authored relationship satisfies every wire that
+    // names it, so nothing is minted and the authored id is what survives.
+    expect(
+      accessEdges(`format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: shared-payload
+    kind: dataObject
+    name: Shared payload
+  - id: map-x
+    kind: mapping-kind
+    name: Map X
+    parts:
+      source: shared-payload
+  - id: app
+    kind: app-kind
+    name: App
+    parts:
+      mapping: map-x
+      payload: shared-payload
+relationships:
+  - id: authored-access
+    kind: access
+    from: map-x
+    to: shared-payload
+`),
+    ).toEqual(['authored-access'])
+  })
+})
+
+describe('#460: a group of one is not a collision', () => {
+  // The regression this rule could most easily cause, and it is not
+  // hypothetical: applying ownership without this exception renamed
+  // `sys-api-component-composition-interface` in the existing suite.
+  //
+  // A wire between two SLOTS of one pattern has no `self` endpoint and so no
+  // owner, but nothing is competing with it. Its ADR 0123 id must survive
+  // untouched, or every such edge in every workspace is renamed - and ADR
+  // 0123's own worked examples are of exactly this shape.
+  const slotToSlot = `format: yarramate/pattern/v1
+id: api-led
+version: "1.0"
+patterns:
+  - kind: aperturex/consulting@1.0#app-kind
+    parts:
+      component:
+        kind: yarramate/core@0.1#applicationComponent
+      interface:
+        kind: yarramate/core@0.1#applicationInterface
+    wiring:
+      - from: component
+        kind: yarramate/core@0.1#composition
+        to: interface
+`
+
+  it('keeps the ADR 0123 id of a slot-to-slot wire with no owner', () => {
+    const result = compileWorkspaceWithProfileContext([
+      { path: 'profiles/consulting.yaml', source: profile },
+      { path: 'patterns/api-led.yaml', source: slotToSlot },
+      {
+        path: 'architecture/main.yaml',
+        source: `format: yarramate/v1
+id: main
+profile: aperturex/consulting@1.0
+concepts:
+  - id: sys-api
+    kind: app-kind
+    name: System API
+    parts:
+      component: sys-component
+      interface: sys-interface
+  - id: sys-component
+    kind: applicationComponent
+    name: System component
+  - id: sys-interface
+    kind: applicationInterface
+    name: System interface
+relationships: []
+`,
+      },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(
+      result.graph.claims
+        .filter(
+          (claim) => claim.predicate === 'yarramate/core@0.1#composition',
+        )
+        .map((claim) => claim.id),
+      // The instance id, the source slot, the core kind, the target slot -
+      // ADR 0123's derivation, untouched.
+    ).toEqual(['sys-api-component-composition-interface'])
+  })
+})


### PR DESCRIPTION
Closes #460.

Two wires could name the same triple and both minted, so one relationship became
two relationship claims. Both carried `origin: 'declared'`, so nothing
downstream could tell them apart.

```
id: app-mapping-access-payload   subject: map-x  →  access  →  shared-payload
id: map-x-access-source          subject: map-x  →  access  →  shared-payload
```

The wiring loop asked whether an **authored** relationship already said it, and
whether the derived id was already a declared subject (`YM420`). It never asked
whether a **previously minted wire** had said it, and the two ids differ by
construction, so `YM420` could not fire either. An authored edge satisfies both
wires, which is why a workspace that writes the relationship down never met this
and one that left it to expansion did.

## The rule

> **An edge with an owner carries its owner's wiring id; an edge with only
> guests carries the id of its triple.**

A wire whose `from` is `self` **owns** the edge, because the edge leaves that
instance, and keeps its ADR 0123 id. A wire whose `from` is a slot is a **guest**
naming somebody else's edge, and defers. Where every wire is a guest, the
owner's wire is absent — its instance is greenfield and an unbound slot wires
nothing — so there is no ADR 0123 id to prefer and the id comes from the triple.

The rule and its wording are the ApertureX session's, after two earlier
proposals were withdrawn under review. See ADR 0141 for why refusal and
triple-derived-everywhere were both rejected.

## A group of one is not a collision, and finding that out is the story

Applying ownership literally **renamed `sys-api-component-composition-interface`
in the existing suite.** A wire between two SLOTS of one pattern
(`component --composition--> interface`) has no `self` endpoint and therefore no
owner, but nothing competes with it. Ownership without this exception would
rename every slot-to-slot edge in every workspace, **including ADR 0123's own
worked examples** — precisely the migration ownership exists to avoid.

So: a group of one keeps its ADR 0123 id, always. **No id changes for a
workspace that compiles today**, and the whole existing suite passes untouched.

This was not reasoned out in advance. It fell out of building the rule and
running the suite, which is the third time on this issue that measurement has
corrected an argument both sessions found convincing.

## Tests

`test/duplicate-wiring.test.ts`, seven cases:

| test | asserts |
|---|---|
| owner and guest name one triple | one claim, `map-x-access-source` |
| keeps the OWNER id | equality with the same workspace minus the guest, **guest declared first** so first-wire-wins fails it |
| every wire a guest | one claim, `map-x-access-shared-payload`, the greenfield case |
| further guests arrive | id unmoved by a third app sorting earlier |
| instance order | `appFirst` and `mappingFirst` agree |
| authored edge | satisfies both wires, mints nothing (the adopter's control) |
| **group of one** | slot-to-slot wire keeps `sys-api-component-composition-interface` |

Mutation-checked:

| mutation | result |
|---|---|
| ignore ownership, first candidate wins | **3 of 7 fail** |
| no dedup, the pre-fix behaviour | **5 of 7 fail** |

## Implementation note

Minting moved from inside the per-instance loop to a pass over collected
candidates, because whether a wire mints depends on wires belonging to other
instances. Claim order downstream is unaffected: `claims` is sorted by id before
emission.

Two consequences are recorded in the ADR rather than fixed on speculation: two
id derivations now coexist in one id space, and they can collide (a data object
literally named `source`), which lands on `YM420` — loudly, but with a message
written for a different cause.

## Verification

`rm -rf dist && pnpm verify`, **exit 0**. 2090 passed, 1 skipped, 123 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
