### PR TITLE
feat(visual): a saved layout keeps its routes, and the browser's fold state reaches the sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### A saved layout keeps its routes, and the fold state the browser sends
+
+Dragging one subject on a routed canvas saved every subject's position, and
+on the next visit the pin put every subject at its saved place, so no edge's
+ends sat where ELK had just put them and every route fell back to the
+stylesheet's straight line: one drag undid the routed layout for good. Seen
+on the reference model. The layout sidecar now carries `routes` beside the
+positions they were computed for, and a route is drawn again wherever both
+ends still sit at their saved place; only the moved subject's edges, and its
+box's, stay straight. A `layered` save writes the bytes it always did.
+
+The same save now actually carries the fold state. The sidecar could hold
+`folded` and `unfolded` since #473 and both hosts wrote them, but the browser
+never sent them and the event schema would have refused them if it had. The
+schema names the sidecar's own definitions for folds and routes, so what the
+browser may send and what the file may hold are one shape.
+
 ### The canvas has five dresses, and the reviewer picks
 
 A **Style** select joins Layout and Direction on the canvas: `current` (what

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -167,7 +167,10 @@ a button that claimed otherwise would be lying about the lifecycle.
 
 Dragging a node saves absolute positions to an adapter-owned sidecar,
 `.yarramate/visual-layout/<projectionId>.yaml` — one
-`yarramate/visual-layout/v1` document per saved projection. It is validated by
+`yarramate/visual-layout/v1` document per saved projection. In a routed mode
+the same save carries the routes the canvas was drawing, as optional `routes`
+keyed by relationship id, each a list of points and where along it the label
+sat, and it carries the fold state (below). It is validated by
 the adapter, never by Core, never routed through `apply`, and never
 `git commit`ed by the runtime. It lives under `.yarramate/` because a
 hand-arranged layout cannot be regenerated from the model, so it is a
@@ -212,11 +215,14 @@ browser: `layered` 278 ms, `routed` 815 ms, `served-by` 805 ms, `bands`
 in about 200 ms. A routed Landscape draws roughly three times the area of
 today's, which was compact only by drawing through things.
 
-**A route belongs to the placement ELK made.** An edge keeps its route only
-while both ends sit exactly where ELK put them. A saved position (the sidecar
-above) or a drag hands that node's edges, and its box's, back to the
-stylesheet's straight line; a fold translates the whole graph, and a route
-survives that intact. Layout is awaited - it always resolved asynchronously,
+**A route belongs to the placement it was computed for.** An edge keeps its
+route only while both ends sit exactly where that placement put them: ELK's
+own, or the saved layout's, whose routes ride in the sidecar beside its
+positions. So a reader who moved one subject keeps every other edge's route on
+the next visit, and only the edges of the moved subject, and of its box, go
+back to the stylesheet's straight line, as they do the moment it is dragged. A
+fold translates the whole graph, and a route survives that intact. Layout is
+awaited - it always resolved asynchronously,
 and the canvas now says so - and overlapping runs resolve last-request-wins,
 so a view switch during a slow layout never lays the previous view's geometry
 over the current one. Every layout, the first included, is scoped to what the
@@ -547,7 +553,10 @@ query tab rather than a refusal: a diagnostic has no warning severity, and this
 is not an error.
 
 Fold state saves beside the positions in the same layout sidecar, as optional
-`folded` and `unfolded` lists, in full every time. Two lists rather than one,
+`folded` and `unfolded` lists, in full every time (the browser sends both with
+every layout save, and the event schema names the sidecar's own definitions
+for them, so what the browser may send and what the file may hold are one
+shape). Two lists rather than one,
 because a view's `fold` is a DEFAULT: a reader who opened a box must not have it
 shut again the moment that default is read back on the next view switch.
 

--- a/docs/adr/0147-a-layout-is-a-way-of-reading-and-the-reviewer-picks-it.md
+++ b/docs/adr/0147-a-layout-is-a-way-of-reading-and-the-reviewer-picks-it.md
@@ -2,6 +2,14 @@
 
 Status: accepted
 
+> Amended after 1.24.0: the route ownership rule below reads "the placement
+> it was computed for", not "the placement ELK made". A drag-save writes the
+> routes the canvas was drawing beside the positions they were computed for
+> (`routes` in the layout sidecar), and a saved route is drawn again wherever
+> both ends still sit at their saved place. Without this one drag pinned every
+> subject and handed every edge back to the straight line for good, which was
+> seen on the reference model. A drag still clears the moved subject's routes.
+
 Two things were reported on the ApertureX reference model on 2026-09-06
 (#489): edges were drawn through boxes, and serving read the wrong way. A
 layout lab built on that model, six treatments side by side with collision

--- a/schema/yarramate-visual-event.schema.json
+++ b/schema/yarramate-visual-event.schema.json
@@ -258,6 +258,7 @@
       }
     },
     "layoutSavePayload": {
+      "description": "What a drag-save carries: the positions, and beside them the fold state (#473) and the routes (ADR 0147) the sidecar keeps. The three optional halves are the sidecar's own definitions, so what the browser may send and what the file may hold cannot drift apart.",
       "type": "object",
       "additionalProperties": false,
       "required": ["projectionId", "positions"],
@@ -267,6 +268,15 @@
         },
         "positions": {
           "$ref": "https://yarramate.org/schema/visual-layout/v1#/$defs/positions"
+        },
+        "folded": {
+          "$ref": "https://yarramate.org/schema/visual-layout/v1#/$defs/subjectIds"
+        },
+        "unfolded": {
+          "$ref": "https://yarramate.org/schema/visual-layout/v1#/$defs/subjectIds"
+        },
+        "routes": {
+          "$ref": "https://yarramate.org/schema/visual-layout/v1#/$defs/routes"
         }
       }
     },

--- a/schema/yarramate-visual-layout.schema.json
+++ b/schema/yarramate-visual-layout.schema.json
@@ -23,6 +23,10 @@
     "unfolded": {
       "description": "The instances this view draws OPEN even though `presentation.fold` says to fold them (#473). Two lists rather than one, because a reader who opened a box must not have it close again the moment the view's default is read back.",
       "$ref": "#/$defs/subjectIds"
+    },
+    "routes": {
+      "description": "The routes the canvas was drawing when the positions were saved (ADR 0147), keyed by relationship id, in absolute canvas coordinates from the source end. A route is applied only while both of its ends still sit where `positions` says; an edge whose end has moved draws straight. Absent means the layout recomputes every route.",
+      "$ref": "#/$defs/routes"
     }
   },
   "$defs": {
@@ -51,6 +55,33 @@
       "properties": {
         "x": { "type": "number" },
         "y": { "type": "number" }
+      }
+    },
+    "routes": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/route"
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["points", "labelAt"],
+      "properties": {
+        "points": {
+          "description": "Source end first, both endpoints included, so a route is never fewer than two points.",
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/position" }
+        },
+        "labelAt": {
+          "description": "How far along the route, in px from the source end, the label's centre sits; null for a route with no label.",
+          "type": ["number", "null"]
+        }
       }
     }
   }

--- a/src/adapters/visual/protocol-contract.ts
+++ b/src/adapters/visual/protocol-contract.ts
@@ -293,6 +293,21 @@ export interface VisualLayoutPositions {
 }
 
 /**
+ * The routes the canvas was drawing when a layout was saved (ADR 0147), keyed
+ * by relationship id: absolute canvas coordinates from the source end, both
+ * endpoints included, and where along the route the label sits. Saved WITH
+ * the positions, because a route is only right for the positions it was
+ * computed for: a reader who moved one subject keeps every other edge's
+ * route, and only the moved subject's edges fall back to a straight line.
+ */
+export interface VisualLayoutRoutes {
+  readonly [relationshipId: string]: {
+    readonly points: readonly { readonly x: number; readonly y: number }[];
+    readonly labelAt: number | null;
+  };
+}
+
+/**
  * A change to a projection document, staged rather than written (ADR 0103).
  *
  * These ride beside the model's operations rather than inside them: Core holds
@@ -358,6 +373,8 @@ export interface VisualLayoutSavePayload {
    */
   readonly folded?: readonly string[];
   readonly unfolded?: readonly string[];
+  /** The routes in force at save time (ADR 0147); absent when nothing was routed. */
+  readonly routes?: VisualLayoutRoutes;
 }
 
 /**

--- a/src/adapters/visual/session-server.ts
+++ b/src/adapters/visual/session-server.ts
@@ -38,6 +38,7 @@ import {
   type VisualFreezeReason,
   type VisualHandoff,
   type VisualLayoutPositions,
+  type VisualLayoutRoutes,
   type VisualLifecycle,
   type VisualResponse,
   type VisualSessionRequest,
@@ -732,17 +733,19 @@ export const startVisualServer = async (
   // like a broken saved view above — presentation state must never fail a
   // session.
   const layoutDir = resolve(options.cwd, ".yarramate/visual-layout");
-  const { layouts, folds } = ((): {
+  const { layouts, folds, routes } = ((): {
     layouts: Record<string, VisualLayoutPositions>;
     folds: Record<string, { folded: string[]; unfolded: string[] }>;
+    routes: Record<string, VisualLayoutRoutes>;
   } => {
     const layouts: Record<string, VisualLayoutPositions> = {};
     const folds: Record<string, { folded: string[]; unfolded: string[] }> = {};
+    const routes: Record<string, VisualLayoutRoutes> = {};
     let entries: readonly string[];
     try {
       entries = readdirSync(layoutDir);
     } catch {
-      return { layouts, folds };
+      return { layouts, folds, routes };
     }
     for (const entry of entries) {
       if (extname(entry) !== ".yaml" && extname(entry) !== ".yml") continue;
@@ -755,8 +758,12 @@ export const startVisualServer = async (
           readonly positions: VisualLayoutPositions;
           readonly folded?: readonly string[];
           readonly unfolded?: readonly string[];
+          readonly routes?: VisualLayoutRoutes;
         };
         layouts[sidecar.projectionId] = sidecar.positions;
+        // The routes the canvas was drawing when it saved (ADR 0147). A
+        // sidecar written before them says nothing, and the layout recomputes.
+        if (sidecar.routes !== undefined) routes[sidecar.projectionId] = sidecar.routes;
         // A sidecar written before #473 has neither list, and says nothing
         // about folding rather than saying "fold nothing" - the view's own
         // default decides for it. Only a sidecar that STATES a fold overrides.
@@ -770,7 +777,7 @@ export const startVisualServer = async (
         // Skipped sidecar: presentation state must never fail a session.
       }
     }
-    return { layouts, folds };
+    return { layouts, folds, routes };
   })();
 
   // `request.initialModel.graph` is the caller's compile (`buildVisualModelGraph`,
@@ -786,6 +793,7 @@ export const startVisualServer = async (
     vocabulary: { conceptKinds: [], relationshipKinds: [] },
     layouts,
     ...(Object.keys(folds).length === 0 ? {} : { folds }),
+    ...(Object.keys(routes).length === 0 ? {} : { routes }),
     sourceDigests: request.initialModel.sourceDigests,
     // The request's model has no projections in it - `visual-model/v1` carries
     // a graph, not a workspace - so the fallback states nothing rather than
@@ -1888,7 +1896,7 @@ export const startVisualServer = async (
         // never `git commit`ed. It never asks the agent anything, so it is
         // answered here directly rather than through the pending queue a
         // poll would drain.
-        const { projectionId, positions, folded, unfolded } = event.payload;
+        const { projectionId, positions, folded, unfolded, routes: savedRoutes } = event.payload;
         if (!views.some((view) => view.id === projectionId)) {
           sendFrame(socket, {
             kind: "layout-save-result",
@@ -1912,12 +1920,18 @@ export const startVisualServer = async (
             // sidecar written by one host is read by the other.
             ...(folded === undefined ? {} : { folded }),
             ...(unfolded === undefined ? {} : { unfolded }),
+            // The routes in force, beside the positions they were computed
+            // for (ADR 0147); a save with nothing routed writes none.
+            ...(savedRoutes === undefined ? {} : { routes: savedRoutes }),
           }),
           "utf8",
         );
         rendered = {
           ...rendered,
           layouts: { ...rendered.layouts, [projectionId]: positions },
+          ...(savedRoutes === undefined
+            ? {}
+            : { routes: { ...rendered.routes, [projectionId]: savedRoutes } }),
           ...(folded === undefined && unfolded === undefined
             ? {}
             : {

--- a/src/adapters/visual/wire.ts
+++ b/src/adapters/visual/wire.ts
@@ -13,6 +13,7 @@ import type {
   VisualKindOption,
   VisualPatternOption,
   VisualLayoutPositions,
+  VisualLayoutRoutes,
   VisualLayoutSaveResultPayload,
   VisualResponse,
   VisualTerminationReason,
@@ -95,6 +96,14 @@ export interface VisualRenderedModel {
       readonly folded: readonly string[]
       readonly unfolded: readonly string[]
     }
+  }
+  /**
+   * The routes each saved layout was drawing (ADR 0147), keyed by projection
+   * id. A sibling of `layouts` for the reason `folds` is: a layout entry is
+   * positions, and widening it would reach every reader of it.
+   */
+  readonly routes?: {
+    readonly [projectionId: string]: VisualLayoutRoutes
   }
   /**
    * Which subject fills which slot of which instance (ADR 0131), and which

--- a/src/visual-app/App.tsx
+++ b/src/visual-app/App.tsx
@@ -623,6 +623,7 @@ const DiagramWorkspace = ({
             showKindLabels={showKindLabels}
             stylePreset={stylePreset}
             savedPositions={state.model.layouts[state.activeView]}
+            savedRoutes={state.model.routes?.[state.activeView]}
             // A read-only drag still moves the node - arranging what is on
             // screen is reading - but the debounced save it would queue goes
             // nowhere: nothing a viewer does may write. The saved-layout pill
@@ -2156,7 +2157,17 @@ export const App = ({
             )
           }
           onClearFilter={clearFilter}
-          onSaveLayout={saveLayout}
+          onSaveLayout={(payload) =>
+            // The reader's fold overrides ride with every save, in full, the
+            // way the sidecar is documented to hold them (#473). The canvas
+            // knows positions and routes; which boxes the reader opened or
+            // shut is workspace state, so it joins here.
+            saveLayout({
+              ...payload,
+              folded: [...workspace.folded],
+              unfolded: [...workspace.unfolded],
+            })
+          }
           onCanvasReady={(png) => {
             canvasPngRef.current = png;
           }}

--- a/src/visual-app/edge-routes.ts
+++ b/src/visual-app/edge-routes.ts
@@ -12,7 +12,11 @@
  */
 import type cytoscape from 'cytoscape'
 import type { Core, EdgeCollection, EdgeSingular, NodeSingular } from 'cytoscape'
-import type { ElkPlacement } from './elk-layout.js'
+import type { ElkPlacement, ElkRoute } from './elk-layout.js'
+import type {
+  VisualLayoutPositions,
+  VisualLayoutRoutes,
+} from '../adapters/visual/protocol-contract.js'
 
 export interface Point {
   readonly x: number
@@ -134,6 +138,9 @@ export function applyEdgeRoutes(
           route.labelAt,
         ) as unknown as cytoscape.Css.Edge,
       )
+      // The route itself, kept on the edge so a drag-save can write it beside
+      // the positions it was computed for (ADR 0147).
+      edge.scratch(ROUTE_SCRATCH, route)
       edge.addClass('routed')
       applied += 1
     }
@@ -147,6 +154,61 @@ export function applyEdgeRoutes(
 export function clearEdgeRoutes(edges: EdgeCollection): void {
   edges.removeClass('routed')
   edges.removeStyle(ROUTE_STYLE_PROPERTIES.join(' '))
+  // `removeScratch` is cytoscape's, absent from its type declarations.
+  ;(edges as unknown as { removeScratch(namespace: string): void }).removeScratch(ROUTE_SCRATCH)
+}
+
+const ROUTE_SCRATCH = '_route'
+
+/**
+ * The routes currently drawn, keyed by relationship id, in the shape the
+ * layout sidecar keeps (ADR 0147). Only routed edges appear: an edge a moved
+ * endpoint handed back to the stylesheet has no route worth saving, which is
+ * exactly what lets a saved layout keep every other edge's route.
+ */
+export function buildRouteMap(edges: EdgeCollection): VisualLayoutRoutes {
+  const routes: Record<string, VisualLayoutRoutes[string]> = {}
+  edges.forEach((edge) => {
+    if (!edge.hasClass('routed')) return
+    const route = edge.scratch(ROUTE_SCRATCH) as ElkRoute | undefined
+    if (route === undefined) return
+    routes[edge.id()] = {
+      points: route.points.map((point) => ({ x: point.x, y: point.y })),
+      labelAt: route.labelAt,
+    }
+  })
+  return routes
+}
+
+/**
+ * Draws the routes a saved layout kept, on every edge that is not already
+ * routed and whose two ends still sit where the saved positions say. The
+ * saved positions are the placement those routes were computed for, so the
+ * same eligibility ELK's own routes get applies verbatim; an end the reader
+ * has since moved leaves its edges on the stylesheet's straight line.
+ */
+export function applySavedRoutes(
+  cy: Core,
+  routes: VisualLayoutRoutes,
+  positions: VisualLayoutPositions,
+): number {
+  const placement: ElkPlacement = {
+    nodes: new Map(Object.entries(positions).map(([id, at]) => [id, { x: at.x, y: at.y }])),
+    edges: new Map(
+      Object.entries(routes).map(([id, route]) => [
+        id,
+        { points: route.points.map((point) => ({ x: point.x, y: point.y })), labelAt: route.labelAt },
+      ]),
+    ),
+  }
+  return applyEdgeRoutes(
+    cy,
+    placement,
+    (edge) =>
+      !edge.hasClass('routed') &&
+      placedByElk(edge.source(), placement) &&
+      placedByElk(edge.target(), placement),
+  )
 }
 
 /**

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_LAYOUT, routesEdges, type LayoutMode } from '../layout-mode.js'
 import { DEFAULT_STYLE_PRESET, presetBlocks, stylePresetOf, type StylePresetId } from './style-presets.js'
 import type {
   VisualLayoutPositions,
+  VisualLayoutRoutes,
   VisualLayoutSavePayload,
 } from '../adapters/visual/protocol-contract.js'
 import {
@@ -51,6 +52,8 @@ import {
 } from './elk-layout.js'
 import {
   applyEdgeRoutes,
+  applySavedRoutes,
+  buildRouteMap,
   clearEdgeRoutes,
   placedByElk,
   registerRouteInvalidation,
@@ -1101,11 +1104,18 @@ const LAYOUT_GENERATION = '_layoutGeneration'
  * drops its answer, positions, routes and fit alike, rather than laying a
  * previous view's geometry over the current one's ids.
  */
+/** What a saved layout holds for the active view, as the canvas honours it. */
+export interface SavedLayout {
+  readonly positions?: VisualLayoutPositions
+  readonly routes?: VisualLayoutRoutes
+}
+
 async function runLayout(
   eles: Core | CollectionReturnValue,
   direction: LayoutDirection,
   mode: LayoutMode,
   showKindLabels: boolean,
+  saved?: SavedLayout,
 ): Promise<void> {
   const cy: Core = 'elements' in eles ? eles : eles.cy()
   const collection = 'elements' in eles ? eles.elements() : eles
@@ -1148,6 +1158,13 @@ async function runLayout(
     placement,
     (edge) => placedByElk(edge.source(), placement) && placedByElk(edge.target(), placement),
   )
+  // Then the routes the saved layout kept, on the edges the pin left
+  // unrouted: an edge between two pinned subjects draws the route it was
+  // saved with, and only an edge touching a subject the reader has since
+  // moved stays on the straight line (ADR 0147).
+  if (saved?.routes !== undefined) {
+    applySavedRoutes(cy, saved.routes, saved.positions ?? {})
+  }
 }
 
 /**
@@ -1204,8 +1221,9 @@ export function relayoutVisible(
   direction: LayoutDirection,
   mode: LayoutMode = DEFAULT_LAYOUT,
   showKindLabels: boolean = true,
+  saved?: SavedLayout,
 ): Promise<void> {
-  return runLayout(cy.elements(':visible'), direction, mode, showKindLabels)
+  return runLayout(cy.elements(':visible'), direction, mode, showKindLabels, saved)
 }
 
 /**
@@ -1234,6 +1252,7 @@ export async function relayoutAfterFold(
   mode: LayoutMode,
   showKindLabels: boolean,
   anchorId: string | null,
+  saved?: SavedLayout,
 ): Promise<boolean> {
   const anchor = anchorId === null ? null : cy.getElementById(anchorId)
   const before =
@@ -1241,7 +1260,7 @@ export async function relayoutAfterFold(
   // Awaited, so the anchor is read from the finished layout. Layout has
   // always resolved asynchronously, and before ADR 0147 this read it before
   // ELK had run: the translation below never fired.
-  await relayoutVisible(cy, direction, mode, showKindLabels)
+  await relayoutVisible(cy, direction, mode, showKindLabels, saved)
   if (cy.destroyed()) return false
   if (before !== null && anchor !== null && anchor.nonempty()) {
     const after = anchor.position()
@@ -1346,6 +1365,15 @@ export function effectiveSavedPositions(
   return discardedViews.has(viewId) ? undefined : saved
 }
 
+/** The same session-local discard, for the routes saved beside the positions. */
+export function effectiveSavedRoutes(
+  saved: VisualLayoutRoutes | undefined,
+  viewId: string,
+  discardedViews: ReadonlySet<string>,
+): VisualLayoutRoutes | undefined {
+  return discardedViews.has(viewId) ? undefined : saved
+}
+
 // Whether a saved layout is actually in force for what is on screen: the
 // sidecar names at least one subject the active view draws. Derived from the
 // view's own match set (`matchedIds ?? every node` - the same base
@@ -1408,7 +1436,15 @@ export function registerDragSave(
       // The unfiltered pseudo-view is not a saved projection; the server
       // rejects a save aimed at it.
       if (projectionId === '') return
-      onSaveLayout({ projectionId, positions: buildPositionMap(cy.nodes()) })
+      // The routes in force beside the positions they were computed for
+      // (ADR 0147); a canvas drawing none writes none, so a `layered` save
+      // produces the bytes it always did.
+      const routes = buildRouteMap(cy.edges())
+      onSaveLayout({
+        projectionId,
+        positions: buildPositionMap(cy.nodes()),
+        ...(Object.keys(routes).length === 0 ? {} : { routes }),
+      })
     }, DRAG_SAVE_DEBOUNCE_MS)
   }
   cy.on('dragfree', 'node', handler)
@@ -1480,6 +1516,8 @@ interface GraphCanvasProps {
   readonly stylePreset: StylePresetId
   /** Saved layout for the active view, or undefined when it has none yet. */
   readonly savedPositions: VisualLayoutPositions | undefined
+  /** The routes that layout was drawing when saved (ADR 0147), if it kept any. */
+  readonly savedRoutes?: VisualLayoutRoutes
   readonly onSaveLayout: (payload: VisualLayoutSavePayload) => void
   /**
    * A kind dropped from the palette (#295): the kind's label and the model
@@ -1526,6 +1564,7 @@ export function GraphCanvas({
   showKindLabels,
   stylePreset,
   savedPositions,
+  savedRoutes,
   onSaveLayout,
   onKindDrop,
   onCanvasReady,
@@ -1552,6 +1591,11 @@ export function GraphCanvas({
     activeViewId,
     discardedViews,
   )
+  const effectiveRoutes = effectiveSavedRoutes(
+    savedRoutes,
+    activeViewId,
+    discardedViews,
+  )
   const onSelectRef = useRef(onSelect)
   const onCanvasReadyRef = useRef(onCanvasReady)
   onCanvasReadyRef.current = onCanvasReady
@@ -1571,6 +1615,7 @@ export function GraphCanvas({
   // Keep latest onSaveLayout and savedPositions for the drag-save handler
   const onSaveLayoutRef = useRef(onSaveLayout)
   const savedPositionsRef = useRef(effectiveSaved)
+  const savedRoutesRef = useRef(effectiveRoutes)
   const dragSaveHandleRef = useRef<DragSaveHandle | null>(null)
   // The viewport a layout (or a resize refit) last left behind. Anything else
   // on screen is the reviewer's own pan/zoom, which a resize must not discard.
@@ -1599,6 +1644,9 @@ export function GraphCanvas({
   useEffect(() => {
     savedPositionsRef.current = effectiveSaved
   }, [effectiveSaved])
+  useEffect(() => {
+    savedRoutesRef.current = effectiveRoutes
+  }, [effectiveRoutes])
 
   // Cancel pending drag-save when the active view changes, so a queued save
   // never lands against a different view's sidecar. Also cleared on unmount.
@@ -1838,6 +1886,7 @@ export function GraphCanvas({
       direction,
       layout,
       showKindLabels,
+      { positions: savedPositionsRef.current, routes: savedRoutesRef.current },
     )
     // EVERY input passed to `graphToElements` above, because an input this
     // effect reads and does not depend on cannot rebuild anything: the
@@ -1904,6 +1953,7 @@ export function GraphCanvas({
       layout,
       showKindLabels,
       changed.length === 1 ? changed[0]! : null,
+      { positions: savedPositionsRef.current, routes: savedRoutesRef.current },
     )
   }, [folded])
 
@@ -1998,7 +2048,10 @@ export function GraphCanvas({
     quickFilterTextRef.current = quickFilterText
     if (pendingViewFitRef.current || matchedChanged) {
       pendingViewFitRef.current = false
-      void relayoutVisible(cyRef.current, direction, layout, showKindLabels)
+      void relayoutVisible(cyRef.current, direction, layout, showKindLabels, {
+        positions: savedPositionsRef.current,
+        routes: savedRoutesRef.current,
+      })
     } else if (quickFilterChanged && fitVisible(cyRef.current)) {
       // A quick-filter keystroke never relayouts - the survivors keep their
       // positions (a reviewer's drags included) and the viewport re-frames
@@ -2027,6 +2080,7 @@ export function GraphCanvas({
   const discardSavedLayout = (): void => {
     setDiscardedViews((prev) => new Set(prev).add(activeViewId))
     savedPositionsRef.current = undefined
+    savedRoutesRef.current = undefined
     dragSaveHandleRef.current?.cancelPending()
     if (cyRef.current !== null) {
       void relayoutVisible(cyRef.current, direction, layout, showKindLabels)

--- a/src/visual-app/local-host.ts
+++ b/src/visual-app/local-host.ts
@@ -563,7 +563,7 @@ export const createLocalHost = (options: LocalHostOptions): LocalEditorHost => {
           commit(input)
           return
         case 'layout.save': {
-          const { projectionId, positions, folded, unfolded } = input.payload
+          const { projectionId, positions, folded, unfolded, routes: savedRoutes } = input.payload
           if (!views.some((view) => view.id === projectionId)) {
             deliver?.frame({
               kind: 'layout-save-result',
@@ -589,6 +589,9 @@ export const createLocalHost = (options: LocalHostOptions): LocalEditorHost => {
                 // means a reload can land between them.
                 ...(folded === undefined ? {} : { folded }),
                 ...(unfolded === undefined ? {} : { unfolded }),
+                // The routes in force beside the positions they were computed
+                // for (ADR 0147); the session server writes the same bytes.
+                ...(savedRoutes === undefined ? {} : { routes: savedRoutes }),
               }),
               expected: held?.revision ?? null,
             },
@@ -606,6 +609,9 @@ export const createLocalHost = (options: LocalHostOptions): LocalEditorHost => {
           model = {
             ...model,
             layouts: { ...model.layouts, [projectionId]: positions },
+            ...(savedRoutes === undefined
+              ? {}
+              : { routes: { ...model.routes, [projectionId]: savedRoutes } }),
             ...(folded === undefined && unfolded === undefined
               ? {}
               : {

--- a/test/edge-routes.test.ts
+++ b/test/edge-routes.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   ROUTE_STYLE_PROPERTIES,
   applyEdgeRoutes,
+  applySavedRoutes,
+  buildRouteMap,
   clearEdgeRoutes,
   placedByElk,
   registerRouteInvalidation,
@@ -199,5 +201,48 @@ describe('registerRouteInvalidation', () => {
     cy.getElementById('a').emit('dragfree')
     expect(cy.getElementById('boxc').hasClass('routed')).toBe(false)
     expect(cy.getElementById('bc').hasClass('routed')).toBe(true)
+  })
+})
+
+// A saved layout keeps the routes beside the positions (ADR 0147), so a
+// reader who moved one subject keeps every other edge's route: the snapshot
+// holds routed edges only, and a saved route is drawn only between two ends
+// that still sit where the saved positions say.
+describe('buildRouteMap and applySavedRoutes', () => {
+  it('snapshots the routed edges and nothing else', () => {
+    const cy = buildCanvas()
+    applyEdgeRoutes(cy, placementOf(cy, twoRoutes()), (edge) => edge.id() === 'ab')
+    const snapshot = buildRouteMap(cy.edges())
+    expect(Object.keys(snapshot)).toEqual(['ab'])
+    expect(snapshot['ab']).toEqual({ points: L_ROUTE, labelAt: 40 })
+    clearEdgeRoutes(cy.edges())
+    expect(buildRouteMap(cy.edges())).toEqual({})
+  })
+
+  it('draws a saved route only between two ends still at their saved positions', () => {
+    const cy = buildCanvas()
+    const applied = applySavedRoutes(cy, Object.fromEntries(twoRoutes()), {
+      a: { x: 0, y: 0 },
+      b: { x: 300, y: 0 },
+      // c was moved after the save: its saved place is not where it sits.
+      c: { x: 900, y: 0 },
+    })
+    expect(applied).toBe(1)
+    expect(cy.getElementById('ab').hasClass('routed')).toBe(true)
+    expect(cy.getElementById('ab').style('curve-style')).toBe('segments')
+    expect(cy.getElementById('bc').hasClass('routed')).toBe(false)
+  })
+
+  it('leaves an edge ELK already routed alone', () => {
+    const cy = buildCanvas()
+    applyEdgeRoutes(cy, placementOf(cy, twoRoutes()), () => true)
+    const before = cy.getElementById('ab').style('segment-distances')
+    const applied = applySavedRoutes(
+      cy,
+      { ab: { points: [{ x: 0, y: -25 }, { x: 0, y: -100 }, { x: 300, y: -100 }, { x: 300, y: -25 }], labelAt: 40 } },
+      { a: { x: 0, y: 0 }, b: { x: 300, y: 0 }, c: { x: 600, y: 0 } },
+    )
+    expect(applied).toBe(0)
+    expect(cy.getElementById('ab').style('segment-distances')).toBe(before)
   })
 })

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applySavedPositions,
   buildPositionMap,
+  effectiveSavedRoutes,
   relayoutAfterFold,
   buildStylesheet,
   DRAG_SAVE_DEBOUNCE_MS,
@@ -16,6 +17,7 @@ import { ASPECT_SHAPES, RELATIONSHIP_NOTATION } from '../src/notation/archimate.
 import { DEFAULT_DIRECTION } from '../src/layout-direction.js'
 import { LAYOUT_MODES } from '../src/layout-mode.js'
 import { rootLayoutOptions } from '../src/visual-app/elk-layout.js'
+import { buildRouteMap } from '../src/visual-app/edge-routes.js'
 import type {
   VisualLayoutPositions,
   VisualLayoutSavePayload,
@@ -126,6 +128,34 @@ describe('layout drag-save and position pinning', () => {
       positions: { node1: { x: 10, y: 20 }, node2: { x: 30, y: 40 } },
     })
 
+    handle.dispose()
+    vi.useRealTimers()
+  })
+
+  it('carries the routes the canvas is drawing beside the positions (ADR 0147)', async () => {
+    const cy = cytoscape({
+      styleEnabled: true,
+      style: buildStylesheet(true, true, false, true, true, 'routed'),
+      layout: { name: 'null' },
+      elements: buildLayoutFixture().elements().jsons() as cytoscape.ElementDefinition[],
+    })
+    await relayoutVisible(cy, 'top-down', 'routed')
+    const routed = cy.edges().filter((edge) => edge.hasClass('routed'))
+    expect(routed.length).toBe(6)
+    vi.useFakeTimers()
+    let saved: VisualLayoutSavePayload | null = null
+    const handle = registerDragSave(cy, () => 'view1', (payload) => {
+      saved = payload
+    })
+    cy.getElementById('a').emit('dragfree')
+    vi.advanceTimersByTime(DRAG_SAVE_DEBOUNCE_MS)
+    const payload = saved as VisualLayoutSavePayload | null
+    expect(Object.keys(payload?.routes ?? {}).sort()).toEqual(routed.map((edge) => edge.id()).sort())
+    Object.values(payload?.routes ?? {}).forEach((route) => {
+      expect(route.points.length).toBeGreaterThanOrEqual(2)
+    })
+    // The positions the routes were computed for ride in the same save.
+    expect(Object.keys(payload?.positions ?? {}).sort()).toEqual(['a', 'b', 'c', 'd', 'e', 'f'])
     handle.dispose()
     vi.useRealTimers()
   })
@@ -541,6 +571,59 @@ describe('layout runs', () => {
       const parsed = edge as unknown as { pstyle(name: string): { bypass?: boolean } | null }
       expect(parsed.pstyle('segment-radii')?.bypass ?? false).toBe(false)
     })
+  })
+
+  // A saved layout keeps the routes it was drawing (ADR 0147). On the next
+  // run the pin moves every subject to its saved place, so none sits where
+  // ELK just put it and ELK's fresh routes fit nothing; the saved routes then
+  // draw between every pair of pinned ends, and only the edges of the subject
+  // the reader moved after the save fall back to the stylesheet.
+  it('keeps the saved routes on every edge the reader did not disturb', async () => {
+    const cy = cytoscape({
+      styleEnabled: true,
+      style: buildStylesheet(true, true, false, true, true, 'routed'),
+      layout: { name: 'null' },
+      elements: buildLayoutFixture().elements().jsons() as cytoscape.ElementDefinition[],
+    })
+    await relayoutVisible(cy, 'top-down', 'routed')
+    // The snapshot a drag-save takes, shifted wholesale so the saved layout is
+    // not ELK's own answer; the routes touching `a` were dropped by that drag.
+    const shift = 1000
+    const routes = Object.fromEntries(
+      Object.entries(buildRouteMap(cy.edges()))
+        .filter(([id]) => !cy.getElementById(id).connectedNodes().contains(cy.getElementById('a')))
+        .map(([id, route]) => [
+          id,
+          { points: route.points.map((p) => ({ x: p.x + shift, y: p.y + shift })), labelAt: route.labelAt },
+        ]),
+    )
+    expect(Object.keys(routes).length).toBe(4)
+    const positions = Object.fromEntries(
+      Object.entries(buildPositionMap(cy.nodes())).map(([id, p]) => [
+        id,
+        // `a` was moved after the save: its saved place is off its old routes.
+        { x: p.x + shift + (id === 'a' ? 400 : 0), y: p.y + shift },
+      ]),
+    )
+    // What the mount handler does on every layoutstop: pin the saved layout.
+    cy.on('layoutstop', () => applySavedPositions(cy, positions))
+    await relayoutVisible(cy, 'top-down', 'routed', true, { positions, routes })
+    const touchingA = cy.getElementById('a').connectedEdges()
+    expect(touchingA.length).toBe(2)
+    touchingA.forEach((edge) => {
+      expect(edge.hasClass('routed')).toBe(false)
+      expect(edge.style('curve-style')).toBe('taxi')
+    })
+    cy.edges()
+      .difference(touchingA)
+      .forEach((edge) => {
+        expect(edge.hasClass('routed')).toBe(true)
+        // A two-point route is drawn straight, a bent one as segments.
+        expect(['segments', 'straight']).toContain(edge.style('curve-style'))
+      })
+    // A discarded view yields no routes to pin, as it yields no positions.
+    expect(effectiveSavedRoutes(routes, 'v', new Set(['v']))).toBeUndefined()
+    expect(effectiveSavedRoutes(routes, 'v', new Set())).toBe(routes)
   })
 
   // A container's title sits in the band above its children, where a route

--- a/test/visual-layout-fold.test.ts
+++ b/test/visual-layout-fold.test.ts
@@ -55,6 +55,28 @@ describe('#473: the layout sidecar carries fold state', () => {
     expect(validate({ ...base, folded: ['checkout', 'checkout'] })).toBe(false)
   })
 
+  // ADR 0147: the routes the canvas was drawing ride beside the positions
+  // they were computed for, so a reader who moved one subject keeps every
+  // other edge's route.
+  it('accepts the routes beside the positions', () => {
+    expect(
+      validate({
+        ...base,
+        routes: {
+          'a-serves-b': { points: [{ x: 0, y: 25 }, { x: 0, y: 100 }, { x: 300, y: 100 }], labelAt: 40 },
+          'b-flows-c': { points: [{ x: 85, y: 0 }, { x: 215, y: 0 }], labelAt: null },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('refuses a route with fewer than two points, a stray key, or a non-numeric label position', () => {
+    expect(validate({ ...base, routes: { e: { points: [{ x: 0, y: 0 }], labelAt: null } } })).toBe(false)
+    expect(validate({ ...base, routes: { e: { points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], labelAt: null, bend: true } } })).toBe(false)
+    expect(validate({ ...base, routes: { e: { points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], labelAt: 'mid' } } })).toBe(false)
+    expect(validate({ ...base, routes: { e: { points: [{ x: 0, y: 0 }, { x: 1, y: 1 }] } } })).toBe(false)
+  })
+
   it('still refuses an unknown key', () => {
     expect(validate({ ...base, collapsed: ['checkout'] })).toBe(false)
   })

--- a/test/visual-layout-save-input.test.ts
+++ b/test/visual-layout-save-input.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { parseVisualBrowserInput } from '../src/adapters/visual/protocol.js'
+
+// The browser's `layout.save` is validated against the event schema before
+// the session server touches it. The sidecar could hold fold state since
+// #473 and both hosts would write it, but the payload definition admitted
+// positions alone, so a browser that sent its folds would have been refused
+// (YMVS109) and none ever did. The payload now names the sidecar's own
+// definitions for folds and routes (ADR 0147), so what the browser may send
+// and what the file may hold are one shape.
+const save = (payload: Record<string, unknown>) =>
+  parseVisualBrowserInput({ type: 'layout.save', lastAcknowledgedSequence: 0, payload })
+
+describe('layout.save from the browser', () => {
+  it('still accepts positions alone', () => {
+    expect(save({ projectionId: 'apps', positions: { checkout: { x: 1, y: 2 } } }).ok).toBe(true)
+  })
+
+  it('accepts the fold state and the routes beside the positions', () => {
+    const parsed = save({
+      projectionId: 'apps',
+      positions: { checkout: { x: 1, y: 2 }, ledger: { x: 300, y: 2 } },
+      folded: ['checkout'],
+      unfolded: [],
+      routes: {
+        'checkout-serves-ledger': {
+          points: [{ x: 86, y: 2 }, { x: 150, y: 2 }, { x: 150, y: 60 }, { x: 215, y: 60 }],
+          labelAt: 64,
+        },
+      },
+    })
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true)
+  })
+
+  it('refuses a route the sidecar could not hold', () => {
+    expect(
+      save({
+        projectionId: 'apps',
+        positions: { checkout: { x: 1, y: 2 } },
+        routes: { e: { points: [{ x: 0, y: 0 }], labelAt: null } },
+      }).ok,
+    ).toBe(false)
+  })
+})

--- a/test/visual-local-host.test.ts
+++ b/test/visual-local-host.test.ts
@@ -384,6 +384,27 @@ concepts:
     })
   })
 
+  it('writes the routes beside the positions, and the next model frame carries them (ADR 0147)', () => {
+    const { store, frames, send } = openHost()
+    const routes = {
+      'checkout-serves-ledger': {
+        points: [{ x: 86, y: 2 }, { x: 150, y: 2 }, { x: 150, y: 60 }, { x: 215, y: 60 }],
+        labelAt: 64,
+      },
+    }
+    send(
+      input('layout.save', {
+        projectionId: 'apps',
+        positions: { checkout: { x: 1, y: 2 }, ledger: { x: 300, y: 60 } },
+        routes,
+      }),
+    )
+    expect(frames.at(-1)?.kind).toBe('layout-save-result')
+    const sidecar = parse(store.held.get('.yarramate/visual-layout/apps.yaml') ?? '') as Record<string, unknown>
+    expect(sidecar['routes']).toEqual(routes)
+    expect('folded' in sidecar).toBe(false)
+  })
+
   it('writes no fold keys at all when the host sends none', () => {
     // Every sidecar written before #473 has neither list, and a host that
     // never folds should keep producing exactly those bytes.


### PR DESCRIPTION
Stacked on #498 (style presets). Merge order: #494 → #496 → #497 → #498 → this.

## What was wrong

Dragging one subject on a routed canvas saved every subject's position. On the next visit the pin put every subject at its saved place, so no edge's ends sat where ELK had just put them, and under the route ownership rule every route fell back to the stylesheet's straight line: one drag undid the routed layout for good. Seen in the lab session on the reference model.

Separately, the browser never sent its fold state with a layout save, and the event schema's `layoutSavePayload` would have refused it (`additionalProperties: false`, positions only). The sidecar could hold `folded`/`unfolded` since #473 and both hosts wrote them; nothing ever arrived.

## What changes

- **Sidecar**: `routes` beside `positions` (`schema/yarramate-visual-layout.schema.json`), keyed by relationship id, each `{ points: ≥2, labelAt: number|null }`.
- **Event schema**: `layoutSavePayload` names the sidecar's own definitions for `folded`, `unfolded` and `routes`, so what the browser may send and what the file may hold are one shape.
- **Canvas**: each applied route is remembered in edge scratch; a drag-save snapshots the routed edges (`buildRouteMap`); after ELK's own routes, `applySavedRoutes` draws a saved route wherever both ends still sit at their saved place. Only the moved subject's edges, and its box's, stay straight. A `layered` save writes the bytes it always did.
- **Hosts**: session server and local host write `routes`, the rendered model carries them, App passes the active view's routes to the canvas and wraps the save with the workspace's folds.
- **Docs**: ADR 0147 amended (ownership rule reads "the placement it was computed for"), VISUAL-ADAPTER sidecar and route sections, CHANGELOG Unreleased.

## Tests

Sidecar schema accepts routes and refuses a one-point route, a stray key, a non-numeric or missing `labelAt`; `parseVisualBrowserInput` accepts folds and routes and refuses a one-point route; the local host writes routes beside positions; `buildRouteMap` snapshots routed edges only; `applySavedRoutes` skips a moved end and an already-routed edge; the drag-save payload carries the routes; and a canvas round trip (routed layout, snapshot, pin everything elsewhere with one subject moved further) keeps every undisturbed edge routed and returns the moved subject's two edges to taxi.

Mutations checked red: skipping `applySavedRoutes` in `runLayout`; dropping `routes` from the drag-save payload.

Clean-slate `pnpm verify`: 147 files, 2421 passed, 1 skipped, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
