### PR TITLE
chore: release 1.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.23.2
 
 ### A kind states its display name beside its id (#473)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch. One fix, no API or schema change.

### A kind states its display name beside its id (#487)

`VisualKindOption.name` shipped in 1.23.0 carrying the display name a profile authored, and **nothing read it** — added to the wire, typechecked, tested, and never connected to a renderer. A pack authoring `Mule API interface` saw it nowhere, and the properties panel offered a bare `mule-api` to a consultant with no way to know what that means.

Both selects and both fact rows now read `Mule API interface (mule-api)`. Kinds whose profile authored no name — every core kind — are unchanged.

The **value** a select carries is untouched and stays the bare label, because that is what a staged operation writes and `apply` refuses anything else as YM401. Pinned by its own test.

Found by the ApertureX session reading a mounted host rather than believing this session's claim about where the name reached.

---

Clean-slate verify: 140 files, 2319 passed, 1 skipped. Tarball 293 files, 2.1 MB.