### PR TITLE
chore: release 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.22.1
 
 ### Rulings as rows is withdrawn
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.22.1** on `main` at `a8cee5a`. Two files: the version in `package.json`
and the `## Unreleased` heading stamped `## 1.22.1`.

A patch that **withdraws a feature and fixes an older bug** (#473, PR #480).

`presentation.showConstraints` shipped in 1.22.0 and never drew a row on any
path. It is removed rather than fixed under pressure. **No release of it was
adopted**, so nothing that authored it exists. ADR 0145 keeps the design and
records why each part of the implementation failed.

The nesting fix is the part that adds something: switching to a view declaring a
different nesting vocabulary drew the previous view's containment, and that has
been true since per-view nesting shipped.

## Release checks, run on this branch

| check | result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `rm -rf dist && pnpm run verify`, clean slate | **exit 0**, 133 files, **2240 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.22.0 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.22.1.tgz`, **292 files**, 2.1 MB |

Tarball is **292 files, back to 1.21.0's count**, and `constraint-rows` appears
nowhere in it — the withdrawal is complete in the shipped bytes, not just in the
source.

## Verified beyond the suite

- **The nesting fix has a browser pass behind it**, run by the ApertureX session
  against this branch's parent: `[composition]` → 70 nested in 57 containers,
  `[composition, assignment]` → 120 in 61, back to 70/57. Both directions.
- `test/graph-canvas-effect-deps.test.ts` reads the source and refuses an input
  to `graphToElements` the element effect does not depend on, mutation-checked
  in both directions — including that adding `folded` turns it red, since that
  would silently replace the anchored fold with a full relayout.

The rows removal itself has not had a browser pass, which matters much less than
it sounds: it is a deletion, and what remains is the code that shipped in
1.21.0 plus the nesting fix that was checked in a browser.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
