### PR TITLE
feat(visual): the served page lays out in a Web Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### The served page lays out in a Web Worker (#490)
+
+A routed layout of a large view takes most of a second, and on the calling
+thread that was a frozen page: 805 ms for `served-by` on the 157-subject
+reference Landscape, 1181 ms for `bands`, and 4.3 s on this repository's
+366-subject "All subjects" view. The page `yarramate-visual` serves now runs
+ELK in a Web Worker, and that same 366-subject layout leaves the page's
+longest main-thread task at 95 ms (measured in Chrome, the two builds side by
+side): vite emits the worker as one more flat asset the
+session server already serves, the page's policy admits it as a same-origin
+worker, and the engine ships once, in the worker, rather than also in the
+chunk the page loads first. The library bundle a host mounts cannot promise
+what its host's policy admits, so it keeps the engine on the calling thread;
+a host that can serve `elkjs/lib/elk-worker.min.js` from its own origin passes
+`workerFactory: () => new Worker(thatUrl)` to `mountEditor` and gets the same.
+The bundled engine is loaded the first time a layout asks for it, so the
+served page never fetches it. ADR 0147 amended.
+
 ### A saved layout keeps its routes, and the fold state the browser sends
 
 Dragging one subject on a routed canvas saved every subject's position, and

--- a/docs/CONSUMING-YARRAMATE.md
+++ b/docs/CONSUMING-YARRAMATE.md
@@ -420,6 +420,15 @@ defaults to `['properties', 'questions']`. This is a UI posture only — pair it
 with a store that refuses writes; the two defenses are independent.
 `mountEditorWith` takes the same flag as its trailing parameter.
 
+Pass `workerFactory` to run the layout engine in a Web Worker (#490). The
+bundle runs ELK on the calling thread by default, and a routed layout of a
+large view freezes the page for most of a second; it cannot ship a worker of
+its own, because an inline worker needs a `blob:` allowance in YOUR policy.
+Serve `elkjs/lib/elk-worker.min.js` from your own origin and pass
+`workerFactory: () => new Worker(thatUrl)`; every layout then runs there. One
+engine per page: the mount that passed a factory owns the worker, and its
+`unmount()` terminates the worker and restores the bundled engine.
+
 The returned handle can also point at the canvas
 (ADR 0118):
 `select(subjectId)` selects a concept or relationship exactly as a canvas tap

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -211,9 +211,16 @@ a view switch restates the declaration (a view that omits `layout` is restored
 to `served-by`, the rule nesting and direction follow), and **Save view**
 writes what is in force. Measured on the 157-subject reference Landscape in a
 browser: `layered` 278 ms, `routed` 815 ms, `served-by` 805 ms, `bands`
-1181 ms, on the main thread; the 65-subject API tiers view runs `served-by`
-in about 200 ms. A routed Landscape draws roughly three times the area of
-today's, which was compact only by drawing through things.
+1181 ms; the 65-subject API tiers view runs `served-by` in about 200 ms. On
+the served page that work runs in a Web Worker (#490): vite emits
+`elk-worker.min-<hash>.js` beside the other assets, the asset route serves it,
+and the page's `default-src 'self'` admits it as a same-origin worker, so the
+page stays responsive through a layout. The library bundle cannot promise
+what its host's policy admits, so it keeps the engine on the calling thread
+unless the host passes `workerFactory` to `mountEditor`
+([CONSUMING-YARRAMATE](CONSUMING-YARRAMATE.md)). A routed Landscape draws
+roughly three times the area of today's, which was compact only by drawing
+through things.
 
 **A route belongs to the placement it was computed for.** An edge keeps its
 route only while both ends sit exactly where that placement put them: ELK's

--- a/docs/adr/0147-a-layout-is-a-way-of-reading-and-the-reviewer-picks-it.md
+++ b/docs/adr/0147-a-layout-is-a-way-of-reading-and-the-reviewer-picks-it.md
@@ -10,6 +10,13 @@ Status: accepted
 > subject and handed every edge back to the straight line for good, which was
 > seen on the reference model. A drag still clears the moved subject's routes.
 
+> Amended after 1.24.0 (#490): the served page runs ELK in a Web Worker. The
+> exclusion below stands for the library bundle, whose host's policy this
+> package cannot promise; that bundle keeps the engine on the calling thread
+> unless the host passes `workerFactory` to `mountEditor`. One seam,
+> `installLayoutEngine` in `src/visual-app/elk-layout.ts`, and the canvas
+> never knows which engine answers.
+
 Two things were reported on the ApertureX reference model on 2026-09-06
 (#489): edges were drawn through boxes, and serving read the wrong way. A
 layout lab built on that model, six treatments side by side with collision
@@ -125,6 +132,8 @@ container's top border stops 22 px above the drawn box, in the label band.
   library bundle a host mounts is one file, and an inline worker needs a
   `blob:` allowance in the HOST's policy that this package cannot promise.
   Tracked as a follow-up for the served page, with the freeze measured (#490).
+  Done since for the served page; the library keeps the exclusion (amendment
+  above).
 - **`elk.layered.compaction.postCompaction.strategy: EDGE_LENGTH`.** It
   throws inside ELK on a nested graph ("Invalid hitboxes for scanline
   constraint calculation").

--- a/src/visual-app/elk-layout.ts
+++ b/src/visual-app/elk-layout.ts
@@ -13,7 +13,7 @@
  * and return plain data, so a test can state what ELK is asked and what is
  * made of its answer without a canvas.
  */
-import ELK from 'elkjs/lib/elk.bundled.js'
+import ELKApi from 'elkjs/lib/elk-api.js'
 import type {
   ElkEdgeSection,
   ElkExtendedEdge,
@@ -407,11 +407,68 @@ export function readElkLayout(laid: ElkNode, reversed: ReadonlySet<string>): Elk
   return { nodes: centres, edges: routes }
 }
 
-// One engine for the page. `elk.bundled.js` runs ELK on the calling thread
-// behind a promise, in the browser and under vitest alike; a Web Worker for
-// the served page is tracked separately (ADR 0147).
-type ElkConstructor = new () => { layout: (graph: ElkNode) => Promise<ElkNode> }
-const ElkEngine = ((ELK as unknown as { default?: ElkConstructor }).default ?? ELK) as ElkConstructor
-const engine = new ElkEngine()
+/**
+ * What lays a graph out. The bundled engine runs ELK on the calling thread
+ * behind a promise, in the browser and under vitest alike, and it is what
+ * every page starts with. A page that can serve a worker file installs an
+ * engine over a Web Worker instead (#490), and the canvas never knows which
+ * it is talking to: `layoutWithElk` is the one door.
+ */
+export interface LayoutEngine {
+  readonly layout: (graph: ElkNode) => Promise<ElkNode>
+  /** Lets go of whatever the engine holds; the bundled one holds nothing. */
+  readonly terminate?: () => void
+}
 
-export const layoutWithElk = (graph: ElkNode): Promise<ElkNode> => engine.layout(graph)
+/**
+ * The worker a page constructs for `workerLayoutEngine`: anything that can be
+ * posted to. elk-api installs `onmessage` on it and speaks its own protocol
+ * to `elkjs/lib/elk-worker.min.js` at the other end, so a host hands over a
+ * `new Worker(url)` of that file and nothing else.
+ */
+export interface LayoutWorker {
+  postMessage(message: unknown): void
+}
+
+type ElkConstructor = new (options?: {
+  readonly workerFactory?: () => Worker
+}) => { layout: (graph: ElkNode) => Promise<ElkNode>; terminateWorker?: () => void }
+const constructorOf = (module: unknown): ElkConstructor =>
+  ((module as { default?: ElkConstructor }).default ?? module) as ElkConstructor
+const WorkerEngine = constructorOf(ELKApi)
+
+// The bundled engine is loaded the first time something asks for it and not
+// before: `elk.bundled.js` is 1.6 MB, and a page that installed a worker
+// engine before its first layout never needs it. Vite splits the dynamic
+// import into a chunk of its own, so the served page ships ELK once, in the
+// worker; the library bundle inlines it, so a host still gets one file.
+let bundled: Promise<LayoutEngine> | undefined
+const bundledEngine = (): Promise<LayoutEngine> =>
+  (bundled ??= import('elkjs/lib/elk.bundled.js').then((module) => new (constructorOf(module))()))
+let installed: LayoutEngine | undefined
+
+/**
+ * An engine that runs ELK in the worker `workerFactory` constructs. The
+ * served page installs one over the worker file vite emits beside its other
+ * assets (#490); a host mounting the library passes its own factory when its
+ * policy lets it serve that file, and leaves the bundled engine otherwise.
+ */
+export function workerLayoutEngine(workerFactory: () => LayoutWorker): LayoutEngine {
+  const api = new WorkerEngine({ workerFactory: () => workerFactory() as unknown as Worker })
+  return {
+    layout: (graph) => api.layout(graph),
+    terminate: () => api.terminateWorker?.(),
+  }
+}
+
+/**
+ * Makes `next` the engine every layout goes through; `undefined` restores the
+ * bundled one. Installing never terminates the engine being replaced: the
+ * page that made it owns it.
+ */
+export function installLayoutEngine(next: LayoutEngine | undefined): void {
+  installed = next
+}
+
+export const layoutWithElk = async (graph: ElkNode): Promise<ElkNode> =>
+  (installed ?? (await bundledEngine())).layout(graph)

--- a/src/visual-app/main.tsx
+++ b/src/visual-app/main.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from 'react-dom/client'
+import ElkWorker from 'elkjs/lib/elk-worker.min.js?worker'
 import { App } from './App.js'
+import { installLayoutEngine, workerLayoutEngine } from './elk-layout.js'
 import { createSocketHost } from './socket-host.js'
 import './styles.css'
 
@@ -15,6 +17,15 @@ if (mount === null) {
  * section on; `mount.tsx` is the one an embedder calls, with a store instead of
  * a socket and only the sections it asked for.
  */
+
+// ELK runs in a Web Worker here (#490): a routed layout of a large view takes
+// most of a second, and on the calling thread that is a frozen page. Vite
+// emits the worker file as one more flat asset the session server's asset
+// route serves, and the page's policy (`default-src 'self'`) admits a
+// same-origin worker. The library bundle has no such certainty about its
+// host's policy, so it stays on the bundled engine unless the host says
+// otherwise (`workerFactory` in `mountEditor`).
+installLayoutEngine(workerLayoutEngine(() => new ElkWorker()))
 
 // No StrictMode: its double mount would open the session socket twice, and this
 // bundle only ever runs as the production build the session server serves.

--- a/src/visual-app/mount.tsx
+++ b/src/visual-app/mount.tsx
@@ -9,6 +9,11 @@ import {
 import type { DecorationMap } from './graph-canvas.js'
 import type { EditorHost } from './editor-host.js'
 import {
+  installLayoutEngine,
+  workerLayoutEngine,
+  type LayoutWorker,
+} from './elk-layout.js'
+import {
   RIGHT_SECTIONS,
   type EditorPointer,
   type RightSectionId,
@@ -72,6 +77,17 @@ export interface MountOptions extends LocalHostOptions {
    * replaces it wholesale through the handle's `setDecorations`.
    */
   readonly decorations?: DecorationMap
+  /**
+   * Runs the layout engine in a Web Worker the host constructs (#490). ELK
+   * otherwise runs on the calling thread, and a routed layout of a large view
+   * freezes the page for most of a second. The bundle cannot promise a worker
+   * itself: an inline one needs a `blob:` allowance in the HOST's policy. A
+   * host that can serve `elkjs/lib/elk-worker.min.js` from its own origin
+   * passes `() => new Worker(thatUrl)`, and every layout runs there. One
+   * engine per page: the mount that passed a factory owns the worker, and
+   * unmounting it terminates the worker and restores the bundled engine.
+   */
+  readonly workerFactory?: () => LayoutWorker
 }
 
 /**
@@ -171,8 +187,13 @@ const READ_SECTIONS: readonly RightSectionId[] = ['properties', 'questions']
 export const mountEditor = (
   element: Element,
   options: MountOptions,
-): MountedEditor =>
-  mountEditorWith(
+): MountedEditor => {
+  const engine =
+    options.workerFactory === undefined
+      ? undefined
+      : workerLayoutEngine(options.workerFactory)
+  if (engine !== undefined) installLayoutEngine(engine)
+  const mounted = mountEditorWith(
     element,
     createLocalHost(options),
     options.sections ??
@@ -180,6 +201,16 @@ export const mountEditor = (
     options.readOnly,
     options.decorations,
   )
+  if (engine === undefined) return mounted
+  return {
+    ...mounted,
+    unmount: () => {
+      mounted.unmount()
+      engine.terminate?.()
+      installLayoutEngine(undefined)
+    },
+  }
+}
 
 /**
  * The same editor over a host the caller built.

--- a/test/elk-layout.test.ts
+++ b/test/elk-layout.test.ts
@@ -6,13 +6,16 @@ import {
   buildElkGraph,
   edgeLabelSize,
   edgeLabelText,
+  installLayoutEngine,
   layoutWithElk,
+  workerLayoutEngine,
   readElkLayout,
   rootLayoutOptions,
   spacingFor,
 } from '../src/visual-app/elk-layout.js'
 import type { ElkNode } from 'elkjs/lib/elk.bundled.js'
 import { LAYOUT_MODES } from '../src/layout-mode.js'
+import type { LayoutWorker } from '../src/visual-app/elk-layout.js'
 
 // Two boxes with a member each, one loose subject, and three relationships:
 // an unnamed serving, a named flow, and an association from the application
@@ -348,5 +351,78 @@ describe('with the engine', () => {
       expect(route.points.length).toBeGreaterThanOrEqual(2)
       expect(route.labelAt).not.toBeNull()
     }
+  })
+})
+
+// The one door the canvas lays out through (#490). Whatever engine a page
+// installs answers every layout; nothing installed, the bundled engine does.
+describe('the layout engine seam', () => {
+  it('routes every layout through the installed engine, and back to the bundled one when it is removed', async () => {
+    const asked: ElkNode[] = []
+    installLayoutEngine({
+      layout: (graph) => {
+        asked.push(graph)
+        return Promise.resolve({ id: 'answered', x: 1, y: 2 })
+      },
+    })
+    try {
+      const graph: ElkNode = { id: 'root', children: [{ id: 'n', width: 170, height: 50 }] }
+      expect(await layoutWithElk(graph)).toEqual({ id: 'answered', x: 1, y: 2 })
+      expect(asked).toEqual([graph])
+    } finally {
+      installLayoutEngine(undefined)
+    }
+    // The bundled engine really lays out: a node gets a place.
+    const laid = await layoutWithElk({
+      id: 'root',
+      layoutOptions: { 'elk.algorithm': 'layered' },
+      children: [{ id: 'n', width: 170, height: 50 }],
+    })
+    expect(typeof laid.children?.[0]?.x).toBe('number')
+  })
+
+  // A stand-in for `elk-worker.min.js` at the other end of elk-api's
+  // protocol: every message carries an id and is answered with that id; a
+  // layout is answered with the graph it was sent, marked.
+  class FakeWorker implements LayoutWorker {
+    onmessage: ((event: { readonly data: unknown }) => void) | null = null
+    readonly posted: { id: number; cmd: string; graph?: ElkNode }[] = []
+    terminated = false
+    postMessage(message: unknown): void {
+      const posted = message as { id: number; cmd: string; graph?: ElkNode }
+      this.posted.push(posted)
+      queueMicrotask(() =>
+        this.onmessage?.({
+          data: {
+            id: posted.id,
+            data: posted.cmd === 'layout' ? { ...posted.graph, laidBy: 'worker' } : [],
+          },
+        }),
+      )
+    }
+    terminate(): void {
+      this.terminated = true
+    }
+  }
+
+  it('speaks elk-api\'s protocol to the worker the factory constructs, once, and terminates it', async () => {
+    const workers: FakeWorker[] = []
+    const engine = workerLayoutEngine(() => {
+      const worker = new FakeWorker()
+      workers.push(worker)
+      return worker
+    })
+    expect(workers.length).toBe(1)
+    const worker = workers[0] as FakeWorker
+    // Construction registers the algorithms before anything is asked.
+    expect(worker.posted[0]?.cmd).toBe('register')
+    const graph: ElkNode = { id: 'root', children: [{ id: 'n', width: 170, height: 50 }] }
+    const laid = (await engine.layout(graph)) as ElkNode & { laidBy?: string }
+    expect(laid.laidBy).toBe('worker')
+    expect(worker.posted.at(-1)?.cmd).toBe('layout')
+    expect(worker.posted.at(-1)?.graph).toEqual(graph)
+    expect(workers.length).toBe(1)
+    engine.terminate?.()
+    expect(worker.terminated).toBe(true)
   })
 })

--- a/test/visual-app-worker-bundle.test.ts
+++ b/test/visual-app-worker-bundle.test.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// The served page runs ELK in a Web Worker (#490). That holds only if vite
+// emitted the worker as one more flat asset the session server's asset route
+// serves, the page reaches it as a same-origin worker, and the engine is not
+// also bundled into the chunk the page loads first. The library bundle, whose
+// host's policy is unknown, ships no worker of its own. This reads the built
+// output, so it runs after `pnpm build`, as the browser-safety scan does.
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+const servedAssets = resolve(repositoryRoot, 'dist/visual-app/assets')
+const libDir = resolve(repositoryRoot, 'dist/visual-app-lib')
+
+// The session server's `ASSET_NAME`: one path segment, no separator.
+const ASSET_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+
+const listOr = (directory: string): readonly string[] => {
+  try {
+    return readdirSync(directory)
+  } catch {
+    return []
+  }
+}
+
+describe('the served page and its layout worker', () => {
+  const served = listOr(servedAssets)
+  const workers = served.filter((name) => /^elk-worker(\.min)?-[A-Za-z0-9_-]+\.js$/.test(name))
+  // Vite names the entry after `index.html`, not after `main.tsx`.
+  const entries = served.filter((name) => /^index-[A-Za-z0-9_-]+\.js$/.test(name))
+
+  it('has something built to check', () => {
+    expect(served.length, 'run `pnpm build` first').toBeGreaterThan(0)
+  })
+
+  it('emits exactly one worker file, flat under assets, that the asset route will serve', () => {
+    expect(workers).toHaveLength(1)
+    expect(ASSET_NAME.test(workers[0] ?? '')).toBe(true)
+  })
+
+  it('has the page construct that worker as a same-origin script and load the engine nowhere else first', () => {
+    expect(entries).toHaveLength(1)
+    const entry = readFileSync(resolve(servedAssets, entries[0] ?? ''), 'utf8')
+    expect(entry.includes('new Worker(')).toBe(true)
+    expect(entry.includes((workers[0] ?? '').replace(/\.js$/, ''))).toBe(true)
+    // The bundled engine is a chunk of its own the page never asks for; it
+    // must not be inside the entry, or the page ships ELK twice. ELK's option
+    // ids are string literals no minifier renames, so they mark the engine.
+    expect(entry.includes('org.eclipse.elk')).toBe(false)
+    expect(readFileSync(resolve(servedAssets, workers[0] ?? ''), 'utf8').includes('org.eclipse.elk')).toBe(true)
+  })
+
+  it('gives the library no worker of its own', () => {
+    const lib = listOr(libDir)
+    expect(lib.length, 'run `pnpm build` first').toBeGreaterThan(0)
+    expect(lib.filter((name) => name.startsWith('elk-worker'))).toEqual([])
+    // One file: the bundled engine is inlined, not split beside it.
+    expect(lib.filter((name) => name.endsWith('.js'))).toEqual(['editor.js'])
+    expect(readFileSync(resolve(libDir, 'editor.js'), 'utf8').includes('org.eclipse.elk')).toBe(true)
+  })
+})

--- a/test/visual-mount.test.ts
+++ b/test/visual-mount.test.ts
@@ -8,11 +8,15 @@ const createRoot = vi.hoisted(() => vi.fn(() => root))
 
 vi.mock('react-dom/client', () => ({ createRoot }))
 import {
+  mountEditor,
   mountEditorWith,
   type DecorationMap,
   type EditorHost,
   type RightSectionId,
 } from '../src/visual-app/mount.js'
+import { layoutWithElk } from '../src/visual-app/elk-layout.js'
+import type { SourceStore } from '../src/source-store.js'
+import type { ResolvedWorkspace } from '../src/workspace.js'
 import {
   editorPointerFor,
   normalizeSelectedElement,
@@ -443,5 +447,65 @@ describe('editorPointerFor', () => {
     expect(pointer.select('app.checkout')).toBe(true)
     expect(pointer.openDraft()).toBe(true)
     expect(pointer.startConnection('app.checkout')).toBe(true)
+  })
+})
+
+// A host that can serve the worker file hands `mountEditor` a factory (#490):
+// every layout then runs in that worker, and unmounting lets it go.
+describe('mountEditor with a workerFactory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const emptyWorkspace: ResolvedWorkspace = {
+    id: 'embedded',
+    documents: [],
+    profiles: [],
+    projections: [],
+    adapterMappings: [],
+    patterns: [],
+    evidence: [],
+    contracts: [],
+  }
+  const store = {} as SourceStore
+
+  it('constructs the worker once, lays out through it, and terminates it on unmount', async () => {
+    const posted: { id: number; cmd: string }[] = []
+    let terminated = 0
+    const worker = {
+      onmessage: null as ((event: { readonly data: unknown }) => void) | null,
+      postMessage(message: unknown) {
+        const sent = message as { id: number; cmd: string; graph?: unknown }
+        posted.push(sent)
+        queueMicrotask(() =>
+          this.onmessage?.({ data: { id: sent.id, data: sent.cmd === 'layout' ? sent.graph : [] } }),
+        )
+      },
+      terminate() {
+        terminated += 1
+      },
+    }
+    const workerFactory = vi.fn(() => worker)
+
+    const editor = mountEditor({} as Element, { store, workspace: emptyWorkspace, workerFactory })
+    expect(workerFactory).toHaveBeenCalledOnce()
+    const laid = await layoutWithElk({ id: 'root' })
+    expect(laid).toEqual({ id: 'root' })
+    expect(posted.at(-1)?.cmd).toBe('layout')
+
+    editor.unmount()
+    expect(root.unmount).toHaveBeenCalledOnce()
+    expect(terminated).toBe(1)
+    // Back on the bundled engine: the worker sees no further layout.
+    const before = posted.length
+    await layoutWithElk({ id: 'root', children: [{ id: 'n', width: 170, height: 50 }] })
+    expect(posted.length).toBe(before)
+  })
+
+  it('leaves the bundled engine in place when no factory is given', () => {
+    const editor = mountEditor({} as Element, { store, workspace: emptyWorkspace })
+    expect(root.render).toHaveBeenCalledOnce()
+    editor.unmount()
+    expect(root.unmount).toHaveBeenCalledOnce()
   })
 })

--- a/vite.visual-lib.config.ts
+++ b/vite.visual-lib.config.ts
@@ -65,5 +65,14 @@ export default defineConfig({
       fileName: () => 'editor.js',
       cssFileName: 'styles',
     },
+    rolldownOptions: {
+      output: {
+        // The engine is a dynamic import so the served page can leave it to
+        // its worker (#490). Here it is inlined: a host copies `editor.js`
+        // and nothing beside it, and a second chunk would be the one file it
+        // does not copy.
+        codeSplitting: false,
+      },
+    },
   },
 })

--- a/vite.visual.config.ts
+++ b/vite.visual.config.ts
@@ -11,6 +11,12 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   root: fileURLToPath(new URL('./src/visual-app/', import.meta.url)),
   base: './',
+  // The layout worker (#490): `main.tsx` imports `elkjs/lib/elk-worker.min.js?worker`
+  // and vite emits it as one more flat, hashed asset under `assets/`, which the
+  // session server's asset route serves like the rest. As a module worker the
+  // file is bundled the way the page is; the classic (iife) form built the
+  // same file behind a warning about an export name it does not have.
+  worker: { format: 'es' },
   build: {
     outDir: fileURLToPath(new URL('./dist/visual-app/', import.meta.url)),
     // Only this directory: `build:node` writes the rest of `dist`.


### PR DESCRIPTION
Stacked on #499 (saved routes). Merge order: #494 → #496 → #497 → #498 → #499 → this.

Closes #490.

## What was wrong

A routed layout of a large view takes most of a second on the calling thread, and the page is frozen for all of it. Measured in Chrome on the same layout code without the worker (the `lab/style-presets` build serving Nabeel's lab session, 1.24.0 plus the presets): 4256 ms longest main-thread task switching to this repository's 366-subject "All subjects" view under `served-by` (the reference Landscape was 805 ms, `bands` 1181 ms).

## What changes

- **Served page**: `main.tsx` imports `elkjs/lib/elk-worker.min.js?worker` and installs a worker engine before the first render. Vite emits the worker as `assets/elk-worker.min-<hash>.js`, a flat name the session server's asset route already serves; the page constructs it as a same-origin module worker, which `default-src 'self'` admits. `worker: { format: 'es' }` in the served config (the iife form built the same file behind an export-name warning).
- **Engine seam** (`src/visual-app/elk-layout.ts`): `LayoutEngine`, `installLayoutEngine`, `workerLayoutEngine` (elk-api over a factory-made worker, `terminate` included). The bundled engine is now a dynamic import loaded on first use, so the served page ships ELK once, in the worker (its entry chunk carries no `org.eclipse.elk` option id; the never-fetched `elk.bundled-<hash>.js` chunk sits beside it).
- **Library**: unchanged behaviour by default (main thread), since the host's policy is unknown. New `workerFactory` option on `mountEditor`: the mount that passes one owns the worker; its `unmount()` terminates it and restores the bundled engine. `codeSplitting: false` in the lib config keeps `editor.js` one file with the engine inlined (4.0 MB raw, as before).
- **Docs**: ADR 0147 amendment (exclusion lifted for the served page, kept for the library), VISUAL-ADAPTER layout section, CONSUMING-YARRAMATE `workerFactory`, CHANGELOG Unreleased.

## Verified

- Browser, worktree build served by the session server: network shows `index-*.js` and `elk-worker.min-*.js` fetched, `elk.bundled-*.js` never; no CSP or worker errors (the one inline-style violation in the console is pre-existing, present on the main-thread session too). Served-by drew routed edges.
- A/B on the 366-subject view, same script on both sessions: longest task 4256 ms (main-thread build) vs 95 ms (this build); worst rAF gap 4272 ms vs 125 ms.
- Tests: the engine seam (installed engine answers, removed engine falls back to a real bundled layout); `workerLayoutEngine` speaks elk-api's protocol to a fake worker (register first, layout answered, factory called once, terminate reaches the worker); `mountEditor` with a `workerFactory` constructs once, lays out through it, terminates on unmount and falls back after; `mountEditor` without one leaves the bundled engine. New `test/visual-app-worker-bundle.test.ts` reads the built output: exactly one flat worker asset matching the asset-name rule, the entry constructs it and carries no engine, the library has no worker file and one `editor.js` with the engine inside.
- Mutations red: `layoutWithElk` ignoring the installed engine (2 tests); `mountEditor` ignoring `workerFactory` (1 test).
- Clean-slate `pnpm verify`: 148 files, 2429 passed, 1 skipped, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ

