### PR TITLE
fix(visual): Save view carries every field the view already declares (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Save view keeps what the view already declares (#493)
+
+Overwriting a view through **Save view** rebuilt its presentation block from
+the form's own fields and dropped every other one: `nesting`, `fold` and
+`notation`. Found by ApertureX on 1.24.0, where a saved API tiers view lost
+`nesting: [composition, assignment]` and went from 69 subjects and 72 edges to
+65 and 105, because nothing contained the members any more. The defect
+predates 1.24.0; 1.24.0 made it bite, since Save is now the way to keep a
+layout pick. The overwritten view's declaration is now carried underneath
+what the form owns; a brand new view still carries nothing.
+
 ## 1.24.0
 
 ### Four ways to lay a view out, and the reviewer picks (#489)

--- a/src/visual-app/save-view.tsx
+++ b/src/visual-app/save-view.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { LayoutDirection } from "../layout-direction.js";
 import type { LayoutMode } from "../layout-mode.js";
-import type { ProjectionQuery } from "../projection.js";
+import type { ProjectionDefinition, ProjectionQuery } from "../projection.js";
 import type {
   VisualViewOperation,
   VisualViewSummary,
@@ -53,10 +53,19 @@ export interface BuildPayloadParams {
   /** Where the overwritten view's document already lives, if there is one. */
   readonly path: string | undefined;
   /**
-   * The folder this document declares. Carried rather than composed: this
-   * builds the presentation block from scratch, so a field it is not given is
-   * a field the save DROPS - and a reviewer who overwrote a view would find it
-   * had left its folder.
+   * Everything the view being overwritten already declares, carried through
+   * in full underneath what this form owns. The form composes the fields it
+   * has controls for; every other field - `nesting`, `fold`, `notation` - is
+   * the view's own opinion and must survive a save that never asked about it.
+   * Measured by ApertureX on 1.24.0: an overwrite that dropped
+   * `nesting: [composition, assignment]` turned 69 subjects and 72 edges into
+   * 65 and 105, because nothing contained the members any more. A new view
+   * has nothing to carry.
+   */
+  readonly declared: ProjectionDefinition["presentation"] | undefined;
+  /**
+   * The folder this document declares, for a NEW view. An overwrite carries
+   * its folder through `declared`; this names the one the opener chose.
    */
   readonly folder: string | undefined;
   readonly title: string;
@@ -92,6 +101,7 @@ export const buildPayload = ({
   id,
   taken,
   path,
+  declared,
   folder,
   title,
   description,
@@ -113,6 +123,10 @@ export const buildPayload = ({
       description,
       query: query ?? {},
       presentation: {
+        // The view's own declaration first, so a field this form has no
+        // control for is kept rather than dropped; what the form owns is
+        // written over it.
+        ...(declared ?? {}),
         layout,
         direction,
         // A folder is written only where there is one to write: an empty
@@ -295,9 +309,9 @@ export function SaveViewDialog({
           id === undefined
             ? undefined
             : activeView?.path,
-        // A new view takes the folder the caller named; an overwrite carries
-        // the one the view already declares, which is not the same thing as
-        // the one this control happens to be holding.
+        // An overwrite carries everything the view already declares; a new
+        // view carries nothing and takes the folder the caller named.
+        declared: id === undefined ? undefined : activeView?.presentation,
         folder: id === undefined ? folder : (activeView?.presentation?.folder),
         title,
         description,

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -34,6 +34,7 @@ const build = (
     id: 'existing-view',
     taken: new Set<string>(),
     path: '.yarramate/projections/existing-view.yaml',
+    declared: undefined,
     folder: undefined,
     title: 'My View',
     description: 'desc',
@@ -142,6 +143,39 @@ describe('buildPayload', () => {
       projectionOf(build({ id: undefined, path: undefined, direction: 'left-right' }))
         .presentation?.direction,
     ).toBe('left-right')
+  })
+
+  // The form composes only the fields it has controls for. Everything else the
+  // view declares - the nesting vocabulary, the fold default, the notation -
+  // is carried underneath, or an overwrite silently strips the view of its
+  // own opinions (found by ApertureX on 1.24.0: a dropped `nesting` turned 69
+  // subjects and 72 edges into 65 and 105).
+  it('carries every field the overwritten view declares and the form does not own', () => {
+    const presentation = projectionOf(
+      build({
+        declared: {
+          nesting: ['composition', 'assignment'],
+          fold: 'instances',
+          notation: 'archimate',
+          layout: 'layered',
+          showLifecycle: false,
+        },
+      }),
+    ).presentation
+    expect(presentation?.nesting).toEqual(['composition', 'assignment'])
+    expect(presentation?.fold).toBe('instances')
+    expect(presentation?.notation).toBe('archimate')
+    // What the form owns is written from the form, over the declaration.
+    expect(presentation?.layout).toBe('layered')
+    expect(presentation?.showLifecycle).toBe(true)
+  })
+
+  it('carries nothing into a brand new view', () => {
+    const presentation = projectionOf(
+      build({ id: undefined, path: undefined, declared: undefined }),
+    ).presentation
+    expect(presentation).not.toHaveProperty('nesting')
+    expect(presentation).not.toHaveProperty('fold')
   })
 
   it('carries the layout mode in force, whichever it is', () => {


### PR DESCRIPTION
Closes #493. Found by the ApertureX session on 1.24.0: overwriting a view through Save view rebuilt `presentation` from the form fields only and dropped `nesting`, `fold` and `notation`; a saved API tiers view lost `nesting: [composition, assignment]` and went from 69 subjects / 72 edges to 65 / 105. Pre-existing before 1.24.0, which made it bite because Save is now how a layout pick is kept.

The overwritten view's declared block is spread underneath the fields the form owns; a brand new view carries nothing. Two tests: the carry, and the new-view case. Mutation (drop the spread) turns the carry test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
