### PR TITLE
feat(visual): five dresses for the canvas, and the reviewer picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### The canvas has five dresses, and the reviewer picks
+
+A **Style** select joins Layout and Direction on the canvas: `current` (what
+shipped), `drafting`, `ink`, `tinted` and `dark`, all over the same notation,
+so a dress changes colour, weight, face and radius and never what a shape
+means. The pick is the reviewer's own: remembered by the browser, never
+written into a view, untouched by a view switch. The notation's glyphs take a
+stroke colour so the dark ground gets light glyphs. ADR 0148.
+
 ### Two residues of the routed modes, measured away
 
 Two labelled edges running side by side could still lay their readings over

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -276,6 +276,20 @@ recorded what those two backends mapped onto and why the obvious ELK choices
 were rejected; it is superseded here. The layout mechanism it expected is the
 four modes above (ADR 0147).
 
+### Style
+
+Five dresses for the same notation, picked from a **Style** select beside
+Layout and Direction ([ADR 0148](adr/0148-a-style-is-the-reviewers-not-the-views.md)):
+`current` (ArchiMate pastels, what shipped), `drafting` (the shell's own
+paper, hairline rules and faces), `ink` (white subjects, the layer in a
+coloured border, ink edges), `tinted` (a contemporary muted palette, 8px
+corners, pill labels) and `dark` (a dark ground, light ink and light glyphs).
+A dress changes colour, weight, face and radius and nothing that means
+anything: shapes, arrowheads, glyph strokes, badges and label wording are the
+notation's under every one. The pick is the reviewer's, remembered in the
+browser's storage and never written into a view; a view switch leaves it
+alone, and a fresh browser opens on `current`.
+
 ### Deleting
 
 **Delete** on a selected subject or relationship asks first, because this is the

--- a/docs/adr/0148-a-style-is-the-reviewers-not-the-views.md
+++ b/docs/adr/0148-a-style-is-the-reviewers-not-the-views.md
@@ -1,0 +1,61 @@
+# A style is the reviewer's, not the view's
+
+Status: accepted
+
+Nabeel asked for the canvas to be modernised and to see the possibilities in
+yarramate-visual itself rather than in mock-ups. Four dresses were built behind
+a Style select on the reference model, looked at, and the decision was to keep
+all of them and let the reviewer choose - the same ruling as for layouts
+([ADR 0147](0147-a-layout-is-a-way-of-reading-and-the-reviewer-picks-it.md)),
+with one difference in where the choice lives.
+
+## Decision
+
+**The canvas has five dresses; the reviewer picks one, and the browser
+remembers it. No view carries a style.**
+
+- **`current`** is what shipped: ArchiMate pastels, 2px borders, grey edges
+  with boxed labels. It appends nothing to the stylesheet, so the base rules
+  alone still decide the picture.
+- **`drafting`** carries the shell's own vocabulary onto the canvas:
+  paper-tinted fills, hairline ink rules, the body face, monospace edge
+  readings with a paper halo, uppercase monospace container titles.
+- **`ink`** is line-first and print-ready: white subjects, the layer carried
+  by a coloured 1.5px border, ink edges, no boxes anywhere.
+- **`tinted`** puts a contemporary muted palette in place of the pastels, 8px
+  corners, slate edges, edge readings on small pills.
+- **`dark`** is a dark ground with deep layer tints, light ink, and light
+  glyphs - the notation's glyph strokes take an ink parameter for it, and
+  nothing else about them moves.
+- **A dress changes nothing that means anything.** Shapes by aspect,
+  arrowheads by kind, glyphs, badges and label wording are the notation's and
+  stay; a preset is a list of stylesheet blocks appended after the base and
+  notation rules and before the marks, so it wins on colour, weight, face and
+  radius and on nothing else. The three modern dresses also draw selection as
+  a 2px accent with a soft glow, and give passive-structure subjects their
+  header band in their own layer's colour.
+- **The style is remembered in the browser** (`localStorage`,
+  `yarramate-visual.style`), never written into a projection or the layout
+  sidecar, and untouched by a view switch. Layout and direction are part of
+  what a view means and a save writes them; a dress is about the reader's eyes,
+  and two readers of one view may want different ones. A browser with no
+  storage, or one that refuses it, opens on `current` and still draws the pick
+  for the session.
+
+## Consequences
+
+- A host that mounts the editor gets the Style select with the other two; the
+  pick lives in the host page's origin storage.
+- `dark` dresses the canvas alone. The shell around it stays on paper; a dark
+  shell is a separate decision about the whole workspace.
+- Adding a dress is one entry in `src/visual-app/style-presets.ts`; the tests
+  hold every dress to recolouring every layer the notation knows.
+
+## Excluded
+
+- **`presentation.style` on the view.** It would make one reader's preference
+  every reader's, and a save from a dark-mode reviewer would restyle the view
+  for the team.
+- **A style as a stylesheet swap.** Presets append rather than replace, so
+  the marks (faults, decorations, selection precedence, ADR 0119) and the
+  notation stay authoritative under every dress.

--- a/src/notation/archimate.ts
+++ b/src/notation/archimate.ts
@@ -51,11 +51,11 @@ const KIND_SHAPE_OVERRIDES: Readonly<Partial<Record<string, Partial<ShapeMeta>>>
   grouping: { borderStyle: 'dashed' },
 }
 
-function svg(body: string): string {
+function svg(body: string, ink: string = INK): string {
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" width="${ICON_SIZE}" height="${ICON_SIZE}" ` +
     `viewBox="0 0 ${ICON_SIZE} ${ICON_SIZE}">` +
-    `<g fill="none" stroke="${INK}" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">${body}</g>` +
+    `<g fill="none" stroke="${ink}" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">${body}</g>` +
     `</svg>`
   )
 }
@@ -245,9 +245,14 @@ export function conceptNotationOf(kindLabel: string): ConceptNotation | null {
   return CONCEPT_NOTATION_BY_ID[kindLabel] ?? null
 }
 
-export function kindGlyphDataUriOf(kindLabel: string): string | null {
+/**
+ * The glyph as a data URI, drawn in `ink` - the notation's own by default, or
+ * the light stroke a dark ground needs (ADR 0148). The stroke is the only
+ * thing that varies; the strokes themselves are the notation's.
+ */
+export function kindGlyphDataUriOf(kindLabel: string, ink: string = INK): string | null {
   const glyph = CONCEPT_NOTATION_BY_ID[kindLabel]?.glyph
-  return glyph == null ? null : toDataUri(svg(glyph))
+  return glyph == null ? null : toDataUri(svg(glyph, ink))
 }
 
 export interface ArrowNotation {

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -39,7 +39,7 @@ import { foldTree } from "../fold-tree.js";
 import type { LayoutDirection } from "../layout-direction.js";
 import type { LayoutMode } from "../layout-mode.js";
 import { LayoutControls } from "./layout-controls.js";
-import type { StylePresetId } from "./style-presets.js";
+import { storeStylePreset, type StylePresetId } from "./style-presets.js";
 import type { ProjectionQuery } from "../projection.js";
 import type { VisualRenderedModel } from "../adapters/visual/wire.js";
 import type { YarramateOperation } from "../operations.js";
@@ -316,7 +316,7 @@ const DiagramWorkspace = ({
   /** The reviewer's picks from the canvas selects (ADR 0147). */
   readonly onLayoutChange: (layout: LayoutMode) => void;
   readonly onDirectionChange: (direction: LayoutDirection) => void;
-  /** LAB: the dress the canvas wears. */
+  /** The dress the canvas wears (ADR 0148). */
   readonly stylePreset: StylePresetId;
   readonly onStyleChange: (preset: StylePresetId) => void;
   readonly showLifecycle: boolean;
@@ -2085,9 +2085,12 @@ export const App = ({
             dispatchWorkspace({ type: "direction.set", direction })
           }
           stylePreset={workspace.stylePreset}
-          onStyleChange={(preset) =>
-            dispatchWorkspace({ type: "style.set", preset })
-          }
+          onStyleChange={(preset) => {
+            // Remembered by the browser before it is drawn: a style is the
+            // reviewer's, and a reload should open on it (ADR 0148).
+            storeStylePreset(preset);
+            dispatchWorkspace({ type: "style.set", preset });
+          }}
           decorations={decorations}
           connection={workspace.connection}
           onConnectTarget={(id) =>

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -39,6 +39,7 @@ import { foldTree } from "../fold-tree.js";
 import type { LayoutDirection } from "../layout-direction.js";
 import type { LayoutMode } from "../layout-mode.js";
 import { LayoutControls } from "./layout-controls.js";
+import type { StylePresetId } from "./style-presets.js";
 import type { ProjectionQuery } from "../projection.js";
 import type { VisualRenderedModel } from "../adapters/visual/wire.js";
 import type { YarramateOperation } from "../operations.js";
@@ -259,6 +260,8 @@ const DiagramWorkspace = ({
   direction,
   onLayoutChange,
   onDirectionChange,
+  stylePreset,
+  onStyleChange,
   showLifecycle,
   showEvidence,
   showOwnership,
@@ -313,6 +316,9 @@ const DiagramWorkspace = ({
   /** The reviewer's picks from the canvas selects (ADR 0147). */
   readonly onLayoutChange: (layout: LayoutMode) => void;
   readonly onDirectionChange: (direction: LayoutDirection) => void;
+  /** LAB: the dress the canvas wears. */
+  readonly stylePreset: StylePresetId;
+  readonly onStyleChange: (preset: StylePresetId) => void;
   readonly showLifecycle: boolean;
   readonly showEvidence: boolean;
   readonly showOwnership: boolean;
@@ -470,6 +476,8 @@ const DiagramWorkspace = ({
               direction={direction}
               onLayoutChange={onLayoutChange}
               onDirectionChange={onDirectionChange}
+              stylePreset={stylePreset}
+              onStyleChange={onStyleChange}
             />
             {/* The palette is the authoring entry when it is reachable; this
               * button is the FALLBACK for a host that mounts without the
@@ -613,6 +621,7 @@ const DiagramWorkspace = ({
             direction={direction}
             layout={layout}
             showKindLabels={showKindLabels}
+            stylePreset={stylePreset}
             savedPositions={state.model.layouts[state.activeView]}
             // A read-only drag still moves the node - arranging what is on
             // screen is reading - but the debounced save it would queue goes
@@ -2074,6 +2083,10 @@ export const App = ({
           }
           onDirectionChange={(direction) =>
             dispatchWorkspace({ type: "direction.set", direction })
+          }
+          stylePreset={workspace.stylePreset}
+          onStyleChange={(preset) =>
+            dispatchWorkspace({ type: "style.set", preset })
           }
           decorations={decorations}
           connection={workspace.connection}

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -18,6 +18,7 @@ import {
 } from '../fold-tree.js'
 import { DEFAULT_DIRECTION, type LayoutDirection } from '../layout-direction.js'
 import { DEFAULT_LAYOUT, routesEdges, type LayoutMode } from '../layout-mode.js'
+import { presetBlocks, stylePresetOf, type StylePresetId } from './style-presets.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -297,6 +298,7 @@ export function buildStylesheet(
   showNudges: boolean,
   showKindLabels: boolean = true,
   layout: LayoutMode = DEFAULT_LAYOUT,
+  stylePreset: StylePresetId = 'current',
 ): cytoscape.StylesheetJsonBlock[] {
   // What an edge says is decided in one place (ADR 0147): the relationship's
   // name, or its reading in this layout's voice - "serves" in a layout that
@@ -657,6 +659,8 @@ export function buildStylesheet(
     ...baseStylesheet,
     ...archimateNodeShapes,
     ...archimateEdgeStyles,
+    // LAB: a style preset dresses the notation; the marks still win last.
+    ...presetBlocks(stylePreset),
     ...markStylesheet,
   ]
 }
@@ -1469,6 +1473,8 @@ interface GraphCanvasProps {
   readonly layout: LayoutMode
   /** Whether an unnamed relationship is labelled with its reading (ADR 0147). */
   readonly showKindLabels: boolean
+  /** LAB: which dress the canvas wears. */
+  readonly stylePreset: StylePresetId
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
@@ -1515,6 +1521,7 @@ export function GraphCanvas({
   direction,
   layout,
   showKindLabels,
+  stylePreset,
   savedPositions,
   onSaveLayout,
   onKindDrop,
@@ -1622,6 +1629,7 @@ export function GraphCanvas({
         showNudges,
         showKindLabels,
         layout,
+        stylePreset,
       ),
       wheelSensitivity: 0.1,
       layout: { name: 'null' },
@@ -1789,11 +1797,12 @@ export function GraphCanvas({
         showNudges,
         showKindLabels,
         layout,
+        stylePreset,
       ),
     )
     // `showKindLabels` and `layout` are here for the LABEL WORDING they
     // change; the relayout a layout change needs is armed below.
-  }, [showLifecycle, showEvidence, showOwnership, showNudges, showKindLabels, layout])
+  }, [showLifecycle, showEvidence, showOwnership, showNudges, showKindLabels, layout, stylePreset])
 
   // Update elements whenever the graph itself changes. Keyed on the graph and
   // nothing else: a full remove/re-add plus an unscoped layout over every
@@ -2076,7 +2085,14 @@ export function GraphCanvas({
         // cytoscape UI extension and finds it mispositioned with the reason
         // already printed and ignored. Rendering is unaffected: the layer
         // holder cytoscape creates inside is already relative.
-        style={{ position: 'relative', width: '100%', height: '100%' }}
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          ...(stylePresetOf(stylePreset).canvas === undefined
+            ? {}
+            : { background: stylePresetOf(stylePreset).canvas }),
+        }}
         onContextMenu={(event) => event.preventDefault()}
         // A kind dragged from the palette (#295). Accepted on the container
         // rather than on any cytoscape element: a new subject belongs to no

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -18,7 +18,7 @@ import {
 } from '../fold-tree.js'
 import { DEFAULT_DIRECTION, type LayoutDirection } from '../layout-direction.js'
 import { DEFAULT_LAYOUT, routesEdges, type LayoutMode } from '../layout-mode.js'
-import { presetBlocks, stylePresetOf, type StylePresetId } from './style-presets.js'
+import { DEFAULT_STYLE_PRESET, presetBlocks, stylePresetOf, type StylePresetId } from './style-presets.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -163,14 +163,16 @@ function badgeLayersFor(
   showEvidence: boolean,
   showOwnership: boolean,
   showNudges: boolean,
+  glyphInk?: string,
 ): BadgeLayer[] {
   const layers: BadgeLayer[] = []
   // Label first, then the core kind it descends from - the same two-step
   // the palette takes. A profile-declared kind is named by its author and
-  // drawn as what it IS.
+  // drawn as what it IS. The stroke is the style's: a dark ground asks for a
+  // light glyph (ADR 0148).
   const icon =
-    kindIconUriOf(String(ele.data('kindLabel'))) ??
-    kindIconUriOf(String(ele.data('coreKindLabel')))
+    kindIconUriOf(String(ele.data('kindLabel')), glyphInk) ??
+    kindIconUriOf(String(ele.data('coreKindLabel')), glyphInk)
   if (icon !== null) {
     layers.push({ image: icon, positionX: '0%', positionY: '0%', size: ICON_SIZE })
   }
@@ -298,8 +300,9 @@ export function buildStylesheet(
   showNudges: boolean,
   showKindLabels: boolean = true,
   layout: LayoutMode = DEFAULT_LAYOUT,
-  stylePreset: StylePresetId = 'current',
+  stylePreset: StylePresetId = DEFAULT_STYLE_PRESET,
 ): cytoscape.StylesheetJsonBlock[] {
+  const glyphInk = stylePresetOf(stylePreset).glyph
   // What an edge says is decided in one place (ADR 0147): the relationship's
   // name, or its reading in this layout's voice - "serves" in a layout that
   // draws the server above, "served by" in one that draws it below - or
@@ -322,7 +325,7 @@ export function buildStylesheet(
       `\u0000${String(ele.data('kindLabel'))}\u0000${String(ele.data('openQuestions'))}`
     const cached = badgeStyleCache.get(key)
     if (cached !== undefined) return cached
-    const layers = badgeLayersFor(ele, showLifecycle, showEvidence, showOwnership, showNudges)
+    const layers = badgeLayersFor(ele, showLifecycle, showEvidence, showOwnership, showNudges, glyphInk)
     const built: BadgeStyleArrays = {
       images: layers.map((layer) => layer.image),
       positionsX: layers.map((layer) => layer.positionX),
@@ -659,7 +662,7 @@ export function buildStylesheet(
     ...baseStylesheet,
     ...archimateNodeShapes,
     ...archimateEdgeStyles,
-    // LAB: a style preset dresses the notation; the marks still win last.
+    // The style preset dresses the notation (ADR 0148); the marks still win last.
     ...presetBlocks(stylePreset),
     ...markStylesheet,
   ]
@@ -1473,7 +1476,7 @@ interface GraphCanvasProps {
   readonly layout: LayoutMode
   /** Whether an unnamed relationship is labelled with its reading (ADR 0147). */
   readonly showKindLabels: boolean
-  /** LAB: which dress the canvas wears. */
+  /** Which dress the canvas wears (ADR 0148). */
   readonly stylePreset: StylePresetId
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined

--- a/src/visual-app/kind-icons.ts
+++ b/src/visual-app/kind-icons.ts
@@ -17,6 +17,6 @@ export { ICON_SIZE }
 // `kindLabel` is a kind's local id (`kindLabelOf` in `src/kind-label.ts`),
 // not the qualified `<profile>#<id>` identity. Unknown label -> no icon, no
 // crash: the top-right slot simply stays empty.
-export function kindIconUriOf(kindLabel: string): string | null {
-  return coreKindGlyphDataUriOf(kindLabel)
+export function kindIconUriOf(kindLabel: string, ink?: string): string | null {
+  return coreKindGlyphDataUriOf(kindLabel, ink)
 }

--- a/src/visual-app/layout-controls.tsx
+++ b/src/visual-app/layout-controls.tsx
@@ -21,28 +21,30 @@ export const DIRECTION_LABELS: Readonly<Record<LayoutDirection, string>> = {
 };
 
 /**
- * The layout and direction selects, on the canvas they arrange (ADR 0147).
+ * The layout, direction and style selects, on the canvas they arrange (ADR
+ * 0147, ADR 0148).
  *
- * The view declares both and a view switch restates them; what a reviewer picks
- * here holds until then, and a save writes it. Shown in read-only hosts too:
- * arranging what is on screen is reading, the same judgement the quick filter
- * and a drag already make.
+ * The view declares layout and direction and a view switch restates them; what
+ * a reviewer picks here holds until then, and a save writes it. The style is
+ * the reviewer's alone: the browser remembers it and no view carries it.
+ * Shown in read-only hosts too: arranging what is on screen is reading, the
+ * same judgement the quick filter and a drag already make.
  */
 export function LayoutControls({
   layout,
   direction,
   onLayoutChange,
   onDirectionChange,
-  stylePreset = "current",
+  stylePreset,
   onStyleChange,
 }: {
   readonly layout: LayoutMode;
   readonly direction: LayoutDirection;
   readonly onLayoutChange: (layout: LayoutMode) => void;
   readonly onDirectionChange: (direction: LayoutDirection) => void;
-  /** LAB: the dress select; absent draws no third select. */
-  readonly stylePreset?: StylePresetId;
-  readonly onStyleChange?: (preset: StylePresetId) => void;
+  /** The dress the canvas wears (ADR 0148), the reviewer's own. */
+  readonly stylePreset: StylePresetId;
+  readonly onStyleChange: (preset: StylePresetId) => void;
 }) {
   return (
     <>
@@ -72,20 +74,18 @@ export function LayoutControls({
           </option>
         ))}
       </select>
-      {onStyleChange === undefined ? null : (
-        <select
-          className="canvas-select"
-          aria-label="Style"
-          value={stylePreset}
-          onChange={(event) => onStyleChange(event.currentTarget.value as StylePresetId)}
-        >
-          {STYLE_PRESETS.map((preset) => (
-            <option key={preset.id} value={preset.id}>
-              {preset.title}
-            </option>
-          ))}
-        </select>
-      )}
+      <select
+        className="canvas-select"
+        aria-label="Style"
+        value={stylePreset}
+        onChange={(event) => onStyleChange(event.currentTarget.value as StylePresetId)}
+      >
+        {STYLE_PRESETS.map((preset) => (
+          <option key={preset.id} value={preset.id}>
+            {preset.title}
+          </option>
+        ))}
+      </select>
     </>
   );
 }

--- a/src/visual-app/layout-controls.tsx
+++ b/src/visual-app/layout-controls.tsx
@@ -1,5 +1,6 @@
 import type { LayoutDirection } from "../layout-direction.js";
 import { LAYOUT_MODES, type LayoutMode } from "../layout-mode.js";
+import { STYLE_PRESETS, type StylePresetId } from "./style-presets.js";
 
 /**
  * What each layout mode is called on the canvas. Iterated by the test against
@@ -32,11 +33,16 @@ export function LayoutControls({
   direction,
   onLayoutChange,
   onDirectionChange,
+  stylePreset = "current",
+  onStyleChange,
 }: {
   readonly layout: LayoutMode;
   readonly direction: LayoutDirection;
   readonly onLayoutChange: (layout: LayoutMode) => void;
   readonly onDirectionChange: (direction: LayoutDirection) => void;
+  /** LAB: the dress select; absent draws no third select. */
+  readonly stylePreset?: StylePresetId;
+  readonly onStyleChange?: (preset: StylePresetId) => void;
 }) {
   return (
     <>
@@ -66,6 +72,20 @@ export function LayoutControls({
           </option>
         ))}
       </select>
+      {onStyleChange === undefined ? null : (
+        <select
+          className="canvas-select"
+          aria-label="Style"
+          value={stylePreset}
+          onChange={(event) => onStyleChange(event.currentTarget.value as StylePresetId)}
+        >
+          {STYLE_PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.title}
+            </option>
+          ))}
+        </select>
+      )}
     </>
   );
 }

--- a/src/visual-app/style-presets.ts
+++ b/src/visual-app/style-presets.ts
@@ -1,11 +1,13 @@
 /**
- * Style presets for the canvas: LAB ONLY, on branch `lab/style-presets`.
+ * The dresses the canvas can wear (ADR 0148).
  *
- * Four directions for how subjects and edges could look, drawn over the same
- * notation (shapes by aspect, arrowheads by kind, glyphs, badges) so only the
- * dress changes. Each preset is a list of stylesheet blocks appended after the
- * base and notation rules, so it wins on the properties it names and inherits
- * everything else. `current` appends nothing.
+ * Five looks for how subjects and edges draw, all over the same notation -
+ * shapes by aspect, arrowheads by kind, glyphs, badges - so only the dress
+ * changes and never what a shape means. Each preset is a list of stylesheet
+ * blocks appended after the base and notation rules, so it wins on the
+ * properties it names and inherits everything else; `current` appends
+ * nothing. A style is the reviewer's, not the view's: it is remembered in the
+ * browser and never written into a projection.
  */
 import type cytoscape from 'cytoscape'
 import { LAYER_COLORS } from '../notation/archimate.js'
@@ -19,15 +21,44 @@ export interface StylePreset {
   readonly blurb: string
   /** The canvas ground behind the drawing; undefined keeps the shell's paper. */
   readonly canvas?: string
+  /** The stroke the kind glyphs draw with; undefined keeps the notation's ink. */
+  readonly glyph?: string
 }
 
 export const STYLE_PRESETS: readonly StylePreset[] = [
-  { id: 'current', title: 'Current', blurb: 'What ships: ArchiMate pastels, 2px borders, Helvetica, grey edges with boxed labels.' },
+  { id: 'current', title: 'Current', blurb: 'ArchiMate pastels, 2px borders, grey edges with boxed labels.' },
   { id: 'drafting', title: 'Drafting', blurb: "The shell's own vocabulary on the canvas: paper-tinted fills, hairline ink rules, the body face, monospace edge readings with a paper halo." },
   { id: 'ink', title: 'Ink', blurb: 'Line-first and print-ready: white subjects, the layer carried by a coloured 1.5px border, ink edges, no boxes anywhere.' },
   { id: 'tinted', title: 'Tinted', blurb: 'A contemporary muted palette in place of the pastels, 8px corners, slate edges, edge readings on small pills.' },
-  { id: 'dark', title: 'Dark', blurb: 'A dark ground with deep layer tints and light ink; glyphs stay ink-coloured and would need a light variant.', canvas: '#12161b' },
+  { id: 'dark', title: 'Dark', blurb: 'A dark ground with deep layer tints, light ink and light glyphs.', canvas: '#12161b', glyph: '#e5e9ed' },
 ]
+
+export const DEFAULT_STYLE_PRESET: StylePresetId = 'current'
+
+/**
+ * Where the browser remembers the reviewer's pick. A style is a preference
+ * about looking, not a fact about the model, so it lives with the browser
+ * rather than in a projection or the layout sidecar; a fresh browser opens
+ * on `current`. Every access is guarded: storage can be absent or refused.
+ */
+export const STYLE_STORAGE_KEY = 'yarramate-visual.style'
+
+export const readStoredStylePreset = (): StylePresetId => {
+  try {
+    const held = globalThis.localStorage?.getItem(STYLE_STORAGE_KEY)
+    return isStylePresetId(held) ? held : DEFAULT_STYLE_PRESET
+  } catch {
+    return DEFAULT_STYLE_PRESET
+  }
+}
+
+export const storeStylePreset = (preset: StylePresetId): void => {
+  try {
+    globalThis.localStorage?.setItem(STYLE_STORAGE_KEY, preset)
+  } catch {
+    // A browser that refuses storage still draws the pick for this session.
+  }
+}
 
 export const stylePresetOf = (id: StylePresetId): StylePreset =>
   STYLE_PRESETS.find((preset) => preset.id === id) ?? STYLE_PRESETS[0]!

--- a/src/visual-app/style-presets.ts
+++ b/src/visual-app/style-presets.ts
@@ -1,0 +1,284 @@
+/**
+ * Style presets for the canvas: LAB ONLY, on branch `lab/style-presets`.
+ *
+ * Four directions for how subjects and edges could look, drawn over the same
+ * notation (shapes by aspect, arrowheads by kind, glyphs, badges) so only the
+ * dress changes. Each preset is a list of stylesheet blocks appended after the
+ * base and notation rules, so it wins on the properties it names and inherits
+ * everything else. `current` appends nothing.
+ */
+import type cytoscape from 'cytoscape'
+import { LAYER_COLORS } from '../notation/archimate.js'
+
+export const STYLE_PRESET_IDS = ['current', 'drafting', 'ink', 'tinted', 'dark'] as const
+export type StylePresetId = (typeof STYLE_PRESET_IDS)[number]
+
+export interface StylePreset {
+  readonly id: StylePresetId
+  readonly title: string
+  readonly blurb: string
+  /** The canvas ground behind the drawing; undefined keeps the shell's paper. */
+  readonly canvas?: string
+}
+
+export const STYLE_PRESETS: readonly StylePreset[] = [
+  { id: 'current', title: 'Current', blurb: 'What ships: ArchiMate pastels, 2px borders, Helvetica, grey edges with boxed labels.' },
+  { id: 'drafting', title: 'Drafting', blurb: "The shell's own vocabulary on the canvas: paper-tinted fills, hairline ink rules, the body face, monospace edge readings with a paper halo." },
+  { id: 'ink', title: 'Ink', blurb: 'Line-first and print-ready: white subjects, the layer carried by a coloured 1.5px border, ink edges, no boxes anywhere.' },
+  { id: 'tinted', title: 'Tinted', blurb: 'A contemporary muted palette in place of the pastels, 8px corners, slate edges, edge readings on small pills.' },
+  { id: 'dark', title: 'Dark', blurb: 'A dark ground with deep layer tints and light ink; glyphs stay ink-coloured and would need a light variant.', canvas: '#12161b' },
+]
+
+export const stylePresetOf = (id: StylePresetId): StylePreset =>
+  STYLE_PRESETS.find((preset) => preset.id === id) ?? STYLE_PRESETS[0]!
+
+export const isStylePresetId = (value: unknown): value is StylePresetId =>
+  typeof value === 'string' && (STYLE_PRESET_IDS as readonly string[]).includes(value)
+
+const BODY_FACE = "'Avenir Next', Avenir, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
+const MONO_FACE = "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+
+type Layer = keyof typeof LAYER_COLORS
+type Palette = Readonly<Record<Layer, { readonly fill: string; readonly border: string }>>
+
+const DRAFTING: Palette = {
+  motivation: { fill: '#dcd9ef', border: '#6f6bb0' },
+  strategy: { fill: '#ece2cd', border: '#a2843f' },
+  business: { fill: '#ecebc4', border: '#9a9440' },
+  application: { fill: '#cfe6e8', border: '#3f8f8f' },
+  technology: { fill: '#d3e6d3', border: '#4f8f4f' },
+  implementation: { fill: '#ebd9da', border: '#b07a7a' },
+  physical: { fill: '#e1e5e7', border: '#7d868c' },
+  composite: { fill: '#e1e5e7', border: '#7d868c' },
+}
+
+const INK: Palette = {
+  motivation: { fill: '#ffffff', border: '#5b52c8' },
+  strategy: { fill: '#ffffff', border: '#b8862b' },
+  business: { fill: '#ffffff', border: '#a89a12' },
+  application: { fill: '#ffffff', border: '#1f8f8f' },
+  technology: { fill: '#ffffff', border: '#2f8f2f' },
+  implementation: { fill: '#ffffff', border: '#c2606a' },
+  physical: { fill: '#ffffff', border: '#6b7680' },
+  composite: { fill: '#ffffff', border: '#6b7680' },
+}
+
+const TINTED: Palette = {
+  motivation: { fill: '#ede9fe', border: '#7c3aed' },
+  strategy: { fill: '#fef3c7', border: '#b45309' },
+  business: { fill: '#fef9c3', border: '#a16207' },
+  application: { fill: '#e0f2fe', border: '#0369a1' },
+  technology: { fill: '#d1fae5', border: '#047857' },
+  implementation: { fill: '#ffe4e6', border: '#be123c' },
+  physical: { fill: '#f1f5f9', border: '#475569' },
+  composite: { fill: '#f1f5f9', border: '#475569' },
+}
+
+const DARK: Palette = {
+  motivation: { fill: '#2a2550', border: '#8b7fe0' },
+  strategy: { fill: '#3a2e14', border: '#c9a355' },
+  business: { fill: '#3a3a10', border: '#c9c355' },
+  application: { fill: '#10344a', border: '#4fb8b8' },
+  technology: { fill: '#10391f', border: '#5fae5f' },
+  implementation: { fill: '#3d1b22', border: '#d89999' },
+  physical: { fill: '#262c33', border: '#6b7680' },
+  composite: { fill: '#262c33', border: '#6b7680' },
+}
+
+type Block = cytoscape.StylesheetJsonBlock
+
+/** One rule per layer for fill and border, plus the passive-structure header band in the layer's own hue. */
+const layerBlocks = (palette: Palette, bandStop = '16%'): Block[] => [
+  ...(Object.keys(palette) as Layer[]).map(
+    (layer): Block => ({
+      selector: `node[layer = "${layer}"]`,
+      style: { 'background-color': palette[layer].fill, 'border-color': palette[layer].border },
+    }),
+  ),
+  ...(Object.keys(palette) as Layer[]).map(
+    (layer): Block => ({
+      selector: `node[layer = "${layer}"][aspect = "passive-structure"]:childless`,
+      style: {
+        'background-fill': 'linear-gradient',
+        'background-gradient-direction': 'to-bottom',
+        'background-gradient-stop-colors': [palette[layer].border, palette[layer].fill],
+        'background-gradient-stop-positions': ['0%', bandStop],
+      } as cytoscape.Css.Node,
+    }),
+  ),
+]
+
+interface Dress {
+  readonly palette: Palette
+  readonly ink: string
+  readonly quiet: string
+  readonly ground: string
+  readonly nodeBorder: number
+  readonly corner: number
+  readonly edge: string
+  readonly edgeWidth: number
+  readonly edgeLabelFace: string
+  readonly edgeLabelColor: string
+  readonly edgeLabelBackground: { readonly color: string; readonly opacity: number; readonly shape: 'rectangle' | 'roundrectangle' }
+  readonly halo: string | null
+  readonly containerFill: { readonly color: string | null; readonly opacity: number }
+  readonly containerBorder: { readonly color: string | null; readonly style: 'solid' | 'dashed'; readonly opacity: number }
+  readonly containerTitle: { readonly face: string; readonly size: number; readonly weight: string; readonly color: string; readonly upper: boolean }
+  readonly select: string
+}
+
+const dressBlocks = (d: Dress): Block[] => [
+  ...layerBlocks(d.palette),
+  {
+    selector: 'node',
+    style: {
+      'border-width': d.nodeBorder,
+      'corner-radius': `${d.corner}px`,
+      'font-family': BODY_FACE,
+      'font-size': 12,
+      'font-weight': 500,
+      color: d.ink,
+    } as cytoscape.Css.Node,
+  },
+  {
+    selector: 'node:parent',
+    style: {
+      ...(d.containerFill.color === null ? {} : { 'background-color': d.containerFill.color }),
+      'background-opacity': d.containerFill.opacity,
+      ...(d.containerBorder.color === null ? {} : { 'border-color': d.containerBorder.color }),
+      'border-style': d.containerBorder.style,
+      'border-width': 1,
+      'border-opacity': d.containerBorder.opacity,
+      'corner-radius': `${d.corner + 4}px`,
+      'font-family': d.containerTitle.face,
+      'font-size': d.containerTitle.size,
+      'font-weight': d.containerTitle.weight,
+      color: d.containerTitle.color,
+      ...(d.containerTitle.upper ? { 'text-transform': 'uppercase' } : {}),
+      'text-margin-y': -6,
+    } as cytoscape.Css.Node,
+  },
+  {
+    selector: 'edge',
+    style: {
+      'line-color': d.edge,
+      'target-arrow-color': d.edge,
+      'source-arrow-color': d.edge,
+      width: d.edgeWidth,
+      'line-cap': 'round',
+      'arrow-scale': 0.85,
+      'font-family': d.edgeLabelFace,
+      'font-size': 9.5,
+      color: d.edgeLabelColor,
+      'text-background-color': d.edgeLabelBackground.color,
+      'text-background-opacity': d.edgeLabelBackground.opacity,
+      'text-background-shape': d.edgeLabelBackground.shape,
+      'text-background-padding': '2px',
+      ...(d.halo === null
+        ? { 'text-outline-width': 0 }
+        : { 'text-outline-color': d.halo, 'text-outline-width': 2, 'text-outline-opacity': 1 }),
+    } as cytoscape.Css.Edge,
+  },
+  {
+    selector: 'edge.lifted',
+    style: { 'line-color': d.quiet, 'target-arrow-color': d.quiet, width: d.edgeWidth + 0.5 } as cytoscape.Css.Edge,
+  },
+  {
+    // Selection as a glow rather than a thick coral border: the accent holds
+    // the outline and a soft overlay lifts the subject off the ground.
+    selector: 'node.selected',
+    style: {
+      'border-color': d.select,
+      'border-width': 2,
+      'overlay-color': d.select,
+      'overlay-opacity': 0.12,
+      'overlay-padding': 6,
+    } as cytoscape.Css.Node,
+  },
+  {
+    selector: 'edge.selected',
+    style: { 'line-color': d.select, 'target-arrow-color': d.select, width: d.edgeWidth + 1 } as cytoscape.Css.Edge,
+  },
+]
+
+const PRESET_BLOCKS: Readonly<Record<StylePresetId, () => Block[]>> = {
+  current: () => [],
+  drafting: () =>
+    dressBlocks({
+      palette: DRAFTING,
+      ink: '#182228',
+      quiet: '#7d868c',
+      ground: '#e8eef0',
+      nodeBorder: 1,
+      corner: 4,
+      edge: '#6b7680',
+      edgeWidth: 1.25,
+      edgeLabelFace: MONO_FACE,
+      edgeLabelColor: '#4a555e',
+      edgeLabelBackground: { color: '#e8eef0', opacity: 0, shape: 'rectangle' },
+      halo: '#e8eef0',
+      containerFill: { color: null, opacity: 0 },
+      containerBorder: { color: '#182228', style: 'dashed', opacity: 0.3 },
+      containerTitle: { face: MONO_FACE, size: 10, weight: '500', color: '#4a555e', upper: true },
+      select: '#2457a6',
+    }),
+  ink: () =>
+    dressBlocks({
+      palette: INK,
+      ink: '#182228',
+      quiet: '#6b7680',
+      ground: '#ffffff',
+      nodeBorder: 1.5,
+      corner: 4,
+      edge: '#182228',
+      edgeWidth: 1.2,
+      edgeLabelFace: BODY_FACE,
+      edgeLabelColor: '#182228',
+      edgeLabelBackground: { color: '#ffffff', opacity: 0, shape: 'rectangle' },
+      halo: '#e8eef0',
+      containerFill: { color: '#182228', opacity: 0.04 },
+      containerBorder: { color: '#182228', style: 'solid', opacity: 0.35 },
+      containerTitle: { face: BODY_FACE, size: 11, weight: '600', color: '#182228', upper: true },
+      select: '#2457a6',
+    }),
+  tinted: () =>
+    dressBlocks({
+      palette: TINTED,
+      ink: '#0f172a',
+      quiet: '#94a3b8',
+      ground: '#e8eef0',
+      nodeBorder: 1,
+      corner: 8,
+      edge: '#64748b',
+      edgeWidth: 1.5,
+      edgeLabelFace: BODY_FACE,
+      edgeLabelColor: '#475569',
+      edgeLabelBackground: { color: '#f8fafc', opacity: 1, shape: 'roundrectangle' },
+      halo: null,
+      containerFill: { color: null, opacity: 0.35 },
+      containerBorder: { color: null, style: 'solid', opacity: 0.5 },
+      containerTitle: { face: BODY_FACE, size: 11, weight: '600', color: '#334155', upper: false },
+      select: '#2563eb',
+    }),
+  dark: () =>
+    dressBlocks({
+      palette: DARK,
+      ink: '#e5e9ed',
+      quiet: '#97a3ae',
+      ground: '#12161b',
+      nodeBorder: 1,
+      corner: 6,
+      edge: '#7f8b96',
+      edgeWidth: 1.25,
+      edgeLabelFace: BODY_FACE,
+      edgeLabelColor: '#b8c2cc',
+      edgeLabelBackground: { color: '#12161b', opacity: 0, shape: 'rectangle' },
+      halo: '#12161b',
+      containerFill: { color: '#1a2027', opacity: 0.7 },
+      containerBorder: { color: '#3a444f', style: 'dashed', opacity: 1 },
+      containerTitle: { face: BODY_FACE, size: 11, weight: '600', color: '#97a3ae', upper: false },
+      select: '#7ea6ec',
+    }),
+}
+
+export const presetBlocks = (id: StylePresetId): Block[] => PRESET_BLOCKS[id]()

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -10,7 +10,7 @@ import {
   type LayoutDirection,
 } from "../layout-direction.js";
 import { DEFAULT_LAYOUT, type LayoutMode } from "../layout-mode.js";
-import type { StylePresetId } from "./style-presets.js";
+import { readStoredStylePreset, type StylePresetId } from "./style-presets.js";
 import type { DecorationMap } from "./graph-canvas.js";
 import type { ContextMenuTarget } from "./context-menu-model.js";
 import type { BottomPanelTabId } from "./query-panel.js";
@@ -412,7 +412,10 @@ export interface VisualWorkspaceState {
   /** Whether an unnamed relationship is labelled with its reading (ADR 0147). */
   readonly showKindLabels: boolean;
   readonly showNudges: boolean;
-  /** LAB: the dress the canvas wears; workspace-only, never written. */
+  /**
+   * The dress the canvas wears (ADR 0148). The reviewer's own: remembered by
+   * the browser, never written into a view, untouched by a view switch.
+   */
   readonly stylePreset: StylePresetId;
 }
 
@@ -729,7 +732,8 @@ export const createVisualWorkspaceState = (
   // On by default: the chip is the canvas half of the interview (#292), and
   // it only draws where a count is non-zero, so a finished model stays calm.
   showNudges: true,
-  stylePreset: "current",
+  // Whatever this browser remembered; `current` on a fresh one.
+  stylePreset: readStoredStylePreset(),
 });
 
 export const visualWorkspaceReducer = (

--- a/src/visual-app/workspace-state.ts
+++ b/src/visual-app/workspace-state.ts
@@ -10,6 +10,7 @@ import {
   type LayoutDirection,
 } from "../layout-direction.js";
 import { DEFAULT_LAYOUT, type LayoutMode } from "../layout-mode.js";
+import type { StylePresetId } from "./style-presets.js";
 import type { DecorationMap } from "./graph-canvas.js";
 import type { ContextMenuTarget } from "./context-menu-model.js";
 import type { BottomPanelTabId } from "./query-panel.js";
@@ -411,6 +412,8 @@ export interface VisualWorkspaceState {
   /** Whether an unnamed relationship is labelled with its reading (ADR 0147). */
   readonly showKindLabels: boolean;
   readonly showNudges: boolean;
+  /** LAB: the dress the canvas wears; workspace-only, never written. */
+  readonly stylePreset: StylePresetId;
 }
 
 export type VisualWorkspaceAction =
@@ -502,6 +505,10 @@ export type VisualWorkspaceAction =
   | {
       readonly type: "layout.set";
       readonly layout: LayoutMode;
+    }
+  | {
+      readonly type: "style.set";
+      readonly preset: StylePresetId;
     }
   | {
       readonly type: "presentation.toggled";
@@ -722,6 +729,7 @@ export const createVisualWorkspaceState = (
   // On by default: the chip is the canvas half of the interview (#292), and
   // it only draws where a count is non-zero, so a finished model stays calm.
   showNudges: true,
+  stylePreset: "current",
 });
 
 export const visualWorkspaceReducer = (
@@ -1020,6 +1028,10 @@ export const visualWorkspaceReducer = (
         : { ...state, layout: action.layout };
     case "presentation.toggled":
       return { ...state, [action.flag]: action.value };
+    case "style.set":
+      return state.stylePreset === action.preset
+        ? state
+        : { ...state, stylePreset: action.preset };
     case "model.replaced": {
       // A menu is anchored to a pointer position over a subject that may not
       // have survived the commit. `contextMenuFor` would return an empty menu

--- a/test/kind-icons.test.ts
+++ b/test/kind-icons.test.ts
@@ -42,6 +42,17 @@ describe('kind icon URIs', () => {
     }
   })
 
+  // A dark ground asks for a light stroke (ADR 0148); the strokes themselves
+  // stay the notation's, only the colour moves.
+  it('draws the glyph in the ink it is asked for', () => {
+    const decode = (uri: string) => decodeURIComponent(uri.slice(uri.indexOf(',') + 1))
+    const ink = decode(kindIconUriOf('businessActor') ?? '')
+    const light = decode(kindIconUriOf('businessActor', '#e5e9ed') ?? '')
+    expect(ink).toContain('stroke="#182228"')
+    expect(light).toContain('stroke="#e5e9ed"')
+    expect(light.replace('#e5e9ed', '#182228')).toBe(ink)
+  })
+
   it('returns null for an unmapped label', () => {
     expect(kindIconUriOf('notAKind')).toBeNull()
   })

--- a/test/layout-controls.test.ts
+++ b/test/layout-controls.test.ts
@@ -8,14 +8,17 @@ import {
   LayoutControls,
 } from '../src/visual-app/layout-controls.js'
 import { LAYOUT_MODES } from '../src/layout-mode.js'
+import { STYLE_PRESETS } from '../src/visual-app/style-presets.js'
 
 const render = (overrides: Partial<Parameters<typeof LayoutControls>[0]> = {}) =>
   renderToStaticMarkup(
     createElement(LayoutControls, {
       layout: 'served-by',
       direction: 'top-down',
+      stylePreset: 'current',
       onLayoutChange: () => {},
       onDirectionChange: () => {},
+      onStyleChange: () => {},
       ...overrides,
     }),
   )
@@ -29,6 +32,13 @@ describe('LayoutControls (ADR 0147)', () => {
     const markup = render()
     for (const mode of LAYOUT_MODES) expect(markup).toContain(`>${LAYOUT_MODE_LABELS[mode]}<`)
     for (const direction of DIRECTIONS) expect(markup).toContain(`>${DIRECTION_LABELS[direction]}<`)
+    // And every dress (ADR 0148), in the third select.
+    expect(markup).toContain('aria-label="Style"')
+    for (const preset of STYLE_PRESETS) expect(markup).toContain(`>${preset.title}<`)
+  })
+
+  it('opens on the style the browser remembered', () => {
+    expect(render({ stylePreset: 'ink' })).toContain('<option value="ink" selected="">Ink</option>')
   })
 
   it('opens on the layout and direction in force', () => {
@@ -43,18 +53,24 @@ describe('LayoutControls (ADR 0147)', () => {
   it('reports a pick to the right handler', () => {
     const onLayoutChange = vi.fn()
     const onDirectionChange = vi.fn()
+    const onStyleChange = vi.fn()
     const element = LayoutControls({
       layout: 'served-by',
       direction: 'top-down',
+      stylePreset: 'current',
       onLayoutChange,
       onDirectionChange,
+      onStyleChange,
     }) as ReactElement<{ children: ReactElement<{ onChange: (event: unknown) => void }>[] }>
-    const [layoutSelect, directionSelect] = element.props.children
+    const [layoutSelect, directionSelect, styleSelect] = element.props.children
     layoutSelect!.props.onChange({ currentTarget: { value: 'routed' } })
     directionSelect!.props.onChange({ currentTarget: { value: 'left-right' } })
+    styleSelect!.props.onChange({ currentTarget: { value: 'dark' } })
     expect(onLayoutChange).toHaveBeenCalledWith('routed')
     expect(onDirectionChange).toHaveBeenCalledWith('left-right')
+    expect(onStyleChange).toHaveBeenCalledWith('dark')
     expect(onLayoutChange).toHaveBeenCalledTimes(1)
     expect(onDirectionChange).toHaveBeenCalledTimes(1)
+    expect(onStyleChange).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/style-presets.test.ts
+++ b/test/style-presets.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_STYLE_PRESET,
+  STYLE_PRESETS,
+  STYLE_PRESET_IDS,
+  STYLE_STORAGE_KEY,
+  isStylePresetId,
+  presetBlocks,
+  readStoredStylePreset,
+  storeStylePreset,
+  stylePresetOf,
+} from '../src/visual-app/style-presets.js'
+import { LAYER_COLORS } from '../src/notation/archimate.js'
+
+const selectorsOf = (id: (typeof STYLE_PRESET_IDS)[number]) =>
+  presetBlocks(id).map((block) => (block as { selector: string }).selector)
+
+describe('style presets (ADR 0148)', () => {
+  it('names every preset once, current first, and opens on it', () => {
+    expect(STYLE_PRESETS.map((preset) => preset.id)).toEqual([...STYLE_PRESET_IDS])
+    expect(DEFAULT_STYLE_PRESET).toBe('current')
+    expect(stylePresetOf('current').title).toBe('Current')
+    for (const preset of STYLE_PRESETS) expect(preset.blurb.length).toBeGreaterThan(20)
+  })
+
+  it('recognises a preset id and refuses anything else', () => {
+    for (const id of STYLE_PRESET_IDS) expect(isStylePresetId(id)).toBe(true)
+    expect(isStylePresetId('neon')).toBe(false)
+    expect(isStylePresetId(null)).toBe(false)
+    expect(stylePresetOf('neon' as never).id).toBe('current')
+  })
+
+  // `current` is what shipped: it must add nothing, so the base stylesheet
+  // alone decides the picture.
+  it('appends nothing for current', () => {
+    expect(presetBlocks('current')).toEqual([])
+  })
+
+  // Every other dress recolours every layer the notation knows, so no layer
+  // is left wearing the pastel of a different dress.
+  it.each(['drafting', 'ink', 'tinted', 'dark'] as const)('%s recolours every layer', (id) => {
+    const selectors = selectorsOf(id)
+    for (const layer of Object.keys(LAYER_COLORS)) {
+      expect(selectors).toContain(`node[layer = "${layer}"]`)
+      expect(selectors).toContain(`node[layer = "${layer}"][aspect = "passive-structure"]:childless`)
+    }
+    for (const selector of ['node', 'node:parent', 'edge', 'edge.lifted', 'node.selected', 'edge.selected']) {
+      expect(selectors).toContain(selector)
+    }
+  })
+
+  // A dark ground needs a light glyph, or the notation's ink strokes vanish
+  // into the fills; the light dresses keep the notation's own ink.
+  it('asks for a light glyph and its own ground only where the ground is dark', () => {
+    expect(stylePresetOf('dark').canvas).toBe('#12161b')
+    expect(stylePresetOf('dark').glyph).toBe('#e5e9ed')
+    for (const id of ['current', 'drafting', 'ink', 'tinted'] as const) {
+      expect(stylePresetOf(id).canvas).toBeUndefined()
+      expect(stylePresetOf(id).glyph).toBeUndefined()
+    }
+  })
+
+  // The browser remembers the pick; a browser with no storage, or storage
+  // that refuses, opens on the default rather than failing.
+  it('remembers the pick in the browser and survives a missing store', () => {
+    const held = new Map<string, string>()
+    const storage = {
+      getItem: (key: string) => held.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        held.set(key, value)
+      },
+    }
+    const previous = (globalThis as { localStorage?: unknown }).localStorage
+    try {
+      ;(globalThis as { localStorage?: unknown }).localStorage = storage
+      expect(readStoredStylePreset()).toBe('current')
+      storeStylePreset('tinted')
+      expect(held.get(STYLE_STORAGE_KEY)).toBe('tinted')
+      expect(readStoredStylePreset()).toBe('tinted')
+      held.set(STYLE_STORAGE_KEY, 'neon')
+      expect(readStoredStylePreset()).toBe('current')
+      ;(globalThis as { localStorage?: unknown }).localStorage = {
+        getItem: () => {
+          throw new Error('refused')
+        },
+        setItem: () => {
+          throw new Error('refused')
+        },
+      }
+      expect(readStoredStylePreset()).toBe('current')
+      expect(() => storeStylePreset('dark')).not.toThrow()
+    } finally {
+      ;(globalThis as { localStorage?: unknown }).localStorage = previous
+    }
+    expect(readStoredStylePreset()).toBe('current')
+  })
+})

--- a/test/visual-app-render.test.ts
+++ b/test/visual-app-render.test.ts
@@ -517,6 +517,8 @@ describe('canvas layout controls', () => {
 
     expect(markup).toContain('aria-label="Layout"')
     expect(markup).toContain('aria-label="Direction"')
+    expect(markup).toContain('aria-label="Style"')
+    expect(markup).toContain('<option value="current" selected="">Current</option>')
     expect(markup).toContain('<option value="served-by" selected="">Served-by</option>')
     expect(markup).toContain('<option value="top-down" selected="">Top-down</option>')
     expect(markup).toContain('>Layer bands<')

--- a/test/visual-workspace-state.test.ts
+++ b/test/visual-workspace-state.test.ts
@@ -437,6 +437,20 @@ describe("visualWorkspaceReducer presentation", () => {
     expect(workspaceState.showKindLabels).toBe(true);
   });
 
+  // The dress is the reviewer's (ADR 0148): it changes through its own
+  // action, restating it mints no new state, and no view switch touches it.
+  it("wears the current dress until the reviewer picks another, whatever the view says", () => {
+    expect(workspaceState.stylePreset).toBe("current");
+    const dark = visualWorkspaceReducer(workspaceState, { type: "style.set", preset: "dark" });
+    expect(dark.stylePreset).toBe("dark");
+    expect(visualWorkspaceReducer(dark, { type: "style.set", preset: "dark" })).toBe(dark);
+    const afterSwitch = presentationActionsFor({ layout: "layered" }).reduce(
+      visualWorkspaceReducer,
+      dark,
+    );
+    expect(afterSwitch.stylePreset).toBe("dark");
+  });
+
   it("adopts a view's kind-label flag and leaves it alone when undeclared", () => {
     const off = presentationActionsFor({ showKindLabels: false }).reduce(
       visualWorkspaceReducer,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "test/elk-layout.test.ts",
     "test/edge-routes.test.ts",
     "test/layout-controls.test.ts",
+    "test/style-presets.test.ts",
     "test/graph-canvas-nesting.test.ts",
     "test/graph-canvas-fold.test.ts",
     "test/kind-palette-patterns.test.ts",

--- a/tsconfig.visual.json
+++ b/tsconfig.visual.json
@@ -35,6 +35,7 @@
     "test/elk-layout.test.ts",
     "test/edge-routes.test.ts",
     "test/layout-controls.test.ts",
+    "test/style-presets.test.ts",
     "test/graph-canvas-nesting.test.ts",
     "test/kind-palette-patterns.test.ts",
     "test/instance-draft-panel.test.ts",


### PR DESCRIPTION
Nabeel looked at four dresses on the reference model in the lab and asked to include them all. This ships them behind a **Style** select beside Layout and Direction: `current` (what shipped, appends nothing), `drafting`, `ink`, `tinted`, `dark`.

- A dress is a list of stylesheet blocks appended after the base and notation rules and before the marks, so it changes colour, weight, face and radius and never what a shape means.
- The pick is the reviewer's: remembered in `localStorage`, never written into a view, untouched by a view switch (ADR 0148 says why not `presentation.style`).
- The notation's glyphs take an ink parameter so the dark ground gets light glyphs; the strokes themselves do not move.

Tests: every dress recolours every layer the notation knows; `current` appends nothing; storage round-trips and survives a missing or refusing store; the select renders every dress and reports the pick; the glyph ink parameter. Three mutations red. Stacked on #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
