### PR TITLE
fix(test): raise testTimeout to 30s, because 5000ms was below the suite's own top end

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,26 @@ Use test-driven development for compiler and validation behaviour. New
 diagnostics should be deterministic and source-located. Keep adapter-specific
 fields outside Core documents and preserve canonical output ordering.
 
+**A `Test timed out` with no assertion failure is probably not your change**
+(#458). `pnpm verify` used to fail intermittently on a busy machine with exactly
+that and nothing else — no assertion, no diff — which reads like a regression in
+whatever you had just touched. It cost real time: a stash-and-reverify cycle to
+establish a change was *not* at fault, and re-runs to decide whether a release
+was safe to tag.
+
+The cause was the timeout, not the tests. Vitest's 5000ms default sat *below*
+this suite's own top end: unloaded, the slowest test takes **9159ms** and eight
+are over 2000ms, because the heaviest ones compile the whole repository
+self-model or read the built browser bundles. `testTimeout` is now 30s.
+
+Two things that looked true and were not, recorded because they are the shape of
+the mistake rather than facts about these ten files. It was first read as worker
+contention over `git` subprocesses, since the files that shell out break first —
+but push the load higher and plain in-process tests time out too, so it is
+starvation, not contention. And a per-file rule keyed on *does this file spawn*
+was built and then thrown away, because the slowest test in the suite does not
+spawn and the rule would have exempted everything except it.
+
 ## Proposing semantic changes
 
 A semantic change should begin with a GitHub Issue so its intended contract can

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,31 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
+    // Vitest's 5000ms default was never right for this suite, and #458 is how
+    // that surfaced: `pnpm verify` failed intermittently on a busy machine with
+    // `Test timed out in 5000ms` and NO assertion failure, which reads exactly
+    // like a regression in whatever you had just changed.
+    //
+    // Measured rather than guessed. Unloaded, the slowest test here takes
+    // 9159ms and eight are over 2000ms — the heaviest compile the whole
+    // repository self-model or read the built browser bundles, and they are
+    // legitimately that slow. So the default sat below the suite's own top end,
+    // and the only reason it was not failing constantly is that the machine is
+    // usually idle.
+    //
+    // Under load it fails properly. Same load average of ~50, same tree: at
+    // 5000ms three files timed out, at 30000ms none did. It was first blamed on
+    // worker contention over `git` subprocesses, because the ten files that
+    // shell out are the ones that break first, but pushing the load higher
+    // times out plain in-process tests too. Starvation, not contention, and a
+    // per-file rule keyed on "does it spawn" would have papered over the
+    // slowest test in the suite, which does not.
+    //
+    // The cost is that a genuinely hung test now takes 30s to fail instead of
+    // 5s. That is paid once by whoever wrote the hang; the old setting was
+    // being paid by everyone else, in re-runs and in stash-and-reverify cycles
+    // to establish that a change was not at fault.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 })


### PR DESCRIPTION
Closes #458.

Two lines of config. The interesting part is that **the issue's own diagnosis
was wrong**, and measuring it is what showed that.

## What the issue said

Worker contention over `git` subprocesses. Ten test files shell out, they are
the ones that break, and capping workers passed at higher load than the default
run failed at. I recommended a per-file timeout keyed on `execFileSync`, on the
grounds that the affected set is "identifiable by a property rather than a list
someone has to maintain".

## What is actually true

**Vitest's 5000ms default sat below this suite's own top end.** Unloaded:

| | |
|---|---|
| slowest test | **9159ms** |
| second slowest | 7231ms |
| tests over 2000ms | 8 |

The heaviest ones compile the whole repository self-model or read the built
browser bundles. They are legitimately that slow. The only reason this was not
failing constantly is that the machine is usually idle.

**It is starvation, not contention.** Push the load past what the issue
measured and plain in-process tests time out too. Under the old config at load
~50, the four failures included `ask-command` (6428ms) and
`visual-app-browser-safety` (8514ms) — neither of which spawns anything.

## The fix, and the thing I built and threw away

`testTimeout: 30_000`, `hookTimeout: 30_000`. That is all.

I first built the per-file rule the issue recommended: a `SUBPROCESS_TESTS` list
in the config, two vitest projects, and `test/subprocess-timeouts.test.ts`
checking the list against the property that defines it, so a file that starts
shelling out fails at authoring time rather than turning flaky later. It worked,
it was mutation-checked, and it was wrong: **the slowest test in the suite does
not spawn**, so the rule would have exempted every file except the one case that
most needed the headroom.

(A smaller lesson from that attempt, kept in the code comment: a detector
matching call names matched its own description of them, so the checker detected
itself. Detecting the `node:child_process` import instead is the honest
property.)

## Controlled comparison

Same tree, same load, config the only variable:

| config | load avg | result |
|---|---|---|
| 5000ms default | ~52 | **3 files failed, 4 timeouts** |
| 30000ms | ~52 | passed |
| 30000ms | **~182** | passed |

The load that used to fail was 19.

## The cost, stated plainly

A genuinely hung test now takes 30s to fail instead of 5s. That is paid once by
whoever wrote the hang. The old setting was being paid by everyone else, in
re-runs and in stash-and-reverify cycles.

`CONTRIBUTING.md` carries the diagnostic note the issue asked for, including
both wrong turns, because they are the shape of the mistake rather than facts
about ten files.

## Verification

`rm -rf dist && pnpm verify`, **exit 0**. 2117 passed, 1 skipped, 126 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
