### PR TITLE
chore: release 1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.23.1
 
 ### A staged slot binding shows on the row where it was made
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **1.23.1** on `main` at `f26edcf`. Two files: the version in `package.json`
and the `## Unreleased` heading stamped `## 1.23.1`.

A patch: one behaviour corrected, no new surface. Fixes a defect in published
1.23.0 (PR #484) where a staged slot binding left no trace on its own row.

## Release checks, run on this branch

| check | result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `rm -rf dist && pnpm run verify`, clean slate | **exit 0**, 139 files, **2313 passed**, 1 skipped |
| `pnpm run changelog:check` | every user-visible commit since v1.23.0 has an entry |
| `npm pack --dry-run --ignore-scripts` | `yarramate-1.23.1.tgz`, **293 files**, 2.1 MB |

Tarball is 293 files, unchanged from 1.23.0: the fix touches existing modules
and ships no new file. No repository source, tests or fixtures.

## Verified in two browsers before the cut

- **Mine**, on the standalone editor: the row reads
  `salesforce-connector (staged)`, the picker is gone, the heading reads
  "SLOTS 20", and all of it survives leaving the subject and re-selecting it.
- **ApertureX**, in their own mounted-library host: the same, plus the case I
  had not checked — **Discard all** returns the section to "19 of 20" with the
  picker back. Fold journeys 6/6, no console errors.

Publication still needs your OTP; I will hand you the command against a fresh
clone at the tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJr9kxFnTuVhLSDupnGV5u
