### PR TITLE
chore: release 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.21.0
 
 ### A view can name an instance and get what it holds
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.21.0** on `main` at `d92ec34`. Two files: the version in `package.json`
and the `## Unreleased` heading stamped `## 1.21.0`.

One feature since 1.20.0: **a view can name an instance and get what it holds**
(#473, PR #476). A query may name pattern instances, and the facet selects each
one together with everything the fold tree would draw inside it, transitively,
read through the view's own `nesting` — the same closure the canvas collapses,
from the same module over the same inputs. Minor rather than patch because the
query surface grows.

**One documented rule moves, and in the open.** Every other facet narrows and
`docs/PROJECTIONS.md` has always said fields combine with AND; this one adds. So
`subjects` and `instances` are now a single identity facet spelled two ways
whose values combine with OR, with every other field ANDing over the union. The
alternative was put to Nabeel with its costs and he chose the union; the doc,
the schema and ADR 0144 all name the exception rather than leaving it to be
found.

Additive throughout, so every view that reads today reads the same.

## Release checks, run on this branch

| check | result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `rm -rf dist && pnpm run verify`, clean slate | **exit 0**, 132 files, **2226 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.20.0 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.21.0.tgz`, **292 files**, 2.1 MB |

Tarball is **292 files, unchanged from 1.20.0**: phase 2 added code to existing
modules rather than new ones, so nothing new ships and nothing dropped. Top
level is `dist/`, `schema/`, `docs/`, `skills/`, `catalogues/`, `profiles/`,
`assets/`, README and LICENCE — no repository source, tests or fixtures.

## What this release was checked against beyond the suite

- **All eight reference closures exact**, measured through the CLI against the
  ApertureX reference's own manifest.
- **Browser pass 4 of 4** by the ApertureX session on the merged commit: a
  projection written through the ordinary write path reads 15 in the rail and 28
  for the system API, "Focus on this instance" opens from the rail row and
  narrows to "15 subjects · 262 excluded", and the phase 1 fold journey is
  unregressed.
- **Startup CPU unmoved**, which matters because error 10021 refused a deploy on
  1.15.1 for exactly this: `yarramate/interrogation` imports at **26.9 ms CPU**,
  in line with the ~30 ms recorded when 1.16.0 fixed it, and the generated
  validator file grew 0.96%. Measured against that recorded figure rather than a
  fresh A/B against main's dist.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
