### PR TITLE
chore: release 1.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.25.2
 
 ### A subject added to an undescribed view can be committed again (#509)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarramate",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "description": "Tool-neutral semantic architecture engine and guided methodology",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump and changelog stamp for 1.25.2: the #507 and #509 fixes (#508, #510). PATCH. Clean-slate `pnpm verify` on this branch: exit 0.

## 1.25.2


### A subject added to an undescribed view can be committed again (#509)

Adding a subject to a view staged a rewrite of the view's document with
`description: ""`, because the editor reads an undeclared description back as
an empty string and the composition wrote it back as one. The schema's
`presentation.description` is non-empty text, so the staged document was
refused (YM201) and **Commit changes** went nowhere. Found by ApertureX on
1.25.1; the write dates from 1.0.0. Five of their six reference views declare
no description, so a consultant could not add a subject to any of them.
An empty title or description is now written as no field at all, wherever a
view is composed: the membership write, Save view, the query tab's Stage and
Duplicate. Clearing a description in Save view removes it rather than keeping
the declared one.

### Restoring a saved layout pins the leaves and lets the boxes follow (#507)

Restoring a saved layout positioned the boxes too. A box's centre is derived
from its members, and cytoscape answers a box being positioned by moving every
member by the difference between the derived centre and the asked one; the
sidecar's box entry was read off the canvas when the drag had already changed
the box's extent, so it differed from the centre the pinned members derive by
a few pixels, and pinning the box moved every member by exactly that, off
their saved places and out of their routes. Found by ApertureX on 1.25.1: on
the reference API tiers, 11 members sat 7.8 px off and 28 routes beyond the
dragged subject's own were dropped. The pin now places leaves only, and a box
sits where its members put it. A folded box is a plain node by then and is
pinned like one.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jbZq5jQucFBwciEYG5TkZ
