### PR TITLE
fix(visual): wider routed lanes and grounded container titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Two residues of the routed modes, measured away
+
+Two labelled edges running side by side could still lay their readings over
+each other: the lanes between parallel edges go from 30 to 60px in the routed
+modes, which measured 0 labels on another label on the reference Landscape
+(from 3) for 5% more width; label spacing and placing labels beside the edge
+were tried and moved nothing. And a container's title, which sits in the band
+above its members, is grounded the way edge labels are, so a route entering
+the box from above no longer cuts through the letters.
+
 ### Every orthogonal edge turns a square corner
 
 Layered drew its taxi bends with a 25px radius and the routed modes drew

--- a/src/visual-app/elk-layout.ts
+++ b/src/visual-app/elk-layout.ts
@@ -98,14 +98,17 @@ const BASE_SPACING: LayoutOptions = {
 
 /**
  * The spacing a mode asks for. A routed mode draws two labelled edges side by
- * side, and at 20px their labels ("serv served by") lay over each other;
- * 30px clears a ten-character reading. `edgeEdgeBetweenLayers` stays at 20 on
- * purpose: it spaces the horizontal channels between layers, and widening it
- * measured as canvas height (8020px to 11624px on the Landscape) for no gain
- * against the overlap it was tried for.
+ * side, and their labels lay over each other unless the lanes are wider than
+ * a reading. Measured on the reference Landscape under served-by, labels
+ * on another label: 20px 14, 30px 3, 60px 0, at a width cost of 5% for the
+ * last step (12,346 to 12,943px); `elk.spacing.labelLabel`, `edgeLabel`, and
+ * placing labels beside the edge instead of on it all left the 3 standing.
+ * `edgeEdgeBetweenLayers` stays at 20 on purpose: it spaces the horizontal
+ * channels between layers, and widening it measured as canvas height (8,020
+ * to 11,624px) for no gain against the same overlap.
  */
 export const spacingFor = (mode: LayoutMode): LayoutOptions =>
-  routesEdges(mode) ? { ...BASE_SPACING, 'elk.spacing.edgeEdge': '30' } : { ...BASE_SPACING }
+  routesEdges(mode) ? { ...BASE_SPACING, 'elk.spacing.edgeEdge': '60' } : { ...BASE_SPACING }
 
 /**
  * The root graph's options for a mode and a direction.

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -409,6 +409,14 @@ export function buildStylesheet(
         'text-valign': 'top',
         'text-margin-y': -8,
         color: '#333333',
+        // The title sits in the band ELK reserves above the children, and an
+        // edge entering the box from above crosses that band on its way in.
+        // The same opaque ground the edge labels use keeps the title legible
+        // where a route passes under it; the route reads as interrupted by a
+        // label, which is what it is.
+        'text-background-color': '#FFFFFF',
+        'text-background-opacity': 1,
+        'text-background-padding': '3px',
       },
     },
     {

--- a/test/elk-layout.test.ts
+++ b/test/elk-layout.test.ts
@@ -86,7 +86,9 @@ describe('rootLayoutOptions', () => {
       expect(options['elk.hierarchyHandling']).toBe('INCLUDE_CHILDREN')
       expect(options['elk.edgeRouting']).toBe('ORTHOGONAL')
       expect(options['elk.edgeLabels.inline']).toBe('true')
-      expect(options['elk.spacing.edgeEdge']).toBe('30')
+      // 60, not 30: measured as the lane width that leaves no label on
+      // another label on the reference Landscape.
+      expect(options['elk.spacing.edgeEdge']).toBe('60')
       expect(options['elk.layered.spacing.edgeEdgeBetweenLayers']).toBe('20')
     }
   })

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -543,6 +543,19 @@ describe('layout runs', () => {
     })
   })
 
+  // A container's title sits in the band above its children, where a route
+  // entering the box from above crosses it. An opaque ground under the title
+  // keeps it legible; without one the route cuts through the letters.
+  it('grounds a container title so a route entering the box does not cut through it', () => {
+    const styleOf = (block: unknown): Record<string, unknown> =>
+      ((block as { style?: Record<string, unknown> }).style ?? {})
+    const parent = buildStylesheet(true, true, false, true).find(
+      (block) => (block as { selector: string }).selector === 'node:parent',
+    )
+    expect(styleOf(parent)['text-background-opacity']).toBe(1)
+    expect(styleOf(parent)['text-background-color']).toBe('#FFFFFF')
+  })
+
   // What an edge says is decided in one place, and the stylesheet asks it in
   // the layout's voice: the same unnamed serving reads "serves" where the
   // server is drawn above and "served by" where it is drawn below. Off, an


### PR DESCRIPTION
The two residues left over from #491, measured before changing anything.

- **Labels side by side.** Two labelled routed edges running in parallel could lay their readings over each other. On the reference Landscape under served-by, labels on another label: 20px lanes 14, 30px 3, 60px 0, at 5% more width for the last step (12,346 to 12,943px). `elk.spacing.labelLabel`, `elk.spacing.edgeLabel` and placing labels beside the edge (`inline: false`, SMART side selection) all left the 3 standing. Routed lanes are 60px now.
- **Container titles.** A title sits in the band above its members, and a route entering the box from above cut through the letters. The title now has the same opaque ground the edge labels use.

Tests pin both; each mutation (30px back, ground removed) turns its test red. Stacked on #496 so the CHANGELOG shares one `## Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
