### PR TITLE
fix(visual): restoring a saved layout pins the leaves and lets the boxes follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Restoring a saved layout pins the leaves and lets the boxes follow (#507)
+
+Restoring a saved layout positioned the boxes too. A box's centre is derived
+from its members, and cytoscape answers a box being positioned by moving every
+member by the difference between the derived centre and the asked one; the
+sidecar's box entry was read off the canvas when the drag had already changed
+the box's extent, so it differed from the centre the pinned members derive by
+a few pixels, and pinning the box moved every member by exactly that, off
+their saved places and out of their routes. Found by ApertureX on 1.25.1: on
+the reference API tiers, 11 members sat 7.8 px off and 28 routes beyond the
+dragged subject's own were dropped. The pin now places leaves only, and a box
+sits where its members put it. A folded box is a plain node by then and is
+pinned like one.
+
 ## 1.25.1
 
 ### The mounted host reads the layout sidecar back, and a commit forgets neither folds nor routes (#503)

--- a/docs/VISUAL-ADAPTER.md
+++ b/docs/VISUAL-ADAPTER.md
@@ -183,7 +183,11 @@ the directory's files, the mounted host hands it what its store lists under
 the directory plus every view's own sidecar path asked for by name, so a store
 that cannot enumerate still restores what it holds. What a sidecar said, or a
 save set, is carried across every recompile, positions, fold state and routes
-alike.
+alike. The pin places leaves only (#507): a box's centre is derived from its
+members, so pinning the members pins the box, and positioning the box itself
+would move them off their saved places by whatever its sidecar entry differs
+from the centre they derive. A folded box is a plain node by then and is
+pinned like one.
 
 ### Layout
 

--- a/docs/adr/0085-a-dragged-position-is-presentation-the-repository-keeps.md
+++ b/docs/adr/0085-a-dragged-position-is-presentation-the-repository-keeps.md
@@ -8,7 +8,12 @@ Status: accepted
 > a drag was kept in the repository and never applied again. The reader takes
 > sources and returns positions, fold state and routes; the server hands it
 > the directory's files, the mounted host what its store lists under the
-> directory plus each view's own sidecar path by name.
+> directory plus each view's own sidecar path by name. And the pin places
+> leaves only (#507): a box's centre is derived from its members, and
+> positioning a box moves them, so a sidecar's box entry, a few pixels off
+> the centre its pinned members derive, had been moving those members off
+> their saved places. The entry is still written, and a folded box, a plain
+> node by the time the pin runs, is pinned by it.
 
 [ADR 0023](0023-state-comparison-visualization-is-adapter-presentation.md)
 settled that visualization is adapter presentation: Core classifies, the

--- a/src/visual-app/graph-canvas.tsx
+++ b/src/visual-app/graph-canvas.tsx
@@ -1343,10 +1343,21 @@ export function buildPositionMap(nodes: NodeCollection): VisualLayoutPositions {
 // that the next whole-canvas drag-save would immortalise. `visible()` is the
 // same judgement `relayoutVisible` scopes by (and returns true wholesale on a
 // style-disabled instance, where nothing is ever hidden).
+//
+// Leaves only (#507). A box's centre is derived from its members, and cytoscape
+// answers a box being positioned by translating every member by the difference
+// between the derived centre and the asked one. The sidecar's box entry was
+// read off the canvas at save time, when the drag had already changed the
+// box's extent, so it differs from the centre the pinned members derive by a
+// few pixels; pinning the box then moved every member by exactly that, off
+// their saved places and out of their routes: 7.8 px and 28 routes on the
+// reference API tiers. Pinning the members pins the box. A folded box is not a
+// parent by the time this runs, `applyFilter` having detached its hidden
+// members, so it is pinned like the leaf it is drawn as.
 export function applySavedPositions(cy: Core, saved: VisualLayoutPositions | undefined): void {
   if (saved === undefined) return
   cy.nodes().forEach((node) => {
-    if (!node.visible()) return
+    if (!node.visible() || node.isParent()) return
     const position = saved[node.id()]
     if (position !== undefined) node.position(position)
   })

--- a/test/graph-canvas-layout.test.ts
+++ b/test/graph-canvas-layout.test.ts
@@ -88,6 +88,44 @@ describe('layout drag-save and position pinning', () => {
     expect(cy.getElementById('hidden').position()).toEqual({ x: 2, y: 2 })
   })
 
+  // A box's centre is derived from its members, and positioning a box moves
+  // them. The sidecar's box entry is a few pixels off the centre its pinned
+  // members derive, so pinning it undid the members' pin by that much and
+  // dropped their routes (#507: 7.8 px, 28 routes on the reference API tiers).
+  it('pins leaves only, so a stale box centre in the sidecar cannot move the members off theirs (#507)', () => {
+    const cy = cytoscape({
+      styleEnabled: true,
+      layout: { name: 'preset' },
+      style: [{ selector: 'node', style: { width: 170, height: 50 } }],
+      // The box AFTER its members, as the canvas holds them: the pin then
+      // reaches the box last, and a box pinned last has the final word.
+      elements: [
+        { data: { id: 'a', parent: 'box' }, position: { x: 0, y: 0 }, group: 'nodes' as const },
+        { data: { id: 'b', parent: 'box' }, position: { x: 200, y: 0 }, group: 'nodes' as const },
+        { data: { id: 'c' }, position: { x: 500, y: 0 }, group: 'nodes' as const },
+        // What a folded box is by the time the pin runs: its members detached,
+        // an ordinary node drawn as the whole (#473).
+        { data: { id: 'folded-box' }, position: { x: 900, y: 0 }, group: 'nodes' as const, classes: 'folded' },
+        { data: { id: 'box' }, group: 'nodes' as const },
+      ],
+    })
+    applySavedPositions(cy, {
+      a: { x: 0, y: 100 },
+      b: { x: 200, y: 100 },
+      // The centre the members derive is (100, 100); the sidecar says 7.8 px more.
+      box: { x: 107.8, y: 100 },
+      c: { x: 600, y: 0 },
+      'folded-box': { x: 950, y: 50 },
+    })
+    expect(cy.getElementById('a').position()).toEqual({ x: 0, y: 100 })
+    expect(cy.getElementById('b').position()).toEqual({ x: 200, y: 100 })
+    expect(cy.getElementById('c').position()).toEqual({ x: 600, y: 0 })
+    ;(cy.nodes() as unknown as { updateCompoundBounds(force: boolean): void }).updateCompoundBounds(true)
+    expect(cy.getElementById('box').position()).toEqual({ x: 100, y: 100 })
+    // Not a parent, so pinned like any leaf.
+    expect(cy.getElementById('folded-box').position()).toEqual({ x: 950, y: 50 })
+  })
+
   it('discard unpins: a discarded view yields nothing to pin, so a fresh layout stands (#273)', () => {
     const cy = canvasWith([['node1', 1, 1]])
     const saved: VisualLayoutPositions = { node1: { x: 100, y: 100 } }


### PR DESCRIPTION
Closes #507.

## What was wrong

`applySavedPositions` walked every visible node, compound boxes included. A box's centre is derived from its members, and cytoscape answers `box.position(p)` by translating every member by `p - derivedCentre`. The sidecar's box entry was read off the canvas at save time, after the drag had changed the box's extent, so it sat a few pixels off the centre the pinned members derive; pinning the box then moved every member by exactly that, off their saved places and out of their routes under the exact-position rule. ApertureX measured it on 1.25.1: 11 members 7.8 px off, 37 of 72 routes back instead of 65. The probe in the new test reproduces the 7.8 px signature with the box ordered after its members, as the canvas holds them.

## What changes

- `applySavedPositions` skips `node.isParent()`. Pinning the members pins the box. A folded box is not a parent by the time the pin runs (`applyFilter` detaches its hidden members, #473), so it is pinned like the leaf it is drawn as. The box entry is still written to the sidecar.
- Docs: ADR 0085 amendment extended, VISUAL-ADAPTER, CHANGELOG Unreleased.

## Tests

- `test/graph-canvas-layout.test.ts`: a box after its two members, a loose node and a folded box (plain node with class `folded`); the sidecar names the leaves' places and a box centre 7.8 px off the one they derive; after the pin every leaf is exactly at its saved place, the box's derived centre is the members' own, and the folded box is at its saved place.

Mutation red: pinning parents too (fails with `{ x: 7.799999999999997, y: 200 }` against `{ x: 0, y: 100 }`, the reference signature).

Clean-slate `pnpm verify`: exit 0; test files 149 passed (149); tests 2439 passed | 1 skipped (2440).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
