### PR TITLE
chore: release 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.25.0
 
 ### The served page lays out in a Web Worker (#490)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog stamp for 1.25.0: six entries since 1.24.0 (#494, #501, #497, #498, #499, #500). MINOR: five style presets, saved routes, the served page laying out in a Web Worker, plus three fixes. Clean-slate `pnpm verify` on this branch: exit 0.

## 1.25.0


### The served page lays out in a Web Worker (#490)

A routed layout of a large view takes most of a second, and on the calling
thread that was a frozen page: 805 ms for `served-by` on the 157-subject
reference Landscape, 1181 ms for `bands`, and 4.3 s on this repository's
366-subject "All subjects" view. The page `yarramate-visual` serves now runs
ELK in a Web Worker, and that same 366-subject layout leaves the page's
longest main-thread task at 95 ms (measured in Chrome, the two builds side by
side): vite emits the worker as one more flat asset the
session server already serves, the page's policy admits it as a same-origin
worker, and the engine ships once, in the worker, rather than also in the
chunk the page loads first. The library bundle a host mounts cannot promise
what its host's policy admits, so it keeps the engine on the calling thread;
a host that can serve `elkjs/lib/elk-worker.min.js` from its own origin passes
`workerFactory: () => new Worker(thatUrl)` to `mountEditor` and gets the same.
The bundled engine is loaded the first time a layout asks for it, so the
served page never fetches it. ADR 0147 amended.

### A saved layout keeps its routes, and the fold state the browser sends

Dragging one subject on a routed canvas saved every subject's position, and
on the next visit the pin put every subject at its saved place, so no edge's
ends sat where ELK had just put them and every route fell back to the
stylesheet's straight line: one drag undid the routed layout for good. Seen
on the reference model. The layout sidecar now carries `routes` beside the
positions they were computed for, and a route is drawn again wherever both
ends still sit at their saved place; only the moved subject's edges, and its
box's, stay straight. A `layered` save writes the bytes it always did.

The same save now actually carries the fold state. The sidecar could hold
`folded` and `unfolded` since #473 and both hosts wrote them, but the browser
never sent them and the event schema would have refused them if it had. The
schema names the sidecar's own definitions for folds and routes, so what the
browser may send and what the file may hold are one shape.

### The canvas has five dresses, and the reviewer picks

A **Style** select joins Layout and Direction on the canvas: `current` (what
shipped), `drafting`, `ink`, `tinted` and `dark`, all over the same notation,
so a dress changes colour, weight, face and radius and never what a shape
means. The pick is the reviewer's own: remembered by the browser, never
written into a view, untouched by a view switch. The notation's glyphs take a
stroke colour so the dark ground gets light glyphs. ADR 0148.

### Two residues of the routed modes, measured away

Two labelled edges running side by side could still lay their readings over
each other: the lanes between parallel edges go from 30 to 60px in the routed
modes, which measured 0 labels on another label on the reference Landscape
(from 3) for 5% more width; label spacing and placing labels beside the edge
were tried and moved nothing. And a container's title, which sits in the band
above its members, is grounded the way edge labels are, so a route entering
the box from above no longer cuts through the letters.

### Every orthogonal edge turns a square corner

Layered drew its taxi bends with a 25px radius and the routed modes drew
square corners; the difference was noticed on the reference model. Rounding
the routed corners was tried first and withdrawn: at a container's border a
rounded bend reads as the edge swerving into or out of the box. Layered now
draws plain `taxi`, the routed modes plain `segments`, and neither asks for a
radius.

### Save view keeps what the view already declares (#493)

Overwriting a view through **Save view** rebuilt its presentation block from
the form's own fields and dropped every other one: `nesting`, `fold` and
`notation`. Found by ApertureX on 1.24.0, where a saved API tiers view lost
`nesting: [composition, assignment]` and went from 69 subjects and 72 edges to
65 and 105, because nothing contained the members any more. The defect
predates 1.24.0; 1.24.0 made it bite, since Save is now the way to keep a
layout pick. The overwritten view's declaration is now carried underneath
what the form owns; a brand new view still carries nothing.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
