### PR TITLE
fix(visual): a kind states its display name beside its id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### A kind states its display name beside its id (#473)
+
+`VisualKindOption.name` shipped in 1.23.0 carrying the display name a profile
+authored, and **nothing read it**. Not one consumer anywhere in the app: it was
+added to the wire, typechecked, tested, and never connected to a renderer. A
+pack that authored `Mule API interface` saw it nowhere, and the properties
+panel offered a bare `mule-api` to a consultant who has no way to know what
+that means.
+
+Both selects and both fact rows in the properties panel now read
+`Mule API interface (mule-api)`: the name a reader needs, then the id the
+document will actually carry. A kind whose profile authored no name - every
+core kind - is unchanged, and a name identical to its own id does not repeat.
+
+The VALUE a select carries is untouched and stays the bare label, because that
+is what a staged operation writes and `apply` refuses anything else as an
+unknown kind (YM401). Pinned by its own test; the mutation that makes the value
+the display text fails it.
+
+Found by the ApertureX session, reading a mounted host rather than believing
+this session's claim about where the name reached.
+
 ### Rulings as rows is withdrawn for good (#473)
 
 `presentation.showConstraints` shipped inert in 1.22.0, was withdrawn in 1.22.1,

--- a/src/kind-label.ts
+++ b/src/kind-label.ts
@@ -7,3 +7,28 @@
  * before; it is still a lot of bundle for one label.
  */
 export const kindLabelOf = (kind: string): string => kind.slice(kind.lastIndexOf('#') + 1)
+
+/**
+ * A kind as a READER should see it on a select or a fact row: the display name
+ * the profile authored, then the id the document will actually carry.
+ *
+ * Both halves, deliberately (Nabeel, 2026-09-05). The properties panel edits
+ * the document, so an architect needs the exact token that lands in the YAML;
+ * a consultant reading the same panel needs to know what `mule-api` means. The
+ * palette can afford the name alone because nothing there is being written.
+ *
+ * NEVER the value of a select. The value stays the bare label, because that is
+ * what the staged operation carries and `apply` refuses a qualified identity as
+ * an unknown kind (YM401).
+ *
+ * Falls back to the label alone where the profile authored no name, which is
+ * every core kind, and where it authored one identical to the id, which would
+ * otherwise read `dataObject (dataObject)`.
+ */
+export const kindOptionText = (option: {
+  readonly label: string
+  readonly name?: string
+}): string =>
+  option.name === undefined || option.name === option.label
+    ? option.label
+    : `${option.name} (${option.label})`

--- a/src/visual-app/subject-draft-panel.tsx
+++ b/src/visual-app/subject-draft-panel.tsx
@@ -4,6 +4,7 @@ import type { CanvasGraph } from '../graph-projection.js'
 import type { YarramateOperation } from '../operations.js'
 import { draftConcept, proposeConceptId } from '../concept-drafting.js'
 import type { VisualKindOption } from '../adapters/visual/protocol-contract.js'
+import { kindOptionText } from '../kind-label.js'
 
 /**
  * Making a subject, the counterpart to the connection tool.
@@ -92,7 +93,7 @@ export const SubjectDraftPanel = ({
             // `apply` refuses the full identity as an unknown kind (`YM401`).
             // `subject-form.tsx` has always done this; this form did not.
             <option key={option.id} value={option.label}>
-              {option.label}
+              {kindOptionText(option)}
             </option>
           ))}
         </select>

--- a/src/visual-app/subject-form.tsx
+++ b/src/visual-app/subject-form.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { kindLabelOf } from '../kind-label.js'
+import { kindLabelOf, kindOptionText } from '../kind-label.js'
 import { relationshipKindOffer } from './relationship-kind-options.js'
 import type { CanvasEdge, CanvasNode } from '../graph-projection.js'
 import type { VisualRenderedModel } from '../adapters/visual/wire.js'
@@ -701,6 +701,14 @@ const MODE_OPTIONS = [
 const kindLabelFor = (kind: string, options: readonly VisualKindOption[]): string =>
   options.find((option) => option.id === kind)?.label ?? kindLabelOf(kind)
 
+// What a READER sees, which is not what the select CARRIES. `kindLabelFor`
+// above resolves the value a staged operation writes and must stay the bare
+// label; this one resolves the text beside it.
+const kindTextFor = (kind: string, options: readonly VisualKindOption[]): string => {
+  const option = options.find((candidate) => candidate.id === kind)
+  return option === undefined ? kindLabelOf(kind) : kindOptionText(option)
+}
+
 export interface ConceptFormProps {
   readonly node: CanvasNode
   readonly model: VisualRenderedModel
@@ -716,7 +724,7 @@ export const ConceptForm = ({ node, model, operations, onStageChange }: ConceptF
   // compile derived - which is the one the canvas and the inspector show.
   const id = node.localId
   const stage = (ops: readonly YarramateOperation[]) => ops.forEach(onStageChange)
-  const kindOptions = model.vocabulary.conceptKinds.map((option) => ({ value: option.label, label: option.label }))
+  const kindOptions = model.vocabulary.conceptKinds.map((option) => ({ value: option.label, label: kindOptionText(option) }))
   const currentKind = kindLabelFor(effective.kind, model.vocabulary.conceptKinds)
 
   return (
@@ -824,7 +832,7 @@ export const ConceptFacts = ({
       <span className="subject-form-label">Identity</span>
       <code>{node.id}</code>
     </div>
-    <FactRow label="Kind" value={kindLabelFor(node.kind, model.vocabulary.conceptKinds)} />
+    <FactRow label="Kind" value={kindTextFor(node.kind, model.vocabulary.conceptKinds)} />
     <FactRow label="Name" value={node.name} />
     <FactRow label="Status" value={node.status ?? ''} />
     <FactRow label="Owner" value={node.owner ?? ''} />
@@ -866,7 +874,7 @@ export const RelationshipFacts = ({
         <span className="subject-form-label">Identity</span>
         <code>{edge.id}</code>
       </div>
-      <FactRow label="Kind" value={kindLabelFor(edge.kind, model.vocabulary.relationshipKinds)} />
+      <FactRow label="Kind" value={kindTextFor(edge.kind, model.vocabulary.relationshipKinds)} />
       <FactRow label="From" value={titleOf(edge.from)} />
       <FactRow label="To" value={titleOf(edge.to)} />
       <FactRow label="Name" value={edge.name ?? ''} />
@@ -908,7 +916,7 @@ export const RelationshipForm = ({ edge, model, operations, onStageChange }: Rel
     currentKind,
   ).options.map((option) => ({
     value: option.label,
-    label: option.label,
+    label: kindOptionText(option),
   }))
   // Endpoints are refs, not addresses: `qualifyReference` leaves an already
   // qualified ref alone, so writing the canvas id keeps a cross-document

--- a/test/kind-option-text.test.ts
+++ b/test/kind-option-text.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { kindOptionText } from '../src/kind-label.js'
+
+/**
+ * What a reader sees where a kind is offered or stated (Nabeel, 2026-09-05).
+ *
+ * The field this reads, `VisualKindOption.name`, shipped in phase 4 with ZERO
+ * consumers: it was added to the wire, typechecked, and never connected to a
+ * renderer, so a profile that authored "Mule API interface" saw it nowhere.
+ * Found by the ApertureX session reading a mounted host rather than assuming.
+ */
+
+describe('kindOptionText', () => {
+  it('states the authored name AND the id the document will carry', () => {
+    // Both halves. The panel edits the document, so an architect needs the
+    // exact token; a consultant needs to know what the token means.
+    expect(kindOptionText({ label: 'mule-api', name: 'Mule API interface' })).toBe(
+      'Mule API interface (mule-api)',
+    )
+  })
+
+  it('says the id alone where the profile authored no name', () => {
+    // Which is every core kind - roughly 140 of them on the reference. A
+    // parenthetical there would be noise on every row.
+    expect(kindOptionText({ label: 'applicationComponent' })).toBe(
+      'applicationComponent',
+    )
+  })
+
+  it('does not repeat a name that is already the id', () => {
+    // A profile may author a name identical to its local id, which would
+    // otherwise read `dataObject (dataObject)`.
+    expect(kindOptionText({ label: 'dataObject', name: 'dataObject' })).toBe(
+      'dataObject',
+    )
+  })
+})

--- a/test/subject-draft-panel.test.ts
+++ b/test/subject-draft-panel.test.ts
@@ -43,6 +43,13 @@ const KINDS = [
     label: 'businessActor',
     coreLabel: 'businessActor',
   },
+  // A profile kind that authored a display name, which core kinds never do.
+  {
+    id: 'aperturex/mule@1.0#mule-api',
+    label: 'mule-api',
+    coreLabel: 'applicationInterface',
+    name: 'Mule API interface',
+  },
 ]
 
 const render = (overrides: { readonly initialKind?: string } = {}) =>
@@ -245,5 +252,26 @@ describe('SubjectDraftPanel', () => {
     // …and no id is claimed twice, in the panel or by two labels.
     expect(new Set(ids).size).toBe(ids.length)
     expect(new Set(fors).size).toBe(fors.length)
+  })
+})
+
+describe('a kind that authored a display name', () => {
+  it('offers the name AND the id, so a reader knows what the token means', () => {
+    // `VisualKindOption.name` shipped in phase 4 with no consumer at all: a
+    // profile could author "Mule API interface" and see it nowhere. Found by
+    // the ApertureX session reading a mounted host.
+    expect(render()).toContain('Mule API interface (mule-api)')
+  })
+
+  it('keeps the bare label as the VALUE the option carries', () => {
+    // The half that must not move. A document names a kind the short way and
+    // `apply` refuses anything else as an unknown kind (YM401), so the text a
+    // reader sees and the token a stage writes are different things.
+    expect(render()).toContain('value="mule-api"')
+    expect(render()).not.toContain('value="Mule API interface (mule-api)"')
+  })
+
+  it('leaves a kind with no authored name exactly as it was', () => {
+    expect(render()).toContain('>applicationComponent</option>')
   })
 })


### PR DESCRIPTION
## The defect

`VisualKindOption.name` shipped in 1.23.0 (#473 phase 4) carrying the display name a profile authored, and **nothing read it**. Not one consumer anywhere in the app — added to the wire, typechecked, tested, and never connected to a renderer. A pack authoring `Mule API interface` saw it nowhere, and the properties panel offered a bare `mule-api` to a consultant with no way to know what that means.

Found by the ApertureX session reading a mounted host, after I asserted in a brief to them that the name reached *"the palette, the properties panel and every kind label"*. It reached one of the three, and not the one I sent them to look at. They were right that the properties panel shows the bare id; I was wrong; and the truth was worse than either of us said, because for **kinds** the field was dead everywhere. What renders on the palette is `VisualPatternOption.name` — a different field on a different type.

## The change

Nabeel's ruling: show both. `Mule API interface (mule-api)` on both selects and both fact rows of the properties panel.

The panel **edits the document**, so an architect needs the exact token that lands in the YAML; a consultant reading the same panel needs to know what the token means. The palette can afford the name alone because nothing there is being written.

A kind whose profile authored no name — every core kind — is unchanged, and a name identical to its own id does not repeat as `dataObject (dataObject)`.

## The trap, and why the split exists

**The VALUE a select carries stays the bare label.** `kindLabelFor` resolves that value and feeds `currentKind`, which is also what `stageConceptScalarChange` writes. A sibling `kindTextFor` resolves the text beside it.

Had the two been merged, every staged kind edit would have written `Mule API interface (mule-api)` into a document, which `apply` refuses as YM401. Pinned by a test asserting the option value is `mule-api` and is **not** the display text.

## Verification

Three rules, three mutations, all caught:

| Mutation | Result |
|---|---|
| ignore the authored name | 2 tests fail |
| make the select value the display text | 1 test fails |
| drop the guard against a name identical to its id | 1 test fails |

Clean-slate verify: 140 files, 2319 passed, 1 skipped.