### PR TITLE
chore: release 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.20.0
 
 ### A pattern instance can draw as one box
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.20.0** on `main` at `e2bf4b5`. Two files: the version in
`package.json` and the `## Unreleased` heading stamped `## 1.20.0`.

One feature since 1.19.1: **a pattern instance can draw as one box** (#473,
PR #474). Folding turns an instance into a single node carrying its members,
with the edges into and out of them lifted onto the box, merged per kind and
ordered pair. Measured on the ApertureX reference through its own manifest:
277 top-level boxes to **172**, 102 members absorbed by eight applications,
Landscape from 157 subjects to **73**, zero conflicts and zero cycles across
six views. Minor rather than patch because the surface grows:
`presentation.fold`, the sidecar's `folded` / `unfolded`,
`PatternMembership.wiring`, and `foldTree` / `foldGraph` on
`yarramate/adapter/visual-graph`. All optional, so nothing that reads today
breaks, and the sidecar stays `visual-layout/v1` on purpose.

One behaviour change rides along: assignment nesting reads CORE kinds instead
of the profile kind's label. Measured over this repository's own model before
adopting - 362 subjects, 47 assignment edges, **zero** verdict changes across
all 22 authored views. ADR 0143.

## Release checks, run on this branch

| check | result |
|---|---|
| `rm -rf dist && pnpm install --frozen-lockfile` | exit 0 |
| `pnpm run verify`, clean slate | **exit 0**, 131 files, **2189 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.19.1 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.20.0.tgz`, **292 files**, 2.1 MB packed |

Tarball is 292 files against 1.19.1's 288, and the four are exactly the new
feature's shipped artefacts: `dist/fold-tree.{js,d.ts}`,
`dist/visual-app-lib/types/fold-tree.d.ts` and
`.../visual-app/slots-model.d.ts`. Top level is `dist/`, `schema/`, `docs/`,
`skills/`, `catalogues/`, `profiles/`, `assets/`, README and LICENCE - no
repository source, tests or fixtures.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
