### PR TITLE
fix(visual): every orthogonal edge turns a square corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Every orthogonal edge turns a square corner
+
+Layered drew its taxi bends with a 25px radius and the routed modes drew
+square corners; the difference was noticed on the reference model. Rounding
+the routed corners was tried first and withdrawn: at a container's border a
+rounded bend reads as the edge swerving into or out of the box. Layered now
+draws plain `taxi`, the routed modes plain `segments`, and neither asks for a
+radius.
+
 ### Save view keeps what the view already declares (#493)
 
 Overwriting a view through **Save view** rebuilt its presentation block from

--- a/src/visual-app/edge-routes.ts
+++ b/src/visual-app/edge-routes.ts
@@ -31,8 +31,6 @@ export const ROUTE_STYLE_PROPERTIES = [
   'target-endpoint',
   'segment-weights',
   'segment-distances',
-  'segment-radii',
-  'radius-type',
   'source-text-offset',
 ] as const
 
@@ -72,6 +70,8 @@ export function routeStyle(
     distances.push((vx * nx + vy * ny).toFixed(2))
   }
   const style: Record<string, string | number> = {
+    // Square corners, the same as layered's `taxi`: rounded bends were tried
+    // and read as edges swerving where they meet a container's border.
     'curve-style': inner.length > 0 ? 'segments' : 'straight',
     // Weights and distances measured against the manual endpoints, not the
     // node centres or cytoscape's own intersections.
@@ -83,8 +83,6 @@ export function routeStyle(
   if (inner.length > 0) {
     style['segment-weights'] = weights.join(' ')
     style['segment-distances'] = distances.join(' ')
-    style['segment-radii'] = '10'
-    style['radius-type'] = 'arc-radius'
   }
   return style
 }

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -468,9 +468,10 @@ export function buildStylesheet(
         width: 1.5,
         // What an edge draws as when nothing routes it: every edge under
         // `layered`, and any edge whose route a moved endpoint invalidated. A
-        // routed edge carries its own geometry as a bypass over this.
-        'curve-style': 'round-taxi',
-        'taxi-radius': 25,
+        // routed edge carries its own geometry as a bypass over this. Square
+        // corners in both cases, by looking: rounded bends read as edges
+        // swerving where they meet a container's border.
+        'curve-style': 'taxi',
         'target-arrow-shape': 'triangle',
         'target-arrow-color': '#999999',
         label: edgeText,
@@ -495,7 +496,7 @@ export function buildStylesheet(
       // exists but cannot be seen or tapped (#306). Bezier is the one curve
       // family cytoscape separates automatically for multi-edges:
       // `control-point-step-size` fans them out, so each stays visible and
-      // individually selectable. Single edges keep `round-taxi` untouched.
+      // individually selectable. Single edges keep `taxi` untouched.
       selector: 'edge.parallel',
       style: {
         'curve-style': 'bezier',

--- a/test/edge-routes.test.ts
+++ b/test/edge-routes.test.ts
@@ -77,8 +77,9 @@ describe('routeStyle', () => {
     // which for a rightward line points down the page.
     expect(style['segment-weights']).toBe('0.0000 1.0000')
     expect(style['segment-distances']).toBe('75.00 75.00')
-    expect(style['segment-radii']).toBe('10')
-    expect(style['radius-type']).toBe('arc-radius')
+    // Square corners, the same as layered: no radius is asked for.
+    expect(style).not.toHaveProperty('segment-radii')
+    expect(style).not.toHaveProperty('radius-type')
     expect(style['source-text-offset']).toBe(40)
   })
 

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -476,7 +476,7 @@ describe('layout runs', () => {
       await relayoutVisible(cy, 'top-down', 'layered')
       cy.edges().forEach((edge) => {
         expect(edge.hasClass('routed')).toBe(false)
-        expect(edge.style('curve-style')).toBe('round-taxi')
+        expect(edge.style('curve-style')).toBe('taxi')
       })
     })
 
@@ -488,7 +488,7 @@ describe('layout runs', () => {
       cy.on('layoutstop', () => applySavedPositions(cy, { a: { x: 5000, y: 5000 } }))
       await relayoutVisible(cy, 'top-down', 'routed')
       expect(cy.getElementById('ab').hasClass('routed')).toBe(false)
-      expect(cy.getElementById('ab').style('curve-style')).toBe('round-taxi')
+      expect(cy.getElementById('ab').style('curve-style')).toBe('taxi')
       expect(cy.getElementById('bc').hasClass('routed')).toBe(true)
     })
 
@@ -517,6 +517,29 @@ describe('layout runs', () => {
         served.getElementById('a').position().y,
       )
       expect(served.getElementById('ab').style('target-arrow-shape')).toBe('vee')
+    })
+  })
+
+  // Square corners in every mode, by looking at the reference model: rounded
+  // bends read as edges swerving where they meet a container's border. So
+  // neither the stylesheet's taxi nor a routed edge asks for a radius.
+  it('turns square corners, layered and routed alike', async () => {
+    const cy = cytoscape({
+      styleEnabled: true,
+      style: buildStylesheet(true, true, false, true, true, 'routed'),
+      layout: { name: 'null' },
+      elements: buildLayoutFixture().elements().jsons() as cytoscape.ElementDefinition[],
+    })
+    expect(cy.edges().first().style('curve-style')).toBe('taxi')
+    await relayoutVisible(cy, 'top-down', 'routed')
+    const bent = cy.edges().filter((edge) => edge.style('curve-style') === 'segments')
+    expect(bent.length).toBeGreaterThan(0)
+    // Plain `segments` draws square corners whatever radius the defaults hold;
+    // only `round-segments` would round them, and no route asks for it.
+    expect(cy.edges().filter((edge) => edge.style('curve-style').startsWith('round')).length).toBe(0)
+    bent.forEach((edge) => {
+      const parsed = edge as unknown as { pstyle(name: string): { bypass?: boolean } | null }
+      expect(parsed.pstyle('segment-radii')?.bypass ?? false).toBe(false)
     })
   })
 

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -513,8 +513,8 @@ describe('parallel relationships between the same pair', () => {
 
   it('resolves parallel edges to a curve style cytoscape separates', () => {
     // The real stylesheet against the real elements, headless: parallel
-    // members leave `round-taxi` for `bezier` with a nonzero step, which is
-    // the mechanism that fans them apart; a single edge keeps `round-taxi`.
+    // members leave `taxi` for `bezier` with a nonzero step, which is
+    // the mechanism that fans them apart; a single edge keeps `taxi`.
     const cy = cytoscape({
       styleEnabled: true,
       elements,

--- a/test/graph-canvas.test.ts
+++ b/test/graph-canvas.test.ts
@@ -525,7 +525,7 @@ describe('parallel relationships between the same pair', () => {
     expect(cy.$id('e2').style('curve-style')).toBe('bezier')
     expect(cy.$id('e4').style('curve-style')).toBe('bezier')
     expect(cy.$id('e1').style('control-point-step-size')).toBe('40px')
-    expect(cy.$id('e5').style('curve-style')).toBe('round-taxi')
+    expect(cy.$id('e5').style('curve-style')).toBe('taxi')
   })
 
   it('does not count an edge consumed into nesting as a parallel member', () => {


### PR DESCRIPTION
Replaces #495, the other way round. Nabeel looked at rounded routed corners on the reference model and read them as edges swerving where they meet a container border, so the call is square corners in every mode: layered draws plain `taxi` (no radius), the routed modes plain `segments`, and no route asks for `segment-radii`.

Tests: `routeStyle` asks for no radius; a routed cycle has no `round-*` curve style and no radius bypass; the stylesheet fallback is `taxi`. Mutation (routed back to `round-segments`) turns the corner test red.

Stacked on #494 so the CHANGELOG entries share one `## Unreleased`; retargets to main when #494 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
