### PR TITLE
fix(editor): a staged slot binding shows on the row where it was made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### A staged slot binding shows on the row where it was made
+
+Picking a subject for an empty slot staged the operation correctly and then the
+row snapped straight back to "to decide", with the only evidence of the pick a
+count in another section. A consultant filled a slot and watched the editor
+forget.
+
+The properties form already overlays staged edits onto the fields it shows,
+which is why a staged name is visible and re-editable. The Slots section is the
+same question asked about `parts`, and was not doing it. It reads the pending
+changeset now: a staged binding shows as the bound subject marked `staged`, the
+picker gives way to it, and the heading counts it, so the section cannot
+disagree with its own rows. Read in tray order the way `apply` replays a batch,
+so a slot picked twice shows the last choice.
+
+Found by the ApertureX session looking at published 1.23.0.
+
 ## 1.23.0
 
 ### A pattern's resolved shape is a public type (PR #482)

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -835,6 +835,7 @@ const SelectedSubjectInspector = ({
         <SlotsSection
           id={node.id}
           model={model}
+          operations={operations}
           // From the pending changeset, the same reading every other drafting
           // surface takes: the graph knows only what has landed (#315).
           reservedIds={stagedSubjectIds(operations)}
@@ -956,18 +957,29 @@ const SlotFiller = ({
 const SlotsSection = ({
   id,
   model,
+  operations,
   reservedIds,
   onStage,
   readOnly,
 }: {
   readonly id: string;
   readonly model: VisualRenderedModel;
+  /** The pending changeset, so a staged binding shows on its row. */
+  readonly operations: readonly YarramateOperation[];
   readonly reservedIds: readonly string[];
   readonly onStage: (operation: YarramateOperation) => void;
   /** A viewer reads the slots and fills none (#298, ADR 0117). */
   readonly readOnly: boolean;
 }) => {
-  const slots = slotsSectionFor(id, model.memberships, model.vacancies);
+  // The pending changeset too, so a staged binding shows on the row where it
+  // was made. Without it the row snapped back to "to decide" and the only
+  // evidence of the pick was a count in another section.
+  const slots = slotsSectionFor(
+    id,
+    model.memberships,
+    model.vacancies,
+    operations,
+  );
   if (slots === null) return null;
   const node = model.graph.nodes.find((candidate) => candidate.id === id);
   // The pattern this instance IS, which is what says what each slot admits.

--- a/src/visual-app/slots-model.ts
+++ b/src/visual-app/slots-model.ts
@@ -12,6 +12,7 @@
  */
 
 import type { PatternMembership, PatternVacancy } from '../compiler.js'
+import type { YarramateOperation } from '../operations.js'
 
 /** One slot of one instance, bound or not. */
 export interface SlotRow {
@@ -33,6 +34,16 @@ export interface SlotRow {
   readonly required: boolean
   /** How many OTHER instances bind the same subject, for a shared part. */
   readonly sharedWith: number
+  /**
+   * Bound by a change that is STAGED and not yet landed (#473 phase 4).
+   *
+   * The compile knows only what landed, so without this a reviewer picks a
+   * subject for an empty slot, the row snaps back to "to decide", and the only
+   * evidence anything happened is a count in another section. The properties
+   * form already overlays staged edits onto the fields it shows, and the slots
+   * are the same question asked about `parts`.
+   */
+  readonly staged?: boolean
 }
 
 export interface SlotsSection {
@@ -58,10 +69,34 @@ export function slotsSectionFor(
   subjectId: string,
   memberships: readonly PatternMembership[] = [],
   vacancies: readonly PatternVacancy[] = [],
+  /**
+   * The pending changeset, so a staged binding shows where it was made. Read
+   * in tray order, the way `apply` replays a batch, so a slot picked twice
+   * shows the LAST choice rather than the first.
+   */
+  staged: readonly YarramateOperation[] = [],
 ): SlotsSection | null {
   const bound = memberships.filter(({ instance }) => instance === subjectId)
   const vacant = vacancies.filter(({ instance }) => instance === subjectId)
   if (bound.length === 0 && vacant.length === 0) return null
+
+  // Staged `parts` for THIS instance, by slot. `add-concept` carries them too,
+  // for an instance minted and bound in one batch.
+  const stagedParts = new Map<string, string>()
+  for (const operation of staged) {
+    const concept =
+      operation.op === 'update-concept' || operation.op === 'add-concept'
+        ? operation.concept
+        : undefined
+    if (concept === undefined) continue
+    // The instance id is qualified in the frame and local in an operation, so
+    // the tail is what the two have in common.
+    const local = subjectId.slice(subjectId.lastIndexOf('#') + 1)
+    if (concept.id !== local && concept.id !== subjectId) continue
+    for (const [slot, member] of Object.entries(concept.parts ?? {})) {
+      if (typeof member === 'string') stagedParts.set(slot, member)
+    }
+  }
 
   // How many instances bind each subject, so a shared part can say so. Counted
   // over EVERY membership, not just this instance's: sharing is a fact about
@@ -87,23 +122,40 @@ export function slotsSectionFor(
         sharedWith: (instancesOf.get(membership.member)?.size ?? 1) - 1,
       }),
     ),
-    ...[...vacant].sort(byName).map(
-      (vacancy): SlotRow => ({
-        slot: vacancy.slot,
-        member: null,
-        wiring: undefined,
-        required: vacancy.required,
-        sharedWith: 0,
-      }),
-    ),
+    ...[...vacant].sort(byName).map((vacancy): SlotRow => {
+      const stagedMember = stagedParts.get(vacancy.slot)
+      return stagedMember === undefined
+        ? {
+            slot: vacancy.slot,
+            member: null,
+            wiring: undefined,
+            required: vacancy.required,
+            sharedWith: 0,
+          }
+        : {
+            slot: vacancy.slot,
+            member: stagedMember,
+            // The wiring is the PATTERN's and does not change with a binding,
+            // but the compile only reports it for a bound slot, so a staged row
+            // has none to report yet.
+            wiring: undefined,
+            required: vacancy.required,
+            sharedWith: 0,
+            staged: true,
+          }
+    }),
   ]
 
+  const stagedCount = rows.filter((row) => row.staged === true).length
   return {
     pattern:
       bound[0]?.pattern ?? vacant[0]?.pattern ?? '',
     rows,
-    boundCount: bound.length,
-    vacantCount: vacant.length,
+    // Staged counts as bound HERE, because the heading sits beside rows that
+    // show the staged binding and a count that disagreed with them would be
+    // the section arguing with itself.
+    boundCount: bound.length + stagedCount,
+    vacantCount: vacant.length - stagedCount,
   }
 }
 
@@ -116,6 +168,9 @@ export function slotRowLabel(row: SlotRow): string {
     return row.required ? 'to decide — required' : 'to decide'
   }
   const marks: string[] = []
+  // Said first, because it changes what the rest of the row MEANS: this is a
+  // decision in the changeset, not one the model holds.
+  if (row.staged === true) marks.push('staged')
   // Marked because it is the one kind of bound slot that does NOT draw inside
   // the box when the instance is folded.
   if (row.wiring === 'context') marks.push('context')

--- a/test/slots-model.test.ts
+++ b/test/slots-model.test.ts
@@ -111,3 +111,122 @@ describe('#473: the Slots section', () => {
     expect(section!.rows[0]!.member).toBe('iface')
   })
 })
+
+describe('#473 phase 4: a staged binding shows on its own row', () => {
+  // Found by the ApertureX session looking at 1.23.0: picking a subject for an
+  // empty slot staged the operation and the row snapped straight back to
+  // "to decide", with the only evidence in another section's count. The
+  // properties form already overlays staged edits onto the fields it shows;
+  // the slots are the same question asked about `parts`, and were not.
+  const bound = (slot: string, member: string) => ({
+    member,
+    slot,
+    instance: 'sys-api',
+    pattern: 'acme/p@1.0#api',
+    wiring: 'owned' as const,
+  })
+  const vacant = (slot: string, required = false) => ({
+    instance: 'sys-api',
+    pattern: 'acme/p@1.0#api',
+    slot,
+    slotKind: 'yarramate/core@0.1#dataObject',
+    required,
+  })
+  const stage = (slot: string, member: string, id = 'sys-api') => ({
+    op: 'update-concept' as const,
+    document: 'architecture/main.yaml',
+    concept: { id, parts: { [slot]: member } },
+  })
+
+  it('turns a vacant row into a bound one, marked staged', () => {
+    const section = slotsSectionFor(
+      'sys-api',
+      [bound('interface', 'sys-interface')],
+      [vacant('payload')],
+      [stage('payload', 'fresh-payload')],
+    )
+    const row = section?.rows.find((candidate) => candidate.slot === 'payload')
+    expect(row?.member).toBe('fresh-payload')
+    expect(row?.staged).toBe(true)
+    expect(slotRowLabel(row!)).toBe('fresh-payload (staged)')
+  })
+
+  it('counts it in the heading, so the section does not argue with itself', () => {
+    const section = slotsSectionFor(
+      'sys-api',
+      [bound('interface', 'sys-interface')],
+      [vacant('payload'), vacant('backend')],
+      [stage('payload', 'fresh-payload')],
+    )
+    expect(section?.boundCount).toBe(2)
+    expect(section?.vacantCount).toBe(1)
+  })
+
+  it('leaves a slot nothing staged alone', () => {
+    const section = slotsSectionFor(
+      'sys-api',
+      [],
+      [vacant('payload'), vacant('backend', true)],
+      [stage('payload', 'fresh-payload')],
+    )
+    const untouched = section?.rows.find(({ slot }) => slot === 'backend')
+    expect(untouched?.member).toBeNull()
+    expect(slotRowLabel(untouched!)).toBe('to decide — required')
+  })
+
+  it('takes the LAST choice when a slot is picked twice', () => {
+    // Tray order, the way `apply` replays a batch.
+    const section = slotsSectionFor(
+      'sys-api',
+      [],
+      [vacant('payload')],
+      [stage('payload', 'first-pick'), stage('payload', 'second-pick')],
+    )
+    expect(section?.rows[0]?.member).toBe('second-pick')
+  })
+
+  it('reads an add-concept that binds parts in the same batch', () => {
+    // An instance minted and bound at once, which the instance form stages.
+    const section = slotsSectionFor(
+      'sys-api',
+      [],
+      [vacant('payload')],
+      [
+        {
+          op: 'add-concept',
+          document: 'architecture/main.yaml',
+          concept: { id: 'sys-api', kind: 'api', name: 'System API', parts: { payload: 'minted' } },
+        },
+      ],
+    )
+    expect(section?.rows[0]?.member).toBe('minted')
+  })
+
+  it('ignores a staged binding on a different instance', () => {
+    const section = slotsSectionFor(
+      'sys-api',
+      [],
+      [vacant('payload')],
+      [stage('payload', 'not-ours', 'other-api')],
+    )
+    expect(section?.rows[0]?.member).toBeNull()
+  })
+
+  it('matches a qualified subject id against a local operation id', () => {
+    // The frame qualifies subject ids and an operation names the local one.
+    const section = slotsSectionFor(
+      'yarrasys/main#sys-api',
+      [],
+      [{ ...vacant('payload'), instance: 'yarrasys/main#sys-api' }],
+      [stage('payload', 'fresh-payload')],
+    )
+    expect(section?.rows[0]?.member).toBe('fresh-payload')
+  })
+
+  it('shows nothing staged as it did before, when the changeset is empty', () => {
+    const section = slotsSectionFor('sys-api', [], [vacant('payload')])
+    expect(section?.rows[0]?.staged).toBeUndefined()
+    expect(section?.boundCount).toBe(0)
+    expect(section?.vacantCount).toBe(1)
+  })
+})


### PR DESCRIPTION
A fix for a defect in published **1.23.0**, found by the ApertureX session
looking at the release. Suggest **1.23.1**: no new surface, one behaviour
corrected.

## The defect

Picking a subject for an empty slot staged `update-concept · parts` correctly,
and then the row snapped straight back to "to decide". The heading stayed at
19 of 20, re-selecting the subject showed the same, and the only evidence
anything had happened was a count in another section. **A consultant fills a
slot and watches the editor forget.**

`slotsSectionFor` read the COMPILE, which knows only what landed. The properties
form beside it already overlays the pending changeset onto its fields, which is
why a staged name is visible and re-editable — the slots ask the same question
about `parts` and were not doing it.

## The fix

The section takes the changeset. A staged binding turns its vacant row into a
bound one marked `staged`, the picker gives way to it, and the heading counts
it — a count that disagreed with the rows beside it would be the section
arguing with itself.

Read in tray order, the way `apply` replays a batch, so a slot bound twice shows
the LAST choice. An `add-concept` carrying `parts` counts too, which is what the
instance form stages. The subject id is qualified in the frame and local in an
operation, so both spellings match.

## Verified

| check | result |
|---|---|
| `rm -rf dist && pnpm verify`, clean slate | **exit 0**, 139 files, **2313 passed**, 1 skipped |
| mutations | 3, each red then reverted: heading ignoring staged, another instance's parts landing here, the mark dropped |
| my browser pass | row reads `salesforce-connector (staged)`, picker gone, heading "SLOTS 20", survives leave-and-return |

**ApertureX pass on this branch, in their own mount** — a confirmation rather
than a discovery: before, "19 of 20" with the picker; after, "Slots 20" and
`backend / salesforce-connector (staged)` with zero pickers left and
`update-concept · patron-checkin-xapi · parts` in the tray; identical after
leaving and re-selecting; **Discard all returns it to "19 of 20" with the picker
back**; fold journeys 6/6; no console errors.

They also noted that "picked twice" is not reachable from the row itself, since
a bound row offers no control — to change a staged pick a consultant discards
it. So the last-write-wins ordering is defensive rather than a path this surface
exposes, which is the right way round.

## Worth recording

This is the same family the programme keeps producing and ADR 0146 names: the
arithmetic was right, the staged operation was right, and what a reader saw was
wrong. Nothing asserted the row AFTER a pick, so the render assertions passed
over it.

I also asserted the opposite when I built 4.5 — that the heading staying at
19 of 20 was correct because "staged is not landed". In isolation that is
defensible; beside a panel that overlays every other staged edit it is the
section contradicting its neighbours, and the row showing no trace at all had no
defence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
