### PR TITLE
chore: release 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.23.0
 
 ### A pattern's resolved shape is a public type (PR #482)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.23.0** on `main` at `6691e57`. Two files: the version in `package.json`
and the `## Unreleased` heading stamped `## 1.23.0`.

One feature since 1.22.1: **the pattern is the unit on the palette** (#473 phase
4, PR #482), plus a fix for a defect that shipped in 1.21.0.

Minor rather than patch because the surface grows: `ResolvedProfileContext`
gains `patterns` and `conceptKindNames`, `VisualRenderedModel.vocabulary` gains
`patterns`, `VisualKindOption` gains `pattern` and `name`, `VisualFilterQueryPayload`
gains `nesting`, and `PatternShape` and its three companions are exported. All
optional, so nothing that reads today changes.

## Release checks, run on this branch

| check | result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `rm -rf dist && pnpm run verify`, clean slate | **exit 0**, 139 files, **2305 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.22.1 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.23.0.tgz`, **293 files**, 2.1 MB |

Tarball is 293 against 1.22.1's 292, and the one addition is exactly the new
panel's shipped type: `dist/visual-app-lib/types/visual-app/instance-draft-panel.d.ts`.
No repository source, tests or fixtures.

## What this release was checked against beyond the suite

- **Every visual item driven live in a browser** on the ApertureX reference: the
  pattern bands, the collapsed ruling row, the instance form completed and
  staged, and the Slots picker on a real vacant slot staging
  `update-concept · patron-checkin-xapi · parts`.
- **Fifteen mutations**, each confirmed red then reverted. Three found the tests
  rather than the code.
- **The 1.21.0 filter defect fixed and confirmed in the browser**: a 65-subject
  view drew all 277 before, and reads "65 subjects · 212 excluded" after.

## Worth stating plainly

Four defects in this phase were found by looking and by nothing else: a mark
rendered at 0×0, a wrong plural, a header wrapping to two lines, and slot rows
drawn as a bulleted list. Every one had passing tests over it. There is now a
test that reads `styles.css`, which is a poor substitute for looking and is what
a headless suite can do.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
