### PR TITLE
fix(visual): routed edges turn their corners like layered ones do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Routed edges turn their corners like layered ones do
+
+A routed edge asked cytoscape for `segments` with a 10px radius, and cytoscape
+rounds a corner only under `round-segments`, so every routed mode drew square
+corners beside `layered`'s 25px `round-taxi` bends. Routed edges now draw as
+`round-segments`, and both modes take their radius from one constant.
+
 ### Save view keeps what the view already declares (#493)
 
 Overwriting a view through **Save view** rebuilt its presentation block from

--- a/src/visual-app/edge-routes.ts
+++ b/src/visual-app/edge-routes.ts
@@ -20,6 +20,15 @@ export interface Point {
 }
 
 /**
+ * The corner radius every orthogonal edge turns with, routed or not. One
+ * number for `round-taxi` (the stylesheet's `taxi-radius`, drawn under
+ * `layered` and on any edge a moved endpoint handed back) and for a routed
+ * edge's `segment-radii`, so the two modes cannot drift apart: they did, at
+ * 25 against 10, and the routed modes read as square-cornered beside layered.
+ */
+export const EDGE_CORNER_RADIUS = 25
+
+/**
  * Every property a route sets. Cleared by name, never by a bare
  * `removeStyle()`: `applyFilter` hides elements through a `display` bypass,
  * and a bare clear would un-hide every filtered edge along with the route.
@@ -72,7 +81,9 @@ export function routeStyle(
     distances.push((vx * nx + vy * ny).toFixed(2))
   }
   const style: Record<string, string | number> = {
-    'curve-style': inner.length > 0 ? 'segments' : 'straight',
+    // `round-segments`, not `segments`: cytoscape rounds a corner only under
+    // the curve style that says so, and ignores `segment-radii` otherwise.
+    'curve-style': inner.length > 0 ? 'round-segments' : 'straight',
     // Weights and distances measured against the manual endpoints, not the
     // node centres or cytoscape's own intersections.
     'edge-distances': 'endpoints',
@@ -83,7 +94,7 @@ export function routeStyle(
   if (inner.length > 0) {
     style['segment-weights'] = weights.join(' ')
     style['segment-distances'] = distances.join(' ')
-    style['segment-radii'] = '10'
+    style['segment-radii'] = String(EDGE_CORNER_RADIUS)
     style['radius-type'] = 'arc-radius'
   }
   return style

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -49,6 +49,7 @@ import {
   type EdgeLabelData,
 } from './elk-layout.js'
 import {
+  EDGE_CORNER_RADIUS,
   applyEdgeRoutes,
   clearEdgeRoutes,
   placedByElk,
@@ -470,7 +471,7 @@ export function buildStylesheet(
         // `layered`, and any edge whose route a moved endpoint invalidated. A
         // routed edge carries its own geometry as a bypass over this.
         'curve-style': 'round-taxi',
-        'taxi-radius': 25,
+        'taxi-radius': EDGE_CORNER_RADIUS,
         'target-arrow-shape': 'triangle',
         'target-arrow-color': '#999999',
         label: edgeText,

--- a/test/edge-routes.test.ts
+++ b/test/edge-routes.test.ts
@@ -1,6 +1,7 @@
 import cytoscape from 'cytoscape'
 import { describe, expect, it } from 'vitest'
 import {
+  EDGE_CORNER_RADIUS,
   ROUTE_STYLE_PROPERTIES,
   applyEdgeRoutes,
   clearEdgeRoutes,
@@ -66,7 +67,9 @@ const twoRoutes = (): Map<string, ElkRoute> =>
 describe('routeStyle', () => {
   it('projects an L-route onto the endpoint line as segments', () => {
     const style = routeStyle(L_ROUTE, { x: 0, y: 0 }, { x: 300, y: 0 }, 40)
-    expect(style['curve-style']).toBe('segments')
+    // `round-segments`, because cytoscape rounds a corner only under the
+    // curve style that says so; plain `segments` ignores the radius.
+    expect(style['curve-style']).toBe('round-segments')
     expect(style['edge-distances']).toBe('endpoints')
     // Offsets from each node's centre, not absolute coordinates: both ends
     // leave and arrive 25px below their node's centre, on its bottom border.
@@ -77,7 +80,7 @@ describe('routeStyle', () => {
     // which for a rightward line points down the page.
     expect(style['segment-weights']).toBe('0.0000 1.0000')
     expect(style['segment-distances']).toBe('75.00 75.00')
-    expect(style['segment-radii']).toBe('10')
+    expect(style['segment-radii']).toBe(String(EDGE_CORNER_RADIUS))
     expect(style['radius-type']).toBe('arc-radius')
     expect(style['source-text-offset']).toBe(40)
   })
@@ -142,7 +145,7 @@ describe('applyEdgeRoutes and clearEdgeRoutes', () => {
     const applied = applyEdgeRoutes(cy, placementOf(cy, twoRoutes()), () => true)
     expect(applied).toBe(2)
     expect(cy.getElementById('ab').hasClass('routed')).toBe(true)
-    expect(cy.getElementById('ab').style('curve-style')).toBe('segments')
+    expect(cy.getElementById('ab').style('curve-style')).toBe('round-segments')
     expect(cy.getElementById('bc').style('curve-style')).toBe('straight')
   })
 

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -16,6 +16,7 @@ import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.
 import { DEFAULT_DIRECTION } from '../src/layout-direction.js'
 import { LAYOUT_MODES } from '../src/layout-mode.js'
 import { rootLayoutOptions } from '../src/visual-app/elk-layout.js'
+import { EDGE_CORNER_RADIUS } from '../src/visual-app/edge-routes.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -471,7 +472,7 @@ describe('layout runs', () => {
       await relayoutVisible(cy, 'top-down', 'routed')
       cy.edges().forEach((edge) => {
         expect(edge.hasClass('routed')).toBe(true)
-        expect(['segments', 'straight']).toContain(edge.style('curve-style'))
+        expect(['round-segments', 'straight']).toContain(edge.style('curve-style'))
       })
       await relayoutVisible(cy, 'top-down', 'layered')
       cy.edges().forEach((edge) => {
@@ -517,6 +518,28 @@ describe('layout runs', () => {
         served.getElementById('a').position().y,
       )
       expect(served.getElementById('ab').style('target-arrow-shape')).toBe('vee')
+    })
+  })
+
+  // A routed corner and a taxi corner turn with the same radius, whichever
+  // mode drew them: the two drifted to 25 against 10 once, and the routed
+  // modes read as square-cornered beside layered.
+  it('turns routed and taxi corners with one radius', async () => {
+    // The six-node cycle, dressed with the production stylesheet: a routed
+    // cycle bends, where a two-node pair routes straight and would have
+    // nothing to round.
+    const cy = cytoscape({
+      styleEnabled: true,
+      style: buildStylesheet(true, true, false, true, true, 'routed'),
+      layout: { name: 'null' },
+      elements: buildLayoutFixture().elements().jsons() as cytoscape.ElementDefinition[],
+    })
+    expect(cy.edges().first().numericStyle('taxi-radius')).toBe(EDGE_CORNER_RADIUS)
+    await relayoutVisible(cy, 'top-down', 'routed')
+    const turned = cy.edges().filter((edge) => edge.style('curve-style') === 'round-segments')
+    expect(turned.length).toBeGreaterThan(0)
+    turned.forEach((edge) => {
+      expect(edge.numericStyle('segment-radii')).toEqual([EDGE_CORNER_RADIUS])
     })
   })
 


### PR DESCRIPTION
Nabeel spotted it in the 1.24.0 build: edges under `layered` turn with a 25px radius and every routed mode draws square corners. A routed edge asked cytoscape for `segments` with `segment-radii: 10`, and cytoscape rounds corners only under `round-segments`; plain `segments` ignores the radius entirely.

Routed edges now draw as `round-segments`, and both the taxi radius and the routed radius come from one constant, `EDGE_CORNER_RADIUS`, so the two modes cannot drift apart again. Tests: `routeStyle` asks for `round-segments`; a routed cycle carries the shared radius on every bending edge and the stylesheet's `taxi-radius` equals it. Mutation (back to `segments`) turns both red.

Stacked on #494 so the CHANGELOG entries share one `## Unreleased`; the base retargets to main when #494 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
