### PR TITLE
chore: release 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.22.0
 
 ### A member held only inside one box now folds into it
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.22.0** on `main` at `d7e8c46`. Two files: the version in `package.json`
and the `## Unreleased` heading stamped `## 1.22.0`.

One feature since 1.21.0: **the one-box fold, and rulings as rows** (#473, PR
#478). Minor rather than patch, and it carries **a behaviour change**: a member
held only inside one box now folds into it, where before any subject bound by
two instances stayed outside. Existing models draw differently. That was put to
Nabeel and cleared on the grounds that production data is disposable.

## Release checks, run on this branch

| check | result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `rm -rf dist && pnpm run verify`, clean slate | **exit 0**, 133 files, **2256 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.21.0 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.22.0.tgz`, **293 files**, 2.1 MB |

Tarball is 293 files against 1.21.0's 292, and the one addition is exactly the
new module's shipped type: `dist/visual-app-lib/types/visual-app/constraint-rows.d.ts`.
Top level is `dist/`, `schema/`, `docs/`, `skills/`, `catalogues/`, `profiles/`,
`assets/`, README and LICENCE — no repository source, tests or fixtures.

## What this release was checked against beyond the suite

- **Reference numbers reproduced to the digit**, and independently by the
  ApertureX session: Landscape 73 → 58 boxes and 153 → 120 edges, whole model
  173 → 158 visible and 172 → 157 top-level.
- **Self-model swept: 22 views, zero containment changes.** The behaviour change
  moves nothing of ours.
- **Nine mutations** confirmed red then reverted, covering the closure walk, the
  ancestor choice, the resolution order, the wiring gate, and every part of the
  rows path.

## What it was NOT checked against, and you should weigh this

**No browser pass.** Chrome's MCP profile is held by another session on this
machine and I have not tried `--isolated`. Rulings-as-rows is a visual feature:
`constraint-rows.ts` is tested pure and `graphToElements` is tested for the
marks, the label, the height and the toggle, but **nobody has looked at a box
carrying 13–18 rows**. The toggle ships OFF by default, so a reader has to ask
for it before anything looks different, which limits the exposure.

I have asked the ApertureX session to run their DOM journey against this. If you
would rather hold the release until that comes back, say so and I will wait.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
