### PR TITLE
fix(interrogation): publish CataloguePatternVacancy on the runtime-pure subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### `CataloguePatternVacancy` reaches the runtime-pure subpath
+
+`yarramate/interrogation` exists so a host that may not import Node builtins —
+a Durable Object, a Worker — can reach the engine. #447 exported
+`CataloguePatternVacancy` from the barrel and **not** from that subpath, so the
+one consumer the subpath exists for had to derive the row type as
+`NonNullable<Parameters<typeof evaluateCatalogue>[6]>[number]` (reported by the
+ApertureX adopter session against 1.18.0).
+
+The export-purity tests could not have caught it and no addition to them could:
+they assert runtime exports, and types are erased before any of it runs. So the
+check now reads the source and asserts a rule rather than a list — every type
+the barrel re-exports from `interrogate-command` must reach the subpath too, so
+a type added to one and forgotten on the other fails here rather than in an
+adopter's editor.
+
 ### An agent can bind a pattern part
 
 `conceptFields` in the operations schema was closed and `parts` was not in it,

--- a/src/interrogation-entry.ts
+++ b/src/interrogation-entry.ts
@@ -20,6 +20,7 @@ export {
   type CatalogueCondition,
   type CatalogueEvidenceObservation,
   type CataloguePatternMembership,
+  type CataloguePatternVacancy,
   type CatalogueLoadResult,
   type CatalogueQuestion,
   type CatalogueSelector,

--- a/test/export-purity.test.ts
+++ b/test/export-purity.test.ts
@@ -137,6 +137,38 @@ describe('the interrogation barrel', () => {
     expect(typeof barrel.qualifiedQuestionId).toBe('function')
   })
 
+  it('publishes every interrogation TYPE the barrel does', () => {
+    // The omission this test exists for, reported by the ApertureX session
+    // against 1.18.0: `CataloguePatternVacancy` reached the barrel and not
+    // this subpath, so a Durable Object host - the one consumer the subpath
+    // exists FOR, since it may not import Node builtins - had to derive the
+    // row type as `NonNullable<Parameters<typeof evaluateCatalogue>[6]>[number]`.
+    //
+    // The runtime assertions above could not catch it, and no addition to them
+    // could: types are erased before any of this runs. So the check reads the
+    // SOURCE, and it is a rule rather than a list - every type the barrel
+    // re-exports from `interrogate-command` must reach the subpath too, so a
+    // type added to one and forgotten on the other fails here rather than in
+    // an adopter's editor.
+    const typeExports = (file: string): readonly string[] => {
+      const source = readFileSync(join(root, file), 'utf8')
+      const block = source
+        .split(/from ['"]\.\/interrogate-command\.js['"]/)[0]!
+        .split(/export \{|import \{/)
+        .pop()!
+      return [...block.matchAll(/type\s+(\w+)/g)]
+        .map((match) => match[1]!)
+        .sort()
+    }
+    const barrel = typeExports('index.ts')
+    const subpath = typeExports('interrogation-entry.ts')
+    // A sanity floor: if the extraction stops finding anything, the assertion
+    // below would pass vacuously and this check would quietly stop working.
+    expect(barrel.length).toBeGreaterThan(5)
+    expect(subpath.length).toBeGreaterThan(5)
+    expect(barrel.filter((name) => !subpath.includes(name))).toEqual([])
+  })
+
   it('composes end to end from the published entry alone', async () => {
     // Through the entry, not through the module: an export that resolves but
     // does not work is what a barrel test is for.


### PR DESCRIPTION
`yarramate/interrogation` exists so a host that may not import Node builtins — a
Durable Object, a Worker — can reach the engine. #447 exported
`CataloguePatternVacancy` from the barrel and **not** from that subpath.

So the one consumer the subpath exists *for* had to write:

```ts
type Vacancy = NonNullable<Parameters<typeof evaluateCatalogue>[6]>[number]
```

Reported by the ApertureX session against published 1.18.0, having hit it in
their own Durable Object host. One line fixes it.

## Why the existing guards missed it, and why no addition to them would have

`test/export-purity.test.ts` already asserts the interrogation subpath publishes
what a host needs. Every one of those assertions is `typeof mod.x === 'function'`
— **runtime** exports. `CataloguePatternVacancy` is a type, erased before any of
that runs, so no runtime assertion could have caught this and adding more would
not help.

The new check reads the **source** instead, and asserts a rule rather than a
list: every type the barrel re-exports from `interrogate-command` must reach the
subpath too. A type added to one and forgotten on the other fails here rather
than in an adopter's editor. It carries a sanity floor so it cannot pass
vacuously if the extraction ever stops matching.

Verified by restoring the exact omission: the guard fails, naming the missing
type.

## On the miss itself

I enumerated seven threading sites for #447 and worked through them
deliberately. The subpath was an eighth I never listed, and it is the one that
matters most for the adopter this feature was built for.

## Verification

`rm -rf dist && pnpm verify`, **exit 0**. 2110 passed, 1 skipped, 125 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
