### PR TITLE
chore: release 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.24.0
 
 ### Four ways to lay a view out, and the reviewer picks (#489)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version 1.24.0: four layout modes with routed edges and the reviewer's pick (#489, PR #491), the reading-phrase labels, and the deliberate hiding of box-to-member edges. MINOR: additive schema (`presentation.layout` widened, `presentation.showKindLabels` added), nothing required added, `cytoscape-elk` removed from the dependency list. A view that declares no `layout` now draws served-by; `layout: layered` keeps the old picture.

Verified on the branch, clean-slate: 145 files, 2394 tests, self-check clean; `npm pack --dry-run` listing inspected (302 files, no source or tests); `changelog:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
