### PR TITLE
fix(visual): an empty title or description is written as no field, so an undescribed view can be edited again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### A subject added to an undescribed view can be committed again (#509)
+
+Adding a subject to a view staged a rewrite of the view's document with
+`description: ""`, because the editor reads an undeclared description back as
+an empty string and the composition wrote it back as one. The schema's
+`presentation.description` is non-empty text, so the staged document was
+refused (YM201) and **Commit changes** went nowhere. Found by ApertureX on
+1.25.1; the write dates from 1.0.0. Five of their six reference views declare
+no description, so a consultant could not add a subject to any of them.
+An empty title or description is now written as no field at all, wherever a
+view is composed: the membership write, Save view, the query tab's Stage and
+Duplicate. Clearing a description in Save view removes it rather than keeping
+the declared one.
+
 ### Restoring a saved layout pins the leaves and lets the boxes follow (#507)
 
 Restoring a saved layout positioned the boxes too. A box's centre is derived

--- a/src/adapters/visual/view-identity.ts
+++ b/src/adapters/visual/view-identity.ts
@@ -139,23 +139,42 @@ export interface SavedView {
   readonly path: string;
 }
 
+/**
+ * The saved document for a view, from what the editor holds of it.
+ *
+ * An EMPTY title or description is written as no field at all (#509). The
+ * schema's `presentation.title` and `.description` are non-empty text, and
+ * the editor reads an undeclared description back as `""`; writing that
+ * string back made every membership edit to an undescribed view a document
+ * the schema refuses (YM201), so a subject added to five of the six
+ * ApertureX reference views could not be committed, since 1.0.0. The
+ * declared presentation is spread first and its own `title`/`description`
+ * set aside, so an emptied field is removed rather than kept from the
+ * declaration: the caller's value is the whole truth about those two.
+ */
 export const composeProjection = (input: {
   readonly id: string;
   readonly title: string;
   readonly description: string;
   readonly query: ProjectionQuery;
   readonly presentation: ProjectionDefinition["presentation"];
-}): ProjectionDefinition => ({
-  format: "yarramate/projection/v1",
-  id: input.id,
-  version: "1.0",
-  query: input.query,
-  presentation: {
-    ...(input.presentation ?? {}),
-    title: input.title,
-    description: input.description,
-  },
-});
+}): ProjectionDefinition => {
+  const { title: _title, description: _description, ...declared } =
+    input.presentation ?? {};
+  return {
+    format: "yarramate/projection/v1",
+    id: input.id,
+    version: "1.0",
+    query: input.query,
+    presentation: {
+      ...declared,
+      ...(input.title.trim() === "" ? {} : { title: input.title }),
+      ...(input.description.trim() === ""
+        ? {}
+        : { description: input.description }),
+    },
+  };
+};
 
 /**
  * Whether a view can be told which subjects it holds.

--- a/test/save-view.test.ts
+++ b/test/save-view.test.ts
@@ -54,6 +54,22 @@ const projectionOf = (operation: ReturnType<typeof buildPayload>) => {
   return operation.projection
 }
 
+// An empty description is no description (#509): the schema refuses "", and
+// clearing the field in this form means removing it, not keeping the one the
+// view declared.
+describe('buildPayload and an empty description', () => {
+  it('writes no description when the field is empty, and drops a declared one that was cleared', () => {
+    const projection = projectionOf(
+      build({
+        description: '',
+        declared: { title: 'Existing', description: 'The old one', nesting: ['composition'] },
+      }),
+    )
+    expect('description' in (projection.presentation ?? {})).toBe(false)
+    expect(projection.presentation).toMatchObject({ title: 'My View', nesting: ['composition'] })
+  })
+})
+
 describe('buildPayload', () => {
   it('writes the document the view already occupies when overwriting', () => {
     const operation = build()

--- a/test/view-identity.test.ts
+++ b/test/view-identity.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { composeProjection, withMembership } from '../src/adapters/visual/view-identity.js'
+import { validateProjection } from '../src/schema-validation.js'
+
+// What the editor holds of a view goes back to disk through one composer.
+// The schema's title and description are non-empty text, and the editor
+// reads an undeclared description back as "", so an empty value has to mean
+// "no field" or every write of an undescribed view is refused (#509).
+describe('composeProjection', () => {
+  const query = { subjects: ['checkout', 'ledger'] }
+
+  it('writes no description for a view that has none, and the document validates', () => {
+    const projection = composeProjection({
+      id: 'api-tiers',
+      title: 'API tiers',
+      description: '',
+      query,
+      presentation: { title: 'API tiers', layout: 'layered', nesting: ['composition', 'assignment'] },
+    })
+    expect(validateProjection(projection), JSON.stringify(validateProjection.errors)).toBe(true)
+    expect(projection.presentation).toEqual({
+      title: 'API tiers',
+      layout: 'layered',
+      nesting: ['composition', 'assignment'],
+    })
+  })
+
+  it('writes the title and description it is given when they say something', () => {
+    const projection = composeProjection({
+      id: 'landscape',
+      title: 'Landscape',
+      description: 'Everything, once',
+      query,
+      presentation: { layout: 'routed' },
+    })
+    expect(projection.presentation).toEqual({
+      layout: 'routed',
+      title: 'Landscape',
+      description: 'Everything, once',
+    })
+  })
+
+  it('treats a blank as empty, and an emptied description as removed rather than kept from the declaration', () => {
+    const projection = composeProjection({
+      id: 'landscape',
+      title: 'Landscape',
+      description: '   ',
+      query,
+      presentation: { title: 'Old title', description: 'The one being cleared', direction: 'left-right' },
+    })
+    expect(projection.presentation).toEqual({ direction: 'left-right', title: 'Landscape' })
+    expect(validateProjection(projection)).toBe(true)
+  })
+
+  it('composes a membership edit on an undescribed view into a document the schema accepts', () => {
+    const saved = composeProjection({
+      id: 'api-tiers',
+      title: 'API tiers',
+      description: '',
+      query,
+      presentation: { title: 'API tiers' },
+    })
+    const amended = withMembership(saved, 'fraud-screening', 'add')
+    expect(amended).not.toBeNull()
+    if (amended === null) return
+    expect(validateProjection(amended), JSON.stringify(validateProjection.errors)).toBe(true)
+    expect(amended.query.subjects).toEqual(['checkout', 'ledger', 'fraud-screening'])
+  })
+})

--- a/test/visual-app-state.test.ts
+++ b/test/visual-app-state.test.ts
@@ -1,3 +1,4 @@
+import { validateProjection } from "../src/schema-validation.js";
 import { describe, expect, it } from "vitest";
 import {
   VISUAL_LIMITS,
@@ -1949,6 +1950,46 @@ describe("visualAppReducer view membership", () => {
       "ledger",
       "fraud-screening",
     ]);
+  });
+
+  // Five of the six ApertureX reference views declare no description, and
+  // the editor reads that back as "". Writing "" into the document made the
+  // membership write a schema violation (YM201) and the commit dead (#509).
+  it("stages a document the schema accepts for a view that declares no description (#509)", () => {
+    const undescribed: VisualViewSummary = {
+      id: "api-tiers",
+      title: "API tiers",
+      description: "",
+      query: { subjects: ["checkout", "ledger"] },
+      presentation: {
+        title: "API tiers",
+        layout: "layered",
+        nesting: ["composition", "assignment"],
+      },
+      path: ".yarramate/projections/api-tiers.yaml",
+      subjectCount: 2,
+    };
+    const state = visualAppReducer(
+      { ...initialVisualAppState, activeView: "api-tiers", views: [undescribed] },
+      {
+        type: "changeset.viewMembership",
+        viewId: "api-tiers",
+        subjectId: "fraud-screening",
+        membership: "add",
+      },
+    );
+    const operation = state.pendingChangeset.viewOperations[0];
+    expect(operation?.op).toBe("write-view");
+    if (operation?.op !== "write-view") return;
+    expect(validateProjection(operation.projection), JSON.stringify(validateProjection.errors)).toBe(true);
+    expect("description" in (operation.projection.presentation ?? {})).toBe(false);
+    // The declaration rides through untouched apart from the membership.
+    expect(operation.projection.presentation).toEqual({
+      title: "API tiers",
+      layout: "layered",
+      nesting: ["composition", "assignment"],
+    });
+    expect(operation.projection.query.subjects).toEqual(["checkout", "ledger", "fraud-screening"]);
   });
 
   it("composes a second edit on top of the first, not on the saved document", () => {


### PR DESCRIPTION
Closes #509.

## What was wrong

`composeProjection` (`src/adapters/visual/view-identity.ts`) wrote `title` and `description` unconditionally. The editor reads an undeclared description back as `""`, so every write of an undescribed view carried `description: ""`, which the projection schema refuses (`presentation.description` is non-empty text, YM201). The membership write on subject add (#255, 1.0.0) is the path a consultant hits: Add subject on API tiers stages `write-view` with the empty description, the commit is refused, and the only signal is the problem line. Five of the six ApertureX reference views declare no description. The reducer tests for the membership write used a described view, which is why they stayed green.

## What changes

- `composeProjection` writes `title`/`description` only when non-blank, and sets the declared presentation's own two aside before spreading it, so an emptied Save view description removes the field rather than keeping the declaration's. All four composers go through it (membership write, Save view, query tab Stage, Duplicate), so all four are fixed at once.
- CHANGELOG Unreleased.

Not changed here, for Nabeel's call: the issue's second half. On the mounted host there is no network to watch: each Commit click re-sends the changeset to the in-process local host, which refuses it again with the same problem line, so the click looks silent. A visible "refused again" signal or a disabled button while a refusal stands is a UX decision rather than a defect in the send path.

## Tests

- New `test/view-identity.test.ts`: an undescribed view composes to a document the schema accepts with no `description` key and the declaration intact; non-empty values are written; a blank counts as empty and an emptied description is removed rather than kept from the declaration; a membership edit on an undescribed view composes to a valid document.
- `test/visual-app-state.test.ts`: the reducer's membership write on an undescribed view (title, layout, nesting declared) stages a schema-valid document with the declaration untouched and the subject added.
- `test/save-view.test.ts`: an empty description writes no field and drops a declared one that was cleared.

Mutation red: writing both fields unconditionally fails 5 tests across the three files.

Clean-slate `pnpm verify`: exit 0; test files 150 passed (150); tests 2444 passed | 1 skipped (2445).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
