### PR TITLE
chore: release 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.19.1
 
 ### A profile's kinds no longer have to be declared parent-first
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog heading only. One entry.

**A profile's kinds no longer have to be declared parent-first** (#470, PR
#471). A kind whose parent was declared below it was refused with `YM407 ... is
not available`, the same message a genuinely missing kind gets, so an author
went looking for a typo while the file already declared the parent three lines
down. Resolution now runs in rounds until one adds nothing.

**Strictly additive.** Everything that compiled before compiles now, and
resolves on the first round, because parent-first was the only order that ever
worked. A parent cycle became newly reachable and is diagnosed as a cycle rather
than as an unavailable parent, reusing `YM407` rather than minting a code.

## Patch rather than minor

No API, no schema, no new field. The behaviour change accepts input that was
previously refused and refuses nothing new; the only other visible change is a
diagnostic message that is now correct in a case it was wrong about.

## One dismissed warning, stated rather than hidden

`node scripts/check-changelog.mjs` reports:

```
Missing a CHANGELOG entry:
  f1b5b0e fix(test): raise testTimeout to 30s ...
```

That commit touched **`CONTRIBUTING.md` and `vitest.config.ts` only**, neither of
which is in `package.json`'s `files`, so it ships nothing to a consumer and
correctly has no entry. It should have carried a `Changelog: none` trailer and I
forgot one; it is merged, so the trailer cannot be added retroactively. The
script is designed to over-report so a reader can dismiss, and this is a
dismissal with its reason recorded rather than a silent one.

## Pre-tag checks

| check | result |
|---|---|
| `pnpm self:check` | no errors |
| `pnpm self:reconcile` | 317 observations, **317 confirmed**, 0 contradicted, 0 unknown |
| unclaimed artifacts | **0** |
| subjects without evidence | **0** |
| new source modules since v1.19.0 | **none** |

`rm -rf dist && pnpm verify`, **exit 0**. 2124 passed, 1 skipped, 127 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
